### PR TITLE
feat(ui): surface audio playback errors as themed toast notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { showToast } from './utils/toast';
 import { BrowserRouter, Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
@@ -433,20 +434,7 @@ export default function App() {
 
   const handleExport = async (since: number) => {
     setExportPickerOpen(false);
-    const showToast = (text: string) => {
-      const toast = document.createElement('div');
-      toast.textContent = text;
-      toast.style.cssText = `
-        position:fixed; bottom:100px; left:50%; transform:translateX(-50%);
-        background:#24273a; color:#cad3f5; border:1px solid #363a4f;
-        padding:10px 20px; border-radius:10px; font-size:14px;
-        z-index:999999; pointer-events:none;
-        box-shadow:0 4px 24px rgba(0,0,0,0.5);
-        white-space:nowrap;
-      `;
-      document.body.appendChild(toast);
-      setTimeout(() => toast.remove(), 4000);
-    };
+
     try {
       const { exportNewAlbumsImage } = await import('./utils/exportNewAlbums');
       const result = await exportNewAlbumsImage(since);

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
+import { showToast } from '../utils/toast';
 import { buildStreamUrl, buildCoverArtUrl, getPlayQueue, savePlayQueue, reportNowPlaying, scrobbleSong, SubsonicSong, getSong, getRandomSongs } from '../api/subsonic';
 import { lastfmScrobble, lastfmUpdateNowPlaying, lastfmLoveTrack, lastfmUnloveTrack, lastfmGetTrackLoved, lastfmGetAllLovedTracks } from '../api/lastfm';
 import { useAuthStore } from './authStore';
@@ -321,12 +322,19 @@ function handleAudioTrackSwitched(duration: number) {
 function handleAudioError(message: string) {
   console.error('[psysonic] Audio error from backend:', message);
   isAudioPaused = false;
+
+  // Show a brief, user-friendly toast. The message from the Rust backend is
+  // already human-readable (e.g. "unsupported format: .opus files cannot be
+  // played (no demuxer)"). Cap it to avoid overflowing the UI.
+  const detail = message.length > 80 ? message.slice(0, 80) + '…' : message;
+  showToast(`Couldn't play track — skipping. ${detail}`, 8000, 'error');
+
   const gen = playGeneration;
   usePlayerStore.setState({ isPlaying: false });
   setTimeout(() => {
     if (playGeneration !== gen) return;
     usePlayerStore.getState().next();
-  }, 500);
+  }, 1500);
 }
 
 /**

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,88 @@
+/**
+ * Lightweight DOM-based toast notification.
+ * Uses the app's CSS custom properties so it respects the active theme.
+ * Multiple toasts stack vertically above each other.
+ */
+
+const TOAST_GAP = 8;
+const TOAST_BOTTOM_ANCHOR = 100;
+
+function getActiveToasts(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('.psysonic-toast'));
+}
+
+function reflow(): void {
+  const toasts = getActiveToasts();
+  let bottom = TOAST_BOTTOM_ANCHOR;
+  for (let i = toasts.length - 1; i >= 0; i--) {
+    toasts[i].style.bottom = `${bottom}px`;
+    bottom += toasts[i].offsetHeight + TOAST_GAP;
+  }
+}
+
+export type ToastVariant = 'error' | 'info';
+
+export function showToast(text: string, durationMs = 4000, variant: ToastVariant = 'info'): void {
+  const isError = variant === 'error';
+
+  const toast = document.createElement('div');
+  toast.className = 'psysonic-toast';
+
+  // Icon + message
+  const icon = document.createElement('span');
+  icon.textContent = isError ? '✕' : 'ℹ';
+  icon.style.cssText = `
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 700;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: ${isError ? 'var(--danger)' : 'var(--accent)'};
+    color: var(--bg-app);
+    line-height: 1;
+  `;
+
+  const msg = document.createElement('span');
+  msg.textContent = text;
+  msg.style.cssText = `flex: 1; min-width: 0;`;
+
+  toast.style.cssText = `
+    position: fixed;
+    bottom: ${TOAST_BOTTOM_ANCHOR}px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    border: 1px solid ${isError ? 'var(--danger)' : 'var(--border)'};
+    border-left: 3px solid ${isError ? 'var(--danger)' : 'var(--accent)'};
+    padding: 10px 16px;
+    border-radius: 8px;
+    font-size: 13.5px;
+    font-weight: 500;
+    z-index: 999999;
+    pointer-events: none;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.45)${isError ? ', 0 0 0 1px color-mix(in srgb, var(--danger) 20%, transparent)' : ''};
+    white-space: normal;
+    word-break: break-word;
+    transition: bottom 150ms ease;
+    max-width: 480px;
+    width: max-content;
+  `;
+
+  toast.appendChild(icon);
+  toast.appendChild(msg);
+  document.body.appendChild(toast);
+  reflow();
+
+  setTimeout(() => {
+    toast.remove();
+    reflow();
+  }, durationMs);
+}


### PR DESCRIPTION
Extract a shared showToast utility (src/utils/toast.ts) that reads the app's CSS custom properties so it respects the active theme. Error toasts use --danger (the theme's red) with a left accent border and icon badge. Multiple toasts stack vertically rather than overlapping.

Wire handleAudioError in playerStore to show an 8-second error toast before skipping to the next track (delay bumped from 0.5s to 1.5s so the user has time to read it). Refactor App.tsx to use the shared utility.

<img width="905" height="389" alt="image" src="https://github.com/user-attachments/assets/2551c1c0-2a45-4c6e-9557-8a467f818a86" />
