### PR TITLE
Fix waveform seekbar flashing back to old position on seek

### DIFF
--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -159,6 +159,11 @@ function handleAudioPlaying(_duration: number) {
 }
 
 function handleAudioProgress(current_time: number, duration: number) {
+  // While a seek is pending, the store already holds the optimistic target
+  // position.  Accepting stale progress from the Rust engine would briefly
+  // snap the waveform back to the old position before the seek completes.
+  if (seekDebounce) return;
+
   const store = usePlayerStore.getState();
   const track = store.currentTrack;
   if (!track) return;


### PR DESCRIPTION
## Summary

When clicking or dragging the waveform seekbar, the playback position briefly flashes back to the previous position before snapping to the new one.

## Root cause

The `seek()` function in the player store optimistically updates `progress` and `currentTime` to the target position immediately, then debounces the actual `audio_seek` IPC call to the Rust backend by 100ms. During that debounce window, `audio:progress` events from the Rust audio engine continue to arrive carrying the **old** playback position, overwriting the optimistic update and causing the visual flash. Once the debounced seek fires, subsequent progress events report the correct new position — but the brief revert is visible as a flicker in the waveform.

## Fix

Skip incoming `audio:progress` events in `handleAudioProgress` while a seek debounce is pending (`seekDebounce !== null`). The store already holds the correct target position from the optimistic update, so dropping stale progress events during this window is safe. Once the debounce fires and `seekDebounce` is cleared, progress events resume normally.

The change is a single guard (early return) at the top of `handleAudioProgress` in `src/store/playerStore.ts`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)