### PR TITLE
fix: album tracklist column picker cutoff and scroll containment issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psysonic",
-  "version": "1.34.11-dev",
+  "version": "1.34.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "psysonic",
-      "version": "1.34.11-dev",
+      "version": "1.34.11",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "@fontsource-variable/figtree": "^5.2.10",

--- a/src/components/AlbumTrackList.tsx
+++ b/src/components/AlbumTrackList.tsx
@@ -532,6 +532,41 @@ export default function AlbumTrackList({
   }
 
   return (
+    <>
+      {/* Column visibility picker - fuera del tracklist para evitar overflow cutoff */}
+      <div className="tracklist-col-picker-wrapper" ref={pickerRef}>
+        <div className="tracklist-col-picker">
+          <button
+            className="tracklist-col-picker-btn"
+            onClick={e => { e.stopPropagation(); setPickerOpen(v => !v); }}
+            data-tooltip={t('albumDetail.columns')}
+          >
+            <ChevronDown size={14} />
+          </button>
+          {pickerOpen && (
+            <div className="tracklist-col-picker-menu">
+              <div className="tracklist-col-picker-label">{t('albumDetail.columns')}</div>
+              {COLUMNS.filter(c => !c.required).map(c => {
+                const label = c.i18nKey ? t(`albumDetail.${c.i18nKey as string}`) : c.key;
+                const isOn = colVisible.has(c.key);
+                return (
+                  <button
+                    key={c.key}
+                    className={`tracklist-col-picker-item${isOn ? ' active' : ''}`}
+                    onClick={() => toggleColumn(c.key)}
+                  >
+                    <span className="tracklist-col-picker-check">
+                      {isOn && <Check size={13} />}
+                    </span>
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
     <div
         className="tracklist"
         ref={tracklistRef}
@@ -573,41 +608,9 @@ export default function AlbumTrackList({
       )}
 
       {/* ── Header ── */}
-      <div style={{ position: 'relative' }}>
+      <div className="tracklist-header-wrapper">
         <div className="tracklist-header" style={gridStyle}>
           {visibleCols.map((colDef, colIndex) => renderHeaderCell(colDef, colIndex))}
-        </div>
-
-        {/* Column visibility picker */}
-        <div className="tracklist-col-picker" ref={pickerRef}>
-          <button
-            className="tracklist-col-picker-btn"
-            onClick={e => { e.stopPropagation(); setPickerOpen(v => !v); }}
-            data-tooltip={t('albumDetail.columns')}
-          >
-            <ChevronDown size={14} />
-          </button>
-          {pickerOpen && (
-            <div className="tracklist-col-picker-menu">
-              <div className="tracklist-col-picker-label">{t('albumDetail.columns')}</div>
-              {COLUMNS.filter(c => !c.required).map(c => {
-                const label = c.i18nKey ? t(`albumDetail.${c.i18nKey as string}`) : c.key;
-                const isOn = colVisible.has(c.key);
-                return (
-                  <button
-                    key={c.key}
-                    className={`tracklist-col-picker-item${isOn ? ' active' : ''}`}
-                    onClick={() => toggleColumn(c.key)}
-                  >
-                    <span className="tracklist-col-picker-check">
-                      {isOn && <Check size={13} />}
-                    </span>
-                    {label}
-                  </button>
-                );
-              })}
-            </div>
-          )}
         </div>
       </div>
 
@@ -649,5 +652,6 @@ export default function AlbumTrackList({
       ))}
 
     </div>
+    </>
   );
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -921,6 +921,7 @@
   display: flex;
   flex-direction: column;
   gap: 0;
+  position: relative; /* Para que el picker posicionado absoluto funcione */
 }
 
 .album-detail-header {
@@ -1396,7 +1397,13 @@
 /* ─ Tracklist ─ */
 .tracklist {
   padding: 0 var(--space-6) var(--space-6);
-  overflow-x: auto;
+  /* El scroll horizontal ahora es natural de la página, no confinado al tracklist */
+  overflow-x: visible;
+}
+
+/* Wrapper para el header con position relative para el picker */
+.tracklist-header-wrapper {
+  position: relative;
 }
 
 .col-center {
@@ -1490,14 +1497,19 @@
 }
 
 /* ── Column visibility picker ── */
+/* Wrapper fuera del tracklist - alineado a la derecha del álbum */
+.tracklist-col-picker-wrapper {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 var(--space-6);
+  margin-bottom: 4px;
+  z-index: 50;
+}
+
 .tracklist-col-picker {
-  position: absolute;
-  top: 0;
-  right: 0;
-  height: 100%;
+  position: relative;
   display: flex;
   align-items: center;
-  padding-right: 4px;
 }
 
 .tracklist-col-picker-btn {


### PR DESCRIPTION
### Problem Description
In the album detail view, two UI issues were affecting usability:

1. **Column picker button was cut off**: The column visibility toggle button (the chevron to show/hide columns) was being visually truncated because it was positioned inside the `.tracklist` container which had `overflow-x: auto`. When the table was wider than the container, the button would be partially or fully hidden.

2. **Scroll was confined to tracklist only**: The horizontal scroll behavior was restricted to just the tracklist songs area, rather than being a natural part of the page scroll. This created an awkward nested scrolling experience.

### Solution

**Changes to [src/components/AlbumTrackList.tsx](cci:7://file:///c:/Users/kveld/Documents/psysonic/src/components/AlbumTrackList.tsx:0:0-0:0):**
- Moved the column visibility picker outside of the `.tracklist` container by wrapping both elements in a React fragment (`<>...</>`)
- The picker is now a sibling element to the tracklist, no longer affected by its overflow properties
- Added `.tracklist-header-wrapper` class to the header container

**Changes to [src/styles/components.css](cci:7://file:///c:/Users/kveld/Documents/psysonic/src/styles/components.css:0:0-0:0):**
- Changed `.tracklist` from `overflow-x: auto` to `overflow-x: visible` to allow horizontal overflow to be handled by the natural page scroll (via `.content-body`)
- Added new `.tracklist-col-picker-wrapper` class with flexbox positioning to align the picker to the right side
- Added `position: relative` to `.album-detail` to provide a positioning context
- Added `.tracklist-header-wrapper` with `position: relative`

### Result
- The column picker button is now fully visible and clickable regardless of table width
- Horizontal scrolling works naturally across the entire page rather than being trapped within the tracklist component

