### PR TITLE
feat(audio): enable OGG/Vorbis playback via symphonia-format-ogg

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rodio = { version = "0.19", default-features = false, features = ["symphonia-all"] }
-symphonia = { version = "0.5", default-features = false, features = ["flac", "mp3", "pcm", "aac", "isomp4", "vorbis", "wav", "adpcm"] }
+symphonia = { version = "0.5", default-features = false, features = ["flac", "mp3", "pcm", "aac", "isomp4", "vorbis", "ogg", "wav", "adpcm"] }
 reqwest = { version = "0.12", features = ["stream", "json"] }
 md5 = "0.7"
 tokio = { version = "1", features = ["rt", "time"] }


### PR DESCRIPTION
Add the "ogg" feature flag to the symphonia dependency, pulling in symphonia-format-ogg v0.5.5. The Vorbis codec was already compiled in; the missing OGG container demuxer was the sole reason .ogg files failed to play. No Rust code changes required — symphonia auto-registers all compiled-in formats at startup.