### PR TITLE
feat: implement column header sorting for playlists and albums

### DIFF
--- a/src/components/AlbumTrackList.tsx
+++ b/src/components/AlbumTrackList.tsx
@@ -44,6 +44,8 @@ const CENTERED_COLS = new Set<ColKey>(['favorite', 'rating', 'duration']);
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
+export type SortKey = 'natural' | 'title' | 'artist' | 'album' | 'favorite' | 'rating' | 'duration';
+
 interface AlbumTrackListProps {
   songs: SubsonicSong[];
   sorted?: boolean;
@@ -57,6 +59,9 @@ interface AlbumTrackListProps {
   onRate: (songId: string, rating: number) => void;
   onToggleSongStar: (song: SubsonicSong, e: React.MouseEvent) => void;
   onContextMenu: (x: number, y: number, track: Track, type: 'song' | 'album' | 'artist' | 'queue-item' | 'album-song') => void;
+  sortKey?: SortKey;
+  sortDir?: 'asc' | 'desc';
+  onSort?: (key: SortKey) => void;
 }
 
 // ── TrackRow (memoised) ───────────────────────────────────────────────────────
@@ -262,6 +267,9 @@ export default function AlbumTrackList({
   onRate,
   onToggleSongStar,
   onContextMenu,
+  sortKey,
+  sortDir,
+  onSort,
 }: AlbumTrackListProps) {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
@@ -375,12 +383,33 @@ export default function AlbumTrackList({
 
   const currentTrackId = currentTrack?.id ?? null;
 
+  // ── Sortable columns ──────────────────────────────────────────────────────
+  const SORTABLE_COLS = new Set<ColKey | 'album'>(['title', 'artist', 'album', 'favorite', 'rating', 'duration']);
+
+  const isSortable = (key: ColKey | string): key is SortKey => SORTABLE_COLS.has(key as ColKey);
+
+  const handleHeaderClick = (key: ColKey | string) => {
+    if (!isSortable(key) || !onSort) return;
+    onSort(key);
+  };
+
+  const renderSortIndicator = (key: SortKey) => {
+    if (sortKey !== key) return null;
+    return (
+      <span style={{ marginLeft: 4, fontSize: 10, opacity: 0.7 }}>
+        {sortDir === 'asc' ? '▲' : '▼'}
+      </span>
+    );
+  };
+
   // ── Header cell renderer ──────────────────────────────────────────────────
   const renderHeaderCell = (colDef: ColDef, colIndex: number) => {
     const key = colDef.key as ColKey;
     const isLastCol = colIndex === visibleCols.length - 1;
     const isCentered = CENTERED_COLS.has(key);
     const label = colDef.i18nKey ? t(`albumDetail.${colDef.i18nKey as string}`) : '';
+    const canSort = isSortable(key) && onSort;
+    const isActive = canSort && sortKey === key;
 
     if (key === 'num') {
       return (
@@ -398,9 +427,23 @@ export default function AlbumTrackList({
     if (key === 'title') {
       const hasNextCol = colIndex + 1 < visibleCols.length;
       return (
-        <div key={key} style={{ position: 'relative', padding: 0, margin: 0, minWidth: 0, overflow: 'hidden' }}>
+        <div
+          key={key}
+          style={{
+            position: 'relative',
+            padding: 0,
+            margin: 0,
+            minWidth: 0,
+            overflow: 'hidden',
+            cursor: canSort ? 'pointer' : 'default',
+            userSelect: 'none',
+          }}
+          onClick={() => handleHeaderClick(key)}
+          className={isActive ? 'tracklist-header-cell-active' : ''}
+        >
           <div style={{ display: 'flex', width: '100%', height: '100%', alignItems: 'center', justifyContent: 'flex-start', paddingLeft: 12 }}>
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{label}</span>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: isActive ? 600 : 400 }}>{label}</span>
+            {canSort && renderSortIndicator(key as SortKey)}
           </div>
           {hasNextCol && (
             <div className="col-resize-handle" onMouseDown={e => startResize(e, colIndex + 1, -1)} />
@@ -411,7 +454,20 @@ export default function AlbumTrackList({
 
     const isResizable = !isLastCol;
     return (
-      <div key={key} style={{ position: 'relative', padding: 0, margin: 0, minWidth: 0, overflow: 'hidden' }}>
+      <div
+        key={key}
+        style={{
+          position: 'relative',
+          padding: 0,
+          margin: 0,
+          minWidth: 0,
+          overflow: 'hidden',
+          cursor: canSort ? 'pointer' : 'default',
+          userSelect: 'none',
+        }}
+        onClick={() => handleHeaderClick(key)}
+        className={isActive ? 'tracklist-header-cell-active' : ''}
+      >
         <div
           style={{
             display: 'flex', width: '100%', height: '100%', alignItems: 'center',
@@ -419,7 +475,8 @@ export default function AlbumTrackList({
             paddingLeft: isCentered ? 0 : 12,
           }}
         >
-          <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{label}</span>
+          <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontWeight: isActive ? 600 : 400 }}>{label}</span>
+          {canSort && isSortable(key) && renderSortIndicator(key as SortKey)}
         </div>
         {isResizable && (
           <div className="col-resize-handle" onMouseDown={e => startResize(e, colIndex, 1)} />

--- a/src/pages/AlbumDetail.tsx
+++ b/src/pages/AlbumDetail.tsx
@@ -60,6 +60,7 @@ export default function AlbumDetail() {
   const [filterText, setFilterText] = useState('');
   const [sortKey, setSortKey] = useState<'natural' | 'title' | 'artist' | 'album' | 'favorite' | 'rating' | 'duration'>('natural');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const [sortClickCount, setSortClickCount] = useState(0);
 
   // Derive a stable albumId for the selectors below (empty string when not yet loaded).
   const albumId = album?.album.id ?? '';
@@ -263,8 +264,22 @@ const handleEnqueueAll = () => {
   };
 
   const handleSort = (key: typeof sortKey) => {
-    if (sortKey === key && key !== 'natural') setSortDir(d => d === 'asc' ? 'desc' : 'asc');
-    else { setSortKey(key); setSortDir('asc'); }
+    if (key === 'natural') return;
+    if (sortKey === key) {
+      const nextCount = sortClickCount + 1;
+      if (nextCount >= 3) {
+        setSortKey('natural');
+        setSortDir('asc');
+        setSortClickCount(0);
+      } else {
+        setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+        setSortClickCount(nextCount);
+      }
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+      setSortClickCount(1);
+    }
   };
 
   // Must be before early returns — hooks must be called unconditionally.

--- a/src/pages/AlbumDetail.tsx
+++ b/src/pages/AlbumDetail.tsx
@@ -58,7 +58,7 @@ export default function AlbumDetail() {
 
   const [albumEntityRating, setAlbumEntityRating] = useState(0);
   const [filterText, setFilterText] = useState('');
-  const [sortKey, setSortKey] = useState<'natural' | 'title' | 'artist'>('natural');
+  const [sortKey, setSortKey] = useState<'natural' | 'title' | 'artist' | 'album' | 'favorite' | 'rating' | 'duration'>('natural');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
 
   // Derive a stable albumId for the selectors below (empty string when not yet loaded).
@@ -262,6 +262,17 @@ const handleEnqueueAll = () => {
     deleteAlbum(album.album.id, serverId);
   };
 
+  const handleSort = (key: typeof sortKey) => {
+    if (sortKey === key && key !== 'natural') setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+    else { setSortKey(key); setSortDir('asc'); }
+  };
+
+  // Must be before early returns — hooks must be called unconditionally.
+  const mergedStarredSongs = useMemo(() => new Set([
+    ...[...starredSongs].filter(id => starredOverrides[id] !== false),
+    ...Object.entries(starredOverrides).filter(([, v]) => v).map(([k]) => k),
+  ]), [starredSongs, starredOverrides]);
+
   const displayedSongs = useMemo(() => {
     if (!album) return [];
     const q = filterText.trim().toLowerCase();
@@ -270,13 +281,31 @@ const handleEnqueueAll = () => {
     if (q) result = result.filter(s => s.title.toLowerCase().includes(q) || (s.artist ?? '').toLowerCase().includes(q));
     if (sortKey !== 'natural') {
       result.sort((a, b) => {
-        const av = sortKey === 'title' ? a.title : (a.artist ?? '');
-        const bv = sortKey === 'title' ? b.title : (b.artist ?? '');
-        return sortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+        let av: string | number;
+        let bv: string | number;
+        switch (sortKey) {
+          case 'title': av = a.title; bv = b.title; break;
+          case 'artist': av = a.artist ?? ''; bv = b.artist ?? ''; break;
+          case 'album': av = a.album ?? ''; bv = b.album ?? ''; break;
+          case 'favorite':
+            av = mergedStarredSongs.has(a.id) ? 1 : 0;
+            bv = mergedStarredSongs.has(b.id) ? 1 : 0;
+            break;
+          case 'rating':
+            av = ratings[a.id] ?? userRatingOverrides[a.id] ?? a.userRating ?? 0;
+            bv = ratings[b.id] ?? userRatingOverrides[b.id] ?? b.userRating ?? 0;
+            break;
+          case 'duration': av = a.duration ?? 0; bv = b.duration ?? 0; break;
+          default: av = a.title; bv = b.title;
+        }
+        if (typeof av === 'number' && typeof bv === 'number') {
+          return sortDir === 'asc' ? av - bv : bv - av;
+        }
+        return sortDir === 'asc' ? (av as string).localeCompare(bv as string) : (bv as string).localeCompare(av as string);
       });
     }
     return result;
-  }, [album, filterText, sortKey, sortDir]);
+  }, [album, filterText, sortKey, sortDir, mergedStarredSongs, ratings, userRatingOverrides]);
 
   // Hooks must be called unconditionally — derive from nullable album state.
   // useMemo is required: buildCoverArtUrl generates a new salt on every call, so without
@@ -285,12 +314,6 @@ const handleEnqueueAll = () => {
   const coverUrl = useMemo(() => album?.album.coverArt ? buildCoverArtUrl(album.album.coverArt, 400) : '', [album?.album.coverArt]);
   const coverKey = useMemo(() => album?.album.coverArt ? coverArtCacheKey(album.album.coverArt, 400) : '', [album?.album.coverArt]);
   const resolvedCoverUrl = useCachedUrl(coverUrl, coverKey);
-
-  // Must be before early returns — hooks must be called unconditionally.
-  const mergedStarredSongs = useMemo(() => new Set([
-    ...[...starredSongs].filter(id => starredOverrides[id] !== false),
-    ...Object.entries(starredOverrides).filter(([, v]) => v).map(([k]) => k),
-  ]), [starredSongs, starredOverrides]);
 
   if (loading) return <div className="loading-center"><div className="spinner" /></div>;
   if (!album) return <div className="empty-state">{t('albumDetail.notFound')}</div>;
@@ -354,21 +377,6 @@ const handleEnqueueAll = () => {
               >×</button>
             )}
           </div>
-          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
-            {(['natural', 'title', 'artist'] as const).map(key => (
-              <button
-                key={key}
-                className={`btn btn-sm ${sortKey === key ? 'btn-surface' : 'btn-ghost'}`}
-                onClick={() => {
-                  if (sortKey === key && key !== 'natural') setSortDir(d => d === 'asc' ? 'desc' : 'asc');
-                  else { setSortKey(key); setSortDir('asc'); }
-                }}
-              >
-                {key === 'natural' ? t('albumDetail.sortNatural') : key === 'title' ? t('albumDetail.sortByTitle') : t('albumDetail.sortByArtist')}
-                {sortKey === key && key !== 'natural' && <span style={{ marginLeft: 3 }}>{sortDir === 'asc' ? '↑' : '↓'}</span>}
-              </button>
-            ))}
-          </div>
         </div>
       )}
 
@@ -385,6 +393,9 @@ const handleEnqueueAll = () => {
         onRate={handleRate}
         onToggleSongStar={toggleSongStar}
         onContextMenu={openContextMenu}
+        sortKey={sortKey}
+        sortDir={sortDir}
+        onSort={handleSort}
       />
 
       {relatedAlbums.length > 0 && (

--- a/src/pages/PlaylistDetail.tsx
+++ b/src/pages/PlaylistDetail.tsx
@@ -114,7 +114,7 @@ export default function PlaylistDetail() {
   const [editingMeta, setEditingMeta] = useState(false);
   const [customCoverId, setCustomCoverId] = useState<string | null>(null);
   const [filterText, setFilterText] = useState('');
-  const [sortKey, setSortKey] = useState<'natural' | 'title' | 'artist'>('natural');
+  const [sortKey, setSortKey] = useState<'natural' | 'title' | 'artist' | 'album' | 'favorite' | 'rating' | 'duration'>('natural');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
   const [starredSongs, setStarredSongs] = useState<Set<string>>(new Set());
   const [hoveredSuggestionId, setHoveredSuggestionId] = useState<string | null>(null);
@@ -471,13 +471,27 @@ export default function PlaylistDetail() {
     if (q) result = result.filter(s => s.title.toLowerCase().includes(q) || (s.artist ?? '').toLowerCase().includes(q));
     if (sortKey !== 'natural') {
       result.sort((a, b) => {
-        const av = sortKey === 'title' ? a.title : (a.artist ?? '');
-        const bv = sortKey === 'title' ? b.title : (b.artist ?? '');
-        return sortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+        let av: string | number;
+        let bv: string | number;
+        const effectiveRating = (s: SubsonicSong) => ratings[s.id] ?? userRatingOverrides[s.id] ?? s.userRating ?? 0;
+        const effectiveStarred = (s: SubsonicSong) => (s.id in starredOverrides ? starredOverrides[s.id] : starredSongs.has(s.id)) ? 1 : 0;
+        switch (sortKey) {
+          case 'title': av = a.title; bv = b.title; break;
+          case 'artist': av = a.artist ?? ''; bv = b.artist ?? ''; break;
+          case 'album': av = a.album ?? ''; bv = b.album ?? ''; break;
+          case 'favorite': av = effectiveStarred(a); bv = effectiveStarred(b); break;
+          case 'rating': av = effectiveRating(a); bv = effectiveRating(b); break;
+          case 'duration': av = a.duration ?? 0; bv = b.duration ?? 0; break;
+          default: av = a.title; bv = b.title;
+        }
+        if (typeof av === 'number' && typeof bv === 'number') {
+          return sortDir === 'asc' ? av - bv : bv - av;
+        }
+        return sortDir === 'asc' ? (av as string).localeCompare(bv as string) : (bv as string).localeCompare(av as string);
       });
     }
     return result;
-  }, [songs, filterText, sortKey, sortDir]);
+  }, [songs, filterText, sortKey, sortDir, ratings, userRatingOverrides, starredOverrides, starredSongs]);
   const displayedTracks = useMemo(
     () => displayedSongs === songs ? tracks : displayedSongs.map(songToTrack),
     [displayedSongs, songs, tracks],
@@ -706,23 +720,6 @@ export default function PlaylistDetail() {
               >×</button>
             )}
           </div>
-          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
-            {(['natural', 'title', 'artist'] as const).map(key => (
-              <button
-                key={key}
-                className={`btn btn-sm ${sortKey === key ? 'btn-surface' : 'btn-ghost'}`}
-                onClick={() => {
-                  if (sortKey === key && key !== 'natural') setSortDir(d => d === 'asc' ? 'desc' : 'asc');
-                  else { setSortKey(key); setSortDir('asc'); }
-                }}
-              >
-                {key === 'natural' ? t('albumDetail.sortNatural')
-                  : key === 'title' ? t('albumDetail.sortByTitle')
-                  : t('albumDetail.sortByArtist')}
-                {sortKey === key && key !== 'natural' && <span style={{ marginLeft: 3 }}>{sortDir === 'asc' ? '↑' : '↓'}</span>}
-              </button>
-            ))}
-          </div>
         </div>
       )}
 
@@ -777,6 +774,29 @@ export default function PlaylistDetail() {
               const isLastCol = colIndex === visibleCols.length - 1;
               const isCentered = PL_CENTERED.has(key);
               const label = colDef.i18nKey ? t(`albumDetail.${colDef.i18nKey}`) : '';
+              const sortableCols = new Set(['title', 'artist', 'favorite', 'rating', 'duration', 'album']);
+              const canSort = sortableCols.has(key);
+              const isSortActive = canSort && sortKey === key;
+
+              const handleSortClick = () => {
+                if (!canSort) return;
+                if (sortKey === key) {
+                  setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+                } else {
+                  setSortKey(key as typeof sortKey);
+                  setSortDir('asc');
+                }
+              };
+
+              const renderSortIndicator = () => {
+                if (!isSortActive) return null;
+                return (
+                  <span style={{ marginLeft: 4, fontSize: 10, opacity: 0.7 }}>
+                    {sortDir === 'asc' ? '▲' : '▼'}
+                  </span>
+                );
+              };
+
               if (key === 'num') return (
                 <div key="num" className="track-num">
                   <span
@@ -790,9 +810,23 @@ export default function PlaylistDetail() {
               if (key === 'title') {
                 const hasNextCol = colIndex + 1 < visibleCols.length;
                 return (
-                  <div key="title" style={{ position: 'relative', padding: 0, margin: 0, minWidth: 0, overflow: 'hidden' }}>
+                  <div
+                    key="title"
+                    onClick={handleSortClick}
+                    style={{
+                      position: 'relative',
+                      padding: 0,
+                      margin: 0,
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      cursor: canSort ? 'pointer' : 'default',
+                      userSelect: 'none',
+                    }}
+                    className={isSortActive ? 'tracklist-header-cell-active' : ''}
+                  >
                     <div style={{ display: 'flex', width: '100%', height: '100%', alignItems: 'center', justifyContent: 'flex-start', paddingLeft: 12 }}>
-                      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{label}</span>
+                      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: isSortActive ? 600 : 400 }}>{label}</span>
+                      {canSort && renderSortIndicator()}
                     </div>
                     {hasNextCol && <div className="col-resize-handle" onMouseDown={e => startResize(e, colIndex + 1, -1)} />}
                   </div>
@@ -800,7 +834,20 @@ export default function PlaylistDetail() {
               }
               if (key === 'delete') return <div key="delete" />;
               return (
-                <div key={key} style={{ position: 'relative', padding: 0, margin: 0, minWidth: 0, overflow: 'hidden' }}>
+                <div
+                  key={key}
+                  onClick={handleSortClick}
+                  style={{
+                    position: 'relative',
+                    padding: 0,
+                    margin: 0,
+                    minWidth: 0,
+                    overflow: 'hidden',
+                    cursor: canSort ? 'pointer' : 'default',
+                    userSelect: 'none',
+                  }}
+                  className={isSortActive ? 'tracklist-header-cell-active' : ''}
+                >
                   <div
                     style={{
                       display: 'flex',
@@ -811,7 +858,8 @@ export default function PlaylistDetail() {
                       paddingLeft: isCentered ? 0 : 12,
                     }}
                   >
-                    <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{label}</span>
+                    <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontWeight: isSortActive ? 600 : 400 }}>{label}</span>
+                    {canSort && renderSortIndicator()}
                   </div>
                   {!isLastCol && key !== 'delete' && (
                     <div className="col-resize-handle" onMouseDown={e => startResize(e, colIndex, 1)} />

--- a/src/pages/PlaylistDetail.tsx
+++ b/src/pages/PlaylistDetail.tsx
@@ -116,6 +116,7 @@ export default function PlaylistDetail() {
   const [filterText, setFilterText] = useState('');
   const [sortKey, setSortKey] = useState<'natural' | 'title' | 'artist' | 'album' | 'favorite' | 'rating' | 'duration'>('natural');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const [sortClickCount, setSortClickCount] = useState(0);
   const [starredSongs, setStarredSongs] = useState<Set<string>>(new Set());
   const [hoveredSuggestionId, setHoveredSuggestionId] = useState<string | null>(null);
   const [contextMenuSongId, setContextMenuSongId] = useState<string | null>(null);
@@ -781,10 +782,19 @@ export default function PlaylistDetail() {
               const handleSortClick = () => {
                 if (!canSort) return;
                 if (sortKey === key) {
-                  setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+                  const nextCount = sortClickCount + 1;
+                  if (nextCount >= 3) {
+                    setSortKey('natural');
+                    setSortDir('asc');
+                    setSortClickCount(0);
+                  } else {
+                    setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+                    setSortClickCount(nextCount);
+                  }
                 } else {
                   setSortKey(key as typeof sortKey);
                   setSortDir('asc');
+                  setSortClickCount(1);
                 }
               };
 


### PR DESCRIPTION
## Column Header Sorting for Playlists and Albums

### Summary

Replaces dedicated sort buttons with clickable column headers, resulting in a cleaner and more intuitive interface. Clicking a column header sorts ascending; clicking again toggles to descending.

### Changes

**Behavior**
- Column headers are now clickable sort triggers
- First click sorts ascending, second click toggles to descending
- Third click restores natural/original order
- Switching to a different column resets to ascending order

**Visual feedback**
- ▲/▼ arrows indicate current sort direction on the active column
- Active column label is displayed in bold

**Cleanup**
- Removed dedicated sort buttons from the toolbar

### Sortable Columns

| Column | Sort type |
|--------|-----------|
| Title | Alphabetical A–Z / Z–A |
| Artist | Alphabetical A–Z / Z–A |
| Album | Alphabetical A–Z / Z–A |
| Favorite | Favorites first / last |
| Rating | Highest / lowest |
| Duration | Shortest / longest |

### Files Changed

- `src/components/AlbumTrackList.tsx` — clickable headers with sort indicators
- `src/pages/AlbumDetail.tsx` — extended sort logic, removed sort buttons
- `src/pages/PlaylistDetail.tsx` — extended sort logic, removed sort buttons

### How to Test

1. Open any album or playlist
2. Click a column header (e.g. "Artist")
3. Verify songs sort in ascending order
4. Click the same header again — order should toggle to descending
5. Click the same header a third time — should restore natural/original order
6. Click a different header — should reset to ascending

### Local Testing

Built and installed locally. Sorting verified to work correctly on both playlists and albums.

## Screenshoots

### Albums

<img width="1331" height="750" alt="{DB45678C-0C4F-4E7F-B88F-C3ED3058578C}" src="https://github.com/user-attachments/assets/7dc69825-37c1-4597-a505-04f3e1d07c34" />

<img width="1302" height="759" alt="{D7E9A7DD-C35C-4570-9AAA-95A150B79EE6}" src="https://github.com/user-attachments/assets/581dfd2a-9a29-4390-abd6-f626b12e3183" />

<img width="1321" height="748" alt="{BEBD8B4C-66D0-45E8-B0FD-559A5F6B27F7}" src="https://github.com/user-attachments/assets/945867d9-840e-49bc-8a22-fb7722bfd6f4" />

<img width="1323" height="750" alt="{E5DDFE84-39B1-4529-BD98-568DA1F3A6B2}" src="https://github.com/user-attachments/assets/4980e5f4-beab-4038-bb8c-25e636a8269e" />

<img width="1318" height="763" alt="{BD49EB84-34C4-4195-A90B-3E6A7B544EA2}" src="https://github.com/user-attachments/assets/a7f9fb82-f8a1-410b-9a24-9460c13b41fc" />

### Playlists

<img width="1283" height="742" alt="{603D6ED5-E577-4B9B-B161-982B573884BA}" src="https://github.com/user-attachments/assets/83c23828-e409-4a22-9f6e-193fb7fa303e" />

<img width="1288" height="751" alt="{A1AF29E2-8DBA-4150-8F95-CC7B29FBBEDA}" src="https://github.com/user-attachments/assets/003c263c-524b-4c66-9916-aaca018f8db8" />

<img width="1292" height="758" alt="{86851455-7F28-4C0E-A0A3-FB7F11B0354F}" src="https://github.com/user-attachments/assets/33df824d-d889-4c16-8f06-4a9a3030379a" />

<img width="1309" height="749" alt="{51E17AEB-D069-4279-870F-4DF3D87E9C27}" src="https://github.com/user-attachments/assets/b286de44-68ca-405b-b52a-9c750086f17c" />

<img width="1309" height="759" alt="{A039DE6F-8FE9-411D-A0A2-F3FB06EFC130}" src="https://github.com/user-attachments/assets/c29904d8-e95b-4275-abbe-66c1851b048a" />
