### PR TITLE
feat(queue): ReplayGain in current-track tech strip

### DIFF
--- a/src/components/QueuePanel.tsx
+++ b/src/components/QueuePanel.tsx
@@ -20,6 +20,21 @@ function formatTime(seconds: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
+function formatQueueReplayGainParts(track: Track, t: TFunction): string[] {
+  const parts: string[] = [];
+  const fmtDb = (db: number) => `${db >= 0 ? '+' : ''}${db.toFixed(1)}`;
+  if (track.replayGainTrackDb != null) {
+    parts.push(t('queue.rgTrack', { db: fmtDb(track.replayGainTrackDb) }));
+  }
+  if (track.replayGainAlbumDb != null) {
+    parts.push(t('queue.rgAlbum', { db: fmtDb(track.replayGainAlbumDb) }));
+  }
+  if (track.replayGainPeak != null) {
+    parts.push(t('queue.rgPeak', { pk: track.replayGainPeak.toFixed(3) }));
+  }
+  return parts;
+}
+
 function renderStars(rating?: number) {
   if (!rating) return null;
   const stars = [];
@@ -420,22 +435,24 @@ export default function QueuePanel() {
 
       {currentTrack && (
         <div className="queue-current-track">
-          {(currentTrack.suffix || currentTrack.bitRate || currentTrack.samplingRate || currentTrack.bitDepth) && (
-            <div className="queue-current-tech">
-              {[
-                currentTrack.suffix?.toUpperCase(),
-                currentTrack.bitRate ? `${currentTrack.bitRate} kbps` : undefined,
-                (() => {
-                  const bd = currentTrack.bitDepth;
-                  const sr = currentTrack.samplingRate ? `${currentTrack.samplingRate / 1000} kHz` : '';
-                  if (bd && sr) return `${bd}/${sr}`;
-                  if (bd) return `${bd}-bit`;
-                  if (sr) return sr;
-                  return undefined;
-                })(),
-              ].filter(Boolean).join(' · ')}
-            </div>
-          )}
+          {(() => {
+            const baseParts = [
+              currentTrack.suffix?.toUpperCase(),
+              currentTrack.bitRate ? `${currentTrack.bitRate} kbps` : undefined,
+              (() => {
+                const bd = currentTrack.bitDepth;
+                const sr = currentTrack.samplingRate ? `${currentTrack.samplingRate / 1000} kHz` : '';
+                if (bd && sr) return `${bd}/${sr}`;
+                if (bd) return `${bd}-bit`;
+                if (sr) return sr;
+                return undefined;
+              })(),
+            ].filter(Boolean) as string[];
+            const rgParts = formatQueueReplayGainParts(currentTrack, t);
+            const techLine = [...baseParts, ...rgParts].join(' · ');
+            if (!techLine) return null;
+            return <div className="queue-current-tech">{techLine}</div>;
+          })()}
           <div className="queue-current-track-body">
             <div className="queue-current-cover">
               {currentTrack.coverArt ? (

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -850,6 +850,9 @@ export const deTranslation = {
     trackPlural: 'Titel',
     showRemaining: 'Restzeit anzeigen',
     showTotal: 'Gesamtzeit anzeigen',
+    rgTrack: 'T {{db}} dB',
+    rgAlbum: 'A {{db}} dB',
+    rgPeak: 'Peak {{pk}}',
   },
   statistics: {
     title: 'Statistiken',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -852,6 +852,9 @@ export const enTranslation = {
     trackPlural: 'tracks',
     showRemaining: 'Show remaining time',
     showTotal: 'Show total time',
+    rgTrack: 'T {{db}} dB',
+    rgAlbum: 'A {{db}} dB',
+    rgPeak: 'Peak {{pk}}',
   },
   statistics: {
     title: 'Statistics',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -853,6 +853,9 @@ export const esTranslation = {
     trackPlural: 'pistas',
     showRemaining: 'Mostrar tiempo restante',
     showTotal: 'Mostrar tiempo total',
+    rgTrack: 'T {{db}} dB',
+    rgAlbum: 'A {{db}} dB',
+    rgPeak: 'Pico {{pk}}',
   },
   statistics: {
     title: 'Estadísticas',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -848,6 +848,9 @@ export const frTranslation = {
     trackPlural: 'pistes',
     showRemaining: 'Afficher le temps restant',
     showTotal: 'Afficher la durée totale',
+    rgTrack: 'T {{db}} dB',
+    rgAlbum: 'A {{db}} dB',
+    rgPeak: 'Pic {{pk}}',
   },
   statistics: {
     title: 'Statistiques',

--- a/src/locales/nb.ts
+++ b/src/locales/nb.ts
@@ -847,6 +847,9 @@ export const nbTranslation = {
     trackPlural: 'spor',
     showRemaining: 'Vis gjenværende tid',
     showTotal: 'Vis total tid',
+    rgTrack: 'T {{db}} dB',
+    rgAlbum: 'A {{db}} dB',
+    rgPeak: 'Topp {{pk}}',
   },
   statistics: {
     title: 'Statistikk',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -847,6 +847,9 @@ export const nlTranslation = {
     trackPlural: 'nummers',
     showRemaining: 'Resterende tijd tonen',
     showTotal: 'Totale tijd tonen',
+    rgTrack: 'T {{db}} dB',
+    rgAlbum: 'A {{db}} dB',
+    rgPeak: 'Piek {{pk}}',
   },
   statistics: {
     title: 'Statistieken',

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -898,6 +898,9 @@ export const ruTranslation = {
     trackPlural: 'треков',
     showRemaining: 'Осталось',
     showTotal: 'Всего',
+    rgTrack: 'Т {{db}} дБ',
+    rgAlbum: 'А {{db}} дБ',
+    rgPeak: 'Пик {{pk}}',
   },
   statistics: {
     title: 'Статистика',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -843,6 +843,9 @@ export const zhTranslation = {
     trackPlural: '首曲目',
     showRemaining: '显示剩余时间',
     showTotal: '显示总时间',
+    rgTrack: '曲目 {{db}} dB',
+    rgAlbum: '专辑 {{db}} dB',
+    rgPeak: '峰值 {{pk}}',
   },
   statistics: {
     title: '统计',


### PR DESCRIPTION
## Summary

Shows **ReplayGain** metadata from the current track (Subsonic / `songToTrack` fields) in the **same grey tech line** above the queue as format, bitrate, and sample rate — so you can see at a glance whether tags are present.

Closes [Psychotoxical/psysonic#195](https://github.com/Psychotoxical/psysonic/issues/195).

## Problem

- Track **format** and **rate** were visible in the queue header strip; **RG** values were not, even when the server sent them.
- Hard to spot **missing ReplayGain** without opening song info elsewhere.

## What changed

- **`QueuePanel`**: builds one `queue-current-tech` string from existing fields plus optional **track gain**, **album gain**, and **track peak** (`replayGainTrackDb`, `replayGainAlbumDb`, `replayGainPeak`).
- The strip is shown when **only** RG data exists.
- **i18n**: compact labels `queue.rgTrack`, `queue.rgAlbum`, `queue.rgPeak` in all shipped locales (`de`, `en`, `es`, `fr`, `nb`, `nl`, `ru`, `zh`).

## Files

| Area | Paths |
|------|--------|
| Queue UI | `src/components/QueuePanel.tsx` |
| Strings | `src/locales/de.ts`, `en.ts`, `es.ts`, `fr.ts`, `nb.ts`, `nl.ts`, `ru.ts`, `zh.ts` |

## How to check

1. Open the **queue** with a track that has ReplayGain on the server — the tech line should include **T** / **A** (or localized equivalents) and **peak** when present.
2. Compare with a track **without** RG tags — those segments should be absent.
3. `npm run build` (or full dev flow).

## Commits

- `feat(queue): show ReplayGain metadata in current-track tech strip`
