### PR TITLE
fix(player): hot playback cache — minor follow-up

### DIFF
--- a/src/hotCachePrefetch.ts
+++ b/src/hotCachePrefetch.ts
@@ -1,16 +1,67 @@
 import { invoke } from '@tauri-apps/api/core';
 import { buildStreamUrl } from './api/subsonic';
 import { useAuthStore } from './store/authStore';
-import { useHotCacheStore } from './store/hotCacheStore';
+import { HOT_CACHE_PROTECT_AFTER_CURRENT, useHotCacheStore, type HotCacheEntry } from './store/hotCacheStore';
 import { useOfflineStore } from './store/offlineStore';
-import { usePlayerStore } from './store/playerStore';
-import { getDeferHotCachePrefetch } from './utils/hotCacheGate';
+import { usePlayerStore, type Track } from './store/playerStore';
+import {
+  bumpHotCachePreviousTrackGrace,
+  clearHotCachePreviousGrace,
+  getDeferHotCachePrefetch,
+} from './utils/hotCacheGate';
 
+/** How many upcoming queue tracks may be prefetched (only current + next are eviction-protected). */
 const PREFETCH_AHEAD = 5;
+
+function entryKey(serverId: string, trackId: string): string {
+  return `${serverId}:${trackId}`;
+}
+
+/** Sum of on-disk bytes for eviction-protected slots (current + next — same span as `evictToFit`). */
+function sumCachedBytesInProtectedWindow(
+  queue: Track[],
+  queueIndex: number,
+  serverId: string,
+  entries: Record<string, HotCacheEntry>,
+): number {
+  const protectLo = Math.max(0, queueIndex);
+  const protectHi = Math.min(queue.length - 1, queueIndex + HOT_CACHE_PROTECT_AFTER_CURRENT);
+  let sum = 0;
+  for (let i = protectLo; i <= protectHi; i++) {
+    const e = entries[entryKey(serverId, queue[i].id)];
+    if (e) sum += e.sizeBytes || 0;
+  }
+  return sum;
+}
+
+/** Conservative size guess so we do not prefetch when the protected window could exceed the cap. */
+function estimateTrackHotCacheBytes(track: Track): number {
+  const sz = track.size;
+  if (typeof sz === 'number' && Number.isFinite(sz) && sz > 0) {
+    return Math.ceil(sz * 1.06);
+  }
+  const dur =
+    typeof track.duration === 'number' && Number.isFinite(track.duration) && track.duration > 0
+      ? track.duration
+      : 240;
+  const sfx = (track.suffix || '').toLowerCase();
+  const lossless = /^(flac|wav|dsf|dff|alac|ape|wv)$/.test(sfx);
+  let kbps =
+    typeof track.bitRate === 'number' && Number.isFinite(track.bitRate) && track.bitRate > 0
+      ? track.bitRate
+      : 320;
+  if (lossless && kbps < 800) {
+    kbps = Math.max(kbps, 900);
+  }
+  const raw = Math.ceil((dur * kbps * 1000) / 8);
+  return Math.max(256 * 1024, Math.ceil(raw * (lossless ? 1.2 : 1.15)));
+}
 
 type PrefetchJob = { trackId: string; serverId: string; suffix: string };
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+/** Fires `replanNow` once grace for the ex-current track ends so eviction can drop it. */
+let graceEvictTimer: ReturnType<typeof setTimeout> | null = null;
 const pendingQueue: PrefetchJob[] = [];
 let workerRunning = false;
 
