### PR TITLE
Fix waveform seekbar jitter caused by player time resizing

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -632,6 +632,15 @@
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   flex-shrink: 0;
+  min-width: 2.5rem;
+}
+
+.player-time:first-child {
+  text-align: right;
+}
+
+.player-time:last-child {
+  text-align: left;
 }
 
 /* Volume section */


### PR DESCRIPTION
## Summary

The waveform seekbar visually jitters/wiggles during playback because the `.player-time` elements (elapsed and duration) can change width as the displayed time string changes length (e.g. `"9:59"` → `"10:00"`). Since the waveform sits between these elements in a flex layout, any size change causes it to resize and redraw.

The root cause is that not all fonts support the `tabular-nums` font-variant — without it, digits have proportional widths, so different time strings produce different element widths.

## Changes

- Add `min-width: 2.5rem` to `.player-time` so the elements maintain a stable size regardless of the time string length
- Right-align the elapsed time and left-align the duration so they sit flush against the waveform edges

🤖 Generated with [Claude Code](https://claude.ai/claude-code)