### PR TITLE
Fix/gapless manual skip immediate

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -1603,7 +1603,11 @@ pub async fn audio_play(
     // audio_chain_preload already appended this URL to the Sink 30 s in
     // advance. The source is live in the queue — just return and let the
     // progress task handle the state transition when the previous source ends.
-    if gapless {
+    //
+    // Never for manual skips: the UI already jumped to this track in JS, but
+    // the current source is still playing until the chain drains. User-initiated
+    // play must clear the chain and start this URL immediately (standard path).
+    if gapless && !manual {
         let already_chained = state.chained_info.lock().unwrap()
             .as_ref()
             .map(|c| c.url == url)

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -1336,6 +1336,9 @@ pub(crate) struct PreloadedTrack {
 pub(crate) struct ChainedInfo {
     /// The URL that was chained — used by audio_play to detect a pre-chain hit.
     url: String,
+    /// Raw file bytes (shared with the chained decoder). Lets manual skip reuse
+    /// them instead of re-downloading after dropping the Sink queue.
+    raw_bytes: Arc<Vec<u8>>,
     duration_secs: f64,
     replay_gain_linear: f32,
     base_volume: f32,
@@ -1495,6 +1498,32 @@ pub struct ProgressPayload {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+/// Subsonic `buildStreamUrl()` uses a fresh random salt on every call, so two
+/// URLs for the same track differ in `t`/`s` query params. Compare a stable key.
+fn playback_identity(url: &str) -> Option<String> {
+    if let Some(path) = url.strip_prefix("psysonic-local://") {
+        return Some(format!("local:{path}"));
+    }
+    if !url.contains("stream.view") {
+        return None;
+    }
+    let q = url.split('?').nth(1)?;
+    for pair in q.split('&') {
+        if let Some(v) = pair.strip_prefix("id=") {
+            let v = v.split('&').next().unwrap_or(v);
+            return Some(format!("stream:{v}"));
+        }
+    }
+    None
+}
+
+fn same_playback_target(a_url: &str, b_url: &str) -> bool {
+    match (playback_identity(a_url), playback_identity(b_url)) {
+        (Some(a), Some(b)) => a == b,
+        _ => a_url == b_url,
+    }
+}
+
 /// Fetch track bytes from the preload cache or via HTTP.
 async fn fetch_data(
     url: &str,
@@ -1505,7 +1534,7 @@ async fn fetch_data(
     // Check preload cache first.
     let cached = {
         let mut preloaded = state.preloaded.lock().unwrap();
-        if preloaded.as_ref().map(|p| p.url == url).unwrap_or(false) {
+        if preloaded.as_ref().is_some_and(|p| same_playback_target(&p.url, url)) {
             preloaded.take().map(|p| p.data)
         } else {
             None
@@ -1610,7 +1639,7 @@ pub async fn audio_play(
     if gapless && !manual {
         let already_chained = state.chained_info.lock().unwrap()
             .as_ref()
-            .map(|c| c.url == url)
+            .map(|c| same_playback_target(&c.url, &url))
             .unwrap_or(false);
         if already_chained {
             return Ok(());
@@ -1621,18 +1650,40 @@ pub async fn audio_play(
     // Used for: manual skip, gapless OFF, first play, or gapless when the
     // proactive chain was not set up in time.
 
+    // Bump generation first so the old progress task stops before we peel
+    // chained_info (avoids a race where it sees current_done + empty chain).
     let gen = state.generation.fetch_add(1, Ordering::SeqCst) + 1;
 
-    // Cancel any pending chain (manual skip while gapless chain was set up).
-    *state.chained_info.lock().unwrap() = None;
+    // Manual skip onto the gapless-pre-chained track: reuse raw bytes (no HTTP;
+    // preload cache was already consumed when the chain was built). Otherwise
+    // clear any stale chain metadata.
+    let reuse_chained_bytes: Option<Vec<u8>> = if gapless && manual {
+        let mut ci = state.chained_info.lock().unwrap();
+        if ci.as_ref().is_some_and(|c| same_playback_target(&c.url, &url)) {
+            ci.take().map(|info| {
+                Arc::try_unwrap(info.raw_bytes).unwrap_or_else(|a| (*a).clone())
+            })
+        } else {
+            *ci = None;
+            None
+        }
+    } else {
+        *state.chained_info.lock().unwrap() = None;
+        None
+    };
 
     // Stop fading-out sink from previous crossfade.
     if let Some(old) = state.fading_out_sink.lock().unwrap().take() {
         old.stop();
     }
 
-    // Fetch bytes (may use preload cache).
-    let data = match fetch_data(&url, &state, gen, &app).await? {
+    // Fetch bytes (preload cache) unless we reused the chained download above.
+    let data = if let Some(d) = reuse_chained_bytes {
+        Some(d)
+    } else {
+        fetch_data(&url, &state, gen, &app).await?
+    };
+    let data = match data {
         Some(d) => d,
         None => return Ok(()), // superseded while downloading
     };
@@ -1820,10 +1871,10 @@ pub async fn audio_chain_preload(
     replay_gain_peak: Option<f32>,
     state: State<'_, AudioEngine>,
 ) -> Result<(), String> {
-    // Idempotent: already chained this URL → nothing to do.
+    // Idempotent: already chained this track → nothing to do.
     {
         let chained = state.chained_info.lock().unwrap();
-        if chained.as_ref().map(|c| c.url == url).unwrap_or(false) {
+        if chained.as_ref().is_some_and(|c| same_playback_target(&c.url, &url)) {
             return Ok(());
         }
     }
@@ -1839,7 +1890,7 @@ pub async fn audio_chain_preload(
     let data: Vec<u8> = {
         let cached = {
             let mut preloaded = state.preloaded.lock().unwrap();
-            if preloaded.as_ref().map(|p| p.url == url).unwrap_or(false) {
+            if preloaded.as_ref().is_some_and(|p| same_playback_target(&p.url, &url)) {
                 preloaded.take().map(|p| p.data)
             } else {
                 None
@@ -1875,6 +1926,8 @@ pub async fn audio_chain_preload(
         return Ok(());
     }
 
+    let raw_bytes = Arc::new(data);
+
     let (gain_linear, effective_volume) = compute_gain(replay_gain_db, replay_gain_peak, volume);
 
     let done_next = Arc::new(AtomicBool::new(false));
@@ -1887,7 +1940,7 @@ pub async fn audio_chain_preload(
         .and_then(|ext| ext.split('?').next())
         .map(|s| s.to_lowercase());
     let built = build_source(
-        data,
+        (*raw_bytes).clone(),
         duration_hint,
         state.eq_gains.clone(),
         state.eq_enabled.clone(),
@@ -1920,6 +1973,7 @@ pub async fn audio_chain_preload(
 
     *state.chained_info.lock().unwrap() = Some(ChainedInfo {
         url,
+        raw_bytes,
         duration_secs,
         replay_gain_linear: gain_linear,
         base_volume: volume.clamp(0.0, 1.0),
@@ -2308,7 +2362,7 @@ pub async fn audio_preload(
 ) -> Result<(), String> {
     {
         let preloaded = state.preloaded.lock().unwrap();
-        if preloaded.as_ref().map(|p| p.url == url).unwrap_or(false) {
+        if preloaded.as_ref().is_some_and(|p| same_playback_target(&p.url, &url)) {
             return Ok(());
         }
     }


### PR DESCRIPTION
# Fix: immediate manual skip with gapless pre-chain and correct URL matching

## Summary

This PR fixes a regression where pressing **Next** (or otherwise starting the upcoming queue track manually) while **gapless** mode and **preload / chain preload** were active caused the **UI to show the new track immediately** but **audio from the previous track to keep playing** for a noticeable period—sometimes several seconds. It also fixes follow-up work so that **reusing pre-downloaded bytes** actually works for Subsonic streaming URLs.

## Problem

### Symptom

1. User enables **gapless playback** and uses **preload** (early / balanced / custom).
2. While track **A** is playing, the engine **pre-chains** track **B** via `audio_chain_preload` (same trigger as preload).
3. User presses **Next** to play **B** now.
4. **Player chrome** updates to **B** right away, but **A** is still heard until **B** finally starts after a delay.

### Why it felt like “preload / gapless”

The behaviour only showed up when the next track had already been **appended to the same Rodio `Sink`** for a seamless end-of-track transition. Manual navigation and that optimisation interacted badly.

## Root causes

### 1. `audio_play` treated “already chained” like “already playing” for every request

When gapless pre-chain had appended **B** to the sink, `audio_play` for **B**’s URL hit a fast path: **return `Ok(())` immediately** so the engine would wait until **A** finished and Rodio moved to **B**.

That is correct for **automatic** gapless handoff, but **wrong for a user-initiated skip**: the frontend already updates `currentTrack` in `playTrack()` before `audio_play` returns, so the user sees **B** while **A** is still audible.

**Change:** only take the “already chained → no-op” path when **`manual` is false**. User-initiated plays always go through the **standard path** (new sink / explicit transition).

### 2. Subsonic stream URLs are never byte-identical between two JS calls

`buildStreamUrl()` in the frontend generates a **new random salt and token on every call** (`t` / `s` query parameters). So:

- `audio_chain_preload` uses `…/stream.view?id=…&t=…&s=…`
- `audio_play` uses the **same track id** but **different** `t` / `s`

Rust compared **`chained_info.url == url`**, so:

- The “reuse chained raw bytes” optimisation **never matched**.
- The **preload cache** in `fetch_data` / `audio_preload` / `audio_chain_preload` also **missed** when the same logical track was requested again with a fresh token.

**Change:** introduce **`playback_identity()`** / **`same_playback_target()`**:

- For `…/stream.view?…`, compare by stable **`id=`** query value.
- For `psysonic-local://…`, compare by path.
- Otherwise fall back to full string equality.

Use this everywhere chain membership and preload hits are decided.

### 3. Reusing downloaded bytes for manual skip

After fixing (1), manual skip still **re-fetched** the file over HTTP because the bytes had been consumed when building the chained decoder, and the preload slot was keyed by the **full** URL (which differed per call).

**Change:** keep **`Arc<Vec<u8>>`** of the file in **`ChainedInfo`**. On **manual** skip, when **`same_playback_target`** says the request is the chained track, **take** that metadata and feed the bytes into the normal decode/play path **without another HTTP download**.

**Ordering:** bump **`generation`** **before** peeling `chained_info`, so the old progress task cannot race with an emptied chain.

## Files changed

- `src-tauri/src/audio.rs` — all logic above (manual vs auto chain short-circuit, identity matching, `raw_bytes` on `ChainedInfo`, preload / fetch cache alignment).

## How to test

1. Enable **gapless** and **preload** (any mode that triggers chain preload before the end of the track).
2. Start playback; wait until the next track is pre-chained (e.g. last ~30 s with default balanced preload, or use **early** mode).
3. Press **Next**.
4. **Expected:** title and audio switch to the next track **together**, without a long stretch of the previous track.
5. Optional: repeat with **offline** `psysonic-local://` URLs if applicable.
6. Let a track **end naturally** with gapless still on — transition should remain **sample-accurate** and **without** double `audio_play` glitches.

## Commits (high level)

1. **`fix(audio): honor manual skip when next track is gapless-pre-chained`** — do not no-op `audio_play` for user-initiated play when the URL is only queued behind the current source.
2. **`fix(audio): match gapless chain and preload by stream id, not full URL`** — Subsonic token query drift + reuse of chained `raw_bytes` + consistent preload cache keys.

## Notes for reviewers

- **Security:** comparing by `id=` does not weaken auth; each URL remains fully validated by the server. We only deduplicate **client-side** bookkeeping for the same track.
- **Scope:** behaviour of **non–`stream.view`** URLs is unchanged aside from falling back to strict string equality.