@@ -18,6 +69,22 @@ function debounceMs(): number {
   const s = useAuthStore.getState().hotCacheDebounceSec;
   if (!Number.isFinite(s) || s < 0) return 0;
   return Math.min(600, s) * 1000;
+}
+
+function scheduleEvictAfterPreviousGrace(): void {
+  if (graceEvictTimer) {
+    clearTimeout(graceEvictTimer);
+    graceEvictTimer = null;
+  }
+  const ms = debounceMs();
+  if (ms <= 0) {
+    void replanNow();
+    return;
+  }
+  graceEvictTimer = setTimeout(() => {
+    graceEvictTimer = null;
+    void replanNow();
+  }, ms);
 }
 
 function enqueueJobs(jobs: PrefetchJob[]) {
@@ -56,13 +123,22 @@ async function runWorker() {
       if (offline.isDownloaded(job.trackId, job.serverId)) continue;
       if (useHotCacheStore.getState().entries[entryKey(job.serverId, job.trackId)]) continue;
 
-      const { queue, queueIndex } = usePlayerStore.getState();
+      const player = usePlayerStore.getState();
+      const { queue, queueIndex } = player;
       const wantIds = new Set(
         queue
           .slice(queueIndex + 1, queueIndex + 1 + PREFETCH_AHEAD)
           .map(t => t.id),
       );
       if (!wantIds.has(job.trackId)) continue;
+
+      const track = queue.find(t => t.id === job.trackId);
+      if (!track) continue;
+      const hotEntries = useHotCacheStore.getState().entries;
+      const occupied = sumCachedBytesInProtectedWindow(queue, queueIndex, job.serverId, hotEntries);
+      const est = estimateTrackHotCacheBytes(track);
+      const isImmediateNext = queue[queueIndex + 1]?.id === job.trackId;
+      if (!isImmediateNext && occupied + est > maxBytes) continue;
 
       const url = buildStreamUrl(job.trackId);
       try {
@@ -76,12 +152,14 @@ async function runWorker() {
         });
         useHotCacheStore.getState().setEntry(job.trackId, job.serverId, res.path, res.size);
         const fresh = usePlayerStore.getState();
+        const authAfter = useAuthStore.getState();
+        const maxAfter = Math.max(0, authAfter.hotCacheMaxMb) * 1024 * 1024;
         await useHotCacheStore.getState().evictToFit(
           fresh.queue,
           fresh.queueIndex,
-          maxBytes,
-          auth.activeServerId,
-          customDir,
+          maxAfter,
+          authAfter.activeServerId ?? '',
+          authAfter.hotCacheDownloadDir || null,
         );
       } catch {
         /* network / HTTP — skip */
@@ -91,10 +169,6 @@ async function runWorker() {
     workerRunning = false;
     if (pendingQueue.length > 0) void runWorker();
   }
-}
-
-function entryKey(serverId: string, trackId: string): string {
-  return `${serverId}:${trackId}`;
 }
 
 function scheduleReplan() {
@@ -133,15 +207,21 @@ async function replanNow() {
   await hot.evictToFit(queue, queueIndex, maxBytes, serverId, customDir);
 
   const targets = queue.slice(queueIndex + 1, queueIndex + 1 + PREFETCH_AHEAD);
+  const immediateNextId = queue[queueIndex + 1]?.id;
+  let projectedOccupied = sumCachedBytesInProtectedWindow(queue, queueIndex, serverId, hot.entries);
   const jobs: PrefetchJob[] = [];
   for (const t of targets) {
     if (offline.isDownloaded(t.id, serverId)) continue;
     if (hot.entries[entryKey(serverId, t.id)]) continue;
-    jobs.push({
-      trackId: t.id,
-      serverId,
-      suffix: t.suffix || 'mp3',
-    });
+    const isImmediateNext = t.id === immediateNextId;
+    if (isImmediateNext) {
+      jobs.push({ trackId: t.id, serverId, suffix: t.suffix || 'mp3' });
+      continue;
+    }
+    const est = estimateTrackHotCacheBytes(t);
+    if (projectedOccupied + est > maxBytes) break;
+    projectedOccupied += est;
+    jobs.push({ trackId: t.id, serverId, suffix: t.suffix || 'mp3' });
   }
   enqueueJobs(jobs);
 }
@@ -157,19 +237,61 @@ export function initHotCachePrefetch(): () => void {
     const q = state.queue;
     const i = state.queueIndex;
     if (q === lastQueueRef && i === lastQueueIndex) return;
+    const prevIdx = lastQueueIndex;
+    const prevQ = lastQueueRef;
     const onlyIndexMoved = q === lastQueueRef && i !== lastQueueIndex;
     lastQueueRef = q;
     lastQueueIndex = i;
+    if (onlyIndexMoved && i > prevIdx && prevIdx >= 0 && Array.isArray(prevQ)) {
+      const left = (prevQ as Track[])[prevIdx];
+      const a = useAuthStore.getState();
+      if (left && a.activeServerId) {
+        bumpHotCachePreviousTrackGrace(left.id, a.activeServerId, a.hotCacheDebounceSec);
+        scheduleEvictAfterPreviousGrace();
+      }
+    }
     if (onlyIndexMoved) void replanNow();
     else scheduleReplan();
   });
 
   let lastAuthSig = '';
-  const unsubAuth = useAuthStore.subscribe(state => {
+  const unsubAuth = useAuthStore.subscribe((state, prev) => {
     const sig = `${state.hotCacheEnabled}:${state.hotCacheDebounceSec}:${state.hotCacheMaxMb}:${state.hotCacheDownloadDir ?? ''}:${state.activeServerId ?? ''}:${state.isLoggedIn}`;
     if (sig === lastAuthSig) return;
     lastAuthSig = sig;
-    if (state.hotCacheEnabled && state.isLoggedIn) scheduleReplan();
+
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+
+    if (!state.hotCacheEnabled || !state.isLoggedIn) {
+      pendingQueue.length = 0;
+      clearHotCachePreviousGrace();
+      return;
+    }
+
+    const budgetSettingsChanged =
+      !prev ||
+      state.hotCacheMaxMb !== prev.hotCacheMaxMb ||
+      state.hotCacheDownloadDir !== prev.hotCacheDownloadDir ||
+      state.hotCacheEnabled !== prev.hotCacheEnabled ||
+      state.activeServerId !== prev.activeServerId ||
+      state.isLoggedIn !== prev.isLoggedIn;
+
+    const onlyDebounceChanged =
+      !!prev &&
+      state.hotCacheDebounceSec !== prev.hotCacheDebounceSec &&
+      !budgetSettingsChanged;
+
+    if (budgetSettingsChanged) {
+      if (prev && state.hotCacheMaxMb < prev.hotCacheMaxMb) {
+        pendingQueue.length = 0;
+      }
+      void replanNow();
+    } else if (onlyDebounceChanged) {
+      scheduleReplan();
+    }
   });
 
   void replanNow();
@@ -179,6 +301,9 @@ export function initHotCachePrefetch(): () => void {
     unsubAuth();
     if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = null;
+    if (graceEvictTimer) clearTimeout(graceEvictTimer);
+    graceEvictTimer = null;
     pendingQueue.length = 0;
+    clearHotCachePreviousGrace();
   };
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -254,15 +254,36 @@ export default function Settings() {
   }, [auth.lastfmSessionKey, auth.lastfmUsername]);
 
   useEffect(() => {
-    if (activeTab === 'audio') {
-      invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null }).then(setHotCacheBytes).catch(() => setHotCacheBytes(0));
-      return;
-    }
     if (activeTab !== 'storage') return;
     getImageCacheSize().then(setImageCacheBytes);
     invoke<number>('get_offline_cache_size', { customDir: auth.offlineDownloadDir || null }).then(setOfflineCacheBytes).catch(() => setOfflineCacheBytes(0));
     invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null }).then(setHotCacheBytes).catch(() => setHotCacheBytes(0));
   }, [activeTab, auth.offlineDownloadDir, auth.hotCacheDownloadDir]);
+
+  /** Live disk usage for hot cache while Audio settings are open (interval + refresh when index changes). */
+  useEffect(() => {
+    if (activeTab !== 'audio') return;
+    const customDir = auth.hotCacheDownloadDir || null;
+    const refresh = () => {
+      invoke<number>('get_hot_cache_size', { customDir })
+        .then(setHotCacheBytes)
+        .catch(() => setHotCacheBytes(0));
+    };
+    refresh();
+    if (!auth.hotCacheEnabled) return;
+    const interval = window.setInterval(refresh, 2000);
+    return () => window.clearInterval(interval);
+  }, [activeTab, auth.hotCacheEnabled, auth.hotCacheDownloadDir]);
+
+  useEffect(() => {
+    if (activeTab !== 'audio' || !auth.hotCacheEnabled) return;
+    const t = window.setTimeout(() => {
+      invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null })
+        .then(setHotCacheBytes)
+        .catch(() => setHotCacheBytes(0));
+    }, 400);
+    return () => window.clearTimeout(t);
+  }, [hotCacheEntries, activeTab, auth.hotCacheEnabled, auth.hotCacheDownloadDir]);
 
   const handleClearCache = useCallback(async () => {
     setClearing(true);

--- a/src/store/hotCacheStore.ts
+++ b/src/store/hotCacheStore.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { invoke } from '@tauri-apps/api/core';
+import { isHotCachePreviousTrackUnderGrace } from '../utils/hotCacheGate';
 import type { Track } from './playerStore';
 
-const PREFETCH_AHEAD = 5;
+/** How many queue slots after the current index are eviction-protected (1 = current + next only). */
+export const HOT_CACHE_PROTECT_AFTER_CURRENT = 1;
 
 export interface HotCacheEntry {
   localPath: string;
@@ -22,7 +24,7 @@ interface HotCacheState {
   touchPlayed: (trackId: string, serverId: string) => void;
   removeEntry: (trackId: string, serverId: string) => void;
   totalBytes: () => number;
-  /** Evict until total size ≤ maxBytes. Respects queue tail first, protects current + next N. */
+  /** Evict until total size ≤ maxBytes. Protects current + next (+ grace for last «previous» track). */
   evictToFit: (
     queue: Track[],
     queueIndex: number,
@@ -103,7 +105,7 @@ export const useHotCacheStore = create<HotCacheState>()(
         if (maxBytes <= 0) return;
 
         const protectLo = Math.max(0, queueIndex);
-        const protectHi = Math.min(queue.length - 1, queueIndex + PREFETCH_AHEAD);
+        const protectHi = Math.min(queue.length - 1, queueIndex + HOT_CACHE_PROTECT_AFTER_CURRENT);
         const protectedIds = new Set<string>();
         for (let i = protectLo; i <= protectHi; i++) {
           protectedIds.add(queue[i].id);
@@ -127,6 +129,7 @@ export const useHotCacheStore = create<HotCacheState>()(
           if (!parsed) continue;
           const { serverId, trackId } = parsed;
           if (protectedIds.has(trackId) && serverId === activeServerId) continue;
+          if (isHotCachePreviousTrackUnderGrace(trackId, serverId)) continue;
 
           const meta = entries[key];
           const lru = lruStamp(meta);

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -32,6 +32,8 @@ export interface Track {
   genre?: string;
   samplingRate?: number;
   bitDepth?: number;
+  /** Subsonic `size` in bytes when provided by the server (helps hot-cache budgeting). */
+  size?: number;
   autoAdded?: boolean;
   radioAdded?: boolean;
 }
@@ -58,6 +60,7 @@ export function songToTrack(song: SubsonicSong): Track {
     genre: song.genre,
     samplingRate: song.samplingRate,
     bitDepth: song.bitDepth,
+    size: song.size,
   };
 }
 

--- a/src/utils/hotCacheGate.ts
+++ b/src/utils/hotCacheGate.ts
@@ -1,10 +1,38 @@
 /** When true, hot-cache prefetch must not start new downloads (playback has priority). */
 let deferHotCachePrefetch = false;
 
+/** Last track that was «current» before a forward queue step — not evicted until debounce elapses. */
+let previousTrackGraceUntilMs = 0;
+let previousTrackGraceTrackId: string | null = null;
+let previousTrackGraceServerId: string | null = null;
+
 export function setDeferHotCachePrefetch(v: boolean): void {
   deferHotCachePrefetch = v;
 }
 
 export function getDeferHotCachePrefetch(): boolean {
   return deferHotCachePrefetch;
+}
+
+/** Call when `queueIndex` advances; the old current track stays eviction-safe for `debounceSec` (capped at 600 s). */
+export function bumpHotCachePreviousTrackGrace(
+  trackId: string,
+  serverId: string,
+  debounceSec: number,
+): void {
+  const sec = Number.isFinite(debounceSec) ? Math.min(600, Math.max(0, debounceSec)) : 0;
+  previousTrackGraceUntilMs = Date.now() + sec * 1000;
+  previousTrackGraceTrackId = trackId;
+  previousTrackGraceServerId = serverId;
+}
+
+export function isHotCachePreviousTrackUnderGrace(trackId: string, serverId: string): boolean {
+  if (!previousTrackGraceTrackId || Date.now() >= previousTrackGraceUntilMs) return false;
+  return previousTrackGraceTrackId === trackId && previousTrackGraceServerId === serverId;
+}
+
+export function clearHotCachePreviousGrace(): void {
+  previousTrackGraceUntilMs = 0;
+  previousTrackGraceTrackId = null;
+  previousTrackGraceServerId = null;
 }


### PR DESCRIPTION
## Summary

**Small fix** pass on the hot playback cache: **size budgeting** (prefetch respects cap except the **immediate next** track), **narrower eviction protection** (current + next only, up to **five** ahead still prefetched when space allows), **grace** so the **previous** current file is not evicted until **`hotCacheDebounceSec`** after a forward skip, **immediate `evictToFit`** when cache **MB / folder / login** change (no queue debounce delay), **fresh limit** after each download, **lossless-aware size estimates**, **`Track.size`** from Subsonic when present, and **live** hot-cache **disk** readout on the **Audio** settings tab (interval + debounced refresh on index changes).

## Problem

- With a **small max MB** and a **wide protected window**, total on-disk cache could stay **above** the cap; shrinking the limit was **delayed** by the same **debounce** as queue edits.
- Users expect at least **current + next** on disk; the **previous** track should not disappear **instantly** on skip when debounce is non-zero.
- Settings showed cache usage only on **tab enter**, not while watching prefetch/eviction.

## What changed

- **`hotCachePrefetch`**: budget check uses **two-slot** protected sum; **next** track skips MB gate; **`replanNow`** on auth budget fields **immediately**; **re-read** `hotCacheMaxMb` before post-download **`evictToFit`**; **forward skip** → **`bumpHotCachePreviousTrackGrace`** + timer **`replanNow`** after debounce; stronger **bitrate/size** heuristics for optional prefetches.
- **`hotCacheGate`**: grace + **`clearHotCachePreviousGrace`** on disable / teardown.
- **`hotCacheStore`**: **`HOT_CACHE_PROTECT_AFTER_CURRENT`**, **`evictToFit`** skips grace-protected entries.
- **`playerStore`**: optional **`Track.size`** from **`song.size`**.
- **`Settings`**: on **Audio** tab — **poll** disk size while hot cache on + **debounced** refresh when **`entries`** change; storage tab effect unchanged for hot size there.

## Files (roughly)

| Area | Files |
|------|--------|
| Prefetch + eviction orchestration | `src/hotCachePrefetch.ts` |
| Grace state | `src/utils/hotCacheGate.ts` |
| Eviction policy | `src/store/hotCacheStore.ts` |
| Track metadata | `src/store/playerStore.ts` |
| Settings UI | `src/pages/Settings.tsx` |

## How to check

1. **Audio** → hot cache **on**, small **max MB**, long queue — **next** should still prefetch; further tracks only if they **fit**; total should track cap better than before.  
2. **Drag max MB slider** down — eviction should run **without** waiting for queue debounce.  
3. **Skip next** — former current should remain in cache until **debounce** elapses, then may be evicted if over budget.  
4. Leave **Audio** open — **«cache used»** updates every ~2 s and after cache index changes.  
5. **`npm run build`**.

## Commits

1. `fix(player): minor hot-cache eviction, prefetch budget, and settings live size`