### PR TITLE
feat: discord rich presence enhancement

### DIFF
--- a/src-tauri/src/discord.rs
+++ b/src-tauri/src/discord.rs
@@ -216,6 +216,19 @@ fn try_connect() -> Option<DiscordIpcClient> {
     Some(client)
 }
 
+/// Apply a template string, replacing placeholders with actual values.
+/// Supported placeholders: {title}, {artist}, {album}, {paused}
+fn apply_template(template: &str, title: &str, artist: &str, album: Option<&str>, is_playing: bool) -> String {
+    let paused_text = if is_playing { "" } else { "Paused — " };
+    let album_text = album.unwrap_or("");
+
+    template
+        .replace("{title}", title)
+        .replace("{artist}", artist)
+        .replace("{album}", album_text)
+        .replace("{paused}", paused_text)
+}
+
 /// Update the Discord Rich Presence activity.
 ///
 /// - `is_playing`: true = playing (timer shown), false = paused (no timer, state shows "Paused").
@@ -225,6 +238,12 @@ fn try_connect() -> Option<DiscordIpcClient> {
 /// - `fetch_itunes_covers`: if true, fetch artwork from the iTunes Search API when no
 ///   `cover_art_url` is provided. If false (default), fall back to the Psysonic app icon
 ///   without making any external request — required for privacy opt-in.
+/// - `details_template`: template string for the "details" field. Default: "{artist} - {title}".
+///   Supported placeholders: {title}, {artist}, {album}, {paused}
+/// - `state_template`: template string for the "state" field. Default: "{album}".
+///   Supported placeholders: {title}, {artist}, {album}, {paused}
+/// - `large_text_template`: template string for the large image tooltip. Default: "{album}".
+///   Supported placeholders: {title}, {artist}, {album}, {paused}
 #[tauri::command]
 pub async fn discord_update_presence(
     state: tauri::State<'_, DiscordState>,
@@ -235,6 +254,9 @@ pub async fn discord_update_presence(
     elapsed_secs: Option<f64>,
     cover_art_url: Option<String>,
     fetch_itunes_covers: bool,
+    details_template: Option<String>,
+    state_template: Option<String>,
+    large_text_template: Option<String>,
 ) -> Result<(), String> {
     // Resolve artwork on a dedicated blocking thread — reqwest::blocking must not
     // run on the Tokio async executor directly.
@@ -273,28 +295,25 @@ pub async fn discord_update_presence(
 
     let client = guard.as_mut().unwrap();
 
-    // Discord RPC only exposes two visible text rows (details + state).
-    // The application name "Psysonic" is shown automatically by Discord as the
-    // header line. Album goes into large_text — visible as a hover tooltip on
-    // the cover art icon.
-    let large_text = album.as_deref().unwrap_or("Psysonic");
+    // Apply templates for the three configurable text fields.
+    let details_str = details_template.as_deref().unwrap_or("{artist} - {title}");
+    let details_text = apply_template(details_str, &title, &artist, album.as_deref(), is_playing);
+
+    let state_str = state_template.as_deref().unwrap_or("{album}");
+    let state_text = apply_template(state_str, &title, &artist, album.as_deref(), is_playing);
+
+    let large_text_str = large_text_template.as_deref().unwrap_or("{album}");
+    let large_text = apply_template(large_text_str, &title, &artist, album.as_deref(), is_playing);
 
     let assets = if let Some(ref url) = artwork_url {
         Assets::new()
             .large_image(url.as_str())
-            .large_text(large_text)
+            .large_text(&large_text)
     } else {
         // Fallback to default Psysonic icon
         Assets::new()
             .large_image("psysonic")
-            .large_text(large_text)
-    };
-
-    // When paused, show "Paused" as the state text (replaces artist name).
-    let state_text: String = if is_playing {
-        artist.clone()
-    } else {
-        "Paused".to_string()
+            .large_text(&large_text)
     };
 
     // ActivityType::Listening causes the Discord client to auto-start a running
@@ -308,7 +327,7 @@ pub async fn discord_update_presence(
 
     let mut activity = Activity::new()
         .activity_type(activity_type)
-        .details(&title)
+        .details(&details_text)
         .state(&state_text)
         .assets(assets);
 

--- a/src-tauri/src/discord.rs
+++ b/src-tauri/src/discord.rs
@@ -34,6 +34,10 @@ pub struct DiscordState {
     pub artwork_cache: Arc<Mutex<HashMap<String, ArtworkCacheEntry>>>,
     /// HTTP client for iTunes API requests. blocking::Client is Clone (Arc-internally).
     pub http_client: Client,
+    /// Last calculated start timestamp for the current track (for freezing timer when paused).
+    pub last_start_timestamp: Mutex<Option<i64>>,
+    /// Track whether we were playing in the last update to detect transitions.
+    pub was_playing: Mutex<bool>,
 }
 
 impl DiscordState {
@@ -45,6 +49,8 @@ impl DiscordState {
                 .timeout(std::time::Duration::from_secs(5))
                 .build()
                 .unwrap_or_else(|_| Client::new()),
+            last_start_timestamp: Mutex::new(None),
+            was_playing: Mutex::new(false),
         }
     }
 }
@@ -219,7 +225,7 @@ fn try_connect() -> Option<DiscordIpcClient> {
 /// Apply a template string, replacing placeholders with actual values.
 /// Supported placeholders: {title}, {artist}, {album}, {paused}
 fn apply_template(template: &str, title: &str, artist: &str, album: Option<&str>, is_playing: bool) -> String {
-    let paused_text = if is_playing { "" } else { "Paused — " };
+    let paused_text = if is_playing { "" } else { "(Paused) " };
     let album_text = album.unwrap_or("");
 
     template
@@ -252,6 +258,7 @@ pub async fn discord_update_presence(
     album: Option<String>,
     is_playing: bool,
     elapsed_secs: Option<f64>,
+    duration_secs: Option<f64>,
     cover_art_url: Option<String>,
     fetch_itunes_covers: bool,
     details_template: Option<String>,
@@ -316,38 +323,33 @@ pub async fn discord_update_presence(
             .large_text(&large_text)
     };
 
-    // ActivityType::Listening causes the Discord client to auto-start a running
-    // timer from "now" even when no timestamps are provided. Switch to Playing
-    // when paused — Playing only shows a timer when timestamps are explicitly set.
-    let activity_type = if is_playing {
-        ActivityType::Listening
-    } else {
-        ActivityType::Playing
-    };
+    // When paused: clear activity completely to avoid any timer issues
+    // When playing: show full activity with timer
+    if !is_playing {
+        if client.clear_activity().is_err() {
+            *guard = None;
+        }
+        return Ok(());
+    }
 
-    let mut activity = Activity::new()
-        .activity_type(activity_type)
+    // Only reach here when playing
+    let activity = Activity::new()
+        .activity_type(ActivityType::Listening)
         .details(&details_text)
         .state(&state_text)
-        .assets(assets);
-
-    // Start timestamp: Discord auto-counts up from this point. We back-calculate
-    // it so the displayed elapsed time matches the actual playback position.
-    // Only set when playing — Playing type without timestamps shows no timer.
-    if is_playing {
-        if let Some(elapsed) = elapsed_secs {
+        .assets(assets)
+        .timestamps(if let Some(elapsed) = elapsed_secs {
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs() as i64;
             let start = now - elapsed.floor() as i64;
-            activity = activity.timestamps(Timestamps::new().start(start));
-        }
-    }
+            Timestamps::new().start(start)
+        } else {
+            Timestamps::new()
+        });
 
     if client.set_activity(activity).is_err() {
-        // IPC pipe broke (Discord restarted etc.) — drop the client so the next
-        // call re-connects.
         *guard = None;
     }
 
@@ -363,5 +365,8 @@ pub fn discord_clear_presence(state: tauri::State<DiscordState>) -> Result<(), S
             *guard = None;
         }
     }
+    // Clear saved timestamp so next track starts fresh
+    let mut start_guard = state.last_start_timestamp.lock().unwrap();
+    *start_guard = None;
     Ok(())
 }

--- a/src-tauri/src/discord.rs
+++ b/src-tauri/src/discord.rs
@@ -34,10 +34,6 @@ pub struct DiscordState {
     pub artwork_cache: Arc<Mutex<HashMap<String, ArtworkCacheEntry>>>,
     /// HTTP client for iTunes API requests. blocking::Client is Clone (Arc-internally).
     pub http_client: Client,
-    /// Last calculated start timestamp for the current track (for freezing timer when paused).
-    pub last_start_timestamp: Mutex<Option<i64>>,
-    /// Track whether we were playing in the last update to detect transitions.
-    pub was_playing: Mutex<bool>,
 }
 
 impl DiscordState {
@@ -49,8 +45,6 @@ impl DiscordState {
                 .timeout(std::time::Duration::from_secs(5))
                 .build()
                 .unwrap_or_else(|_| Client::new()),
-            last_start_timestamp: Mutex::new(None),
-            was_playing: Mutex::new(false),
         }
     }
 }
@@ -223,16 +217,13 @@ fn try_connect() -> Option<DiscordIpcClient> {
 }
 
 /// Apply a template string, replacing placeholders with actual values.
-/// Supported placeholders: {title}, {artist}, {album}, {paused}
-fn apply_template(template: &str, title: &str, artist: &str, album: Option<&str>, is_playing: bool) -> String {
-    let paused_text = if is_playing { "" } else { "(Paused) " };
+/// Supported placeholders: {title}, {artist}, {album}
+fn apply_template(template: &str, title: &str, artist: &str, album: Option<&str>) -> String {
     let album_text = album.unwrap_or("");
-
     template
         .replace("{title}", title)
         .replace("{artist}", artist)
         .replace("{album}", album_text)
-        .replace("{paused}", paused_text)
 }
 
 /// Update the Discord Rich Presence activity.
@@ -245,11 +236,11 @@ fn apply_template(template: &str, title: &str, artist: &str, album: Option<&str>
 ///   `cover_art_url` is provided. If false (default), fall back to the Psysonic app icon
 ///   without making any external request — required for privacy opt-in.
 /// - `details_template`: template string for the "details" field. Default: "{artist} - {title}".
-///   Supported placeholders: {title}, {artist}, {album}, {paused}
+///   Supported placeholders: {title}, {artist}, {album}
 /// - `state_template`: template string for the "state" field. Default: "{album}".
-///   Supported placeholders: {title}, {artist}, {album}, {paused}
+///   Supported placeholders: {title}, {artist}, {album}
 /// - `large_text_template`: template string for the large image tooltip. Default: "{album}".
-///   Supported placeholders: {title}, {artist}, {album}, {paused}
+///   Supported placeholders: {title}, {artist}, {album}
 #[tauri::command]
 pub async fn discord_update_presence(
     state: tauri::State<'_, DiscordState>,
@@ -258,7 +249,6 @@ pub async fn discord_update_presence(
     album: Option<String>,
     is_playing: bool,
     elapsed_secs: Option<f64>,
-    duration_secs: Option<f64>,
     cover_art_url: Option<String>,
     fetch_itunes_covers: bool,
     details_template: Option<String>,
@@ -304,13 +294,13 @@ pub async fn discord_update_presence(
 
     // Apply templates for the three configurable text fields.
     let details_str = details_template.as_deref().unwrap_or("{artist} - {title}");
-    let details_text = apply_template(details_str, &title, &artist, album.as_deref(), is_playing);
+    let details_text = apply_template(details_str, &title, &artist, album.as_deref());
 
     let state_str = state_template.as_deref().unwrap_or("{album}");
-    let state_text = apply_template(state_str, &title, &artist, album.as_deref(), is_playing);
+    let state_text = apply_template(state_str, &title, &artist, album.as_deref());
 
     let large_text_str = large_text_template.as_deref().unwrap_or("{album}");
-    let large_text = apply_template(large_text_str, &title, &artist, album.as_deref(), is_playing);
+    let large_text = apply_template(large_text_str, &title, &artist, album.as_deref());
 
     let assets = if let Some(ref url) = artwork_url {
         Assets::new()
@@ -365,8 +355,5 @@ pub fn discord_clear_presence(state: tauri::State<DiscordState>) -> Result<(), S
             *guard = None;
         }
     }
-    // Clear saved timestamp so next track starts fresh
-    let mut start_guard = state.last_start_timestamp.lock().unwrap();
-    *start_guard = None;
     Ok(())
 }

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1,1162 +1,2262 @@
 export const deTranslation = {
+
   sidebar: {
+
     library: 'Bibliothek',
+
     mainstage: 'Mainstage',
+
     newReleases: 'Neueste',
+
     allAlbums: 'Alle Alben',
+
     randomAlbums: 'Zufallsalben',
+
     randomPicker: 'Mix erstellen',
+
     artists: 'Künstler',
+
     randomMix: 'Zufallsmix',
+
     favorites: 'Favoriten',
+
     nowPlaying: 'Now Playing',
+
     system: 'System',
+
     statistics: 'Statistiken',
+
     settings: 'Einstellungen',
+
     help: 'Hilfe',
+
     expand: 'Sidebar einblenden',
+
     collapse: 'Sidebar ausblenden',
+
     downloadingTracks: '{{n}} Tracks werden gecacht…',
+
     syncingTracks: 'Synchronisiere {{done}}/{{total}}…',
+
     cancelDownload: 'Download abbrechen',
+
     offlineLibrary: 'Offline-Bibliothek',
+
     genres: 'Genres',
+
     playlists: 'Playlists',
+
     mostPlayed: 'Meistgehört',
+
     radio: 'Internetradio',
+
     folderBrowser: 'Ordner-Browser',
+
     deviceSync: 'Gerätesync',
+
     libraryScope: 'Bibliotheksumfang',
+
     allLibraries: 'Alle Bibliotheken',
+
     expandPlaylists: 'Playlists ausklappen',
+
     collapsePlaylists: 'Playlists einklappen',
+
   },
+
   home: {
+
     hero: 'Featured',
+
     starred: 'Persönliche Favoriten',
+
     recent: 'Zuletzt hinzugefügt',
+
     mostPlayed: 'Meistgehört',
+
     recentlyPlayed: 'Kürzlich gespielt',
+
     discover: 'Entdecken',
+
     loadMore: 'Mehr laden',
+
     discoverMore: 'Mehr entdecken',
+
     discoverArtists: 'Künstler entdecken',
+
     discoverArtistsMore: 'Alle Künstler'
+
   },
+
   hero: {
+
     eyebrow: 'Album des Augenblicks',
+
     playAlbum: 'Album abspielen',
+
     enqueue: 'Einreihen',
+
     enqueueTooltip: 'Ganzes Album zur Warteschlange hinzufügen',
+
   },
+
   search: {
+
     placeholder: 'Suchen nach Künstler, Album oder Song…',
+
     noResults: 'Keine Ergebnisse für „{{query}}"',
+
     artists: 'Künstler',
+
     albums: 'Alben',
+
     songs: 'Songs',
+
     clearLabel: 'Suche leeren',
+
     title: 'Suche',
+
     resultsFor: 'Ergebnisse für „{{query}}"',
+
     album: 'Album',
+
     advanced: 'Erweiterte Suche',
+
     advancedSearchTerm: 'Suchbegriff',
+
     advancedSearchPlaceholder: 'Titel, Album, Künstler…',
+
     advancedGenre: 'Genre',
+
     advancedAllGenres: 'Alle Genres',
+
     advancedYear: 'Jahr',
+
     advancedYearFrom: 'von',
+
     advancedYearTo: 'bis',
+
     advancedAll: 'Alle',
+
     advancedSearch: 'Suchen',
+
     advancedEmpty: 'Suchbegriff eingeben oder Filter wählen, um zu beginnen.',
+
     advancedNoResults: 'Keine Ergebnisse gefunden.',
+
     advancedGenreNote: 'Songs werden zufällig aus dem Genre gewählt.',
+
     recentSearches: 'Zuletzt gesucht',
+
     browse: 'Stöbern',
+
     emptyHint: 'Was möchtest du hören?',
+
     genres: 'Genres',
+
   },
+
   nowPlaying: {
+
     tooltip: 'Wer hört was?',
+
     title: 'Wer hört was?',
+
     loading: 'Lädt…',
+
     nobody: 'Gerade hört niemand Musik.',
+
     minutesAgo: 'vor {{n}}m',
+
     nothingPlaying: 'Noch nichts am Laufen. Leg einen Track auf!',
+
     aboutArtist: 'Über den Künstler',
+
     fromAlbum: 'Aus diesem Album',
+
     viewAlbum: 'Album öffnen',
+
     goToArtist: 'Zum Künstler',
+
     readMore: 'Mehr lesen',
+
     showLess: 'Weniger anzeigen',
+
     genreInfo: 'Genre',
+
     trackInfo: 'Track-Info',
+
   },
+
   contextMenu: {
+
     playNow: 'Direkt abspielen',
+
     playNext: 'Als Nächstes abspielen',
+
     addToQueue: 'Zur Warteschlange hinzufügen',
+
     enqueueAlbum: 'Ganzes Album einreihen',
+
     startRadio: 'Radio starten',
+
     instantMix: 'Instant Mix',
+
     instantMixFailed: 'Instant Mix konnte nicht erstellt werden — Server- oder Pluginfehler.',
+
     cliMixNeedsTrack: 'Es läuft nichts — starte zuerst die Wiedergabe und führe den Mix-Befehl erneut aus.',
+
     lfmLove: 'Auf Last.fm liken',
+
     lfmUnlove: 'Last.fm-Like entfernen',
+
     favorite: 'Favorisieren',
+
     favoriteArtist: 'Künstler favorisieren',
+
     favoriteAlbum: 'Album favorisieren',
+
     unfavorite: 'Aus Favoriten entfernen',
+
     unfavoriteArtist: 'Künstler aus Favoriten entfernen',
+
     unfavoriteAlbum: 'Album aus Favoriten entfernen',
+
     removeFromQueue: 'Diesen Song entfernen',
+
     removeFromPlaylist: 'Aus Playlist entfernen',
+
     openAlbum: 'Album öffnen',
+
     goToArtist: 'Zum Künstler',
+
     download: 'Herunterladen (ZIP)',
+
     addToPlaylist: 'Zur Playlist hinzufügen',
+
     selectedPlaylists: '{{count}} Playlists ausgewählt',
+
     selectedAlbums: '{{count}} Alben ausgewählt',
+
     selectedArtists: '{{count}} Künstler ausgewählt',
+
     songInfo: 'Song-Infos',
+
   },
+
   albumDetail: {
+
     back: 'Zurück',
+
     playAll: 'Alle abspielen',
+
     enqueue: 'Einreihen',
+
     enqueueTooltip: 'Ganzes Album zur Warteschlange hinzufügen',
+
     artistBio: 'Künstler-Bio',
+
     download: 'Download (ZIP)',
+
     downloading: 'Lade…',
+
     cacheOffline: 'Offline verfügbar machen',
+
     offlineCached: 'Offline verfügbar',
+
     offlineDownloading: 'Wird gecacht… ({{n}}/{{total}})',
+
     removeOffline: 'Offline-Cache löschen',
+
     offlineStorageFull: 'Offline-Speicher voll (Limit: {{mb}} MB). Lösche ein Album aus der Offline-Bibliothek oder erhöhe das Limit in den Einstellungen.',
+
     offlineStorageGoToSettings: 'Einstellungen',
+
     offlineStorageGoToLibrary: 'Offline-Bibliothek',
+
     favoriteAdd: 'Zu Favoriten hinzufügen',
+
     favoriteRemove: 'Aus Favoriten entfernen',
+
     favorite: 'Als Favorit',
+
     noBio: 'Keine Biografie verfügbar.',
+
     moreByArtist: 'Mehr von {{artist}}',
+
     tracksCount: '{{n}} Tracks',
+
     goToArtist: 'Zu {{artist}} wechseln',
+
     moreLabelAlbums: 'Weitere Alben von {{label}} anzeigen',
+
     trackTitle: 'Titel',
+
     trackAlbum: 'Album',
+
     trackArtist: 'Interpret',
+
     trackGenre: 'Genre',
+
     trackFormat: 'Format',
+
     trackFavorite: 'Favorit',
+
     trackRating: 'Bewertung',
+
     trackDuration: 'Dauer',
+
     trackTotal: 'Gesamt',
+
     columns: 'Spalten',
-    resetColumns: 'Zurücksetzen',
+
     notFound: 'Album nicht gefunden.',
+
     bioModal: 'Künstler-Biografie',
+
     bioClose: 'Schließen',
+
     ratingLabel: 'Bewertung',
+
     enlargeCover: 'Vergrößern',
+
     filterSongs: 'Titel filtern…',
+
     sortNatural: 'Reihenfolge',
+
     sortByTitle: 'A–Z (Titel)',
+
     sortByArtist: 'A–Z (Künstler)',
+
     sortByAlbum: 'A–Z (Album)',
+
   },
+
   entityRating: {
+
     albumShort: 'Albumbewertung',
+
     artistShort: 'Künstlerbewertung',
+
     albumAriaLabel: 'Albumbewertung',
+
     artistAriaLabel: 'Künstlerbewertung',
+
     saveFailed: 'Bewertung konnte nicht gespeichert werden.',
+
   },
+
   artistDetail: {
+
     back: 'Zurück',
+
     albums: 'Alben',
+
     album: 'Album',
+
     playAll: 'Alle abspielen',
+
     shuffle: 'Zufallswiedergabe',
+
     radio: 'Radio',
+
     loading: 'Lädt…',
+
     noRadio: 'Keine ähnlichen Titel für diesen Künstler gefunden.',
+
     notFound: 'Künstler nicht gefunden.',
+
     albumsBy: 'Alben von {{name}}',
+
     topTracks: 'Beliebteste Titel',
+
     noAlbums: 'Keine Alben gefunden.',
+
     trackTitle: 'Titel',
+
     trackAlbum: 'Album',
+
     trackDuration: 'Dauer',
+
     favoriteAdd: 'Zu Favoriten hinzufügen',
+
     favoriteRemove: 'Aus Favoriten entfernen',
+
     favorite: 'Als Favorit',
+
     albumCount_one: '{{count}} Album',
+
     albumCount_other: '{{count}} Alben',
+
     openedInBrowser: 'Im Browser geöffnet',
+
     featuredOn: 'Auch enthalten auf',
+
     similarArtists: 'Ähnliche Künstler',
+
     cacheOffline: 'Diskografie offline speichern',
+
     offlineCached: 'Diskografie gecacht',
+
     offlineDownloading: 'Wird gecacht… ({{done}}/{{total}} Alben)',
+
     uploadImage: 'Künstlerbild hochladen',
+
     uploadImageError: 'Bild konnte nicht hochgeladen werden',
+
   },
+
   favorites: {
+
     title: 'Favoriten',
+
     empty: 'Du hast noch keine Favoriten gespeichert.',
+
     artists: 'Künstler',
+
     albums: 'Alben',
+
     songs: 'Songs',
+
     enqueueAll: 'Alle in die Warteschlange',
+
     playAll: 'Alle abspielen',
+
     removeSong: 'Aus Favoriten entfernen',
+
     stations: 'Radiosender',
+
     showingFiltered: 'Zeige {{filtered}} von {{total}} ({{artist}})',
+
     showingCount: 'Zeige {{filtered}} von {{total}}',
+
     clearArtistFilter: 'Künstlerfilter zurücksetzen',
+
     noFilterResults: 'Keine Ergebnisse mit den ausgewählten Filtern.',
+
     allArtists: 'Alle Künstler',
+
   },
+
   randomLanding: {
+
     title: 'Mix erstellen',
+
     mixByTracks: 'Mix nach Titeln',
+
     mixByTracksDesc: 'Zufällige Auswahl aus deiner gesamten Mediathek',
+
     mixByAlbums: 'Mix nach Alben',
+
     mixByAlbumsDesc: 'Zufällige Alben für neue Entdeckungen',
+
   },
+
   randomAlbums: {
+
     title: 'Zufallsalben',
+
     refresh: 'Neu laden',
+
   },
+
   genres: {
+
     title: 'Genres',
+
     genreCount: 'Genres',
+
     albumCount_one: '{{count}} Album',
+
     albumCount_other: '{{count}} Alben',
+
     loading: 'Genres werden geladen…',
+
     empty: 'Keine Genres gefunden.',
+
     albumsLoading: 'Alben werden geladen…',
+
     albumsEmpty: 'Keine Alben in diesem Genre gefunden.',
+
     loadMore: 'Mehr laden',
+
     back: 'Zurück',
+
   },
+
   randomMix: {
+
     title: 'Zufallsmix',
+
     remix: 'Neu mixen',
+
     remixTooltip: 'Neue Songs laden',
+
     remixGenre: '{{genre}} neu mixen',
+
     remixTooltipGenre: 'Neue {{genre}}-Songs laden',
+
     playAll: 'Alle abspielen',
+
     trackTitle: 'Titel',
+
     trackArtist: 'Künstler',
+
     trackAlbum: 'Album',
+
     trackFavorite: 'Favorit',
+
     trackDuration: 'Dauer',
+
     favoriteAdd: 'Zu Favoriten hinzufügen',
+
     favoriteRemove: 'Aus Favoriten entfernen',
+
     play: 'Abspielen',
+
     trackGenre: 'Genre',
+
     excludeAudiobooks: 'Hörbücher & Hörspiele ausschließen',
+
     excludeAudiobooksDesc: 'Prüft Keywords gegen Genre, Titel, Album und Künstler — z. B. Hörbuch, Audiobook, Spoken Word, …',
+
     genreBlocked: 'Keyword gesperrt',
+
     genreAddedToBlacklist: 'Zur Filterliste hinzugefügt',
+
     genreAlreadyBlocked: 'Bereits gesperrt',
+
     artistBlocked: 'Künstler gesperrt',
+
     artistAddedToBlacklist: 'Künstler zur Filterliste hinzugefügt',
+
     artistClickHint: 'Klicken um diesen Künstler zu sperren',
+
     blacklistToggle: 'Keyword-Filter',
+
     genreMixTitle: 'Genre-Mix',
+
     genreMixDesc: 'Top 20 Genres nach Songanzahl — klicken für einen Zufallsmix',
+
     genreMixAll: 'Alle Songs',
+
     genreMixLoadMore: '10 weitere laden',
+
     genreMixNoGenres: 'Keine Genres auf dem Server gefunden.',
+
     shuffleGenres: 'Andere Genres anzeigen',
+
     filterPanelTitle: 'Filter',
+
     filterPanelDesc: 'Genre-Tag oder Künstlername in der Liste anklicken, um ihn aus zukünftigen Mixes auszuschließen.',
+
     genreClickHint: 'Genre-Tag anklicken,\num es als Filter-Keyword hinzuzufügen.\nPrüft Genre, Titel, Album & Künstler.',
+
   },
+
   albums: {
+
     title: 'Alle Alben',
+
     sortByName: 'A–Z (Album)',
+
     sortByArtist: 'A–Z (Künstler)',
+
     sortNewest: 'Neueste zuerst',
+
     sortRandom: 'Zufällig',
+
     yearFrom: 'Von',
+
     yearTo: 'Bis',
+
     yearFilterClear: 'Jahresfilter zurücksetzen',
+
     yearFilterLabel: 'Jahr',
+
     select: 'Mehrfachauswahl',
+
     startSelect: 'Mehrfachauswahl aktivieren',
+
     cancelSelect: 'Abbrechen',
+
     selectionCount: '{{count}} ausgewählt',
+
     downloadZips: 'ZIPs herunterladen',
+
     addOffline: 'Offline hinzufügen',
+
     downloadingZip: 'Lade {{current}}/{{total}} herunter: {{name}}',
+
     downloadZipDone: '{{count}} ZIP(s) heruntergeladen',
+
     downloadZipFailed: 'Download fehlgeschlagen: {{name}}',
+
     offlineQueuing: '{{count}} Album(s) für Offline einreihen…',
+
     offlineFailed: '{{name}} konnte nicht offline hinzugefügt werden',
+
   },
+
   artists: {
+
     title: 'Künstler',
+
     search: 'Suchen…',
+
     all: 'Alle',
+
     gridView: 'Gitteransicht',
+
     listView: 'Listenansicht',
+
     imagesOn: 'Künstlerbilder aktiv — kann Netzwerk- und Systemlast erhöhen',
+
     imagesOff: 'Künstlerbilder deaktiviert — zeigt nur Initialen',
+
     loadMore: 'Mehr laden',
+
     notFound: 'Keine Künstler gefunden.',
+
     albumCount_one: '{{count}} Album',
+
     albumCount_other: '{{count}} Alben',
+
     selectionCount: '{{count}} ausgewählt',
+
     select: 'Mehrfachauswahl',
+
     startSelect: 'Mehrfachauswahl aktivieren',
+
     cancelSelect: 'Abbrechen',
+
     addToPlaylist: 'Zur Playlist hinzufügen',
+
   },
+
   login: {
+
     subtitle: 'Dein Navidrome Desktop Player',
+
     serverName: 'Server-Name (optional)',
+
     serverNamePlaceholder: 'Mein Navidrome',
+
     serverUrl: 'Server-URL',
+
     serverUrlPlaceholder: '192.168.1.100:4533 oder https://music.example.com',
+
     username: 'Benutzername',
+
     usernamePlaceholder: 'admin',
+
     password: 'Passwort',
+
     showPassword: 'Passwort anzeigen',
+
     hidePassword: 'Passwort verstecken',
+
     connect: 'Verbinden',
+
     connecting: 'Verbinde…',
+
     connected: 'Verbunden!',
+
     error: 'Verbindung fehlgeschlagen – bitte Daten prüfen.',
+
     urlRequired: 'Bitte Server-URL eingeben.',
+
     savedServers: 'Gespeicherte Server',
+
     addNew: 'Oder neuen Server hinzufügen',
+
   },
+
   connection: {
+
     connected: 'Verbunden',
+
     connectedTo: 'Verbunden mit {{server}}',
+
     disconnected: 'Getrennt',
+
     disconnectedFrom: '{{server}} nicht erreichbar — klicken für Einstellungen',
+
     checking: 'Verbinde…',
+
     extern: 'Extern',
+
     offlineTitle: 'Keine Serververbindung',
+
     offlineSubtitle: '{{server}} ist nicht erreichbar. Prüfe Netzwerk oder Server.',
+
     offlineModeBanner: 'Offline-Modus — Wiedergabe aus lokalem Cache',
+
     offlineNoCacheBanner: 'Keine Serververbindung — {{server}} nicht erreichbar',
+
     offlineLibraryTitle: 'Offline-Bibliothek',
+
     offlineLibraryEmpty: 'Noch keine Alben gecacht. Online gehen, Album öffnen und "Offline verfügbar machen" klicken.',
+
     offlineAlbumCount: '{{n}} Album',
+
     offlineAlbumCount_plural: '{{n}} Alben',
+
     offlineFilterAll: 'Alle',
+
     offlineFilterAlbums: 'Alben',
+
     offlineFilterPlaylists: 'Playlists',
+
     offlineFilterArtists: 'Diskografien',
+
     retry: 'Erneut versuchen',
+
     serverSettings: 'Server-Einstellungen',
+
     switchServerTitle: 'Server wechseln',
+
     switchServerHint: 'Klicken, um einen anderen gespeicherten Server zu wählen.',
+
     manageServers: 'Server verwalten…',
+
     switchFailed: 'Wechsel fehlgeschlagen — Server nicht erreichbar.',
+
     lastfmConnected: 'Last.fm verbunden als @{{user}}',
+
     lastfmSessionInvalid: 'Session ungültig — klicken zum Neu-Verbinden',
+
   },
+
   common: {
+
     albums: 'Alben',
+
     album: 'Album',
+
     loading: 'Lade…',
+
     loadingMore: 'Lade…',
+
     loadingPlaylists: 'Lade Playlists…',
+
     noAlbums: 'Keine Alben gefunden.',
+
     downloading: 'Lade…',
+
     downloadZip: 'Download (ZIP)',
+
     back: 'Zurück',
+
     cancel: 'Abbrechen',
+
     save: 'Speichern',
+
     delete: 'Löschen',
+
     use: 'Verwenden',
+
     add: 'Hinzufügen',
+
     active: 'Aktiv',
+
     download: 'Herunterladen',
+
     chooseDownloadFolder: 'Download-Ordner wählen',
+
     noFolderSelected: 'Kein Ordner ausgewählt',
+
     rememberDownloadFolder: 'Ordner merken',
+
     filterGenre: 'Genre-Filter',
+
     filterSearchGenres: 'Genres suchen…',
+
     filterNoGenres: 'Keine Genres gefunden',
+
     filterClear: 'Zurücksetzen',
+
     play: 'Abspielen',
+
     bulkSelected: '{{count}} ausgewählt',
+
     clearSelection: 'Auswahl aufheben',
+
     bulkAddToPlaylist: 'Zur Playlist hinzufügen',
+
     bulkRemoveFromPlaylist: 'Aus Playlist entfernen',
+
     bulkClear: 'Auswahl aufheben',
+
     updaterAvailable: 'Update verfügbar',
+
     updaterVersion: 'v{{version}} verfügbar',
+
     updaterWebsite: 'Website',
+
     updaterModalTitle: 'Neue Version verfügbar',
+
     updaterChangelog: 'Was ist neu',
+
     updaterDownloadBtn: 'Jetzt herunterladen',
+
     updaterSkipBtn: 'Version überspringen',
+
     updaterRemindBtn: 'Später erinnern',
+
     updaterDone: 'Download abgeschlossen',
+
     updaterShowFolder: 'Im Ordner anzeigen',
+
     updaterInstallHint: 'Psysonic schließen und das Installationsprogramm manuell ausführen.',
+
     updaterAurHint: 'Update über AUR installieren:',
+
     updaterErrorMsg: 'Download fehlgeschlagen',
+
     updaterRetryBtn: 'Erneut versuchen',
+
     durationHoursMinutes: '{{hours}} Std. {{minutes}} Min.',
+
     durationMinutesOnly: '{{minutes}} Min.',
+
     updaterOpenGitHub: 'Auf GitHub öffnen',
+
     filters: 'Filter',
+
     more: 'mehr',
+
     yearRange: 'Jahresbereich',
+
     clearAll: 'Alles zurücksetzen',
+
   },
+
   settings: {
+
     title: 'Einstellungen',
+
     language: 'Sprache',
+
     languageEn: 'Englisch',
+
     languageDe: 'Deutsch',
+
     languageFr: 'Französisch',
+
     languageNl: 'Niederländisch',
+
     languageZh: 'Chinesisch',
+
     languageNb: 'Norwegisch',
+
     languageRu: 'Russisch',
+
     font: 'Schriftart',
+
     theme: 'Design',
+
     appearance: 'Darstellung',
+
     servers: 'Server',
+
     serverName: 'Server-Name',
+
     serverUrl: 'Server-URL',
+
     serverUrlPlaceholder: '192.168.1.100:4533 oder https://music.example.com',
+
     serverUsername: 'Benutzername',
+
     serverPassword: 'Passwort',
+
     addServer: 'Server hinzufügen',
+
     addServerTitle: 'Neuen Server hinzufügen',
+
     useServer: 'Verwenden',
+
     deleteServer: 'Löschen',
+
     noServers: 'Keine Server gespeichert.',
+
     serverActive: 'Aktiv',
+
     confirmDeleteServer: 'Server „{{name}}" löschen?',
+
     serverConnecting: 'Verbinde…',
+
     serverConnected: 'Verbunden!',
+
     serverFailed: 'Verbindung fehlgeschlagen.',
+
     testBtn: 'Verbindung testen',
+
     testingBtn: 'Teste…',
+
     serverCompatible: 'Kompatibel mit: Navidrome · Gonic · Airsonic · Subsonic',
+
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+
     audiomuseDesc:
+
       'Aktivieren, wenn dieser Server das <pluginLink>AudioMuse-AI-Navidrome-Plugin</pluginLink> nutzt. Schaltet Instant Mix pro Titel frei und nutzt ähnliche Künstler vom Server statt Last.fm auf Künstlerseiten.',
+
     audiomuseIssueHint:
+
       'Instant Mix ist kürzlich fehlgeschlagen — Navidrome-Plugin und AudioMuse-API prüfen. Ohne Server-Treffer werden ähnliche Künstler über Last.fm geladen.',
+
     connected: 'Verbunden',
+
     failed: 'Fehlgeschlagen',
+
     eqTitle: 'Equalizer',
+
     eqEnabled: 'Equalizer aktivieren',
+
     eqPreset: 'Preset',
+
     eqPresetCustom: 'Benutzerdefiniert',
+
     eqPresetBuiltin: 'Eingebaute Presets',
+
     eqPresetCustomGroup: 'Meine Presets',
+
     eqSavePreset: 'Als Preset speichern',
+
     eqPresetName: 'Preset-Name…',
+
     eqDeletePreset: 'Preset löschen',
+
     eqResetBands: 'Auf Flat zurücksetzen',
+
     eqPreGain: 'Vorverstärkung',
+
     eqResetPreGain: 'Vorverstärkung zurücksetzen',
+
     eqAutoEqTitle: 'AutoEQ Kopfhörer-Suche',
+
     eqAutoEqPlaceholder: 'Kopfhörer / IEM Modell suchen…',
+
     eqAutoEqSearching: 'Suche…',
+
     eqAutoEqNoResults: 'Keine Ergebnisse gefunden',
+
     eqAutoEqError: 'Suche fehlgeschlagen',
+
     eqAutoEqRateLimit: 'GitHub Rate-Limit erreicht — in einer Minute erneut versuchen',
+
     eqAutoEqFetchError: 'EQ-Profil konnte nicht geladen werden',
+
     lfmTitle: 'Last.fm',
+
     lfmConnect: 'Mit Last.fm verbinden',
+
     lfmConnecting: 'Warte auf Bestätigung…',
+
     lfmConfirm: 'Ich habe die App autorisiert',
+
     lfmConnected: 'Verbunden als',
+
     lfmDisconnect: 'Trennen',
+
     lfmConnectDesc: 'Verbinde deinen Last.fm Account, um Scrobbling und Now-Playing-Updates direkt aus Psysonic heraus zu aktivieren — keine Navidrome-Konfiguration erforderlich.',
+
     lfmOpenBrowser: 'Es öffnet sich ein Browserfenster. Autorisiere Psysonic auf Last.fm und klicke dann unten auf den Button.',
+
     lfmScrobbles: '{{n}} Scrobbles',
+
     lfmMemberSince: 'Dabei seit {{year}}',
+
     scrobbleEnabled: 'Scrobbling aktiviert',
+
     scrobbleDesc: 'Songs nach 50% Laufzeit an Last.fm senden',
+
     behavior: 'App-Verhalten',
+
     cacheTitle: 'Max. Speichergröße',
+
     cacheDesc: 'Cover und Künstlerbilder. Wenn voll, werden die ältesten Einträge automatisch entfernt. Offline-Alben werden nicht automatisch gelöscht, aber beim manuellen Cache leeren entfernt.',
+
     cacheUsedImages: 'Bilder:',
+
     cacheUsedOffline: 'Offline-Tracks:',
+
     cacheUsedHot: 'Belegter Speicher:',
+
     hotCacheTrackCount: 'Titel im Cache:',
+
     cacheMaxLabel: 'Max. Größe',
+
     cacheClearBtn: 'Cache leeren',
+
     cacheClearWarning: 'Alle Offline-Alben werden damit aus der Bibliothek entfernt.',
+
     cacheClearConfirm: 'Alles löschen',
+
     cacheClearCancel: 'Abbrechen',
+
     offlineDirTitle: 'Offline-Bibliothek (In-App)',
+
     offlineDirDesc: 'Speicherort für Titel, die du innerhalb von Psysonic offline verfügbar machst.',
+
     offlineDirDefault: 'Standard (App-Daten)',
+
     offlineDirChange: 'Verzeichnis ändern',
+
     offlineDirClear: 'Auf Standard zurücksetzen',
+
     offlineDirHint: 'Neue Downloads werden an diesem Ort gespeichert. Bestehende Downloads verbleiben am ursprünglichen Pfad.',
+
     hotCacheTitle: 'Hot-Playback-Cache',
+
     hotCacheAlphaBadge: 'Alpha',
+
     hotCacheDisclaimer: 'Lädt kommende Warteschlangen-Titel vor und behält zuletzt gespielte. Bei aktivierter Option: Speicherplatz und Netzwerk.',
+
     hotCacheDirDefault: 'Standard (App-Daten)',
+
     hotCacheDirChange: 'Ordner ändern',
+
     hotCacheDirClear: 'Auf Standard zurücksetzen',
+
     hotCacheDirHint: 'Beim Ordnerwechsel wird der App-Index zurückgesetzt; alte Dateien bleiben am alten Ort, bis Sie sie löschen.',
+
     hotCacheEnabled: 'Hot-Playback-Cache aktivieren',
+
     hotCacheMaxMb: 'Maximale Cache-Größe',
+
     hotCacheDebounce: 'Debounce bei Warteschlangen-Änderungen',
+
     hotCacheDebounceImmediate: 'Sofort',
+
     hotCacheDebounceSeconds: '{{n}} s',
+
     hotCacheClearBtn: 'Hot-Cache leeren',
+
     audioOutputDevice: 'Audio-Ausgabegerät',
+
     audioOutputDeviceDesc: 'Wähle das Audiogerät, über das Psysonic spielt. Änderungen werden sofort übernommen und starten den aktuellen Track neu.',
+
     audioOutputDeviceDefault: 'Systemstandard',
+
     audioOutputDeviceRefresh: 'Geräteliste aktualisieren',
+
     audioOutputDeviceOsDefaultNow: 'aktuelle Systemausgabe',
+
     audioOutputDeviceListError: 'Audiogeräteliste konnte nicht geladen werden.',
+
     audioOutputDeviceNotInCurrentList: 'nicht in der aktuellen Liste',
+
     hiResTitle: 'Native Hi-Res-Wiedergabe',
+
     hiResEnabled: 'Native Hi-Res-Wiedergabe aktivieren',
+
     hiResDesc: "Standardmäßig wird auf 44,1 kHz begrenzt (maximale Stabilität). Nur aktivieren, wenn Hardware und Netzwerk zuverlässig hohe Abtastraten (88,2 kHz+) unterstützen.",
+
     showArtistImages: 'Künstlerbilder anzeigen',
+
     showArtistImagesDesc: 'Lädt und zeigt Künstlerbilder in der Künstlerübersicht. Standardmäßig deaktiviert, um Server-I/O und Netzwerklast bei großen Bibliotheken zu reduzieren.',
+
     showTrayIcon: 'Tray-Icon anzeigen',
+
     showTrayIconDesc: 'Psysonic-Icon im System-Tray / in der Menüleiste anzeigen.',
+
     minimizeToTray: 'Im Tray minimieren',
+
     minimizeToTrayDesc: 'Beim Schließen des Fensters läuft Psysonic weiter im System-Tray statt zu beenden.',
+
     discordRichPresence: 'Discord Rich Presence',
+
     discordRichPresenceDesc: 'Zeigt den aktuell gespielten Titel im Discord-Profil an. Discord muss dafür geöffnet sein.',
+
     useCustomTitlebar: 'Eigene Titelleiste',
+
     useCustomTitlebarDesc: 'Ersetzt die System-Titelleiste durch eine eingebaute, die zum App-Theme passt. Deaktivieren, um die native GNOME/GTK-Titelleiste zu verwenden.',
+
     discordAppleCovers: 'Cover über Apple Music für Discord laden',
+
     discordAppleCoversDesc: 'Sendet Künstler- und Albumname an die Apple-Such-API, um Cover für dein Discord-Profil zu finden. Standardmäßig aus Datenschutzgründen deaktiviert.',
+
+    discordTemplates: 'Benutzerdefinierte Textvorlagen',
+
+    discordTemplatesDesc: 'Passe an, welche Informationen in deinem Discord-Profil angezeigt werden. Variablen: {title}, {artist}, {album}, {paused}',
+
+    discordTemplateDetails: 'Primäre Zeile (details)',
+
+    discordTemplateState: 'Sekundäre Zeile (state)',
+
+    discordTemplateLargeText: 'Album-Tooltip (largeText)',
+
     nowPlayingEnabled: 'Im Livefenster anzeigen',
+
     nowPlayingEnabledDesc: 'Überträgt den aktuell gespielten Titel an die Livehörer-Ansicht des Servers. Deaktivieren, um keine Wiedergabedaten zu senden.',
+
     lyricsServerFirst: 'Server-Lyrics bevorzugen',
+
     lyricsServerFirstDesc: 'Server-seitige Lyrics (eingebettete Tags, Sidecar-Dateien) vor LRCLIB abfragen. Deaktivieren, um LRCLIB zuerst zu verwenden.',
+
     enableNeteaselyrics: 'Netease Cloud Music Lyrics',
+
     enableNeteaselyricsDesc: 'Netease Cloud Music als letzte Lyrics-Quelle verwenden, wenn Server und LRCLIB nichts liefern. Besonders gut für asiatische und internationale Musik.',
+
     lyricsSourcesTitle: 'Lyrics-Quellen',
+
     lyricsSourcesDesc: 'Wähle, welche Quellen für Lyrics abgefragt werden und in welcher Reihenfolge. Ziehen zum Sortieren. Deaktivierte Quellen werden übersprungen.',
+
     lyricsSourceServer: 'Server',
+
     lyricsSourceLrclib: 'LRCLIB',
+
     lyricsSourceNetease: 'Netease Cloud Music',
+
     downloadsTitle: 'ZIP-Export & Archivierung',
+
     downloadsFolderDesc: 'Zielverzeichnis für Alben, die du als ZIP-Datei auf deinen Computer herunterlädst.',
+
     downloadsDefault: 'Standard-Downloads-Ordner',
+
     pickFolder: 'Auswählen',
+
     pickFolderTitle: 'Download-Ordner auswählen',
+
     clearFolder: 'Download-Ordner löschen',
+
     logout: 'Abmelden',
+
     aboutTitle: 'Über Psysonic',
+
     aboutDesc: 'Ein moderner Desktop-Musikplayer für Subsonic-kompatible Server (Navidrome, Gonic u. a.). Basiert auf Tauri v2 mit einer nativen Rust-Audio-Engine — schlank und schnell, aber vollgepackt mit Features: Wellenform-Seekbar, synchronisierte Lyrics, Last.fm-Integration, 10-Band-EQ, Crossfade, nahtlose Wiedergabe, Replay Gain, Genre-Browser und eine große Theme-Bibliothek.',
+
     aboutLicense: 'Lizenz',
+
     aboutLicenseText: 'GNU GPL v3 — kostenlos nutzbar, veränderbar und unter gleicher Lizenz weiterzugeben.',
+
     aboutRepo: 'Quellcode auf GitHub',
+
     aboutVersion: 'Version',
+
     aboutBuiltWith: 'Gebaut mit Tauri · React · TypeScript · Rust/rodio',
+
     aboutAiCredit: 'Mit freundlicher Unterstützung von Claude Code by Anthropic',
+
     aboutContributorsLabel: 'Mitwirkende',
+
     aboutSpecialThanksLabel: 'Besonderer Dank',
+
     changelog: 'Changelog',
+
     showChangelogOnUpdate: "'Was ist neu' bei Update anzeigen",
+
     showChangelogOnUpdateDesc: 'Zeigt automatisch die Neuerungen an, wenn eine neue Version zum ersten Mal gestartet wird.',
+
     randomMixTitle: 'Zufallsmix',
+
     randomMixBlacklistTitle: 'Eigene Filter-Keywords',
+
     randomMixBlacklistDesc: 'Songs werden ausgeschlossen, wenn ein Keyword auf Genre, Titel, Album oder Künstler zutrifft (aktiv wenn die Checkbox oben an ist).',
+
     randomMixBlacklistPlaceholder: 'Keyword hinzufügen…',
+
     randomMixBlacklistAdd: 'Hinzufügen',
+
     randomMixBlacklistEmpty: 'Noch keine eigenen Keywords hinzugefügt.',
+
     randomMixHardcodedTitle: 'Eingebaute Keywords (aktiv wenn Checkbox an)',
+
     tabAudio: 'Audio',
+
     tabStorage: 'Speicher & Downloads',
+
     tabAppearance: 'Darstellung',
+
     homeCustomizerTitle: 'Startseite',
+
     sidebarTitle: 'Seitenleiste',
+
     sidebarReset: 'Zurücksetzen',
+
     sidebarDrag: 'Ziehen zum Umsortieren',
+
     sidebarFixed: 'Immer sichtbar',
-    randomNavSplitTitle: 'Mix-Navigation aufteilen',
-    randomNavSplitDesc: '"Zufallsmix" und "Zufallsalben" als separate Sidebar-Einträge statt als "Mix erstellen"-Hub anzeigen.',
+
     tabInput: 'Eingabe',
+
     tabServer: 'Server',
+
     shortcutsReset: 'Auf Standard zurücksetzen',
+
     shortcutListening: 'Taste drücken…',
+
     shortcutUnbound: '—',
+
     shortcutClear: 'Löschen',
+
     globalShortcutsTitle: 'Globale Shortcuts',
+
     globalShortcutsNote: 'Funktionieren systemweit, auch wenn Psysonic im Hintergrund läuft. Mindestens Ctrl, Alt oder Super als Modifier erforderlich.',
+
     shortcutPlayPause: 'Wiedergabe / Pause',
+
     shortcutNext: 'Nächster Titel',
+
     shortcutPrev: 'Vorheriger Titel',
+
     shortcutVolumeUp: 'Lautstärke erhöhen',
+
     shortcutVolumeDown: 'Lautstärke verringern',
+
     shortcutSeekForward: '10s vorspulen',
+
     shortcutSeekBackward: '10s zurückspulen',
+
     shortcutToggleQueue: 'Warteschlange ein-/ausblenden',
+
     shortcutOpenFolderBrowser: '{{folderBrowser}} öffnen',
+
     shortcutFullscreenPlayer: 'Vollbild-Player',
+
     shortcutNativeFullscreen: 'Nativer Vollbildmodus',
+
     tabSystem: 'System',
+
     tabGeneral: 'Allgemein',
+
     ratingsSectionTitle: 'Bewertungen',
+
     ratingsSkipStarTitle: 'Skip → 1 Stern',
+
     ratingsSkipStarDesc:
+
       'Wird ein Titel mehrmals hintereinander übersprungen, bekommt er automatisch 1★. Nur für noch nicht bewertete Titel.',
+
     ratingsSkipStarThresholdLabel: 'Skips',
+
     ratingsMixFilterTitle: 'Nach Bewertung filtern',
+
     ratingsMixFilterDesc:
+
       'Gering bewertete Titel in {{mix}} und {{albums}} ausblenden. Nochmals auf den gewählten Stern klicken, um den Filter zu deaktivieren.',
+
     ratingsMixMinSong: 'Titel',
+
     ratingsMixMinAlbum: 'Alben',
+
     ratingsMixMinArtist: 'Interpreten',
+
     ratingsMixMinThresholdAria: 'Mindest-Sterne: {{label}}',
+
     backupTitle: 'Backup & Wiederherstellung',
+
     backupExport: 'Einstellungen exportieren',
+
     backupExportDesc: 'Speichert alle Einstellungen, Serverprofile, Last.fm-Konfiguration, Theme, EQ und Tastenkürzel in eine .psybkp-Datei. Passwörter werden im Klartext gespeichert — Datei sicher aufbewahren.',
+
     backupImport: 'Einstellungen importieren',
+
     backupImportDesc: 'Stellt Einstellungen aus einer .psybkp-Datei wieder her. Die App wird nach dem Import neu geladen.',
+
     backupImportConfirm: 'Alle aktuellen Einstellungen werden überschrieben. Fortfahren?',
+
     backupSuccess: 'Backup gespeichert',
+
     backupImportSuccess: 'Einstellungen wiederhergestellt — wird neu geladen…',
+
     backupImportError: 'Ungültige oder beschädigte Backup-Datei.',
+
     playbackTitle: 'Wiedergabe',
+
     replayGain: 'Replay Gain',
+
     replayGainDesc: 'Lautstärke mit ReplayGain-Metadaten normalisieren',
+
     replayGainMode: 'Modus',
+
     replayGainTrack: 'Track',
+
     replayGainAlbum: 'Album',
+
     replayGainPreGain: 'Pre-Gain (getaggte Dateien)',
+
     replayGainFallback: 'Fallback (ohne Tags / Radio)',
+
     crossfade: 'Crossfade',
+
     crossfadeDesc: 'Überblendung zwischen Tracks',
+
     crossfadeSecs: '{{n}} s',
+
     notWithGapless: 'Nicht verfügbar wenn Nahtlose Wiedergabe aktiv ist',
+
     notWithCrossfade: 'Nicht verfügbar wenn Crossfade aktiv ist',
+
     gapless: 'Nahtlose Wiedergabe',
+
     gaplessDesc: 'Nächsten Track vorpuffern um Lücken zwischen Songs zu vermeiden',
+
     preloadMode: 'Nächsten Track vorpuffern',
+
     preloadModeDesc: 'Wann mit dem Puffern des nächsten Tracks begonnen werden soll',
+
     nextTrackBufferingTitle: 'Nächster Track – Pufferung',
+
     preloadHotCacheMutualExclusive: 'Preload und Hot Cache erfüllen denselben Zweck – nur eine Methode kann gleichzeitig aktiv sein. Das Aktivieren einer deaktiviert die andere automatisch.',
+
     preloadOff: 'Aus',
+
     preloadBalanced: 'Ausgewogen (30 s vor Ende)',
+
     preloadEarly: 'Früh (nach 5 s Wiedergabe)',
+
     preloadCustom: 'Benutzerdefiniert',
+
     preloadCustomSeconds: 'Sekunden vor Ende: {{n}}',
+
     infiniteQueue: 'Endlose Warteschlange',
+
     infiniteQueueDesc: 'Automatisch Zufallstitel anhängen wenn die Warteschlange leer wird',
+
     experimental: 'Experimentell',
+
     fsPlayerSection: 'Vollbild-Player',
+
     fsShowArtistPortrait: 'Künstlerfoto anzeigen',
+
     fsShowArtistPortraitDesc: 'Künstlerfoto (oder Albumcover) auf der rechten Seite des Vollbild-Players anzeigen.',
+
     fsPortraitDim: 'Abdunkelung des Fotos',
+
     seekbarStyle: 'Seekbar-Stil',
+
     seekbarStyleDesc: 'Aussehen der Wiedergabe-Seekbar auswählen',
+
     seekbarWaveform: 'Wellenform',
+
     seekbarLinedot: 'Linie & Punkt',
+
     seekbarBar: 'Balken',
+
     seekbarThick: 'Dicker Balken',
+
     seekbarSegmented: 'Segmentiert',
+
     seekbarNeon: 'Neonröhre',
+
     seekbarPulsewave: 'Pulswelle',
+
     seekbarParticletrail: 'Partikel-Spur',
+
     seekbarLiquidfill: 'Flüssigkeit',
+
     seekbarRetrotape: 'Retro-Band',
+
     themeSchedulerTitle: 'Theme-Zeitplan',
+
     themeSchedulerEnable: 'Theme-Zeitplan aktivieren',
+
     themeSchedulerEnableSub: 'Wechselt automatisch zwischen zwei Themes basierend auf der Uhrzeit',
+
     themeSchedulerDayTheme: 'Tages-Theme',
+
     themeSchedulerDayStart: 'Tag beginnt um',
+
     themeSchedulerNightTheme: 'Nacht-Theme',
+
     themeSchedulerNightStart: 'Nacht beginnt um',
+
     themeSchedulerActiveHint: 'Theme-Zeitplan ist aktiv - Themes werden automatisch gewechselt.',
+
     visualOptionsTitle: 'Visuelle Optionen',
+
     coverArtBackground: 'Cover-Hintergrund',
+
     coverArtBackgroundSub: 'Zeigt verschwommenes Cover als Hintergrund in Album/Playlist-Kopfzeilen',
+
     playlistCoverPhoto: 'Playlist-Coverfoto',
+
     playlistCoverPhotoSub: 'Zeigt Coverfoto-Raster in der Playlist-Detailansicht',
+
     showBitrate: 'Bitrate anzeigen',
+
     showBitrateSub: 'Audio-Bitrate in Track-Listen anzeigen',
+
     uiScaleTitle: 'Interface-Skalierung',
+
     uiScaleLabel: 'Zoom',
+
   },
+
   changelog: {
+
     modalTitle: 'Was ist neu',
+
     dontShowAgain: 'Nicht mehr anzeigen',
+
     close: 'Verstanden',
+
   },
+
   help: {
+
     title: 'Hilfe',
+
     s1: 'Erste Schritte',
+
     q1: 'Welche Server sind kompatibel?',
+
     a1: 'Psysonic funktioniert mit jedem Subsonic-kompatiblen Server: Navidrome, Gonic, Subsonic, Airsonic und anderen. Navidrome ist die empfohlene Wahl.',
+
     q2: 'Wie verbinde ich mich mit meinem Server?',
+
     a2: 'Öffne die Einstellungen und klicke auf "Server hinzufügen". Gib die Server-URL (z. B. 192.168.1.100:4533), Benutzername und Passwort ein. Psysonic testet die Verbindung vor dem Speichern — bei Fehler wird nichts gespeichert.',
+
     q3: 'Kann ich mehrere Server verwenden?',
+
     a3: 'Ja. Du kannst beliebig viele Server in den Einstellungen hinzufügen und jederzeit zwischen ihnen wechseln. Immer ist nur ein Server aktiv.',
+
     s2: 'Wiedergabe',
+
     q4: 'Wie spiele ich Musik ab?',
+
     a4: 'Doppelklick auf einen Track startet die Wiedergabe. Auf Album- und Künstlerseiten gibt es "Alle abspielen". Tracks lassen sich auch per Drag & Drop in die Warteschlange ziehen.',
+
     q5: 'Welche Tastenkürzel gibt es?',
+
     a5: 'Leertaste = Play / Pause · Escape = Vollbild schließen. Medientasten (Play/Pause, Weiter, Zurück) funktionieren auf allen Plattformen. Unter Linux bitte die Buttons in der Playerleiste nutzen. In-App-Kürzel und systemweite globale Shortcuts können in Einstellungen → Tastenkürzel / Globale Shortcuts angepasst werden.',
+
     q6: 'Was ist die Warteschlange?',
+
     a6: 'Die Warteschlange zeigt alle kommenden Tracks. Öffnen mit dem Panel-Icon oben rechts im Header (neben dem Now-Playing-Indikator). Tracks per Drag & Drop umsortieren, mit dem Shuffle-Button mischen oder als Playlist speichern.',
+
     q7: 'Wie öffne ich den Vollbild-Player?',
+
     a7: 'Klick auf das Album-Cover unten in der Playerleiste oder auf das Expand-Icon daneben. Mit Escape wieder schließen.',
+
     q8: 'Wie funktioniert die Wiederholfunktion?',
+
     a8: 'Klick auf den Wiederhol-Button in der Playerleiste, um zwischen den Modi zu wechseln: Aus → Alles wiederholen → Einen wiederholen.',
+
     s3: 'Bibliothek',
+
     q9: 'Wie lade ich ein Album herunter?',
+
     a9: 'Auf der Album-Detailseite auf "Download (ZIP)" klicken. Der Server packt das Album zunächst in eine ZIP-Datei — bei großen Alben oder verlustfreien Dateien (FLAC / WAV) kann es einen Moment dauern, bevor der Download tatsächlich startet. Das ist normal: Der Fortschrittsbalken erscheint erst, wenn der Server fertig ist und die Übertragung beginnt.',
+
     q10: 'Wie markiere ich Tracks und Alben als Favoriten?',
+
     a10: 'Das Stern-Icon auf einem Track oder im Album-Header anklicken. Markierte Einträge erscheinen im Bereich "Favoriten" in der Seitenleiste.',
+
     q11: 'Was ist das Karussell auf der Startseite?',
+
     a11: 'Das Banner oben auf der Startseite wählt zufällige Alben aus der Bibliothek und rotiert alle 10 Sekunden weiter. Mit den Punkten kann man manuell springen, Klick auf das Banner öffnet das Album.',
+
     s4: 'Einstellungen',
+
     q12: 'Wie ändere ich das Theme?',
+
     a12: 'Einstellungen → Design. Eine große Auswahl an Themes in 8 Gruppen: Psysonic Themes, Mediaplayer, Betriebssysteme, Spiele, Filme, Serien, Social Media und Open-Source-Classics (Catppuccin, Nord, Gruvbox, Nightfox).',
+
     q13: 'Wie ändere ich die Sprache?',
+
     a13: 'Einstellungen → Sprache. Englisch, Deutsch, Französisch, Niederländisch und Chinesisch werden unterstützt.',
+
     q15: 'Wie lege ich einen Download-Ordner fest?',
+
     a15: 'Einstellungen → App-Verhalten → Download-Ordner. Beliebigen Ordner wählen — heruntergeladene Alben werden dort als ZIP gespeichert. Ohne eigenen Ordner landet alles im Standard-Downloads-Ordner.',
+
     s5: 'Scrobbling',
+
     q16: 'Wie funktioniert Scrobbling?',
+
     a16: 'Psysonic scrobbled direkt zu Last.fm — keine Navidrome-Konfiguration nötig. Last.fm-Konto in Einstellungen → Last.fm verbinden und Scrobbling dort aktivieren.',
+
     q17: 'Wann wird ein Scrobble gesendet?',
+
     a17: 'Ein Scrobble wird übermittelt, wenn 50 % eines Tracks gehört wurden.',
+
     q22: 'Was ist die Waveform in der Playerleiste?',
+
     a22: 'Die Waveform-Leiste ersetzt den klassischen Fortschrittsbalken. Klick auf eine beliebige Stelle zum Springen, ziehen zum Scrubben. Der gespielte Teil leuchtet in einem Blau-Mauve-Farbverlauf, der gepufferte Bereich erscheint etwas heller, der ungespielter Teil ist abgeblendet.',
+
     q24: 'Kann ich die Warteschlange mischen?',
+
     a24: 'Ja. Die Warteschlange öffnen und auf das Shuffle-Icon im Header klicken. Der aktuell laufende Track bleibt an Position 1 — alle restlichen Tracks werden zufällig neu geordnet.',
+
     q25: 'Öffnen Last.fm- und Wikipedia-Links auf Künstlerseiten im Browser?',
+
     a25: 'Ja — sie öffnen sich im Standard-Systembrowser. Der Button zeigt kurz eine Bestätigungsmeldung beim Klick.',
+
     s7: 'Zufallsmix',
+
     q26: 'Was ist der Zufallsmix?',
+
     a26: 'Der Zufallsmix erstellt eine Playlist aus zufälligen Tracks deiner gesamten Bibliothek. Über "Zufallsmix" in der Seitenleiste erreichbar, dann "Neuer Mix" klicken. Die Anzahl der Tracks ist vor der Generierung einstellbar.',
+
     q27: 'Was ist der Keyword-Filter?',
+
     a27: 'Der Keyword-Filter schließt Tracks aus, deren Genre, Titel oder Album bestimmte Wörter enthält. Hörbücher werden automatisch gefiltert. Eigene Keywords in Einstellungen → Zufallsmix hinzufügen oder per Klick auf ein Genre-Tag direkt in der Trackliste.',
+
     q28: 'Was ist der Super-Genre-Mix?',
+
     a28: 'Der Super-Genre-Mix fasst die Bibliothek in übergeordnete Kategorien zusammen (Rock, Metal, Electronic, Jazz, Klassik usw.) und erstellt daraus einen fokussierten Mix. Einen Kategorie-Chip unterhalb der Trackliste auswählen. Ergebnisse erscheinen schrittweise, während die einzelnen Sub-Genres geladen werden.',
+
     s6: 'Problemlösung',
+
     q18: 'Cover und Künstlerbilder laden langsam.',
+
     a18: 'Bilder werden beim ersten Aufruf vom Server geholt und dann 30 Tage lokal gecacht. Bei langsamen Server-Festplatten kann der erste Seitenaufruf einen Moment dauern. Danach geht alles sofort.',
+
     q19: 'Der Verbindungstest schlägt fehl.',
+
     a19: 'URL inklusive Port prüfen (z. B. http://192.168.1.100:4533). Sicherstellen, dass keine Firewall die Verbindung blockiert. Im lokalen Netzwerk http:// statt https:// versuchen. Benutzername und Passwort kontrollieren.',
+
     q20: 'Kein Ton unter Linux.',
+
     a20: 'Psysonic ist als .deb (Ubuntu/Debian), .rpm (Fedora/RHEL) und über AUR für Arch/CachyOS verfügbar (yay -S psysonic). Es gibt kein AppImage. Falls kein Ton kommt, sicherstellen, dass PipeWire oder PulseAudio läuft.',
+
     q21: 'Die App zeigt einen schwarzen Bildschirm unter Linux.',
+
     a21: 'Meist ein GPU/EGL-Treiberproblem in WebKitGTK. Mit GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1 starten. Das AUR-Paket und die offiziellen .deb/.rpm-Pakete setzen diese Variablen automatisch.',
+
     q29: 'Was sind Crossfade und nahtlose Wiedergabe?',
+
     a29: 'Beides sind experimentelle Audiofunktionen in Einstellungen → Audio. Nahtlose Wiedergabe puffert den nächsten Track vor, um Stille zu eliminieren. Crossfade blendet den aktuellen Track aus, während der nächste eingeblendet wird — Dauer (1–10 s) einstellbar.',
+
     q30: 'Zeigt Psysonic Songtexte an?',
+
     a30: 'Ja. Klick auf das Mikrofon-Icon in der Playerleiste öffnet den Lyrics-Tab im Queue-Panel. Psysonic lädt Texte automatisch von LRCLIB. Sind synchronisierte Lyrics verfügbar, wird die aktuelle Zeile hervorgehoben und scrollt in Echtzeit mit. Bei reinen Texten wird der Volltext statisch angezeigt.',
+
     q31: 'Kann ich Tastenkürzel anpassen?',
+
     a31: 'Ja. Einstellungen → Tastenkürzel erlaubt das Neuzuordnen von In-App-Aktionen (Play/Pause, Weiter, Zurück, Lautstärke, Vollbild u. v. m.). Einstellungen → Globale Shortcuts ermöglicht systemweite Kürzel, die auch im Hintergrund ausgelöst werden.',
+
     q32: 'Kann ich die Schriftart ändern?',
+
     a32: 'Ja. Einstellungen → Schriftart bietet 10 Schriften zur Auswahl, darunter IBM Plex Mono, Fira Code, JetBrains Mono und Courier Prime. Die gewählte Schrift gilt für die gesamte Oberfläche.',
+
     s8: 'Offline-Modus',
+
     q34: 'Was ist der Offline-Modus?',
+
     a34: 'Der Offline-Modus (Beta) ermöglicht das Zwischenspeichern von Alben auf dem Gerät, sodass die Wiedergabe ohne aktive Serververbindung möglich ist. Gecachte Tracks werden lokal gespeichert und direkt von der Festplatte abgespielt — ohne Netzwerkzugriff.',
+
     q35: 'Wie speichere ich ein Album für die Offline-Nutzung?',
+
     a35: 'Album öffnen und auf das Download-Symbol im Album-Header klicken. Psysonic lädt alle Tracks im Hintergrund herunter. Der Fortschritt wird am Button angezeigt. Nach dem Download wird das Symbol grün. Gecachte Alben können in der Offline-Bibliothek (Seitenleiste) verwaltet und gelöscht werden.',
+
     q36: 'Wie viel Speicherplatz darf der Cache belegen?',
+
     a36: 'In Einstellungen → Bibliothek kann eine maximale Cache-Größe festgelegt werden. Wird das Limit erreicht, erscheint ein Warnbanner auf der Albumseite. Einzelne Alben können in der Offline-Bibliothek gelöscht werden, um Speicherplatz freizugeben.',
+
     q37: 'Wie bewerte ich Songs, Alben und Künstler?',
+
     a37: 'Psysonic unterstützt 1–5-Sterne-Bewertungen über die OpenSubsonic-API (erfordert Navidrome ≥ 0.53). Songs können in der Trackliste eines Albums oder einer Playlist (Spalte „Bewertung"), über das Rechtsklick-Kontextmenü oder direkt in der Playerleiste unterhalb des Künstlernamens bewertet werden. Alben werden auf der Albumdetailseite bewertet, Künstler auf der Künstlerseite. Bewertungen werden sofort an den Server übertragen.',
+
     q38: 'Kann ich eine Bewertung entfernen oder ändern?',
+
     a38: 'Ja. Ein erneuter Klick auf den bereits aktiven Stern entfernt die Bewertung vollständig – der zweite Klick auf denselben Stern löscht sie also. Um eine Bewertung zu ändern, einfach einen anderen Stern anklicken.',
+
     q39: 'Was ist Skip-to-1★ und der Bewertungsfilter?',
+
     a39: 'Skip-to-1★ vergibt automatisch eine 1-Stern-Bewertung, wenn ein Song mehrfach hintereinander manuell übersprungen wird. Aktivierung und Schwellenwert in Einstellungen → Bewertungen. Dort lässt sich auch eine Mindestbewertung für Zufalls-Mix und Zufallsalben festlegen – so werden nur Songs, Alben oder Künstler ab einer bestimmten Sternzahl in generierten Mixes berücksichtigt.',
+
     q40: 'Was ist der Ordner-Browser?',
+
     a40: 'Der Ordner-Browser (Sidebar) ermöglicht die Navigation im Musikverzeichnis des Servers über ein Miller-Column-Layout. Ein Klick auf einen Ordner öffnet dessen Inhalt; über das Play-Symbol lassen sich Ordner direkt abspielen oder zur Warteschlange hinzufügen.',
+
     q41: 'Was ist der Theme-Scheduler?',
+
     a41: 'Einstellungen → Darstellung → Theme automatisch wechseln: Tagesthema und Nachtthema mit Startzeiten konfigurieren. Psysonic wechselt automatisch zur eingestellten Uhrzeit. Ist der Scheduler aktiv, erscheint im Theme-Picker ein Hinweis, warum manuelle Änderungen keine sofortige Wirkung haben.',
+
     q42: 'Kann ich die Benutzeroberfläche vergrößern oder verkleinern?',
+
     a42: 'Ja. Einstellungen → Darstellung → Anzeigeskalierung ermöglicht eine Skalierung der gesamten Oberfläche zwischen 80 % und 125 %, unabhängig von der Systemschriftgröße.',
+
     q43: 'Kann ich den Stil der Seekbar ändern?',
+
     a43: 'Ja. Einstellungen → Darstellung → Seekbar-Stil bietet 10 Stile: Wellenform, Linie & Punkt, Balken, Dicker Balken, Segmentiert, Neon-Glow, Pulswelle, Partikelspur, Flüssigfüllung und Retro-Tape.',
+
     q44: 'Was ist AutoEQ?',
+
     a44: 'Der 10-Band-EQ in Einstellungen → Audio enthält eine AutoEQ-Suche. Kopfhörermodell eingeben – Psysonic lädt das Korrekturprofil aus der AutoEQ-Datenbank und überträgt es automatisch auf die EQ-Bänder.',
+
     q45: 'Was ist Replay Gain?',
+
     a45: 'Replay Gain normalisiert die Lautstärke, sodass laute und leise Alben auf einem gleichmäßigen Pegel wiedergegeben werden. Aktivierung in Einstellungen → Audio → Replay Gain; Modus Track (pro Song) oder Album (behält die relative Dynamik innerhalb eines Albums).',
+
     q46: 'Was ist der Hot Cache?',
+
     a46: 'Der Hot Cache (Alpha, Einstellungen → Bibliothek) lädt die nächsten Songs der Warteschlange vorab auf die Festplatte, damit die Wiedergabe ohne Pufferverzögerung startet – besonders nützlich bei langsamen oder entfernten Servern. Psysonic hält den aktuellen Track und die nächsten 5 im Cache und verdrängt ältere Einträge, wenn das Größenlimit erreicht wird. Cache-Größe und Debounce-Verzögerung sind konfigurierbar.',
+
     q47: 'Kann ich eine Playlist offline cachen?',
+
     a47: 'Ja. In den Playlist-Details auf das Download-Symbol klicken – alle Tracks werden im Hintergrund heruntergeladen. Ist die Playlist vollständig gecacht, wechselt das Symbol zu einem roten Papierkorb; ein erneuter Klick entfernt die Playlist aus dem Offline-Cache.',
-    q48: 'Was ist die Infinite Queue?',
-    a48: 'Wenn die Warteschlange leer läuft und Wiederholen deaktiviert ist, fügt Psysonic automatisch zufällige Tracks aus deiner Bibliothek hinzu, damit die Wiedergabe nie stoppt. Automatisch hinzugefügte Tracks erscheinen unterhalb des Trenners „— Automatisch hinzugefügt —". Umschalten über das Unendlichkeitssymbol im Warteschlangen-Header. In Einstellungen → Warteschlange kann der automatische Nachschub auf ein bestimmtes Genre beschränkt werden.',
-    q49: 'Kann ich Psysonic über die Kommandozeile bedienen?',
-    a49: 'Ja – das Psysonic-Binary kann die laufende App fernsteuern. Beispiele: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one, --player star / unstar, --player rating 1–5. Außerdem: Server wechseln (--player server list / set), Ausgabegerät wählen (--player audio-device list / set), Bibliotheks-Ordner filtern (--player library list / set), Instant Mix starten (--player mix new / append) und Suche (--player search track|album|artist <Suchbegriff>). Vollständige Hilfe: psysonic --player --help. Shell-Completions für bash und zsh sind über psysonic completions verfügbar.',
-    q50: 'Wie verwalte ich Playlists?',
-    a50: 'Über „Playlists" in der Seitenleiste. Mit „Neue Playlist" eine Playlist erstellen. In der Playlist-Detailansicht können Tracks per Drag & Drop umsortiert, mit dem ×-Button entfernt und über die Songsuche neue hinzugefügt werden. Die „Vorschläge"-Sektion macht Empfehlungen basierend auf dem Inhalt der Playlist. Rechtsklick auf einen Track für weitere Optionen.',
-    q51: 'Kann ich meine Einstellungen sichern und wiederherstellen?',
-    a51: 'Ja. Einstellungen → Backup & Restore ermöglicht den Export aller Einstellungen, Serverprofile, Themes und Tastenkürzel in eine JSON-Datei. Auf einem anderen Gerät oder nach einer Neuinstallation importieren, um alles auf einmal wiederherzustellen. Passwörter sind in der Sicherung enthalten – die Datei sicher aufbewahren.',
-    q52: 'Wie ändere ich das Audioausgabegerät?',
-    a52: 'Einstellungen → Audio → Ausgabegerät. Psysonic listet alle verfügbaren Ausgaben auf. Auswahl wechselt die Wiedergabe sofort. Den Aktualisierungsbutton daneben nutzen, wenn ein Gerät nach dem App-Start angeschlossen wurde. Unter Linux werden ALSA-Gerätenamen bereinigt angezeigt.',
-    q53: 'Was ist Device Sync?',
-    a53: 'Device Sync überträgt Alben, Playlists oder ganze Künstler auf einen USB-Stick oder eine SD-Karte. Über „Device Sync" in der Seitenleiste öffnen, einen Zielordner auf dem Laufwerk wählen, Quellen in den Browser-Tabs auswählen und auf „Auf Gerät übertragen" klicken. Psysonic lädt die Tracks vom Server und legt sie in der durch die Dateinamen-Vorlage definierten Ordnerstruktur ab.',
-    q54: 'Was ist die Dateinamen-Vorlage in Device Sync?',
-    a54: 'Die Dateinamen-Vorlage steuert, wie Tracks auf dem Gerät benannt und organisiert werden. Vorgaben (Standard, Multi-Disc, Alt. Ordner) auswählen oder selbst aus den klickbaren Token-Chips zusammenbauen: {artist}, {album}, {title}, {track_number}, {disc_number}, {year} und / als Ordner-Trennzeichen. Eine Live-Vorschau zeigt, wie ein Beispiel-Track benannt würde.',
-    q55: 'Funktioniert Device Sync plattformübergreifend?',
-    a55: 'Ja. Das auf dem Gerät gespeicherte Manifest (psysonic-sync.json) enthält die beim Sync verwendete Dateinamen-Vorlage. Wird Device Sync auf einem anderen Betriebssystem mit anderer Vorlage geöffnet, erkennt Psysonic die bereits vorhandenen Dateien korrekt – Alben werden nicht fälschlich als ausstehend angezeigt.',
-    s9: 'Device Sync',
-    q56: 'Was ist Internet Radio?',
-    a56: 'Die Internetradio-Seite (Seitenleiste) ermöglicht die Wiedergabe beliebiger Livestreams direkt in Psysonic. Sender werden vom Navidrome-Server bezogen – dort über das Admin-Panel hinzufügen oder eine .pls- / .m3u-Datei importieren. Die Wiedergabe erfolgt über HTML5-Audio, nicht den Rust-Audio-Engine – einige EQ- und Replay-Gain-Einstellungen gelten daher nicht für Radio.',
-    q57: 'Welche Stream-Formate unterstützt Internet Radio?',
-    a57: 'Psysonic unterstützt alle Formate, die der Audio-Stack des Systems dekodieren kann: MP3, AAC, OGG Vorbis und die meisten HLS-Streams. Da HTML5-Audio verwendet wird, hängt die Codec-Unterstützung von der Plattform ab – MP3 und AAC funktionieren überall.',
-    s10: 'Internet Radio',
-    q58: 'Woher bezieht Psysonic Songtexte?',
-    a58: 'Psysonic unterstützt drei Lyrics-Quellen, alle konfigurierbar in Einstellungen → Lyrics: Navidrome-Server (eingebettete/OpenSubsonic-Lyrics), LRCLIB (community-gepflegte synchronisierte Texte) und NetEase Cloud Music (umfangreicher internationaler Katalog). Jede Quelle kann aktiviert/deaktiviert und per Drag & Drop priorisiert werden. Synchronisierte Lyrics scrollen automatisch und unterstützen Klick-zum-Springen.',
-    q59: 'Gibt es eine Ansicht, was andere Nutzer gerade hören?',
-    a59: 'Ja. Das Broadcast-Symbol oben rechts im Header öffnet das „Now Playing"-Dropdown. Es zeigt, was andere Nutzer auf dem Navidrome-Server gerade hören – aktualisiert alle 10 Sekunden. Der eigene Eintrag verschwindet beim Pausieren.',
+
   },
+
   queue: {
+
     title: 'Warteschlange',
+
     savePlaylist: 'Playlist speichern',
+
     updatePlaylist: 'Playlist aktualisieren',
+
     filterPlaylists: 'Playlists filtern…',
+
     playlistName: 'Name der Playlist',
+
     cancel: 'Abbrechen',
+
     save: 'Speichern',
+
     loadPlaylist: 'Playlist laden',
+
     loading: 'Lade…',
+
     noPlaylists: 'Keine Playlists gefunden.',
+
     load: 'Warteschlange ersetzen & abspielen',
+
     appendToQueue: 'An Warteschlange anhängen',
+
     delete: 'Löschen',
+
     deleteConfirm: 'Playlist "{{name}}" löschen?',
+
     clear: 'Leeren',
+
     shuffle: 'Warteschlange mischen',
+
     gapless: 'Nahtlos',
+
     crossfade: 'Crossfade',
+
     infiniteQueue: 'Endlose Warteschlange',
+
     autoAdded: '— Automatisch hinzugefügt —',
+
     radioAdded: '— Radio —',
+
     hide: 'Verbergen',
+
     close: 'Schließen',
+
     nextTracks: 'Nächste Titel',
+
     emptyQueue: 'Die Warteschlange ist leer.',
+
     trackSingular: 'Titel',
+
     trackPlural: 'Titel',
+
     showRemaining: 'Restzeit anzeigen',
+
     showTotal: 'Gesamtzeit anzeigen',
+
   },
+
   statistics: {
+
     title: 'Statistiken',
+
     recentlyPlayed: 'Zuletzt gehört',
+
     mostPlayed: 'Meistgespielte Alben',
+
     highestRated: 'Höchstbewertete Alben',
+
     genreDistribution: 'Genre-Verteilung (Top 20)',
+
     loadMore: 'Mehr laden',
+
     statArtists: 'Künstler',
+
     statArtistsTooltip: 'Nur Album-Künstler — Künstler, die ausschließlich als Track-Künstler vorkommen (Featured, Gast usw.) und kein eigenes Album haben, werden nicht gezählt.',
+
     statAlbums: 'Alben',
+
     statSongs: 'Songs',
+
     statGenres: 'Genres',
+
     statPlaytime: 'Gesamtspielzeit',
+
     genreInsights: 'Genre-Einblicke',
+
     formatDistribution: 'Format-Verteilung',
+
     formatSample: 'Stichprobe von {{n}} Titeln',
+
     computing: 'Wird berechnet…',
+
     genreSongs: '{{count}} Songs',
+
     genreAlbums: '{{count}} Alben',
+
     recentlyAdded: 'Neu hinzugefügt',
+
     decadeDistribution: 'Alben nach Jahrzehnt',
+
     decadeAlbums_one: '{{count}} Album',
+
     decadeAlbums_other: '{{count}} Alben',
+
     decadeUnknown: 'Unbekannt',
+
     lfmTitle: 'Last.fm Statistiken',
+
     lfmTopArtists: 'Top-Künstler',
+
     lfmTopAlbums: 'Top-Alben',
+
     lfmTopTracks: 'Top-Titel',
+
     lfmPlays: '{{count}} Plays',
+
     lfmPeriodOverall: 'Gesamt',
+
     lfmPeriod7day: '7 Tage',
+
     lfmPeriod1month: '1 Monat',
+
     lfmPeriod3month: '3 Monate',
+
     lfmPeriod6month: '6 Monate',
+
     lfmPeriod12month: '12 Monate',
+
     lfmNotConnected: 'Verbinde Last.fm in den Einstellungen, um deine Statistiken zu sehen.',
+
     lfmRecentTracks: 'Zuletzt gescrobbelt',
+
     lfmNowPlaying: 'Läuft gerade',
+
     lfmJustNow: 'gerade eben',
+
     lfmMinutesAgo: 'vor {{n}} Min.',
+
     lfmHoursAgo: 'vor {{n}} Std.',
+
     lfmDaysAgo: 'vor {{n}} Tagen',
+
     topRatedSongs: 'Bestbewertete Songs',
+
     topRatedArtists: 'Bestbewertete Künstler',
+
     noRatedSongs: 'Noch keine bewerteten Songs. Songs in Album- oder Playlist-Ansicht bewerten.',
+
     noRatedArtists: 'Noch keine bewerteten Künstler.',
+
   },
+
   player: {
+
     regionLabel: 'Musikplayer',
+
     openFullscreen: 'Vollbild-Player öffnen',
+
     fullscreen: 'Vollbild-Player',
+
     closeFullscreen: 'Vollbild schließen',
+
     closeTooltip: 'Schließen (Esc)',
+
     noTitle: 'Kein Titel',
+
     stop: 'Stop',
+
     prev: 'Vorheriger Titel',
+
     play: 'Play',
+
     pause: 'Pause',
+
     next: 'Nächster Titel',
+
     repeat: 'Wiederholen',
+
     repeatOff: 'Aus',
+
     repeatAll: 'Alle',
+
     repeatOne: 'Einen',
+
     progress: 'Songfortschritt',
+
     volume: 'Lautstärke',
+
     toggleQueue: 'Warteschlange umschalten',
+
     lyrics: 'Lyrics',
+
     fsLyricsToggle: 'Lyrics im Vollbild',
+
     lyricsLoading: 'Lyrics werden geladen…',
+
     lyricsNotFound: 'Keine Lyrics für diesen Titel gefunden',
+
     lyricsSourceServer: 'Quelle: Server',
+
     lyricsSourceLrclib: 'Quelle: LRCLIB',
+
     lyricsSourceNetease: 'Quelle: Netease',
+
   },
+
   songInfo: {
+
     title: 'Song-Infos',
+
     songTitle: 'Titel',
+
     artist: 'Künstler',
+
     album: 'Album',
+
     albumArtist: 'Album-Künstler',
+
     year: 'Jahr',
+
     genre: 'Genre',
+
     duration: 'Länge',
+
     track: 'Track',
+
     format: 'Format',
+
     bitrate: 'Bitrate',
+
     sampleRate: 'Abtastrate',
+
     bitDepth: 'Bittiefe',
+
     channels: 'Kanäle',
+
     fileSize: 'Dateigröße',
+
     path: 'Speicherort',
+
     replayGainTrack: 'RG Track Gain',
+
     replayGainAlbum: 'RG Album Gain',
+
     replayGainPeak: 'RG Track Peak',
+
     mono: 'Mono',
+
     stereo: 'Stereo',
+
   },
+
   playlists: {
+
     title: 'Playlists',
+
     newPlaylist: 'Neue Playlist',
+
     unnamed: 'Unbenannte Playlist',
+
     createName: 'Playlist-Name…',
+
     create: 'Erstellen',
+
     cancel: 'Abbrechen',
+
     empty: 'Noch keine Playlists.',
+
     emptyPlaylist: 'Diese Playlist ist leer.',
+
     addFirstSong: 'Ersten Song hinzufügen',
+
     notFound: 'Playlist nicht gefunden.',
+
     songs: '{{n}} Songs',
+
     playAll: 'Alle abspielen',
+
     shuffle: 'Zufallswiedergabe',
+
     addToQueue: 'Zur Warteschlange',
+
     back: 'Zurück zu Playlists',
+
     deletePlaylist: 'Löschen',
+
     confirmDelete: 'Nochmals klicken zum Bestätigen',
+
     removeSong: 'Aus Playlist entfernen',
+
     addSongs: 'Songs hinzufügen',
+
     searchPlaceholder: 'Bibliothek durchsuchen…',
+
     noResults: 'Keine Ergebnisse.',
+
     suggestions: 'Vorgeschlagene Songs',
+
     noSuggestions: 'Keine Vorschläge verfügbar.',
+
     titleBadge: 'Playlist',
+
     refreshSuggestions: 'Neue Vorschläge',
+
     addSong: 'Zur Playlist hinzufügen',
+
     addSelected: 'Ausgewählte hinzufügen',
+
     cacheOffline: 'Playlist offline speichern',
+
     offlineCached: 'Playlist gecacht',
+
     removeOffline: 'Aus Offline-Cache entfernen',
+
     offlineDownloading: 'Wird gecacht… ({{done}}/{{total}} Alben)',
+
     publicLabel: 'Öffentlich',
+
     privateLabel: 'Privat',
+
     editMeta: 'Playlist bearbeiten',
+
     editNamePlaceholder: 'Playlist-Name…',
+
     editCommentPlaceholder: 'Beschreibung hinzufügen…',
+
     editPublic: 'Öffentliche Playlist',
+
     editSave: 'Speichern',
+
     editCancel: 'Abbrechen',
+
     changeCover: 'Coverbild ändern',
+
     changeCoverLabel: 'Foto ändern',
+
     removeCover: 'Foto entfernen',
+
     coverUpdated: 'Cover aktualisiert',
+
     metaSaved: 'Playlist aktualisiert',
+
     downloadZip: 'Herunterladen (ZIP)',
+
     // Toast notifications for multi-select
+
     addSuccess: '{{count}} Songs zu {{playlist}} hinzugefügt',
+
     addPartial: '{{added}} hinzugefügt, {{skipped}} übersprungen (Duplikate)',
+
     addAllSkipped: 'Alle übersprungen ({{count}} Duplikate)',
+
     addError: 'Fehler beim Hinzufügen von Songs',
+
     createAndAddSuccess: 'Playlist "{{playlist}}" mit {{count}} Songs erstellt',
+
     createError: 'Fehler beim Erstellen der Playlist',
+
     deleteSuccess: '{{count}} Playlists gelöscht',
+
     deleteFailed: 'Fehler beim Löschen von {{name}}',
+
     deleteSelected: 'Ausgewählte löschen',
+
     mergeSuccess: '{{count}} Songs in {{playlist}} zusammengeführt',
+
     mergeNoNewSongs: 'Keine neuen Songs zum Hinzufügen',
+
     mergeError: 'Fehler beim Zusammenführen von Playlists',
+
     mergeInto: 'Zusammenführen in',
+
     selectionCount: '{{count}} ausgewählt',
+
     select: 'Auswählen',
+
     startSelect: 'Auswahl aktivieren',
+
     cancelSelect: 'Abbrechen',
+
     loadingAlbums: '{{count}} Alben werden aufgelöst…',
+
     loadingArtists: '{{count}} Künstler werden aufgelöst…',
+
     myPlaylists: 'Meine Playlists',
+
     noOtherPlaylists: 'Keine anderen Playlists verfügbar',
+
     addToPlaylistSuccess: '{{count}} Songs zu {{playlist}} hinzugefügt',
+
     addToPlaylistNoNew: 'Keine neuen Songs für {{playlist}}',
+
     addToPlaylistError: 'Fehler beim Hinzufügen zur Playlist',
+
     removeSuccess: 'Song aus Playlist entfernt',
+
     removeError: 'Fehler beim Entfernen aus der Playlist',
+
     importCSV: 'CSV importieren',
+
     importCSVTooltip: 'Aus Spotify-CSV importieren',
+
     csvImportReport: 'CSV-Importbericht',
+
     csvImportTotal: 'Gesamt',
+
     csvImportAdded: 'Hinzugefügt',
+
     csvImportDuplicates: 'Duplikate',
+
     csvImportNotFound: 'Nicht gefunden',
+
     csvImportNetworkErrors: 'Netzwerkfehler',
+
     csvImportDuplicatesTitle: 'Doppelte Titel (bereits in Playlist):',
+
     csvImportNotFoundTitle: 'Nicht gefundene Titel:',
+
     csvImportNetworkErrorsTitle: 'Netzwerkfehler (Import kann wiederholt werden):',
+
     csvImportDownloadReport: 'Bericht herunterladen',
+
     csvImportClose: 'Schließen',
+
     csvImportNoValidTracks: 'Keine gültigen Titel in CSV-Datei gefunden',
+
     csvImportFailed: 'CSV-Import fehlgeschlagen',
+
     csvImportToast: '{{added}} hinzugefügt, {{notFound}} nicht gefunden, {{duplicates}} Duplikate',
+
   },
+
   mostPlayed: {
+
     title: 'Meistgehört',
+
     topArtists: 'Top-Künstler',
+
     topAlbums: 'Top-Alben',
+
     plays: '{{n}}× gespielt',
+
     sortMost: 'Meiste Plays zuerst',
+
     sortLeast: 'Wenigste Plays zuerst',
+
     loadMore: 'Mehr Alben laden',
+
     noData: 'Noch keine Wiedergabedaten. Fang an zu hören!',
+
     noArtists: 'Alle Künstler herausgefiltert.',
+
     filterCompilations: 'Sampler-Künstler ausblenden (Various Artists, Soundtracks usw.)',
+
     filterCompilationsShort: 'Sampler ausblenden',
+
   },
+
   radio: {
+
     title: 'Internetradio',
+
     empty: 'Keine Radiosender konfiguriert.',
+
     addStation: 'Sender hinzufügen',
+
     editStation: 'Bearbeiten',
+
     deleteStation: 'Sender löschen',
+
     confirmDelete: 'Zum Bestätigen erneut klicken',
+
     stationName: 'Sendername…',
+
     streamUrl: 'Stream-URL…',
+
     homepageUrl: 'Homepage-URL (optional)',
+
     save: 'Speichern',
+
     cancel: 'Abbrechen',
+
     live: 'LIVE',
+
     liveStream: 'Internetradio',
+
     openHomepage: 'Homepage öffnen',
+
     changeCoverLabel: 'Cover ändern',
+
     removeCover: 'Cover entfernen',
+
     browseDirectory: 'Verzeichnis durchsuchen',
+
     directoryPlaceholder: 'Sender suchen…',
+
     noResults: 'Keine Sender gefunden.',
+
     stationAdded: 'Sender hinzugefügt',
+
     filterAll: 'Alle',
+
     filterFavorites: 'Favoriten',
+
     sortManual: 'Manuell',
+
     sortAZ: 'A → Z',
+
     sortZA: 'Z → A',
+
     sortNewest: 'Neueste',
+
     favorite: 'Zu Favoriten hinzufügen',
+
     unfavorite: 'Aus Favoriten entfernen',
+
     noFavorites: 'Keine Lieblingssender.',
+
     listenerCount_one: '{{count}} Hörer',
+
     listenerCount_other: '{{count}} Hörer',
+
     recentlyPlayed: 'Zuletzt gespielt',
+
     upNext: 'Als Nächstes',
+
   },
+
   folderBrowser: {
+
     empty: 'Leerer Ordner',
+
     error: 'Laden fehlgeschlagen',
+
   },
+
   deviceSync: {
+
     title: 'Gerätesync',
+
     targetFolder: 'Zielordner',
+
     noFolderChosen: 'Kein Ordner gewählt',
+
     selectDrive: 'Laufwerk auswählen…',
+
     refreshDrives: 'Laufwerke aktualisieren',
+
     noDrivesDetected: 'Keine Wechseldatenträger erkannt',
+
     browseManual: 'Manuell durchsuchen…',
+
     free: 'frei',
+
     notMountedVolume: 'Ziel befindet sich nicht auf einem eingehängten Laufwerk. Das Gerät wurde möglicherweise getrennt.',
+
     chooseFolder: 'Auswählen…',
+
     filenameTemplate: 'Dateinamen-Vorlage',
+
     targetDevice: 'Zielgerät',
+
     templateHint: 'Variablen: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
+
     onDevice: 'Auf dem Gerät',
+
     addSources: 'Hinzufügen…',
+
     colName: 'Name',
+
     colType: 'Typ',
+
     syncResult: '{{done}} übertragen, {{skipped}} bereits aktuell ({{total}} gesamt)',
+
     deleteFromDevice: 'Vom Gerät löschen ({{count}})',
+
     confirmDelete: '{{count}} Eintrag/Einträge vom Gerät löschen: {{names}}?',
+
     deleteComplete: '{{count}} Eintrag/Einträge vom Gerät entfernt.',
-    manifestImported: '{{count}} Quelle(n) aus Geräte-Manifest importiert.',
+
     selectedSources: 'Ausgewählte Quellen',
+
     noSourcesSelected: 'Keine Quellen ausgewählt. Klicke auf Einträge im Browser um sie hinzuzufügen.',
+
     clearAll: 'Alle entfernen',
+
     tabPlaylists: 'Wiedergabelisten',
+
     tabAlbums: 'Alben',
+
     tabArtists: 'Künstler',
+
     searchPlaceholder: 'Suche…',
+
     syncButton: 'Auf Gerät übertragen',
+
     actionTransfer: 'Auf Gerät übertragen',
+
     actionDelete: 'Vom Gerät löschen',
+
     actionApplyAll: 'Änderungen synchronisieren',
+
     templatePreview: 'Vorschau',
-    templatePresetStandard: 'Standard',
-    templatePresetMultiDisc: 'Multi-Disc',
-    templatePresetAltFolder: 'Alt. Ordner',
-    tokenSlashHint: '/ = Ordner-Trennzeichen',
+
     cancel: 'Abbrechen',
+
     noTargetDir: 'Bitte zuerst einen Zielordner auswählen.',
+
     noSources: 'Bitte mindestens eine Quelle auswählen.',
+
     noTracks: 'Keine Tracks in den ausgewählten Quellen gefunden.',
+
     fetchError: 'Fehler beim Laden der Tracks vom Server.',
+
     syncComplete: 'Übertragung abgeschlossen.',
+
     dismiss: 'Schließen',
-    cancelSync: 'Abbrechen',
-    syncCancelled: 'Sync abgebrochen ({{done}} / {{total}} übertragen).',
+
     colStatus: 'Status',
+
     statusSynced: 'Synchronisiert',
+
     statusPending: 'Ausstehend',
+
     statusDeletion: 'Löschung',
+
     markForDeletion: 'Zur Löschung markieren',
+
     removeSource: 'Entfernen',
+
     undoDeletion: 'Löschung rückgängig',
+
     syncInBackground: 'Sync gestartet — du kannst die Seite verlassen.',
+
     syncInProgress: '{{done}} / {{total}} Tracks…',
+
     syncSummary: 'Sync-Zusammenfassung',
+
     calculating: 'Payload wird berechnet…',
+
     filesToAdd: 'Hinzuzufügende Dateien:',
+
     filesToDelete: 'Zu löschende Dateien:',
+
     netChange: 'Nettoänderung:',
+
     availableSpace: 'Verfügbarer Speicher:',
+
     spaceWarning: 'Warnung: Das Zielgerät hat nicht genug gemeldeten Speicherplatz.',
+
     proceed: 'Sync durchführen',
+
     notEnoughSpace: 'Nicht genug physischer Speicherplatz erkannt!',
+
     liveSearch: 'Live',
+
     randomAlbumsLabel: 'Zufallsalben',
+
   },
+
 };
+

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -540,7 +540,7 @@ export const deTranslation = {
     discordAppleCovers: 'Cover über Apple Music für Discord laden',
     discordAppleCoversDesc: 'Sendet Künstler- und Albumname an die Apple-Such-API, um Cover für dein Discord-Profil zu finden. Standardmäßig aus Datenschutzgründen deaktiviert.',
     discordTemplates: 'Benutzerdefinierte Textvorlagen',
-    discordTemplatesDesc: 'Passen Sie an, welche Informationen in Ihrem Discord-Profil angezeigt werden. Variablen: {title}, {artist}, {album}, {paused}',
+    discordTemplatesDesc: 'Passen Sie an, welche Informationen in Ihrem Discord-Profil angezeigt werden. Variablen: {title}, {artist}, {album}',
     discordTemplateDetails: 'Primäre Zeile (details)',
     discordTemplateState: 'Sekundäre Zeile (state)',
     discordTemplateLargeText: 'Album-Tooltip (largeText)',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1,2262 +1,1167 @@
 export const deTranslation = {
-
   sidebar: {
-
     library: 'Bibliothek',
-
     mainstage: 'Mainstage',
-
     newReleases: 'Neueste',
-
     allAlbums: 'Alle Alben',
-
     randomAlbums: 'Zufallsalben',
-
     randomPicker: 'Mix erstellen',
-
     artists: 'Künstler',
-
     randomMix: 'Zufallsmix',
-
     favorites: 'Favoriten',
-
     nowPlaying: 'Now Playing',
-
     system: 'System',
-
     statistics: 'Statistiken',
-
     settings: 'Einstellungen',
-
     help: 'Hilfe',
-
     expand: 'Sidebar einblenden',
-
     collapse: 'Sidebar ausblenden',
-
     downloadingTracks: '{{n}} Tracks werden gecacht…',
-
     syncingTracks: 'Synchronisiere {{done}}/{{total}}…',
-
     cancelDownload: 'Download abbrechen',
-
     offlineLibrary: 'Offline-Bibliothek',
-
     genres: 'Genres',
-
     playlists: 'Playlists',
-
     mostPlayed: 'Meistgehört',
-
     radio: 'Internetradio',
-
     folderBrowser: 'Ordner-Browser',
-
     deviceSync: 'Gerätesync',
-
     libraryScope: 'Bibliotheksumfang',
-
     allLibraries: 'Alle Bibliotheken',
-
     expandPlaylists: 'Playlists ausklappen',
-
     collapsePlaylists: 'Playlists einklappen',
-
   },
-
   home: {
-
     hero: 'Featured',
-
     starred: 'Persönliche Favoriten',
-
     recent: 'Zuletzt hinzugefügt',
-
     mostPlayed: 'Meistgehört',
-
     recentlyPlayed: 'Kürzlich gespielt',
-
     discover: 'Entdecken',
-
     loadMore: 'Mehr laden',
-
     discoverMore: 'Mehr entdecken',
-
     discoverArtists: 'Künstler entdecken',
-
     discoverArtistsMore: 'Alle Künstler'
-
   },
-
   hero: {
-
     eyebrow: 'Album des Augenblicks',
-
     playAlbum: 'Album abspielen',
-
     enqueue: 'Einreihen',
-
     enqueueTooltip: 'Ganzes Album zur Warteschlange hinzufügen',
-
   },
-
   search: {
-
     placeholder: 'Suchen nach Künstler, Album oder Song…',
-
     noResults: 'Keine Ergebnisse für „{{query}}"',
-
     artists: 'Künstler',
-
     albums: 'Alben',
-
     songs: 'Songs',
-
     clearLabel: 'Suche leeren',
-
     title: 'Suche',
-
     resultsFor: 'Ergebnisse für „{{query}}"',
-
     album: 'Album',
-
     advanced: 'Erweiterte Suche',
-
     advancedSearchTerm: 'Suchbegriff',
-
     advancedSearchPlaceholder: 'Titel, Album, Künstler…',
-
     advancedGenre: 'Genre',
-
     advancedAllGenres: 'Alle Genres',
-
     advancedYear: 'Jahr',
-
     advancedYearFrom: 'von',
-
     advancedYearTo: 'bis',
-
     advancedAll: 'Alle',
-
     advancedSearch: 'Suchen',
-
     advancedEmpty: 'Suchbegriff eingeben oder Filter wählen, um zu beginnen.',
-
     advancedNoResults: 'Keine Ergebnisse gefunden.',
-
     advancedGenreNote: 'Songs werden zufällig aus dem Genre gewählt.',
-
     recentSearches: 'Zuletzt gesucht',
-
     browse: 'Stöbern',
-
     emptyHint: 'Was möchtest du hören?',
-
     genres: 'Genres',
-
   },
-
   nowPlaying: {
-
     tooltip: 'Wer hört was?',
-
     title: 'Wer hört was?',
-
     loading: 'Lädt…',
-
     nobody: 'Gerade hört niemand Musik.',
-
     minutesAgo: 'vor {{n}}m',
-
     nothingPlaying: 'Noch nichts am Laufen. Leg einen Track auf!',
-
     aboutArtist: 'Über den Künstler',
-
     fromAlbum: 'Aus diesem Album',
-
     viewAlbum: 'Album öffnen',
-
     goToArtist: 'Zum Künstler',
-
     readMore: 'Mehr lesen',
-
     showLess: 'Weniger anzeigen',
-
     genreInfo: 'Genre',
-
     trackInfo: 'Track-Info',
-
   },
-
   contextMenu: {
-
     playNow: 'Direkt abspielen',
-
     playNext: 'Als Nächstes abspielen',
-
     addToQueue: 'Zur Warteschlange hinzufügen',
-
     enqueueAlbum: 'Ganzes Album einreihen',
-
     startRadio: 'Radio starten',
-
     instantMix: 'Instant Mix',
-
     instantMixFailed: 'Instant Mix konnte nicht erstellt werden — Server- oder Pluginfehler.',
-
     cliMixNeedsTrack: 'Es läuft nichts — starte zuerst die Wiedergabe und führe den Mix-Befehl erneut aus.',
-
     lfmLove: 'Auf Last.fm liken',
-
     lfmUnlove: 'Last.fm-Like entfernen',
-
     favorite: 'Favorisieren',
-
     favoriteArtist: 'Künstler favorisieren',
-
     favoriteAlbum: 'Album favorisieren',
-
     unfavorite: 'Aus Favoriten entfernen',
-
     unfavoriteArtist: 'Künstler aus Favoriten entfernen',
-
     unfavoriteAlbum: 'Album aus Favoriten entfernen',
-
     removeFromQueue: 'Diesen Song entfernen',
-
     removeFromPlaylist: 'Aus Playlist entfernen',
-
     openAlbum: 'Album öffnen',
-
     goToArtist: 'Zum Künstler',
-
     download: 'Herunterladen (ZIP)',
-
     addToPlaylist: 'Zur Playlist hinzufügen',
-
     selectedPlaylists: '{{count}} Playlists ausgewählt',
-
     selectedAlbums: '{{count}} Alben ausgewählt',
-
     selectedArtists: '{{count}} Künstler ausgewählt',
-
     songInfo: 'Song-Infos',
-
   },
-
   albumDetail: {
-
     back: 'Zurück',
-
     playAll: 'Alle abspielen',
-
     enqueue: 'Einreihen',
-
     enqueueTooltip: 'Ganzes Album zur Warteschlange hinzufügen',
-
     artistBio: 'Künstler-Bio',
-
     download: 'Download (ZIP)',
-
     downloading: 'Lade…',
-
     cacheOffline: 'Offline verfügbar machen',
-
     offlineCached: 'Offline verfügbar',
-
     offlineDownloading: 'Wird gecacht… ({{n}}/{{total}})',
-
     removeOffline: 'Offline-Cache löschen',
-
     offlineStorageFull: 'Offline-Speicher voll (Limit: {{mb}} MB). Lösche ein Album aus der Offline-Bibliothek oder erhöhe das Limit in den Einstellungen.',
-
     offlineStorageGoToSettings: 'Einstellungen',
-
     offlineStorageGoToLibrary: 'Offline-Bibliothek',
-
     favoriteAdd: 'Zu Favoriten hinzufügen',
-
     favoriteRemove: 'Aus Favoriten entfernen',
-
     favorite: 'Als Favorit',
-
     noBio: 'Keine Biografie verfügbar.',
-
     moreByArtist: 'Mehr von {{artist}}',
-
     tracksCount: '{{n}} Tracks',
-
     goToArtist: 'Zu {{artist}} wechseln',
-
     moreLabelAlbums: 'Weitere Alben von {{label}} anzeigen',
-
     trackTitle: 'Titel',
-
     trackAlbum: 'Album',
-
     trackArtist: 'Interpret',
-
     trackGenre: 'Genre',
-
     trackFormat: 'Format',
-
     trackFavorite: 'Favorit',
-
     trackRating: 'Bewertung',
-
     trackDuration: 'Dauer',
-
     trackTotal: 'Gesamt',
-
     columns: 'Spalten',
-
+    resetColumns: 'Zurücksetzen',
     notFound: 'Album nicht gefunden.',
-
     bioModal: 'Künstler-Biografie',
-
     bioClose: 'Schließen',
-
     ratingLabel: 'Bewertung',
-
     enlargeCover: 'Vergrößern',
-
     filterSongs: 'Titel filtern…',
-
     sortNatural: 'Reihenfolge',
-
     sortByTitle: 'A–Z (Titel)',
-
     sortByArtist: 'A–Z (Künstler)',
-
     sortByAlbum: 'A–Z (Album)',
-
   },
-
   entityRating: {
-
     albumShort: 'Albumbewertung',
-
     artistShort: 'Künstlerbewertung',
-
     albumAriaLabel: 'Albumbewertung',
-
     artistAriaLabel: 'Künstlerbewertung',
-
     saveFailed: 'Bewertung konnte nicht gespeichert werden.',
-
   },
-
   artistDetail: {
-
     back: 'Zurück',
-
     albums: 'Alben',
-
     album: 'Album',
-
     playAll: 'Alle abspielen',
-
     shuffle: 'Zufallswiedergabe',
-
     radio: 'Radio',
-
     loading: 'Lädt…',
-
     noRadio: 'Keine ähnlichen Titel für diesen Künstler gefunden.',
-
     notFound: 'Künstler nicht gefunden.',
-
     albumsBy: 'Alben von {{name}}',
-
     topTracks: 'Beliebteste Titel',
-
     noAlbums: 'Keine Alben gefunden.',
-
     trackTitle: 'Titel',
-
     trackAlbum: 'Album',
-
     trackDuration: 'Dauer',
-
     favoriteAdd: 'Zu Favoriten hinzufügen',
-
     favoriteRemove: 'Aus Favoriten entfernen',
-
     favorite: 'Als Favorit',
-
     albumCount_one: '{{count}} Album',
-
     albumCount_other: '{{count}} Alben',
-
     openedInBrowser: 'Im Browser geöffnet',
-
     featuredOn: 'Auch enthalten auf',
-
     similarArtists: 'Ähnliche Künstler',
-
     cacheOffline: 'Diskografie offline speichern',
-
     offlineCached: 'Diskografie gecacht',
-
     offlineDownloading: 'Wird gecacht… ({{done}}/{{total}} Alben)',
-
     uploadImage: 'Künstlerbild hochladen',
-
     uploadImageError: 'Bild konnte nicht hochgeladen werden',
-
   },
-
   favorites: {
-
     title: 'Favoriten',
-
     empty: 'Du hast noch keine Favoriten gespeichert.',
-
     artists: 'Künstler',
-
     albums: 'Alben',
-
     songs: 'Songs',
-
     enqueueAll: 'Alle in die Warteschlange',
-
     playAll: 'Alle abspielen',
-
     removeSong: 'Aus Favoriten entfernen',
-
     stations: 'Radiosender',
-
     showingFiltered: 'Zeige {{filtered}} von {{total}} ({{artist}})',
-
     showingCount: 'Zeige {{filtered}} von {{total}}',
-
     clearArtistFilter: 'Künstlerfilter zurücksetzen',
-
     noFilterResults: 'Keine Ergebnisse mit den ausgewählten Filtern.',
-
     allArtists: 'Alle Künstler',
-
   },
-
   randomLanding: {
-
     title: 'Mix erstellen',
-
     mixByTracks: 'Mix nach Titeln',
-
     mixByTracksDesc: 'Zufällige Auswahl aus deiner gesamten Mediathek',
-
     mixByAlbums: 'Mix nach Alben',
-
     mixByAlbumsDesc: 'Zufällige Alben für neue Entdeckungen',
-
   },
-
   randomAlbums: {
-
     title: 'Zufallsalben',
-
     refresh: 'Neu laden',
-
   },
-
   genres: {
-
     title: 'Genres',
-
     genreCount: 'Genres',
-
     albumCount_one: '{{count}} Album',
-
     albumCount_other: '{{count}} Alben',
-
     loading: 'Genres werden geladen…',
-
     empty: 'Keine Genres gefunden.',
-
     albumsLoading: 'Alben werden geladen…',
-
     albumsEmpty: 'Keine Alben in diesem Genre gefunden.',
-
     loadMore: 'Mehr laden',
-
     back: 'Zurück',
-
   },
-
   randomMix: {
-
     title: 'Zufallsmix',
-
     remix: 'Neu mixen',
-
     remixTooltip: 'Neue Songs laden',
-
     remixGenre: '{{genre}} neu mixen',
-
     remixTooltipGenre: 'Neue {{genre}}-Songs laden',
-
     playAll: 'Alle abspielen',
-
     trackTitle: 'Titel',
-
     trackArtist: 'Künstler',
-
     trackAlbum: 'Album',
-
     trackFavorite: 'Favorit',
-
     trackDuration: 'Dauer',
-
     favoriteAdd: 'Zu Favoriten hinzufügen',
-
     favoriteRemove: 'Aus Favoriten entfernen',
-
     play: 'Abspielen',
-
     trackGenre: 'Genre',
-
     excludeAudiobooks: 'Hörbücher & Hörspiele ausschließen',
-
     excludeAudiobooksDesc: 'Prüft Keywords gegen Genre, Titel, Album und Künstler — z. B. Hörbuch, Audiobook, Spoken Word, …',
-
     genreBlocked: 'Keyword gesperrt',
-
     genreAddedToBlacklist: 'Zur Filterliste hinzugefügt',
-
     genreAlreadyBlocked: 'Bereits gesperrt',
-
     artistBlocked: 'Künstler gesperrt',
-
     artistAddedToBlacklist: 'Künstler zur Filterliste hinzugefügt',
-
     artistClickHint: 'Klicken um diesen Künstler zu sperren',
-
     blacklistToggle: 'Keyword-Filter',
-
     genreMixTitle: 'Genre-Mix',
-
     genreMixDesc: 'Top 20 Genres nach Songanzahl — klicken für einen Zufallsmix',
-
     genreMixAll: 'Alle Songs',
-
     genreMixLoadMore: '10 weitere laden',
-
     genreMixNoGenres: 'Keine Genres auf dem Server gefunden.',
-
     shuffleGenres: 'Andere Genres anzeigen',
-
     filterPanelTitle: 'Filter',
-
     filterPanelDesc: 'Genre-Tag oder Künstlername in der Liste anklicken, um ihn aus zukünftigen Mixes auszuschließen.',
-
     genreClickHint: 'Genre-Tag anklicken,\num es als Filter-Keyword hinzuzufügen.\nPrüft Genre, Titel, Album & Künstler.',
-
   },
-
   albums: {
-
     title: 'Alle Alben',
-
     sortByName: 'A–Z (Album)',
-
     sortByArtist: 'A–Z (Künstler)',
-
     sortNewest: 'Neueste zuerst',
-
     sortRandom: 'Zufällig',
-
     yearFrom: 'Von',
-
     yearTo: 'Bis',
-
     yearFilterClear: 'Jahresfilter zurücksetzen',
-
     yearFilterLabel: 'Jahr',
-
     select: 'Mehrfachauswahl',
-
     startSelect: 'Mehrfachauswahl aktivieren',
-
     cancelSelect: 'Abbrechen',
-
     selectionCount: '{{count}} ausgewählt',
-
     downloadZips: 'ZIPs herunterladen',
-
     addOffline: 'Offline hinzufügen',
-
     downloadingZip: 'Lade {{current}}/{{total}} herunter: {{name}}',
-
     downloadZipDone: '{{count}} ZIP(s) heruntergeladen',
-
     downloadZipFailed: 'Download fehlgeschlagen: {{name}}',
-
     offlineQueuing: '{{count}} Album(s) für Offline einreihen…',
-
     offlineFailed: '{{name}} konnte nicht offline hinzugefügt werden',
-
   },
-
   artists: {
-
     title: 'Künstler',
-
     search: 'Suchen…',
-
     all: 'Alle',
-
     gridView: 'Gitteransicht',
-
     listView: 'Listenansicht',
-
     imagesOn: 'Künstlerbilder aktiv — kann Netzwerk- und Systemlast erhöhen',
-
     imagesOff: 'Künstlerbilder deaktiviert — zeigt nur Initialen',
-
     loadMore: 'Mehr laden',
-
     notFound: 'Keine Künstler gefunden.',
-
     albumCount_one: '{{count}} Album',
-
     albumCount_other: '{{count}} Alben',
-
     selectionCount: '{{count}} ausgewählt',
-
     select: 'Mehrfachauswahl',
-
     startSelect: 'Mehrfachauswahl aktivieren',
-
     cancelSelect: 'Abbrechen',
-
     addToPlaylist: 'Zur Playlist hinzufügen',
-
   },
-
   login: {
-
     subtitle: 'Dein Navidrome Desktop Player',
-
     serverName: 'Server-Name (optional)',
-
     serverNamePlaceholder: 'Mein Navidrome',
-
     serverUrl: 'Server-URL',
-
     serverUrlPlaceholder: '192.168.1.100:4533 oder https://music.example.com',
-
     username: 'Benutzername',
-
     usernamePlaceholder: 'admin',
-
     password: 'Passwort',
-
     showPassword: 'Passwort anzeigen',
-
     hidePassword: 'Passwort verstecken',
-
     connect: 'Verbinden',
-
     connecting: 'Verbinde…',
-
     connected: 'Verbunden!',
-
     error: 'Verbindung fehlgeschlagen – bitte Daten prüfen.',
-
     urlRequired: 'Bitte Server-URL eingeben.',
-
     savedServers: 'Gespeicherte Server',
-
     addNew: 'Oder neuen Server hinzufügen',
-
   },
-
   connection: {
-
     connected: 'Verbunden',
-
     connectedTo: 'Verbunden mit {{server}}',
-
     disconnected: 'Getrennt',
-
     disconnectedFrom: '{{server}} nicht erreichbar — klicken für Einstellungen',
-
     checking: 'Verbinde…',
-
     extern: 'Extern',
-
     offlineTitle: 'Keine Serververbindung',
-
     offlineSubtitle: '{{server}} ist nicht erreichbar. Prüfe Netzwerk oder Server.',
-
     offlineModeBanner: 'Offline-Modus — Wiedergabe aus lokalem Cache',
-
     offlineNoCacheBanner: 'Keine Serververbindung — {{server}} nicht erreichbar',
-
     offlineLibraryTitle: 'Offline-Bibliothek',
-
     offlineLibraryEmpty: 'Noch keine Alben gecacht. Online gehen, Album öffnen und "Offline verfügbar machen" klicken.',
-
     offlineAlbumCount: '{{n}} Album',
-
     offlineAlbumCount_plural: '{{n}} Alben',
-
     offlineFilterAll: 'Alle',
-
     offlineFilterAlbums: 'Alben',
-
     offlineFilterPlaylists: 'Playlists',
-
     offlineFilterArtists: 'Diskografien',
-
     retry: 'Erneut versuchen',
-
     serverSettings: 'Server-Einstellungen',
-
     switchServerTitle: 'Server wechseln',
-
     switchServerHint: 'Klicken, um einen anderen gespeicherten Server zu wählen.',
-
     manageServers: 'Server verwalten…',
-
     switchFailed: 'Wechsel fehlgeschlagen — Server nicht erreichbar.',
-
     lastfmConnected: 'Last.fm verbunden als @{{user}}',
-
     lastfmSessionInvalid: 'Session ungültig — klicken zum Neu-Verbinden',
-
   },
-
   common: {
-
     albums: 'Alben',
-
     album: 'Album',
-
     loading: 'Lade…',
-
     loadingMore: 'Lade…',
-
     loadingPlaylists: 'Lade Playlists…',
-
     noAlbums: 'Keine Alben gefunden.',
-
     downloading: 'Lade…',
-
     downloadZip: 'Download (ZIP)',
-
     back: 'Zurück',
-
     cancel: 'Abbrechen',
-
     save: 'Speichern',
-
     delete: 'Löschen',
-
     use: 'Verwenden',
-
     add: 'Hinzufügen',
-
     active: 'Aktiv',
-
     download: 'Herunterladen',
-
     chooseDownloadFolder: 'Download-Ordner wählen',
-
     noFolderSelected: 'Kein Ordner ausgewählt',
-
     rememberDownloadFolder: 'Ordner merken',
-
     filterGenre: 'Genre-Filter',
-
     filterSearchGenres: 'Genres suchen…',
-
     filterNoGenres: 'Keine Genres gefunden',
-
     filterClear: 'Zurücksetzen',
-
     play: 'Abspielen',
-
     bulkSelected: '{{count}} ausgewählt',
-
     clearSelection: 'Auswahl aufheben',
-
     bulkAddToPlaylist: 'Zur Playlist hinzufügen',
-
     bulkRemoveFromPlaylist: 'Aus Playlist entfernen',
-
     bulkClear: 'Auswahl aufheben',
-
     updaterAvailable: 'Update verfügbar',
-
     updaterVersion: 'v{{version}} verfügbar',
-
     updaterWebsite: 'Website',
-
     updaterModalTitle: 'Neue Version verfügbar',
-
     updaterChangelog: 'Was ist neu',
-
     updaterDownloadBtn: 'Jetzt herunterladen',
-
     updaterSkipBtn: 'Version überspringen',
-
     updaterRemindBtn: 'Später erinnern',
-
     updaterDone: 'Download abgeschlossen',
-
     updaterShowFolder: 'Im Ordner anzeigen',
-
     updaterInstallHint: 'Psysonic schließen und das Installationsprogramm manuell ausführen.',
-
     updaterAurHint: 'Update über AUR installieren:',
-
     updaterErrorMsg: 'Download fehlgeschlagen',
-
     updaterRetryBtn: 'Erneut versuchen',
-
     durationHoursMinutes: '{{hours}} Std. {{minutes}} Min.',
-
     durationMinutesOnly: '{{minutes}} Min.',
-
     updaterOpenGitHub: 'Auf GitHub öffnen',
-
     filters: 'Filter',
-
     more: 'mehr',
-
     yearRange: 'Jahresbereich',
-
     clearAll: 'Alles zurücksetzen',
-
   },
-
   settings: {
-
     title: 'Einstellungen',
-
     language: 'Sprache',
-
     languageEn: 'Englisch',
-
     languageDe: 'Deutsch',
-
     languageFr: 'Französisch',
-
     languageNl: 'Niederländisch',
-
     languageZh: 'Chinesisch',
-
     languageNb: 'Norwegisch',
-
     languageRu: 'Russisch',
-
     font: 'Schriftart',
-
     theme: 'Design',
-
     appearance: 'Darstellung',
-
     servers: 'Server',
-
     serverName: 'Server-Name',
-
     serverUrl: 'Server-URL',
-
     serverUrlPlaceholder: '192.168.1.100:4533 oder https://music.example.com',
-
     serverUsername: 'Benutzername',
-
     serverPassword: 'Passwort',
-
     addServer: 'Server hinzufügen',
-
     addServerTitle: 'Neuen Server hinzufügen',
-
     useServer: 'Verwenden',
-
     deleteServer: 'Löschen',
-
     noServers: 'Keine Server gespeichert.',
-
     serverActive: 'Aktiv',
-
     confirmDeleteServer: 'Server „{{name}}" löschen?',
-
     serverConnecting: 'Verbinde…',
-
     serverConnected: 'Verbunden!',
-
     serverFailed: 'Verbindung fehlgeschlagen.',
-
     testBtn: 'Verbindung testen',
-
     testingBtn: 'Teste…',
-
     serverCompatible: 'Kompatibel mit: Navidrome · Gonic · Airsonic · Subsonic',
-
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
-
     audiomuseDesc:
-
       'Aktivieren, wenn dieser Server das <pluginLink>AudioMuse-AI-Navidrome-Plugin</pluginLink> nutzt. Schaltet Instant Mix pro Titel frei und nutzt ähnliche Künstler vom Server statt Last.fm auf Künstlerseiten.',
-
     audiomuseIssueHint:
-
       'Instant Mix ist kürzlich fehlgeschlagen — Navidrome-Plugin und AudioMuse-API prüfen. Ohne Server-Treffer werden ähnliche Künstler über Last.fm geladen.',
-
     connected: 'Verbunden',
-
     failed: 'Fehlgeschlagen',
-
     eqTitle: 'Equalizer',
-
     eqEnabled: 'Equalizer aktivieren',
-
     eqPreset: 'Preset',
-
     eqPresetCustom: 'Benutzerdefiniert',
-
     eqPresetBuiltin: 'Eingebaute Presets',
-
     eqPresetCustomGroup: 'Meine Presets',
-
     eqSavePreset: 'Als Preset speichern',
-
     eqPresetName: 'Preset-Name…',
-
     eqDeletePreset: 'Preset löschen',
-
     eqResetBands: 'Auf Flat zurücksetzen',
-
     eqPreGain: 'Vorverstärkung',
-
     eqResetPreGain: 'Vorverstärkung zurücksetzen',
-
     eqAutoEqTitle: 'AutoEQ Kopfhörer-Suche',
-
     eqAutoEqPlaceholder: 'Kopfhörer / IEM Modell suchen…',
-
     eqAutoEqSearching: 'Suche…',
-
     eqAutoEqNoResults: 'Keine Ergebnisse gefunden',
-
     eqAutoEqError: 'Suche fehlgeschlagen',
-
     eqAutoEqRateLimit: 'GitHub Rate-Limit erreicht — in einer Minute erneut versuchen',
-
     eqAutoEqFetchError: 'EQ-Profil konnte nicht geladen werden',
-
     lfmTitle: 'Last.fm',
-
     lfmConnect: 'Mit Last.fm verbinden',
-
     lfmConnecting: 'Warte auf Bestätigung…',
-
     lfmConfirm: 'Ich habe die App autorisiert',
-
     lfmConnected: 'Verbunden als',
-
     lfmDisconnect: 'Trennen',
-
     lfmConnectDesc: 'Verbinde deinen Last.fm Account, um Scrobbling und Now-Playing-Updates direkt aus Psysonic heraus zu aktivieren — keine Navidrome-Konfiguration erforderlich.',
-
     lfmOpenBrowser: 'Es öffnet sich ein Browserfenster. Autorisiere Psysonic auf Last.fm und klicke dann unten auf den Button.',
-
     lfmScrobbles: '{{n}} Scrobbles',
-
     lfmMemberSince: 'Dabei seit {{year}}',
-
     scrobbleEnabled: 'Scrobbling aktiviert',
-
     scrobbleDesc: 'Songs nach 50% Laufzeit an Last.fm senden',
-
     behavior: 'App-Verhalten',
-
     cacheTitle: 'Max. Speichergröße',
-
     cacheDesc: 'Cover und Künstlerbilder. Wenn voll, werden die ältesten Einträge automatisch entfernt. Offline-Alben werden nicht automatisch gelöscht, aber beim manuellen Cache leeren entfernt.',
-
     cacheUsedImages: 'Bilder:',
-
     cacheUsedOffline: 'Offline-Tracks:',
-
     cacheUsedHot: 'Belegter Speicher:',
-
     hotCacheTrackCount: 'Titel im Cache:',
-
     cacheMaxLabel: 'Max. Größe',
-
     cacheClearBtn: 'Cache leeren',
-
     cacheClearWarning: 'Alle Offline-Alben werden damit aus der Bibliothek entfernt.',
-
     cacheClearConfirm: 'Alles löschen',
-
     cacheClearCancel: 'Abbrechen',
-
     offlineDirTitle: 'Offline-Bibliothek (In-App)',
-
     offlineDirDesc: 'Speicherort für Titel, die du innerhalb von Psysonic offline verfügbar machst.',
-
     offlineDirDefault: 'Standard (App-Daten)',
-
     offlineDirChange: 'Verzeichnis ändern',
-
     offlineDirClear: 'Auf Standard zurücksetzen',
-
     offlineDirHint: 'Neue Downloads werden an diesem Ort gespeichert. Bestehende Downloads verbleiben am ursprünglichen Pfad.',
-
     hotCacheTitle: 'Hot-Playback-Cache',
-
     hotCacheAlphaBadge: 'Alpha',
-
     hotCacheDisclaimer: 'Lädt kommende Warteschlangen-Titel vor und behält zuletzt gespielte. Bei aktivierter Option: Speicherplatz und Netzwerk.',
-
     hotCacheDirDefault: 'Standard (App-Daten)',
-
     hotCacheDirChange: 'Ordner ändern',
-
     hotCacheDirClear: 'Auf Standard zurücksetzen',
-
     hotCacheDirHint: 'Beim Ordnerwechsel wird der App-Index zurückgesetzt; alte Dateien bleiben am alten Ort, bis Sie sie löschen.',
-
     hotCacheEnabled: 'Hot-Playback-Cache aktivieren',
-
     hotCacheMaxMb: 'Maximale Cache-Größe',
-
     hotCacheDebounce: 'Debounce bei Warteschlangen-Änderungen',
-
     hotCacheDebounceImmediate: 'Sofort',
-
     hotCacheDebounceSeconds: '{{n}} s',
-
     hotCacheClearBtn: 'Hot-Cache leeren',
-
     audioOutputDevice: 'Audio-Ausgabegerät',
-
     audioOutputDeviceDesc: 'Wähle das Audiogerät, über das Psysonic spielt. Änderungen werden sofort übernommen und starten den aktuellen Track neu.',
-
     audioOutputDeviceDefault: 'Systemstandard',
-
     audioOutputDeviceRefresh: 'Geräteliste aktualisieren',
-
     audioOutputDeviceOsDefaultNow: 'aktuelle Systemausgabe',
-
     audioOutputDeviceListError: 'Audiogeräteliste konnte nicht geladen werden.',
-
     audioOutputDeviceNotInCurrentList: 'nicht in der aktuellen Liste',
-
     hiResTitle: 'Native Hi-Res-Wiedergabe',
-
     hiResEnabled: 'Native Hi-Res-Wiedergabe aktivieren',
-
     hiResDesc: "Standardmäßig wird auf 44,1 kHz begrenzt (maximale Stabilität). Nur aktivieren, wenn Hardware und Netzwerk zuverlässig hohe Abtastraten (88,2 kHz+) unterstützen.",
-
     showArtistImages: 'Künstlerbilder anzeigen',
-
     showArtistImagesDesc: 'Lädt und zeigt Künstlerbilder in der Künstlerübersicht. Standardmäßig deaktiviert, um Server-I/O und Netzwerklast bei großen Bibliotheken zu reduzieren.',
-
     showTrayIcon: 'Tray-Icon anzeigen',
-
     showTrayIconDesc: 'Psysonic-Icon im System-Tray / in der Menüleiste anzeigen.',
-
     minimizeToTray: 'Im Tray minimieren',
-
     minimizeToTrayDesc: 'Beim Schließen des Fensters läuft Psysonic weiter im System-Tray statt zu beenden.',
-
     discordRichPresence: 'Discord Rich Presence',
-
     discordRichPresenceDesc: 'Zeigt den aktuell gespielten Titel im Discord-Profil an. Discord muss dafür geöffnet sein.',
-
     useCustomTitlebar: 'Eigene Titelleiste',
-
     useCustomTitlebarDesc: 'Ersetzt die System-Titelleiste durch eine eingebaute, die zum App-Theme passt. Deaktivieren, um die native GNOME/GTK-Titelleiste zu verwenden.',
-
     discordAppleCovers: 'Cover über Apple Music für Discord laden',
-
     discordAppleCoversDesc: 'Sendet Künstler- und Albumname an die Apple-Such-API, um Cover für dein Discord-Profil zu finden. Standardmäßig aus Datenschutzgründen deaktiviert.',
-
     discordTemplates: 'Benutzerdefinierte Textvorlagen',
-
-    discordTemplatesDesc: 'Passe an, welche Informationen in deinem Discord-Profil angezeigt werden. Variablen: {title}, {artist}, {album}, {paused}',
-
+    discordTemplatesDesc: 'Passen Sie an, welche Informationen in Ihrem Discord-Profil angezeigt werden. Variablen: {title}, {artist}, {album}, {paused}',
     discordTemplateDetails: 'Primäre Zeile (details)',
-
     discordTemplateState: 'Sekundäre Zeile (state)',
-
     discordTemplateLargeText: 'Album-Tooltip (largeText)',
-
     nowPlayingEnabled: 'Im Livefenster anzeigen',
-
     nowPlayingEnabledDesc: 'Überträgt den aktuell gespielten Titel an die Livehörer-Ansicht des Servers. Deaktivieren, um keine Wiedergabedaten zu senden.',
-
     lyricsServerFirst: 'Server-Lyrics bevorzugen',
-
     lyricsServerFirstDesc: 'Server-seitige Lyrics (eingebettete Tags, Sidecar-Dateien) vor LRCLIB abfragen. Deaktivieren, um LRCLIB zuerst zu verwenden.',
-
     enableNeteaselyrics: 'Netease Cloud Music Lyrics',
-
     enableNeteaselyricsDesc: 'Netease Cloud Music als letzte Lyrics-Quelle verwenden, wenn Server und LRCLIB nichts liefern. Besonders gut für asiatische und internationale Musik.',
-
     lyricsSourcesTitle: 'Lyrics-Quellen',
-
     lyricsSourcesDesc: 'Wähle, welche Quellen für Lyrics abgefragt werden und in welcher Reihenfolge. Ziehen zum Sortieren. Deaktivierte Quellen werden übersprungen.',
-
     lyricsSourceServer: 'Server',
-
     lyricsSourceLrclib: 'LRCLIB',
-
     lyricsSourceNetease: 'Netease Cloud Music',
-
     downloadsTitle: 'ZIP-Export & Archivierung',
-
     downloadsFolderDesc: 'Zielverzeichnis für Alben, die du als ZIP-Datei auf deinen Computer herunterlädst.',
-
     downloadsDefault: 'Standard-Downloads-Ordner',
-
     pickFolder: 'Auswählen',
-
     pickFolderTitle: 'Download-Ordner auswählen',
-
     clearFolder: 'Download-Ordner löschen',
-
     logout: 'Abmelden',
-
     aboutTitle: 'Über Psysonic',
-
     aboutDesc: 'Ein moderner Desktop-Musikplayer für Subsonic-kompatible Server (Navidrome, Gonic u. a.). Basiert auf Tauri v2 mit einer nativen Rust-Audio-Engine — schlank und schnell, aber vollgepackt mit Features: Wellenform-Seekbar, synchronisierte Lyrics, Last.fm-Integration, 10-Band-EQ, Crossfade, nahtlose Wiedergabe, Replay Gain, Genre-Browser und eine große Theme-Bibliothek.',
-
     aboutLicense: 'Lizenz',
-
     aboutLicenseText: 'GNU GPL v3 — kostenlos nutzbar, veränderbar und unter gleicher Lizenz weiterzugeben.',
-
     aboutRepo: 'Quellcode auf GitHub',
-
     aboutVersion: 'Version',
-
     aboutBuiltWith: 'Gebaut mit Tauri · React · TypeScript · Rust/rodio',
-
     aboutAiCredit: 'Mit freundlicher Unterstützung von Claude Code by Anthropic',
-
     aboutContributorsLabel: 'Mitwirkende',
-
     aboutSpecialThanksLabel: 'Besonderer Dank',
-
     changelog: 'Changelog',
-
     showChangelogOnUpdate: "'Was ist neu' bei Update anzeigen",
-
     showChangelogOnUpdateDesc: 'Zeigt automatisch die Neuerungen an, wenn eine neue Version zum ersten Mal gestartet wird.',
-
     randomMixTitle: 'Zufallsmix',
-
     randomMixBlacklistTitle: 'Eigene Filter-Keywords',
-
     randomMixBlacklistDesc: 'Songs werden ausgeschlossen, wenn ein Keyword auf Genre, Titel, Album oder Künstler zutrifft (aktiv wenn die Checkbox oben an ist).',
-
     randomMixBlacklistPlaceholder: 'Keyword hinzufügen…',
-
     randomMixBlacklistAdd: 'Hinzufügen',
-
     randomMixBlacklistEmpty: 'Noch keine eigenen Keywords hinzugefügt.',
-
     randomMixHardcodedTitle: 'Eingebaute Keywords (aktiv wenn Checkbox an)',
-
     tabAudio: 'Audio',
-
     tabStorage: 'Speicher & Downloads',
-
     tabAppearance: 'Darstellung',
-
     homeCustomizerTitle: 'Startseite',
-
     sidebarTitle: 'Seitenleiste',
-
     sidebarReset: 'Zurücksetzen',
-
     sidebarDrag: 'Ziehen zum Umsortieren',
-
     sidebarFixed: 'Immer sichtbar',
-
+    randomNavSplitTitle: 'Mix-Navigation aufteilen',
+    randomNavSplitDesc: '"Zufallsmix" und "Zufallsalben" als separate Sidebar-Einträge statt als "Mix erstellen"-Hub anzeigen.',
     tabInput: 'Eingabe',
-
     tabServer: 'Server',
-
     shortcutsReset: 'Auf Standard zurücksetzen',
-
     shortcutListening: 'Taste drücken…',
-
     shortcutUnbound: '—',
-
     shortcutClear: 'Löschen',
-
     globalShortcutsTitle: 'Globale Shortcuts',
-
     globalShortcutsNote: 'Funktionieren systemweit, auch wenn Psysonic im Hintergrund läuft. Mindestens Ctrl, Alt oder Super als Modifier erforderlich.',
-
     shortcutPlayPause: 'Wiedergabe / Pause',
-
     shortcutNext: 'Nächster Titel',
-
     shortcutPrev: 'Vorheriger Titel',
-
     shortcutVolumeUp: 'Lautstärke erhöhen',
-
     shortcutVolumeDown: 'Lautstärke verringern',
-
     shortcutSeekForward: '10s vorspulen',
-
     shortcutSeekBackward: '10s zurückspulen',
-
     shortcutToggleQueue: 'Warteschlange ein-/ausblenden',
-
     shortcutOpenFolderBrowser: '{{folderBrowser}} öffnen',
-
     shortcutFullscreenPlayer: 'Vollbild-Player',
-
     shortcutNativeFullscreen: 'Nativer Vollbildmodus',
-
     tabSystem: 'System',
-
     tabGeneral: 'Allgemein',
-
     ratingsSectionTitle: 'Bewertungen',
-
     ratingsSkipStarTitle: 'Skip → 1 Stern',
-
     ratingsSkipStarDesc:
-
       'Wird ein Titel mehrmals hintereinander übersprungen, bekommt er automatisch 1★. Nur für noch nicht bewertete Titel.',
-
     ratingsSkipStarThresholdLabel: 'Skips',
-
     ratingsMixFilterTitle: 'Nach Bewertung filtern',
-
     ratingsMixFilterDesc:
-
       'Gering bewertete Titel in {{mix}} und {{albums}} ausblenden. Nochmals auf den gewählten Stern klicken, um den Filter zu deaktivieren.',
-
     ratingsMixMinSong: 'Titel',
-
     ratingsMixMinAlbum: 'Alben',
-
     ratingsMixMinArtist: 'Interpreten',
-
     ratingsMixMinThresholdAria: 'Mindest-Sterne: {{label}}',
-
     backupTitle: 'Backup & Wiederherstellung',
-
     backupExport: 'Einstellungen exportieren',
-
     backupExportDesc: 'Speichert alle Einstellungen, Serverprofile, Last.fm-Konfiguration, Theme, EQ und Tastenkürzel in eine .psybkp-Datei. Passwörter werden im Klartext gespeichert — Datei sicher aufbewahren.',
-
     backupImport: 'Einstellungen importieren',
-
     backupImportDesc: 'Stellt Einstellungen aus einer .psybkp-Datei wieder her. Die App wird nach dem Import neu geladen.',
-
     backupImportConfirm: 'Alle aktuellen Einstellungen werden überschrieben. Fortfahren?',
-
     backupSuccess: 'Backup gespeichert',
-
     backupImportSuccess: 'Einstellungen wiederhergestellt — wird neu geladen…',
-
     backupImportError: 'Ungültige oder beschädigte Backup-Datei.',
-
     playbackTitle: 'Wiedergabe',
-
     replayGain: 'Replay Gain',
-
     replayGainDesc: 'Lautstärke mit ReplayGain-Metadaten normalisieren',
-
     replayGainMode: 'Modus',
-
     replayGainTrack: 'Track',
-
     replayGainAlbum: 'Album',
-
     replayGainPreGain: 'Pre-Gain (getaggte Dateien)',
-
     replayGainFallback: 'Fallback (ohne Tags / Radio)',
-
     crossfade: 'Crossfade',
-
     crossfadeDesc: 'Überblendung zwischen Tracks',
-
     crossfadeSecs: '{{n}} s',
-
     notWithGapless: 'Nicht verfügbar wenn Nahtlose Wiedergabe aktiv ist',
-
     notWithCrossfade: 'Nicht verfügbar wenn Crossfade aktiv ist',
-
     gapless: 'Nahtlose Wiedergabe',
-
     gaplessDesc: 'Nächsten Track vorpuffern um Lücken zwischen Songs zu vermeiden',
-
     preloadMode: 'Nächsten Track vorpuffern',
-
     preloadModeDesc: 'Wann mit dem Puffern des nächsten Tracks begonnen werden soll',
-
     nextTrackBufferingTitle: 'Nächster Track – Pufferung',
-
     preloadHotCacheMutualExclusive: 'Preload und Hot Cache erfüllen denselben Zweck – nur eine Methode kann gleichzeitig aktiv sein. Das Aktivieren einer deaktiviert die andere automatisch.',
-
     preloadOff: 'Aus',
-
     preloadBalanced: 'Ausgewogen (30 s vor Ende)',
-
     preloadEarly: 'Früh (nach 5 s Wiedergabe)',
-
     preloadCustom: 'Benutzerdefiniert',
-
     preloadCustomSeconds: 'Sekunden vor Ende: {{n}}',
-
     infiniteQueue: 'Endlose Warteschlange',
-
     infiniteQueueDesc: 'Automatisch Zufallstitel anhängen wenn die Warteschlange leer wird',
-
     experimental: 'Experimentell',
-
     fsPlayerSection: 'Vollbild-Player',
-
     fsShowArtistPortrait: 'Künstlerfoto anzeigen',
-
     fsShowArtistPortraitDesc: 'Künstlerfoto (oder Albumcover) auf der rechten Seite des Vollbild-Players anzeigen.',
-
     fsPortraitDim: 'Abdunkelung des Fotos',
-
     seekbarStyle: 'Seekbar-Stil',
-
     seekbarStyleDesc: 'Aussehen der Wiedergabe-Seekbar auswählen',
-
     seekbarWaveform: 'Wellenform',
-
     seekbarLinedot: 'Linie & Punkt',
-
     seekbarBar: 'Balken',
-
     seekbarThick: 'Dicker Balken',
-
     seekbarSegmented: 'Segmentiert',
-
     seekbarNeon: 'Neonröhre',
-
     seekbarPulsewave: 'Pulswelle',
-
     seekbarParticletrail: 'Partikel-Spur',
-
     seekbarLiquidfill: 'Flüssigkeit',
-
     seekbarRetrotape: 'Retro-Band',
-
     themeSchedulerTitle: 'Theme-Zeitplan',
-
     themeSchedulerEnable: 'Theme-Zeitplan aktivieren',
-
     themeSchedulerEnableSub: 'Wechselt automatisch zwischen zwei Themes basierend auf der Uhrzeit',
-
     themeSchedulerDayTheme: 'Tages-Theme',
-
     themeSchedulerDayStart: 'Tag beginnt um',
-
     themeSchedulerNightTheme: 'Nacht-Theme',
-
     themeSchedulerNightStart: 'Nacht beginnt um',
-
     themeSchedulerActiveHint: 'Theme-Zeitplan ist aktiv - Themes werden automatisch gewechselt.',
-
     visualOptionsTitle: 'Visuelle Optionen',
-
     coverArtBackground: 'Cover-Hintergrund',
-
     coverArtBackgroundSub: 'Zeigt verschwommenes Cover als Hintergrund in Album/Playlist-Kopfzeilen',
-
     playlistCoverPhoto: 'Playlist-Coverfoto',
-
     playlistCoverPhotoSub: 'Zeigt Coverfoto-Raster in der Playlist-Detailansicht',
-
     showBitrate: 'Bitrate anzeigen',
-
     showBitrateSub: 'Audio-Bitrate in Track-Listen anzeigen',
-
     uiScaleTitle: 'Interface-Skalierung',
-
     uiScaleLabel: 'Zoom',
-
   },
-
   changelog: {
-
     modalTitle: 'Was ist neu',
-
     dontShowAgain: 'Nicht mehr anzeigen',
-
     close: 'Verstanden',
-
   },
-
   help: {
-
     title: 'Hilfe',
-
     s1: 'Erste Schritte',
-
     q1: 'Welche Server sind kompatibel?',
-
     a1: 'Psysonic funktioniert mit jedem Subsonic-kompatiblen Server: Navidrome, Gonic, Subsonic, Airsonic und anderen. Navidrome ist die empfohlene Wahl.',
-
     q2: 'Wie verbinde ich mich mit meinem Server?',
-
     a2: 'Öffne die Einstellungen und klicke auf "Server hinzufügen". Gib die Server-URL (z. B. 192.168.1.100:4533), Benutzername und Passwort ein. Psysonic testet die Verbindung vor dem Speichern — bei Fehler wird nichts gespeichert.',
-
     q3: 'Kann ich mehrere Server verwenden?',
-
     a3: 'Ja. Du kannst beliebig viele Server in den Einstellungen hinzufügen und jederzeit zwischen ihnen wechseln. Immer ist nur ein Server aktiv.',
-
     s2: 'Wiedergabe',
-
     q4: 'Wie spiele ich Musik ab?',
-
     a4: 'Doppelklick auf einen Track startet die Wiedergabe. Auf Album- und Künstlerseiten gibt es "Alle abspielen". Tracks lassen sich auch per Drag & Drop in die Warteschlange ziehen.',
-
     q5: 'Welche Tastenkürzel gibt es?',
-
     a5: 'Leertaste = Play / Pause · Escape = Vollbild schließen. Medientasten (Play/Pause, Weiter, Zurück) funktionieren auf allen Plattformen. Unter Linux bitte die Buttons in der Playerleiste nutzen. In-App-Kürzel und systemweite globale Shortcuts können in Einstellungen → Tastenkürzel / Globale Shortcuts angepasst werden.',
-
     q6: 'Was ist die Warteschlange?',
-
     a6: 'Die Warteschlange zeigt alle kommenden Tracks. Öffnen mit dem Panel-Icon oben rechts im Header (neben dem Now-Playing-Indikator). Tracks per Drag & Drop umsortieren, mit dem Shuffle-Button mischen oder als Playlist speichern.',
-
     q7: 'Wie öffne ich den Vollbild-Player?',
-
     a7: 'Klick auf das Album-Cover unten in der Playerleiste oder auf das Expand-Icon daneben. Mit Escape wieder schließen.',
-
     q8: 'Wie funktioniert die Wiederholfunktion?',
-
     a8: 'Klick auf den Wiederhol-Button in der Playerleiste, um zwischen den Modi zu wechseln: Aus → Alles wiederholen → Einen wiederholen.',
-
     s3: 'Bibliothek',
-
     q9: 'Wie lade ich ein Album herunter?',
-
     a9: 'Auf der Album-Detailseite auf "Download (ZIP)" klicken. Der Server packt das Album zunächst in eine ZIP-Datei — bei großen Alben oder verlustfreien Dateien (FLAC / WAV) kann es einen Moment dauern, bevor der Download tatsächlich startet. Das ist normal: Der Fortschrittsbalken erscheint erst, wenn der Server fertig ist und die Übertragung beginnt.',
-
     q10: 'Wie markiere ich Tracks und Alben als Favoriten?',
-
     a10: 'Das Stern-Icon auf einem Track oder im Album-Header anklicken. Markierte Einträge erscheinen im Bereich "Favoriten" in der Seitenleiste.',
-
     q11: 'Was ist das Karussell auf der Startseite?',
-
     a11: 'Das Banner oben auf der Startseite wählt zufällige Alben aus der Bibliothek und rotiert alle 10 Sekunden weiter. Mit den Punkten kann man manuell springen, Klick auf das Banner öffnet das Album.',
-
     s4: 'Einstellungen',
-
     q12: 'Wie ändere ich das Theme?',
-
     a12: 'Einstellungen → Design. Eine große Auswahl an Themes in 8 Gruppen: Psysonic Themes, Mediaplayer, Betriebssysteme, Spiele, Filme, Serien, Social Media und Open-Source-Classics (Catppuccin, Nord, Gruvbox, Nightfox).',
-
     q13: 'Wie ändere ich die Sprache?',
-
     a13: 'Einstellungen → Sprache. Englisch, Deutsch, Französisch, Niederländisch und Chinesisch werden unterstützt.',
-
     q15: 'Wie lege ich einen Download-Ordner fest?',
-
     a15: 'Einstellungen → App-Verhalten → Download-Ordner. Beliebigen Ordner wählen — heruntergeladene Alben werden dort als ZIP gespeichert. Ohne eigenen Ordner landet alles im Standard-Downloads-Ordner.',
-
     s5: 'Scrobbling',
-
     q16: 'Wie funktioniert Scrobbling?',
-
     a16: 'Psysonic scrobbled direkt zu Last.fm — keine Navidrome-Konfiguration nötig. Last.fm-Konto in Einstellungen → Last.fm verbinden und Scrobbling dort aktivieren.',
-
     q17: 'Wann wird ein Scrobble gesendet?',
-
     a17: 'Ein Scrobble wird übermittelt, wenn 50 % eines Tracks gehört wurden.',
-
     q22: 'Was ist die Waveform in der Playerleiste?',
-
     a22: 'Die Waveform-Leiste ersetzt den klassischen Fortschrittsbalken. Klick auf eine beliebige Stelle zum Springen, ziehen zum Scrubben. Der gespielte Teil leuchtet in einem Blau-Mauve-Farbverlauf, der gepufferte Bereich erscheint etwas heller, der ungespielter Teil ist abgeblendet.',
-
     q24: 'Kann ich die Warteschlange mischen?',
-
     a24: 'Ja. Die Warteschlange öffnen und auf das Shuffle-Icon im Header klicken. Der aktuell laufende Track bleibt an Position 1 — alle restlichen Tracks werden zufällig neu geordnet.',
-
     q25: 'Öffnen Last.fm- und Wikipedia-Links auf Künstlerseiten im Browser?',
-
     a25: 'Ja — sie öffnen sich im Standard-Systembrowser. Der Button zeigt kurz eine Bestätigungsmeldung beim Klick.',
-
     s7: 'Zufallsmix',
-
     q26: 'Was ist der Zufallsmix?',
-
     a26: 'Der Zufallsmix erstellt eine Playlist aus zufälligen Tracks deiner gesamten Bibliothek. Über "Zufallsmix" in der Seitenleiste erreichbar, dann "Neuer Mix" klicken. Die Anzahl der Tracks ist vor der Generierung einstellbar.',
-
     q27: 'Was ist der Keyword-Filter?',
-
     a27: 'Der Keyword-Filter schließt Tracks aus, deren Genre, Titel oder Album bestimmte Wörter enthält. Hörbücher werden automatisch gefiltert. Eigene Keywords in Einstellungen → Zufallsmix hinzufügen oder per Klick auf ein Genre-Tag direkt in der Trackliste.',
-
     q28: 'Was ist der Super-Genre-Mix?',
-
     a28: 'Der Super-Genre-Mix fasst die Bibliothek in übergeordnete Kategorien zusammen (Rock, Metal, Electronic, Jazz, Klassik usw.) und erstellt daraus einen fokussierten Mix. Einen Kategorie-Chip unterhalb der Trackliste auswählen. Ergebnisse erscheinen schrittweise, während die einzelnen Sub-Genres geladen werden.',
-
     s6: 'Problemlösung',
-
     q18: 'Cover und Künstlerbilder laden langsam.',
-
     a18: 'Bilder werden beim ersten Aufruf vom Server geholt und dann 30 Tage lokal gecacht. Bei langsamen Server-Festplatten kann der erste Seitenaufruf einen Moment dauern. Danach geht alles sofort.',
-
     q19: 'Der Verbindungstest schlägt fehl.',
-
     a19: 'URL inklusive Port prüfen (z. B. http://192.168.1.100:4533). Sicherstellen, dass keine Firewall die Verbindung blockiert. Im lokalen Netzwerk http:// statt https:// versuchen. Benutzername und Passwort kontrollieren.',
-
     q20: 'Kein Ton unter Linux.',
-
     a20: 'Psysonic ist als .deb (Ubuntu/Debian), .rpm (Fedora/RHEL) und über AUR für Arch/CachyOS verfügbar (yay -S psysonic). Es gibt kein AppImage. Falls kein Ton kommt, sicherstellen, dass PipeWire oder PulseAudio läuft.',
-
     q21: 'Die App zeigt einen schwarzen Bildschirm unter Linux.',
-
     a21: 'Meist ein GPU/EGL-Treiberproblem in WebKitGTK. Mit GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1 starten. Das AUR-Paket und die offiziellen .deb/.rpm-Pakete setzen diese Variablen automatisch.',
-
     q29: 'Was sind Crossfade und nahtlose Wiedergabe?',
-
     a29: 'Beides sind experimentelle Audiofunktionen in Einstellungen → Audio. Nahtlose Wiedergabe puffert den nächsten Track vor, um Stille zu eliminieren. Crossfade blendet den aktuellen Track aus, während der nächste eingeblendet wird — Dauer (1–10 s) einstellbar.',
-
     q30: 'Zeigt Psysonic Songtexte an?',
-
     a30: 'Ja. Klick auf das Mikrofon-Icon in der Playerleiste öffnet den Lyrics-Tab im Queue-Panel. Psysonic lädt Texte automatisch von LRCLIB. Sind synchronisierte Lyrics verfügbar, wird die aktuelle Zeile hervorgehoben und scrollt in Echtzeit mit. Bei reinen Texten wird der Volltext statisch angezeigt.',
-
     q31: 'Kann ich Tastenkürzel anpassen?',
-
     a31: 'Ja. Einstellungen → Tastenkürzel erlaubt das Neuzuordnen von In-App-Aktionen (Play/Pause, Weiter, Zurück, Lautstärke, Vollbild u. v. m.). Einstellungen → Globale Shortcuts ermöglicht systemweite Kürzel, die auch im Hintergrund ausgelöst werden.',
-
     q32: 'Kann ich die Schriftart ändern?',
-
     a32: 'Ja. Einstellungen → Schriftart bietet 10 Schriften zur Auswahl, darunter IBM Plex Mono, Fira Code, JetBrains Mono und Courier Prime. Die gewählte Schrift gilt für die gesamte Oberfläche.',
-
     s8: 'Offline-Modus',
-
     q34: 'Was ist der Offline-Modus?',
-
     a34: 'Der Offline-Modus (Beta) ermöglicht das Zwischenspeichern von Alben auf dem Gerät, sodass die Wiedergabe ohne aktive Serververbindung möglich ist. Gecachte Tracks werden lokal gespeichert und direkt von der Festplatte abgespielt — ohne Netzwerkzugriff.',
-
     q35: 'Wie speichere ich ein Album für die Offline-Nutzung?',
-
     a35: 'Album öffnen und auf das Download-Symbol im Album-Header klicken. Psysonic lädt alle Tracks im Hintergrund herunter. Der Fortschritt wird am Button angezeigt. Nach dem Download wird das Symbol grün. Gecachte Alben können in der Offline-Bibliothek (Seitenleiste) verwaltet und gelöscht werden.',
-
     q36: 'Wie viel Speicherplatz darf der Cache belegen?',
-
     a36: 'In Einstellungen → Bibliothek kann eine maximale Cache-Größe festgelegt werden. Wird das Limit erreicht, erscheint ein Warnbanner auf der Albumseite. Einzelne Alben können in der Offline-Bibliothek gelöscht werden, um Speicherplatz freizugeben.',
-
     q37: 'Wie bewerte ich Songs, Alben und Künstler?',
-
     a37: 'Psysonic unterstützt 1–5-Sterne-Bewertungen über die OpenSubsonic-API (erfordert Navidrome ≥ 0.53). Songs können in der Trackliste eines Albums oder einer Playlist (Spalte „Bewertung"), über das Rechtsklick-Kontextmenü oder direkt in der Playerleiste unterhalb des Künstlernamens bewertet werden. Alben werden auf der Albumdetailseite bewertet, Künstler auf der Künstlerseite. Bewertungen werden sofort an den Server übertragen.',
-
     q38: 'Kann ich eine Bewertung entfernen oder ändern?',
-
     a38: 'Ja. Ein erneuter Klick auf den bereits aktiven Stern entfernt die Bewertung vollständig – der zweite Klick auf denselben Stern löscht sie also. Um eine Bewertung zu ändern, einfach einen anderen Stern anklicken.',
-
     q39: 'Was ist Skip-to-1★ und der Bewertungsfilter?',
-
     a39: 'Skip-to-1★ vergibt automatisch eine 1-Stern-Bewertung, wenn ein Song mehrfach hintereinander manuell übersprungen wird. Aktivierung und Schwellenwert in Einstellungen → Bewertungen. Dort lässt sich auch eine Mindestbewertung für Zufalls-Mix und Zufallsalben festlegen – so werden nur Songs, Alben oder Künstler ab einer bestimmten Sternzahl in generierten Mixes berücksichtigt.',
-
     q40: 'Was ist der Ordner-Browser?',
-
     a40: 'Der Ordner-Browser (Sidebar) ermöglicht die Navigation im Musikverzeichnis des Servers über ein Miller-Column-Layout. Ein Klick auf einen Ordner öffnet dessen Inhalt; über das Play-Symbol lassen sich Ordner direkt abspielen oder zur Warteschlange hinzufügen.',
-
     q41: 'Was ist der Theme-Scheduler?',
-
     a41: 'Einstellungen → Darstellung → Theme automatisch wechseln: Tagesthema und Nachtthema mit Startzeiten konfigurieren. Psysonic wechselt automatisch zur eingestellten Uhrzeit. Ist der Scheduler aktiv, erscheint im Theme-Picker ein Hinweis, warum manuelle Änderungen keine sofortige Wirkung haben.',
-
     q42: 'Kann ich die Benutzeroberfläche vergrößern oder verkleinern?',
-
     a42: 'Ja. Einstellungen → Darstellung → Anzeigeskalierung ermöglicht eine Skalierung der gesamten Oberfläche zwischen 80 % und 125 %, unabhängig von der Systemschriftgröße.',
-
     q43: 'Kann ich den Stil der Seekbar ändern?',
-
     a43: 'Ja. Einstellungen → Darstellung → Seekbar-Stil bietet 10 Stile: Wellenform, Linie & Punkt, Balken, Dicker Balken, Segmentiert, Neon-Glow, Pulswelle, Partikelspur, Flüssigfüllung und Retro-Tape.',
-
     q44: 'Was ist AutoEQ?',
-
     a44: 'Der 10-Band-EQ in Einstellungen → Audio enthält eine AutoEQ-Suche. Kopfhörermodell eingeben – Psysonic lädt das Korrekturprofil aus der AutoEQ-Datenbank und überträgt es automatisch auf die EQ-Bänder.',
-
     q45: 'Was ist Replay Gain?',
-
     a45: 'Replay Gain normalisiert die Lautstärke, sodass laute und leise Alben auf einem gleichmäßigen Pegel wiedergegeben werden. Aktivierung in Einstellungen → Audio → Replay Gain; Modus Track (pro Song) oder Album (behält die relative Dynamik innerhalb eines Albums).',
-
     q46: 'Was ist der Hot Cache?',
-
     a46: 'Der Hot Cache (Alpha, Einstellungen → Bibliothek) lädt die nächsten Songs der Warteschlange vorab auf die Festplatte, damit die Wiedergabe ohne Pufferverzögerung startet – besonders nützlich bei langsamen oder entfernten Servern. Psysonic hält den aktuellen Track und die nächsten 5 im Cache und verdrängt ältere Einträge, wenn das Größenlimit erreicht wird. Cache-Größe und Debounce-Verzögerung sind konfigurierbar.',
-
     q47: 'Kann ich eine Playlist offline cachen?',
-
     a47: 'Ja. In den Playlist-Details auf das Download-Symbol klicken – alle Tracks werden im Hintergrund heruntergeladen. Ist die Playlist vollständig gecacht, wechselt das Symbol zu einem roten Papierkorb; ein erneuter Klick entfernt die Playlist aus dem Offline-Cache.',
-
+    q48: 'Was ist die Infinite Queue?',
+    a48: 'Wenn die Warteschlange leer läuft und Wiederholen deaktiviert ist, fügt Psysonic automatisch zufällige Tracks aus deiner Bibliothek hinzu, damit die Wiedergabe nie stoppt. Automatisch hinzugefügte Tracks erscheinen unterhalb des Trenners „— Automatisch hinzugefügt —". Umschalten über das Unendlichkeitssymbol im Warteschlangen-Header. In Einstellungen → Warteschlange kann der automatische Nachschub auf ein bestimmtes Genre beschränkt werden.',
+    q49: 'Kann ich Psysonic über die Kommandozeile bedienen?',
+    a49: 'Ja – das Psysonic-Binary kann die laufende App fernsteuern. Beispiele: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one, --player star / unstar, --player rating 1–5. Außerdem: Server wechseln (--player server list / set), Ausgabegerät wählen (--player audio-device list / set), Bibliotheks-Ordner filtern (--player library list / set), Instant Mix starten (--player mix new / append) und Suche (--player search track|album|artist <Suchbegriff>). Vollständige Hilfe: psysonic --player --help. Shell-Completions für bash und zsh sind über psysonic completions verfügbar.',
+    q50: 'Wie verwalte ich Playlists?',
+    a50: 'Über „Playlists" in der Seitenleiste. Mit „Neue Playlist" eine Playlist erstellen. In der Playlist-Detailansicht können Tracks per Drag & Drop umsortiert, mit dem ×-Button entfernt und über die Songsuche neue hinzugefügt werden. Die „Vorschläge"-Sektion macht Empfehlungen basierend auf dem Inhalt der Playlist. Rechtsklick auf einen Track für weitere Optionen.',
+    q51: 'Kann ich meine Einstellungen sichern und wiederherstellen?',
+    a51: 'Ja. Einstellungen → Backup & Restore ermöglicht den Export aller Einstellungen, Serverprofile, Themes und Tastenkürzel in eine JSON-Datei. Auf einem anderen Gerät oder nach einer Neuinstallation importieren, um alles auf einmal wiederherzustellen. Passwörter sind in der Sicherung enthalten – die Datei sicher aufbewahren.',
+    q52: 'Wie ändere ich das Audioausgabegerät?',
+    a52: 'Einstellungen → Audio → Ausgabegerät. Psysonic listet alle verfügbaren Ausgaben auf. Auswahl wechselt die Wiedergabe sofort. Den Aktualisierungsbutton daneben nutzen, wenn ein Gerät nach dem App-Start angeschlossen wurde. Unter Linux werden ALSA-Gerätenamen bereinigt angezeigt.',
+    q53: 'Was ist Device Sync?',
+    a53: 'Device Sync überträgt Alben, Playlists oder ganze Künstler auf einen USB-Stick oder eine SD-Karte. Über „Device Sync" in der Seitenleiste öffnen, einen Zielordner auf dem Laufwerk wählen, Quellen in den Browser-Tabs auswählen und auf „Auf Gerät übertragen" klicken. Psysonic lädt die Tracks vom Server und legt sie in der durch die Dateinamen-Vorlage definierten Ordnerstruktur ab.',
+    q54: 'Was ist die Dateinamen-Vorlage in Device Sync?',
+    a54: 'Die Dateinamen-Vorlage steuert, wie Tracks auf dem Gerät benannt und organisiert werden. Vorgaben (Standard, Multi-Disc, Alt. Ordner) auswählen oder selbst aus den klickbaren Token-Chips zusammenbauen: {artist}, {album}, {title}, {track_number}, {disc_number}, {year} und / als Ordner-Trennzeichen. Eine Live-Vorschau zeigt, wie ein Beispiel-Track benannt würde.',
+    q55: 'Funktioniert Device Sync plattformübergreifend?',
+    a55: 'Ja. Das auf dem Gerät gespeicherte Manifest (psysonic-sync.json) enthält die beim Sync verwendete Dateinamen-Vorlage. Wird Device Sync auf einem anderen Betriebssystem mit anderer Vorlage geöffnet, erkennt Psysonic die bereits vorhandenen Dateien korrekt – Alben werden nicht fälschlich als ausstehend angezeigt.',
+    s9: 'Device Sync',
+    q56: 'Was ist Internet Radio?',
+    a56: 'Die Internetradio-Seite (Seitenleiste) ermöglicht die Wiedergabe beliebiger Livestreams direkt in Psysonic. Sender werden vom Navidrome-Server bezogen – dort über das Admin-Panel hinzufügen oder eine .pls- / .m3u-Datei importieren. Die Wiedergabe erfolgt über HTML5-Audio, nicht den Rust-Audio-Engine – einige EQ- und Replay-Gain-Einstellungen gelten daher nicht für Radio.',
+    q57: 'Welche Stream-Formate unterstützt Internet Radio?',
+    a57: 'Psysonic unterstützt alle Formate, die der Audio-Stack des Systems dekodieren kann: MP3, AAC, OGG Vorbis und die meisten HLS-Streams. Da HTML5-Audio verwendet wird, hängt die Codec-Unterstützung von der Plattform ab – MP3 und AAC funktionieren überall.',
+    s10: 'Internet Radio',
+    q58: 'Woher bezieht Psysonic Songtexte?',
+    a58: 'Psysonic unterstützt drei Lyrics-Quellen, alle konfigurierbar in Einstellungen → Lyrics: Navidrome-Server (eingebettete/OpenSubsonic-Lyrics), LRCLIB (community-gepflegte synchronisierte Texte) und NetEase Cloud Music (umfangreicher internationaler Katalog). Jede Quelle kann aktiviert/deaktiviert und per Drag & Drop priorisiert werden. Synchronisierte Lyrics scrollen automatisch und unterstützen Klick-zum-Springen.',
+    q59: 'Gibt es eine Ansicht, was andere Nutzer gerade hören?',
+    a59: 'Ja. Das Broadcast-Symbol oben rechts im Header öffnet das „Now Playing"-Dropdown. Es zeigt, was andere Nutzer auf dem Navidrome-Server gerade hören – aktualisiert alle 10 Sekunden. Der eigene Eintrag verschwindet beim Pausieren.',
   },
-
   queue: {
-
     title: 'Warteschlange',
-
     savePlaylist: 'Playlist speichern',
-
     updatePlaylist: 'Playlist aktualisieren',
-
     filterPlaylists: 'Playlists filtern…',
-
     playlistName: 'Name der Playlist',
-
     cancel: 'Abbrechen',
-
     save: 'Speichern',
-
     loadPlaylist: 'Playlist laden',
-
     loading: 'Lade…',
-
     noPlaylists: 'Keine Playlists gefunden.',
-
     load: 'Warteschlange ersetzen & abspielen',
-
     appendToQueue: 'An Warteschlange anhängen',
-
     delete: 'Löschen',
-
     deleteConfirm: 'Playlist "{{name}}" löschen?',
-
     clear: 'Leeren',
-
     shuffle: 'Warteschlange mischen',
-
     gapless: 'Nahtlos',
-
     crossfade: 'Crossfade',
-
     infiniteQueue: 'Endlose Warteschlange',
-
     autoAdded: '— Automatisch hinzugefügt —',
-
     radioAdded: '— Radio —',
-
     hide: 'Verbergen',
-
     close: 'Schließen',
-
     nextTracks: 'Nächste Titel',
-
     emptyQueue: 'Die Warteschlange ist leer.',
-
     trackSingular: 'Titel',
-
     trackPlural: 'Titel',
-
     showRemaining: 'Restzeit anzeigen',
-
     showTotal: 'Gesamtzeit anzeigen',
-
   },
-
   statistics: {
-
     title: 'Statistiken',
-
     recentlyPlayed: 'Zuletzt gehört',
-
     mostPlayed: 'Meistgespielte Alben',
-
     highestRated: 'Höchstbewertete Alben',
-
     genreDistribution: 'Genre-Verteilung (Top 20)',
-
     loadMore: 'Mehr laden',
-
     statArtists: 'Künstler',
-
     statArtistsTooltip: 'Nur Album-Künstler — Künstler, die ausschließlich als Track-Künstler vorkommen (Featured, Gast usw.) und kein eigenes Album haben, werden nicht gezählt.',
-
     statAlbums: 'Alben',
-
     statSongs: 'Songs',
-
     statGenres: 'Genres',
-
     statPlaytime: 'Gesamtspielzeit',
-
     genreInsights: 'Genre-Einblicke',
-
     formatDistribution: 'Format-Verteilung',
-
     formatSample: 'Stichprobe von {{n}} Titeln',
-
     computing: 'Wird berechnet…',
-
     genreSongs: '{{count}} Songs',
-
     genreAlbums: '{{count}} Alben',
-
     recentlyAdded: 'Neu hinzugefügt',
-
     decadeDistribution: 'Alben nach Jahrzehnt',
-
     decadeAlbums_one: '{{count}} Album',
-
     decadeAlbums_other: '{{count}} Alben',
-
     decadeUnknown: 'Unbekannt',
-
     lfmTitle: 'Last.fm Statistiken',
-
     lfmTopArtists: 'Top-Künstler',
-
     lfmTopAlbums: 'Top-Alben',
-
     lfmTopTracks: 'Top-Titel',
-
     lfmPlays: '{{count}} Plays',
-
     lfmPeriodOverall: 'Gesamt',
-
     lfmPeriod7day: '7 Tage',
-
     lfmPeriod1month: '1 Monat',
-
     lfmPeriod3month: '3 Monate',
-
     lfmPeriod6month: '6 Monate',
-
     lfmPeriod12month: '12 Monate',
-
     lfmNotConnected: 'Verbinde Last.fm in den Einstellungen, um deine Statistiken zu sehen.',
-
     lfmRecentTracks: 'Zuletzt gescrobbelt',
-
     lfmNowPlaying: 'Läuft gerade',
-
     lfmJustNow: 'gerade eben',
-
     lfmMinutesAgo: 'vor {{n}} Min.',
-
     lfmHoursAgo: 'vor {{n}} Std.',
-
     lfmDaysAgo: 'vor {{n}} Tagen',
-
     topRatedSongs: 'Bestbewertete Songs',
-
     topRatedArtists: 'Bestbewertete Künstler',
-
     noRatedSongs: 'Noch keine bewerteten Songs. Songs in Album- oder Playlist-Ansicht bewerten.',
-
     noRatedArtists: 'Noch keine bewerteten Künstler.',
-
   },
-
   player: {
-
     regionLabel: 'Musikplayer',
-
     openFullscreen: 'Vollbild-Player öffnen',
-
     fullscreen: 'Vollbild-Player',
-
     closeFullscreen: 'Vollbild schließen',
-
     closeTooltip: 'Schließen (Esc)',
-
     noTitle: 'Kein Titel',
-
     stop: 'Stop',
-
     prev: 'Vorheriger Titel',
-
     play: 'Play',
-
     pause: 'Pause',
-
     next: 'Nächster Titel',
-
     repeat: 'Wiederholen',
-
     repeatOff: 'Aus',
-
     repeatAll: 'Alle',
-
     repeatOne: 'Einen',
-
     progress: 'Songfortschritt',
-
     volume: 'Lautstärke',
-
     toggleQueue: 'Warteschlange umschalten',
-
     lyrics: 'Lyrics',
-
     fsLyricsToggle: 'Lyrics im Vollbild',
-
     lyricsLoading: 'Lyrics werden geladen…',
-
     lyricsNotFound: 'Keine Lyrics für diesen Titel gefunden',
-
     lyricsSourceServer: 'Quelle: Server',
-
     lyricsSourceLrclib: 'Quelle: LRCLIB',
-
     lyricsSourceNetease: 'Quelle: Netease',
-
   },
-
   songInfo: {
-
     title: 'Song-Infos',
-
     songTitle: 'Titel',
-
     artist: 'Künstler',
-
     album: 'Album',
-
     albumArtist: 'Album-Künstler',
-
     year: 'Jahr',
-
     genre: 'Genre',
-
     duration: 'Länge',
-
     track: 'Track',
-
     format: 'Format',
-
     bitrate: 'Bitrate',
-
     sampleRate: 'Abtastrate',
-
     bitDepth: 'Bittiefe',
-
     channels: 'Kanäle',
-
     fileSize: 'Dateigröße',
-
     path: 'Speicherort',
-
     replayGainTrack: 'RG Track Gain',
-
     replayGainAlbum: 'RG Album Gain',
-
     replayGainPeak: 'RG Track Peak',
-
     mono: 'Mono',
-
     stereo: 'Stereo',
-
   },
-
   playlists: {
-
     title: 'Playlists',
-
     newPlaylist: 'Neue Playlist',
-
     unnamed: 'Unbenannte Playlist',
-
     createName: 'Playlist-Name…',
-
     create: 'Erstellen',
-
     cancel: 'Abbrechen',
-
     empty: 'Noch keine Playlists.',
-
     emptyPlaylist: 'Diese Playlist ist leer.',
-
     addFirstSong: 'Ersten Song hinzufügen',
-
     notFound: 'Playlist nicht gefunden.',
-
     songs: '{{n}} Songs',
-
     playAll: 'Alle abspielen',
-
     shuffle: 'Zufallswiedergabe',
-
     addToQueue: 'Zur Warteschlange',
-
     back: 'Zurück zu Playlists',
-
     deletePlaylist: 'Löschen',
-
     confirmDelete: 'Nochmals klicken zum Bestätigen',
-
     removeSong: 'Aus Playlist entfernen',
-
     addSongs: 'Songs hinzufügen',
-
     searchPlaceholder: 'Bibliothek durchsuchen…',
-
     noResults: 'Keine Ergebnisse.',
-
     suggestions: 'Vorgeschlagene Songs',
-
     noSuggestions: 'Keine Vorschläge verfügbar.',
-
     titleBadge: 'Playlist',
-
     refreshSuggestions: 'Neue Vorschläge',
-
     addSong: 'Zur Playlist hinzufügen',
-
     addSelected: 'Ausgewählte hinzufügen',
-
     cacheOffline: 'Playlist offline speichern',
-
     offlineCached: 'Playlist gecacht',
-
     removeOffline: 'Aus Offline-Cache entfernen',
-
     offlineDownloading: 'Wird gecacht… ({{done}}/{{total}} Alben)',
-
     publicLabel: 'Öffentlich',
-
     privateLabel: 'Privat',
-
     editMeta: 'Playlist bearbeiten',
-
     editNamePlaceholder: 'Playlist-Name…',
-
     editCommentPlaceholder: 'Beschreibung hinzufügen…',
-
     editPublic: 'Öffentliche Playlist',
-
     editSave: 'Speichern',
-
     editCancel: 'Abbrechen',
-
     changeCover: 'Coverbild ändern',
-
     changeCoverLabel: 'Foto ändern',
-
     removeCover: 'Foto entfernen',
-
     coverUpdated: 'Cover aktualisiert',
-
     metaSaved: 'Playlist aktualisiert',
-
     downloadZip: 'Herunterladen (ZIP)',
-
     // Toast notifications for multi-select
-
     addSuccess: '{{count}} Songs zu {{playlist}} hinzugefügt',
-
     addPartial: '{{added}} hinzugefügt, {{skipped}} übersprungen (Duplikate)',
-
     addAllSkipped: 'Alle übersprungen ({{count}} Duplikate)',
-
     addError: 'Fehler beim Hinzufügen von Songs',
-
     createAndAddSuccess: 'Playlist "{{playlist}}" mit {{count}} Songs erstellt',
-
     createError: 'Fehler beim Erstellen der Playlist',
-
     deleteSuccess: '{{count}} Playlists gelöscht',
-
     deleteFailed: 'Fehler beim Löschen von {{name}}',
-
     deleteSelected: 'Ausgewählte löschen',
-
     mergeSuccess: '{{count}} Songs in {{playlist}} zusammengeführt',
-
     mergeNoNewSongs: 'Keine neuen Songs zum Hinzufügen',
-
     mergeError: 'Fehler beim Zusammenführen von Playlists',
-
     mergeInto: 'Zusammenführen in',
-
     selectionCount: '{{count}} ausgewählt',
-
     select: 'Auswählen',
-
     startSelect: 'Auswahl aktivieren',
-
     cancelSelect: 'Abbrechen',
-
     loadingAlbums: '{{count}} Alben werden aufgelöst…',
-
     loadingArtists: '{{count}} Künstler werden aufgelöst…',
-
     myPlaylists: 'Meine Playlists',
-
     noOtherPlaylists: 'Keine anderen Playlists verfügbar',
-
     addToPlaylistSuccess: '{{count}} Songs zu {{playlist}} hinzugefügt',
-
     addToPlaylistNoNew: 'Keine neuen Songs für {{playlist}}',
-
     addToPlaylistError: 'Fehler beim Hinzufügen zur Playlist',
-
     removeSuccess: 'Song aus Playlist entfernt',
-
     removeError: 'Fehler beim Entfernen aus der Playlist',
-
     importCSV: 'CSV importieren',
-
     importCSVTooltip: 'Aus Spotify-CSV importieren',
-
     csvImportReport: 'CSV-Importbericht',
-
     csvImportTotal: 'Gesamt',
-
     csvImportAdded: 'Hinzugefügt',
-
     csvImportDuplicates: 'Duplikate',
-
     csvImportNotFound: 'Nicht gefunden',
-
     csvImportNetworkErrors: 'Netzwerkfehler',
-
     csvImportDuplicatesTitle: 'Doppelte Titel (bereits in Playlist):',
-
     csvImportNotFoundTitle: 'Nicht gefundene Titel:',
-
     csvImportNetworkErrorsTitle: 'Netzwerkfehler (Import kann wiederholt werden):',
-
     csvImportDownloadReport: 'Bericht herunterladen',
-
     csvImportClose: 'Schließen',
-
     csvImportNoValidTracks: 'Keine gültigen Titel in CSV-Datei gefunden',
-
     csvImportFailed: 'CSV-Import fehlgeschlagen',
-
     csvImportToast: '{{added}} hinzugefügt, {{notFound}} nicht gefunden, {{duplicates}} Duplikate',
-
   },
-
   mostPlayed: {
-
     title: 'Meistgehört',
-
     topArtists: 'Top-Künstler',
-
     topAlbums: 'Top-Alben',
-
     plays: '{{n}}× gespielt',
-
     sortMost: 'Meiste Plays zuerst',
-
     sortLeast: 'Wenigste Plays zuerst',
-
     loadMore: 'Mehr Alben laden',
-
     noData: 'Noch keine Wiedergabedaten. Fang an zu hören!',
-
     noArtists: 'Alle Künstler herausgefiltert.',
-
     filterCompilations: 'Sampler-Künstler ausblenden (Various Artists, Soundtracks usw.)',
-
     filterCompilationsShort: 'Sampler ausblenden',
-
   },
-
   radio: {
-
     title: 'Internetradio',
-
     empty: 'Keine Radiosender konfiguriert.',
-
     addStation: 'Sender hinzufügen',
-
     editStation: 'Bearbeiten',
-
     deleteStation: 'Sender löschen',
-
     confirmDelete: 'Zum Bestätigen erneut klicken',
-
     stationName: 'Sendername…',
-
     streamUrl: 'Stream-URL…',
-
     homepageUrl: 'Homepage-URL (optional)',
-
     save: 'Speichern',
-
     cancel: 'Abbrechen',
-
     live: 'LIVE',
-
     liveStream: 'Internetradio',
-
     openHomepage: 'Homepage öffnen',
-
     changeCoverLabel: 'Cover ändern',
-
     removeCover: 'Cover entfernen',
-
     browseDirectory: 'Verzeichnis durchsuchen',
-
     directoryPlaceholder: 'Sender suchen…',
-
     noResults: 'Keine Sender gefunden.',
-
     stationAdded: 'Sender hinzugefügt',
-
     filterAll: 'Alle',
-
     filterFavorites: 'Favoriten',
-
     sortManual: 'Manuell',
-
     sortAZ: 'A → Z',
-
     sortZA: 'Z → A',
-
     sortNewest: 'Neueste',
-
     favorite: 'Zu Favoriten hinzufügen',
-
     unfavorite: 'Aus Favoriten entfernen',
-
     noFavorites: 'Keine Lieblingssender.',
-
     listenerCount_one: '{{count}} Hörer',
-
     listenerCount_other: '{{count}} Hörer',
-
     recentlyPlayed: 'Zuletzt gespielt',
-
     upNext: 'Als Nächstes',
-
   },
-
   folderBrowser: {
-
     empty: 'Leerer Ordner',
-
     error: 'Laden fehlgeschlagen',
-
   },
-
   deviceSync: {
-
     title: 'Gerätesync',
-
     targetFolder: 'Zielordner',
-
     noFolderChosen: 'Kein Ordner gewählt',
-
     selectDrive: 'Laufwerk auswählen…',
-
     refreshDrives: 'Laufwerke aktualisieren',
-
     noDrivesDetected: 'Keine Wechseldatenträger erkannt',
-
     browseManual: 'Manuell durchsuchen…',
-
     free: 'frei',
-
     notMountedVolume: 'Ziel befindet sich nicht auf einem eingehängten Laufwerk. Das Gerät wurde möglicherweise getrennt.',
-
     chooseFolder: 'Auswählen…',
-
     filenameTemplate: 'Dateinamen-Vorlage',
-
     targetDevice: 'Zielgerät',
-
     templateHint: 'Variablen: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
-
     onDevice: 'Auf dem Gerät',
-
     addSources: 'Hinzufügen…',
-
     colName: 'Name',
-
     colType: 'Typ',
-
     syncResult: '{{done}} übertragen, {{skipped}} bereits aktuell ({{total}} gesamt)',
-
     deleteFromDevice: 'Vom Gerät löschen ({{count}})',
-
     confirmDelete: '{{count}} Eintrag/Einträge vom Gerät löschen: {{names}}?',
-
     deleteComplete: '{{count}} Eintrag/Einträge vom Gerät entfernt.',
-
+    manifestImported: '{{count}} Quelle(n) aus Geräte-Manifest importiert.',
     selectedSources: 'Ausgewählte Quellen',
-
     noSourcesSelected: 'Keine Quellen ausgewählt. Klicke auf Einträge im Browser um sie hinzuzufügen.',
-
     clearAll: 'Alle entfernen',
-
     tabPlaylists: 'Wiedergabelisten',
-
     tabAlbums: 'Alben',
-
     tabArtists: 'Künstler',
-
     searchPlaceholder: 'Suche…',
-
     syncButton: 'Auf Gerät übertragen',
-
     actionTransfer: 'Auf Gerät übertragen',
-
     actionDelete: 'Vom Gerät löschen',
-
     actionApplyAll: 'Änderungen synchronisieren',
-
     templatePreview: 'Vorschau',
-
+    templatePresetStandard: 'Standard',
+    templatePresetMultiDisc: 'Multi-Disc',
+    templatePresetAltFolder: 'Alt. Ordner',
+    tokenSlashHint: '/ = Ordner-Trennzeichen',
     cancel: 'Abbrechen',
-
     noTargetDir: 'Bitte zuerst einen Zielordner auswählen.',
-
     noSources: 'Bitte mindestens eine Quelle auswählen.',
-
     noTracks: 'Keine Tracks in den ausgewählten Quellen gefunden.',
-
     fetchError: 'Fehler beim Laden der Tracks vom Server.',
-
     syncComplete: 'Übertragung abgeschlossen.',
-
     dismiss: 'Schließen',
-
+    cancelSync: 'Abbrechen',
+    syncCancelled: 'Sync abgebrochen ({{done}} / {{total}} übertragen).',
     colStatus: 'Status',
-
     statusSynced: 'Synchronisiert',
-
     statusPending: 'Ausstehend',
-
     statusDeletion: 'Löschung',
-
     markForDeletion: 'Zur Löschung markieren',
-
     removeSource: 'Entfernen',
-
     undoDeletion: 'Löschung rückgängig',
-
     syncInBackground: 'Sync gestartet — du kannst die Seite verlassen.',
-
     syncInProgress: '{{done}} / {{total}} Tracks…',
-
     syncSummary: 'Sync-Zusammenfassung',
-
     calculating: 'Payload wird berechnet…',
-
     filesToAdd: 'Hinzuzufügende Dateien:',
-
     filesToDelete: 'Zu löschende Dateien:',
-
     netChange: 'Nettoänderung:',
-
     availableSpace: 'Verfügbarer Speicher:',
-
     spaceWarning: 'Warnung: Das Zielgerät hat nicht genug gemeldeten Speicherplatz.',
-
     proceed: 'Sync durchführen',
-
     notEnoughSpace: 'Nicht genug physischer Speicherplatz erkannt!',
-
     liveSearch: 'Live',
-
     randomAlbumsLabel: 'Zufallsalben',
-
   },
-
 };
-

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,1165 +1,2268 @@
 export const enTranslation = {
+
   sidebar: {
+
     library: 'Library',
+
     mainstage: 'Mainstage',
+
     newReleases: 'New Releases',
+
     allAlbums: 'All Albums',
+
     randomAlbums: 'Random Albums',
+
     randomPicker: 'Build a Mix',
+
     artists: 'Artists',
+
     randomMix: 'Random Mix',
+
     favorites: 'Favorites',
+
     nowPlaying: 'Now Playing',
+
     system: 'System',
+
     statistics: 'Statistics',
+
     settings: 'Settings',
+
     help: 'Help',
+
     expand: 'Expand Sidebar',
+
     collapse: 'Collapse Sidebar',
 
+
+
     downloadingTracks: 'Caching {{n}} tracks…',
+
     syncingTracks: 'Syncing {{done}}/{{total}}…',
+
     cancelDownload: 'Cancel download',
+
     offlineLibrary: 'Offline Library',
+
     genres: 'Genres',
+
     playlists: 'Playlists',
+
     mostPlayed: 'Most Played',
+
     radio: 'Internet Radio',
+
     folderBrowser: 'Folder Browser',
+
     deviceSync: 'Device Sync',
+
     libraryScope: 'Library scope',
+
     allLibraries: 'All libraries',
+
     expandPlaylists: 'Expand playlists',
+
     collapsePlaylists: 'Collapse playlists',
+
   },
+
   home: {
+
     hero: 'Featured',
+
     starred: 'Personal Favorites',
+
     recent: 'Recently Added',
+
     mostPlayed: 'Most Played',
+
     recentlyPlayed: 'Recently Played',
+
     discover: 'Discover',
+
     loadMore: 'Load More',
+
     discoverMore: 'Discover More',
+
     discoverArtists: 'Discover Artists',
+
     discoverArtistsMore: 'All Artists'
+
   },
+
   hero: {
+
     eyebrow: 'Featured Album',
+
     playAlbum: 'Play Album',
+
     enqueue: 'Enqueue',
+
     enqueueTooltip: 'Add entire album to queue',
+
   },
+
   search: {
+
     placeholder: 'Search for artist, album or song…',
+
     noResults: 'No results for "{{query}}"',
+
     artists: 'Artists',
+
     albums: 'Albums',
+
     songs: 'Songs',
+
     clearLabel: 'Clear search',
+
     title: 'Search',
+
     resultsFor: 'Results for "{{query}}"',
+
     album: 'Album',
+
     advanced: 'Advanced Search',
+
     advancedSearchTerm: 'Search term',
+
     advancedSearchPlaceholder: 'Title, album, artist…',
+
     advancedGenre: 'Genre',
+
     advancedAllGenres: 'All genres',
+
     advancedYear: 'Year',
+
     advancedYearFrom: 'from',
+
     advancedYearTo: 'to',
+
     advancedAll: 'All',
+
     advancedSearch: 'Search',
+
     advancedEmpty: 'Enter a search term or select a filter to begin.',
+
     advancedNoResults: 'No results found.',
+
     advancedGenreNote: 'Songs are randomly selected from this genre.',
+
     recentSearches: 'Recent Searches',
+
     browse: 'Browse',
+
     emptyHint: 'What do you want to hear?',
+
     genres: 'Genres',
+
   },
+
   nowPlaying: {
+
     tooltip: 'Who is listening?',
+
     title: 'Who is listening?',
+
     loading: 'Loading…',
+
     nobody: 'Nobody is currently listening.',
+
     minutesAgo: '{{n}}m ago',
+
     nothingPlaying: 'Nothing playing yet. Start a track!',
+
     aboutArtist: 'About the Artist',
+
     fromAlbum: 'From this Album',
+
     viewAlbum: 'View Album',
+
     goToArtist: 'Go to Artist',
+
     readMore: 'Read more',
+
     showLess: 'Show less',
+
     genreInfo: 'Genre',
+
     trackInfo: 'Track Info',
+
   },
+
   contextMenu: {
+
     playNow: 'Play Now',
+
     playNext: 'Play Next',
+
     addToQueue: 'Add to Queue',
+
     enqueueAlbum: 'Enqueue Album',
+
     startRadio: 'Start Radio',
+
     instantMix: 'Instant Mix',
+
     instantMixFailed: 'Could not build Instant Mix — server or plugin error.',
+
     cliMixNeedsTrack: 'Nothing is playing — start playback first, then run the mix command again.',
+
     lfmLove: 'Love on Last.fm',
+
     lfmUnlove: 'Unlove on Last.fm',
+
     favorite: 'Favorite',
+
     favoriteArtist: 'Favorite Artist',
+
     favoriteAlbum: 'Favorite Album',
+
     unfavorite: 'Remove from Favorites',
+
     unfavoriteArtist: 'Remove Artist from Favorites',
+
     unfavoriteAlbum: 'Remove Album from Favorites',
+
     removeFromQueue: 'Remove from Queue',
+
     removeFromPlaylist: 'Remove from Playlist',
+
     openAlbum: 'Open Album',
+
     goToArtist: 'Go to Artist',
+
     download: 'Download (ZIP)',
+
     addToPlaylist: 'Add to Playlist',
+
     selectedPlaylists: '{{count}} playlists selected',
+
     selectedAlbums: '{{count}} albums selected',
+
     selectedArtists: '{{count}} artists selected',
+
     songInfo: 'Song Info',
+
   },
+
   albumDetail: {
+
     back: 'Back',
+
     playAll: 'Play All',
+
     enqueue: 'Enqueue',
+
     enqueueTooltip: 'Add entire album to queue',
+
     artistBio: 'Artist Bio',
+
     download: 'Download (ZIP)',
+
     downloading: 'Loading…',
+
     cacheOffline: 'Make available offline',
+
     offlineCached: 'Available offline',
+
     offlineDownloading: 'Caching… ({{n}}/{{total}})',
+
     removeOffline: 'Remove offline cache',
+
     offlineStorageFull: 'Offline storage full (limit: {{mb}} MB). Free up space by deleting an album from your Offline Library, or increase the limit in Settings.',
+
     offlineStorageGoToLibrary: 'Offline Library',
+
     offlineStorageGoToSettings: 'Settings',
+
     favoriteAdd: 'Add to Favorites',
+
     favoriteRemove: 'Remove from Favorites',
+
     favorite: 'Favorite',
+
     noBio: 'No biography available.',
+
     moreByArtist: 'More by {{artist}}',
+
     tracksCount: '{{n}} Tracks',
+
     goToArtist: 'Go to {{artist}}',
+
     moreLabelAlbums: 'More albums on {{label}}',
+
     trackTitle: 'Title',
+
     trackAlbum: 'Album',
+
     trackArtist: 'Artist',
+
     trackGenre: 'Genre',
+
     trackFormat: 'Format',
+
     trackFavorite: 'Favorite',
+
     trackRating: 'Rating',
+
     trackDuration: 'Duration',
+
     trackTotal: 'Total',
+
     columns: 'Columns',
-    resetColumns: 'Reset to defaults',
+
     notFound: 'Album not found.',
+
     bioModal: 'Artist Biography',
+
     bioClose: 'Close',
+
     ratingLabel: 'Rating',
+
     enlargeCover: 'Enlarge',
+
     filterSongs: 'Filter songs…',
+
     sortNatural: 'Natural',
+
     sortByTitle: 'A–Z (Title)',
+
     sortByArtist: 'A–Z (Artist)',
+
     sortByAlbum: 'A–Z (Album)',
+
   },
+
   entityRating: {
+
     albumShort: 'Album rating',
+
     artistShort: 'Artist rating',
+
     albumAriaLabel: 'Album rating',
+
     artistAriaLabel: 'Artist rating',
+
     saveFailed: 'Could not save rating.',
+
   },
+
   artistDetail: {
+
     back: 'Back',
+
     albums: 'Albums',
+
     album: 'Album',
+
     playAll: 'Play All',
+
     shuffle: 'Shuffle',
+
     radio: 'Radio',
+
     loading: 'Loading…',
+
     noRadio: 'No similar tracks found for this artist.',
+
     notFound: 'Artist not found.',
+
     albumsBy: 'Albums by {{name}}',
+
     topTracks: 'Top Tracks',
+
     noAlbums: 'No albums found.',
+
     trackTitle: 'Title',
+
     trackAlbum: 'Album',
+
     trackDuration: 'Duration',
+
     favoriteAdd: 'Add to Favorites',
+
     favoriteRemove: 'Remove from Favorites',
+
     favorite: 'Favorite',
+
     albumCount_one: '{{count}} Album',
+
     albumCount_other: '{{count}} Albums',
+
     openedInBrowser: 'Opened in browser',
+
     featuredOn: 'Also Featured On',
+
     similarArtists: 'Similar Artists',
+
     cacheOffline: 'Save discography offline',
+
     offlineCached: 'Discography cached',
+
     offlineDownloading: 'Caching… ({{done}}/{{total}} albums)',
+
     uploadImage: 'Upload artist image',
+
     uploadImageError: 'Failed to upload image',
+
   },
+
   favorites: {
+
     title: 'Favorites',
+
     empty: "You haven't saved any favorites yet.",
+
     artists: 'Artists',
+
     albums: 'Albums',
+
     songs: 'Songs',
+
     enqueueAll: 'Add all to queue',
+
     playAll: 'Play all',
+
     removeSong: 'Remove from favorites',
+
     stations: 'Radio Stations',
+
     showingFiltered: 'Showing {{filtered}} of {{total}} ({{artist}})',
+
     showingCount: 'Showing {{filtered}} of {{total}}',
+
     clearArtistFilter: 'Clear artist filter',
+
     noFilterResults: 'No results with selected filters.',
+
     allArtists: 'All Artists',
+
   },
+
   randomLanding: {
+
     title: 'Build a Mix',
+
     mixByTracks: 'Mix by Tracks',
+
     mixByTracksDesc: 'Random selection of tracks from your entire library',
+
     mixByAlbums: 'Mix by Albums',
+
     mixByAlbumsDesc: 'Random album picks for your next discovery',
+
   },
+
   randomAlbums: {
+
     title: 'Random Albums',
+
     refresh: 'Refresh',
+
   },
+
   genres: {
+
     title: 'Genres',
+
     genreCount: 'Genres',
+
     albumCount_one: '{{count}} album',
+
     albumCount_other: '{{count}} albums',
+
     loading: 'Loading genres…',
+
     empty: 'No genres found.',
+
     albumsLoading: 'Loading albums…',
+
     albumsEmpty: 'No albums found for this genre.',
+
     loadMore: 'Load more',
+
     back: 'Back',
+
   },
+
   randomMix: {
+
     title: 'Random Mix',
+
     remix: 'Remix',
+
     remixTooltip: 'Load new random songs',
+
     remixGenre: 'Remix {{genre}}',
+
     remixTooltipGenre: 'Load new {{genre}} songs',
+
     playAll: 'Play All',
+
     trackTitle: 'Title',
+
     trackArtist: 'Artist',
+
     trackAlbum: 'Album',
+
     trackFavorite: 'Favorite',
+
     trackDuration: 'Duration',
+
     favoriteAdd: 'Add to Favorites',
+
     favoriteRemove: 'Remove from Favorites',
+
     play: 'Play',
+
     trackGenre: 'Genre',
+
     excludeAudiobooks: 'Exclude audiobooks & radio plays',
+
     excludeAudiobooksDesc: 'Matches keywords against genre, title, album, and artist — e.g. Hörbuch, Audiobook, Spoken Word, …',
+
     genreBlocked: 'Keyword blocked',
+
     genreAddedToBlacklist: 'Added to filter list',
+
     genreAlreadyBlocked: 'Already blocked',
+
     artistBlocked: 'Artist blocked',
+
     artistAddedToBlacklist: 'Artist added to filter list',
+
     artistClickHint: 'Click to block this artist',
+
     blacklistToggle: 'Keyword Filter',
+
     genreMixTitle: 'Genre Mix',
+
     genreMixDesc: 'Top 20 genres by song count — click to load a random mix',
+
     genreMixAll: 'All Songs',
+
     genreMixLoadMore: 'Load 10 more',
+
     genreMixNoGenres: 'No genres found on server.',
+
     shuffleGenres: 'Show different genres',
+
     filterPanelTitle: 'Filters',
+
     filterPanelDesc: 'Click a genre tag or artist name in the tracklist below to block it from future mixes.',
+
     genreClickHint: 'Click a genre tag to add it\nas a filter keyword.\nMatches genre, title, album & artist.',
+
   },
+
   albums: {
+
     title: 'All Albums',
+
     sortByName: 'A–Z (Album)',
+
     sortByArtist: 'A–Z (Artist)',
+
     sortNewest: 'Newest first',
+
     sortRandom: 'Random',
+
     yearFrom: 'From',
+
     yearTo: 'To',
+
     yearFilterClear: 'Clear year filter',
+
     yearFilterLabel: 'Year',
+
     select: 'Multi-select',
+
     startSelect: 'Enable multi-select',
+
     cancelSelect: 'Cancel',
+
     selectionCount: '{{count}} selected',
+
     downloadZips: 'Download ZIPs',
+
     addOffline: 'Add Offline',
+
     downloadingZip: 'Downloading {{current}}/{{total}}: {{name}}',
+
     downloadZipDone: '{{count}} ZIP(s) downloaded',
+
     downloadZipFailed: 'Failed to download {{name}}',
+
     offlineQueuing: 'Queuing {{count}} album(s) for offline…',
+
     offlineFailed: 'Failed to add {{name}} offline',
+
   },
+
   artists: {
+
     title: 'Artists',
+
     search: 'Search…',
+
     all: 'All',
+
     gridView: 'Grid view',
+
     listView: 'List view',
+
     imagesOn: 'Artist images on — may increase network and system load',
+
     imagesOff: 'Artist images off — showing initials only',
+
     loadMore: 'Load more',
+
     notFound: 'No artists found.',
+
     albumCount_one: '{{count}} Album',
+
     albumCount_other: '{{count}} Albums',
+
     selectionCount: '{{count}} selected',
+
     select: 'Multi-select',
+
     startSelect: 'Enable multi-select',
+
     cancelSelect: 'Cancel',
+
     addToPlaylist: 'Add to Playlist',
+
   },
+
   login: {
+
     subtitle: 'Your Navidrome Desktop Player',
+
     serverName: 'Server Name (optional)',
+
     serverNamePlaceholder: 'My Navidrome',
+
     serverUrl: 'Server URL',
+
     serverUrlPlaceholder: '192.168.1.100:4533 or https://music.example.com',
+
     username: 'Username',
+
     usernamePlaceholder: 'admin',
+
     password: 'Password',
+
     showPassword: 'Show password',
+
     hidePassword: 'Hide password',
+
     connect: 'Connect',
+
     connecting: 'Connecting…',
+
     connected: 'Connected!',
+
     error: 'Connection failed – please check your details.',
+
     urlRequired: 'Please enter a server URL.',
+
     savedServers: 'Saved Servers',
+
     addNew: 'Or add a new server',
+
   },
+
   connection: {
+
     connected: 'Connected',
+
     connectedTo: 'Connected to {{server}}',
+
     disconnected: 'Disconnected',
+
     disconnectedFrom: 'Cannot reach {{server}} — click to check settings',
+
     checking: 'Connecting…',
+
     extern: 'Extern',
+
     offlineTitle: 'No server connection',
+
     offlineSubtitle: 'Cannot reach {{server}}. Check your network or server.',
+
     offlineModeBanner: 'Offline Mode — playing from local cache',
+
     offlineNoCacheBanner: 'No server connection — cannot reach {{server}}',
+
     offlineLibraryTitle: 'Offline Library',
+
     offlineLibraryEmpty: 'No albums cached yet. Go online, open an album and click "Make available offline".',
+
     offlineAlbumCount: '{{n}} album',
+
     offlineAlbumCount_plural: '{{n}} albums',
+
     offlineFilterAll: 'All',
+
     offlineFilterAlbums: 'Albums',
+
     offlineFilterPlaylists: 'Playlists',
+
     offlineFilterArtists: 'Discographies',
+
     retry: 'Retry',
+
     serverSettings: 'Server Settings',
+
     switchServerTitle: 'Switch server',
+
     switchServerHint: 'Click to choose another saved server.',
+
     manageServers: 'Manage servers…',
+
     switchFailed: 'Could not switch — server unreachable.',
+
     lastfmConnected: 'Last.fm connected as @{{user}}',
+
     lastfmSessionInvalid: 'Session invalid — click to re-connect',
+
   },
+
   common: {
+
     albums: 'Albums',
+
     album: 'Album',
+
     loading: 'Loading…',
+
     loadingMore: 'Loading…',
+
     loadingPlaylists: 'Loading Playlists…',
+
     noAlbums: 'No albums found.',
+
     downloading: 'Downloading…',
+
     downloadZip: 'Download (ZIP)',
+
     back: 'Back',
+
     cancel: 'Cancel',
+
     save: 'Save',
+
     delete: 'Delete',
+
     use: 'Use',
+
     add: 'Add',
+
     active: 'Active',
+
     download: 'Download',
+
     chooseDownloadFolder: 'Choose download folder',
+
     noFolderSelected: 'No folder selected',
+
     rememberDownloadFolder: 'Remember this folder',
+
     filterGenre: 'Genre Filter',
+
     filterSearchGenres: 'Search genres…',
+
     filterNoGenres: 'No genres match',
+
     filterClear: 'Clear',
+
     play: 'Play',
+
     bulkSelected: '{{count}} selected',
+
     clearSelection: 'Clear selection',
+
     bulkAddToPlaylist: 'Add to Playlist',
+
     bulkRemoveFromPlaylist: 'Remove from Playlist',
+
     bulkClear: 'Clear selection',
+
     updaterAvailable: 'Update available',
+
     updaterVersion: 'v{{version}} is available',
+
     updaterWebsite: 'Website',
+
     updaterModalTitle: 'New Version Available',
+
     updaterChangelog: "What's New",
+
     updaterDownloadBtn: 'Download Now',
+
     updaterSkipBtn: 'Skip this Version',
+
     updaterRemindBtn: 'Remind me Later',
+
     updaterDone: 'Download complete',
+
     updaterShowFolder: 'Show in Folder',
+
     updaterInstallHint: 'Close Psysonic and run the installer manually.',
+
     updaterAurHint: 'Install the update via AUR:',
+
     updaterErrorMsg: 'Download failed',
+
     updaterRetryBtn: 'Retry',
+
     durationHoursMinutes: '{{hours}}h {{minutes}}m',
+
     durationMinutesOnly: '{{minutes}}m',
+
     updaterOpenGitHub: 'Open on GitHub',
+
     filters: 'Filters',
+
     more: 'more',
+
     yearRange: 'Year Range',
+
     clearAll: 'Clear all',
+
   },
+
   settings: {
+
     title: 'Settings',
+
     language: 'Language',
+
     languageEn: 'English',
+
     languageDe: 'German',
+
     languageFr: 'French',
+
     languageNl: 'Dutch',
+
     languageZh: 'Chinese',
+
     languageNb: 'Norwegian',
+
     languageRu: 'Russian',
+
     languageEs: 'Spanish',
+
     font: 'Font',
+
     theme: 'Theme',
+
     appearance: 'Appearance',
+
     servers: 'Servers',
+
     serverName: 'Server Name',
+
     serverUrl: 'Server URL',
+
     serverUrlPlaceholder: '192.168.1.100:4533 or https://music.example.com',
+
     serverUsername: 'Username',
+
     serverPassword: 'Password',
+
     addServer: 'Add Server',
+
     addServerTitle: 'Add New Server',
+
     useServer: 'Use',
+
     deleteServer: 'Delete',
+
     noServers: 'No servers saved.',
+
     serverActive: 'Active',
+
     confirmDeleteServer: 'Delete server "{{name}}"?',
+
     serverConnecting: 'Connecting…',
+
     serverConnected: 'Connected!',
+
     serverFailed: 'Connection failed.',
+
     testBtn: 'Test Connection',
+
     testingBtn: 'Testing…',
+
     serverCompatible: 'Compatible with: Navidrome · Gonic · Airsonic · Subsonic',
+
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+
     audiomuseDesc:
+
       'Turn on if this server has the <pluginLink>AudioMuse-AI Navidrome plugin</pluginLink> configured. Enables Instant Mix from tracks and uses server-side similar artists instead of Last.fm on artist pages.',
+
     audiomuseIssueHint:
+
       'Instant Mix failed recently — check the Navidrome plugin and AudioMuse API. Similar artists fall back to Last.fm when the server returns none.',
+
     connected: 'Connected',
+
     failed: 'Failed',
+
     eqTitle: 'Equalizer',
+
     eqEnabled: 'Enable Equalizer',
+
     eqPreset: 'Preset',
+
     eqPresetCustom: 'Custom',
+
     eqPresetBuiltin: 'Built-in Presets',
+
     eqPresetCustomGroup: 'My Presets',
+
     eqSavePreset: 'Save as Preset',
+
     eqPresetName: 'Preset name…',
+
     eqDeletePreset: 'Delete preset',
+
     eqResetBands: 'Reset to Flat',
+
     eqPreGain: 'Pre-gain',
+
     eqResetPreGain: 'Reset pre-gain',
+
     eqAutoEqTitle: 'AutoEQ Headphone Lookup',
+
     eqAutoEqPlaceholder: 'Search headphone / IEM model…',
+
     eqAutoEqSearching: 'Searching…',
+
     eqAutoEqNoResults: 'No results found',
+
     eqAutoEqError: 'Search failed',
+
     eqAutoEqRateLimit: 'GitHub rate limit reached — try again in a minute',
+
     eqAutoEqFetchError: 'Failed to fetch EQ profile',
+
     lfmTitle: 'Last.fm',
+
     lfmConnect: 'Connect with Last.fm',
+
     lfmConnecting: 'Waiting for authorisation…',
+
     lfmConfirm: 'I have authorised the app',
+
     lfmConnected: 'Connected as',
+
     lfmDisconnect: 'Disconnect',
+
     lfmConnectDesc: 'Connect your Last.fm account to enable scrobbling and Now Playing updates directly from Psysonic — no Navidrome configuration required.',
+
     lfmOpenBrowser: 'A browser window will open. Authorise Psysonic on Last.fm, then click the button below.',
+
     lfmScrobbles: '{{n}} scrobbles',
+
     lfmMemberSince: 'Member since {{year}}',
+
     scrobbleEnabled: 'Scrobbling enabled',
+
     scrobbleDesc: 'Send songs to Last.fm after 50% playtime',
+
     behavior: 'App Behavior',
+
     cacheTitle: 'Max. Storage Size',
+
     cacheDesc: 'Cover art and artist images. When full, the oldest entries are removed automatically. Offline albums are not auto-removed, but will be deleted when clearing the cache manually.',
+
     cacheUsedImages: 'Images:',
+
     cacheUsedOffline: 'Offline tracks:',
+
     cacheUsedHot: 'Size on disk:',
+
     hotCacheTrackCount: 'Tracks in cache:',
+
     cacheMaxLabel: 'Max. size',
+
     cacheClearBtn: 'Clear Cache',
+
     cacheClearWarning: 'This will also remove all offline albums from the library.',
+
     cacheClearConfirm: 'Clear Everything',
+
     cacheClearCancel: 'Cancel',
+
     offlineDirTitle: 'Offline Library (In-App)',
+
     offlineDirDesc: 'Storage location for tracks you make available offline within Psysonic.',
+
     offlineDirDefault: 'Default (App Data)',
+
     offlineDirChange: 'Change Directory',
+
     offlineDirClear: 'Reset to Default',
+
     offlineDirHint: 'New downloads will use this location. Existing downloads remain at their original path.',
+
     hotCacheTitle: 'Hot playback cache',
+
     hotCacheAlphaBadge: 'Alpha',
+
     hotCacheDisclaimer: 'Preloads upcoming queue tracks and keeps previous ones. When enabled, uses disk space and network.',
+
     hotCacheDirDefault: 'Default (App Data)',
+
     hotCacheDirChange: 'Change folder',
+
     hotCacheDirClear: 'Reset to default',
+
     hotCacheDirHint: 'Changing the folder resets the in-app index; files already on disk stay where they are until you remove them.',
+
     hotCacheEnabled: 'Enable hot playback cache',
+
     hotCacheMaxMb: 'Maximum cache size',
+
     hotCacheDebounce: 'Queue change debounce',
+
     hotCacheDebounceImmediate: 'Immediate',
+
     hotCacheDebounceSeconds: '{{n}} s',
+
     hotCacheClearBtn: 'Clear hot cache',
+
     audioOutputDevice: 'Audio Output Device',
+
     audioOutputDeviceDesc: 'Select which audio device Psysonic plays through. Changes take effect immediately and restart the current track.',
+
     audioOutputDeviceDefault: 'System Default',
+
     audioOutputDeviceRefresh: 'Refresh device list',
+
     audioOutputDeviceOsDefaultNow: 'current system output',
+
     audioOutputDeviceListError: 'Could not load the audio device list.',
+
     audioOutputDeviceNotInCurrentList: 'not in current list',
+
     hiResTitle: 'Native Hi-Res Playback',
+
     hiResEnabled: 'Enable native hi-res playback',
+
     hiResDesc: "Forces 44.1 kHz output by default for maximum stability. Enable only if your hardware and network reliably support high sample rates (88.2 kHz+).",
+
     showArtistImages: 'Show Artist Images',
+
     showArtistImagesDesc: 'Load and display artist images in the Artists overview. Disabled by default to reduce server disk I/O and network load on large libraries.',
+
     showTrayIcon: 'Show Tray Icon',
+
     showTrayIconDesc: 'Display the Psysonic icon in the system notification area / menu bar.',
+
     minimizeToTray: 'Minimize to Tray',
+
     minimizeToTrayDesc: 'When closing the window, keep Psysonic running in the system tray instead of quitting.',
+
     discordRichPresence: 'Discord Rich Presence',
+
     discordRichPresenceDesc: 'Show the currently playing track on your Discord profile. Requires Discord to be running.',
+
     useCustomTitlebar: 'Custom title bar',
+
     useCustomTitlebarDesc: 'Replace the system title bar with a built-in one that matches the app theme. Disable to use the native GNOME/GTK title bar.',
+
     discordAppleCovers: 'Fetch covers from Apple Music for Discord',
+
     discordAppleCoversDesc: 'Sends the artist and album name to Apple\'s search API to find cover art for your Discord profile. Disabled by default for privacy.',
+
+    discordTemplates: 'Custom text templates',
+
+    discordTemplatesDesc: 'Customize what information is shown on your Discord profile. Variables: {title}, {artist}, {album}, {paused}',
+
+    discordTemplateDetails: 'Primary line (details)',
+
+    discordTemplateState: 'Secondary line (state)',
+
+    discordTemplateLargeText: 'Album tooltip (largeText)',
+
     nowPlayingEnabled: 'Show in Now Playing',
+
     nowPlayingEnabledDesc: 'Broadcast your currently playing track to the server\'s live listener view. Disable to stop sending playback data.',
+
     lyricsServerFirst: 'Prefer server lyrics',
+
     lyricsServerFirstDesc: 'Check server-provided lyrics (embedded tags, sidecar files) before querying LRCLIB. Disable to use LRCLIB first.',
+
     enableNeteaselyrics: 'Netease Cloud Music lyrics',
+
     enableNeteaselyricsDesc: 'Use Netease Cloud Music as a last-resort lyrics source when server and LRCLIB both return nothing. Best coverage for Asian and international music.',
+
     lyricsSourcesTitle: 'Lyrics Sources',
+
     lyricsSourcesDesc: 'Choose which sources to query for lyrics and in what order. Drag to reorder. Disabled sources are skipped entirely.',
+
     lyricsSourceServer: 'Server',
+
     lyricsSourceLrclib: 'LRCLIB',
+
     lyricsSourceNetease: 'Netease Cloud Music',
+
     downloadsTitle: 'ZIP Export & Archiving',
+
     downloadsFolderDesc: 'Destination folder for albums you download as a ZIP file to your computer.',
+
     downloadsDefault: 'Default Downloads Folder',
+
     pickFolder: 'Select',
+
     pickFolderTitle: 'Select Download Folder',
+
     clearFolder: 'Clear download folder',
+
     logout: 'Logout',
+
     aboutTitle: 'About Psysonic',
+
     aboutDesc: 'A modern desktop music player for Subsonic-compatible servers (Navidrome, Gonic, and others). Built on Tauri v2 with a native Rust audio engine — lightweight and fast, yet packed with features: waveform seekbar, synchronized lyrics, Last.fm integration, 10-band EQ, crossfade, gapless playback, Replay Gain, genre browsing, and a large library of themes.',
+
     aboutLicense: 'License',
+
     aboutLicenseText: 'GNU GPL v3 — free to use, modify, and distribute under the same license.',
+
     aboutRepo: 'Source Code on GitHub',
+
     aboutVersion: 'Version',
+
     aboutBuiltWith: 'Built with Tauri · React · TypeScript · Rust/rodio',
+
     aboutAiCredit: 'Developed with the support of Claude Code by Anthropic',
+
     aboutContributorsLabel: 'Contributors',
+
     aboutSpecialThanksLabel: 'Special Thanks',
+
     changelog: 'Changelog',
+
     showChangelogOnUpdate: "Show 'What's New' on update",
+
     showChangelogOnUpdateDesc: "Automatically show what's new when a new version is launched for the first time.",
+
     randomMixTitle: 'Random Mix',
+
     randomMixBlacklistTitle: 'Custom Filter Keywords',
+
     randomMixBlacklistDesc: 'Songs are excluded when any keyword matches their genre, title, album, or artist (active when the checkbox above is on).',
+
     randomMixBlacklistPlaceholder: 'Add keyword…',
+
     randomMixBlacklistAdd: 'Add',
+
     randomMixBlacklistEmpty: 'No custom keywords added yet.',
+
     randomMixHardcodedTitle: 'Built-in keywords (active when checkbox is on)',
+
     tabAudio: 'Audio',
+
     tabStorage: 'Storage & Downloads',
+
     tabAppearance: 'Appearance',
+
     homeCustomizerTitle: 'Home Page',
+
     sidebarTitle: 'Sidebar',
+
     sidebarReset: 'Reset to default',
+
     sidebarDrag: 'Drag to reorder',
+
     sidebarFixed: 'Always visible',
-    randomNavSplitTitle: 'Split Mix navigation',
-    randomNavSplitDesc: 'Show "Random Mix" and "Random Albums" as separate sidebar entries instead of the "Build a Mix" hub.',
+
     tabInput: 'Input',
+
     tabServer: 'Server',
+
     tabSystem: 'System',
+
     tabGeneral: 'General',
+
     ratingsSectionTitle: 'Ratings',
+
     ratingsSkipStarTitle: 'Skip for 1 star',
+
     ratingsSkipStarDesc:
+
       'After several skips in a row, set the track to 1★. Only for tracks not yet rated.',
+
     ratingsSkipStarThresholdLabel: 'Skips',
+
     ratingsMixFilterTitle: 'Filter by rating',
+
     ratingsMixFilterDesc:
+
       'Filter low-rated items in {{mix}} and {{albums}}. Click the selected star again to turn off the threshold.',
+
     ratingsMixMinSong: 'Songs',
+
     ratingsMixMinAlbum: 'Albums',
+
     ratingsMixMinArtist: 'Artists',
+
     ratingsMixMinThresholdAria: 'Minimum stars: {{label}}',
+
     backupTitle: 'Backup & Restore',
+
     backupExport: 'Export settings',
+
     backupExportDesc: 'Saves all settings, server profiles, Last.fm config, theme, EQ and keybindings to a .psybkp file. Passwords are stored in plaintext — keep the file secure.',
+
     backupImport: 'Import settings',
+
     backupImportDesc: 'Restores settings from a .psybkp file. The app will reload after import.',
+
     backupImportConfirm: 'This will overwrite all current settings. Continue?',
+
     backupSuccess: 'Backup saved',
+
     backupImportSuccess: 'Settings restored — reloading…',
+
     backupImportError: 'Invalid or corrupted backup file.',
+
     shortcutsReset: 'Reset to defaults',
+
     shortcutListening: 'Press a key…',
+
     shortcutUnbound: '—',
+
     globalShortcutsTitle: 'Global Shortcuts',
+
     globalShortcutsNote: 'Work system-wide even when Psysonic is in the background. Requires Ctrl, Alt, or Super as a modifier.',
+
     shortcutClear: 'Clear',
+
     shortcutPlayPause: 'Play / Pause',
+
     shortcutNext: 'Next track',
+
     shortcutPrev: 'Previous track',
+
     shortcutVolumeUp: 'Volume up',
+
     shortcutVolumeDown: 'Volume down',
+
     shortcutSeekForward: 'Seek forward 10s',
+
     shortcutSeekBackward: 'Seek backward 10s',
+
     shortcutToggleQueue: 'Toggle queue',
+
     shortcutOpenFolderBrowser: 'Open {{folderBrowser}}',
+
     shortcutFullscreenPlayer: 'Fullscreen player',
+
     shortcutNativeFullscreen: 'Native fullscreen',
+
     playbackTitle: 'Playback',
+
     replayGain: 'Replay Gain',
+
     replayGainDesc: 'Normalize track volume using ReplayGain metadata',
+
     replayGainMode: 'Mode',
+
     replayGainTrack: 'Track',
+
     replayGainAlbum: 'Album',
+
     replayGainPreGain: 'Pre-Gain (tagged files)',
+
     replayGainFallback: 'Fallback (untagged / radio)',
+
     crossfade: 'Crossfade',
+
     crossfadeDesc: 'Fade between tracks',
+
     crossfadeSecs: '{{n}} s',
+
     notWithGapless: 'Not available while Gapless is active',
+
     notWithCrossfade: 'Not available while Crossfade is active',
+
     gapless: 'Gapless Playback',
+
     gaplessDesc: 'Pre-buffer next track to eliminate gaps between songs',
+
     preloadMode: 'Preload Next Track',
+
     preloadModeDesc: 'When to start buffering the next track in the queue',
+
     nextTrackBufferingTitle: 'Next Track Buffering',
+
     preloadHotCacheMutualExclusive: 'Preload and Hot Cache serve the same purpose — only one can be active at a time. Enabling one will automatically disable the other.',
+
     preloadOff: 'Off',
+
     preloadBalanced: 'Balanced (30 s before end)',
+
     preloadEarly: 'Early (after 5 s of playback)',
+
     preloadCustom: 'Custom',
+
     preloadCustomSeconds: 'Seconds before end: {{n}}',
+
     infiniteQueue: 'Infinite Queue',
+
     infiniteQueueDesc: 'Automatically append random tracks when the queue runs out',
+
     experimental: 'Experimental',
+
     fsPlayerSection: 'Fullscreen Player',
+
     fsShowArtistPortrait: 'Show artist photo',
+
     fsShowArtistPortraitDesc: 'Display the artist photo (or album art) on the right side of the fullscreen player.',
+
     fsPortraitDim: 'Photo dimming',
+
     seekbarStyle: 'Seekbar Style',
+
     seekbarStyleDesc: 'Choose the look of the player seek bar',
+
     seekbarWaveform: 'Waveform',
+
     seekbarLinedot: 'Line & Dot',
+
     seekbarBar: 'Bar',
+
     seekbarThick: 'Thick Bar',
+
     seekbarSegmented: 'Segmented',
+
     seekbarNeon: 'Neon Glow',
+
     seekbarPulsewave: 'Pulse Wave',
+
     seekbarParticletrail: 'Particle Trail',
+
     seekbarLiquidfill: 'Liquid Fill',
+
     seekbarRetrotape: 'Retro Tape',
+
     themeSchedulerTitle: 'Auto-Switch Theme',
+
     themeSchedulerEnable: 'Enable Theme Scheduler',
+
     themeSchedulerEnableSub: 'Automatically switch between two themes based on the time of day',
+
     themeSchedulerDayTheme: 'Day Theme',
+
     themeSchedulerDayStart: 'Day Starts At',
+
     themeSchedulerNightTheme: 'Night Theme',
+
     themeSchedulerNightStart: 'Night Starts At',
+
     themeSchedulerActiveHint: 'Theme Scheduler is active - theme changes are managed automatically.',
+
     visualOptionsTitle: 'Visual Options',
+
     coverArtBackground: 'Cover Art Background',
+
     coverArtBackgroundSub: 'Show blurred cover art as background in album/playlist headers',
+
     playlistCoverPhoto: 'Playlist Cover Photo',
+
     playlistCoverPhotoSub: 'Show cover photo grid in playlist detail view',
+
     showBitrate: 'Show Bitrate',
+
     showBitrateSub: 'Display audio bitrate in track listings',
+
     uiScaleTitle: 'Interface Scale',
+
     uiScaleLabel: 'Zoom',
+
   },
+
   changelog: {
+
     modalTitle: "What's New",
+
     dontShowAgain: "Don't show again",
+
     close: 'Got it',
+
   },
+
   help: {
+
     title: 'Help',
+
     s1: 'Getting Started',
+
     q1: 'Which servers are compatible?',
+
     a1: 'Psysonic works with any Subsonic-compatible server: Navidrome, Gonic, Subsonic, Airsonic, and others. Navidrome is the recommended choice.',
+
     q2: 'How do I connect to my server?',
+
     a2: 'Open Settings and click "Add Server". Enter the server URL (e.g. 192.168.1.100:4533), your username, and password. Psysonic tests the connection before saving — nothing is stored if the connection fails.',
+
     q3: 'Can I use multiple servers?',
+
     a3: 'Yes. You can add as many servers as you like in Settings and switch between them at any time. Only one server is active at a time.',
+
     s2: 'Playback',
+
     q4: 'How do I play music?',
+
     a4: 'Double-click any track to play it. On album and artist pages, use "Play All" to start the whole album. You can also drag tracks into the queue panel.',
+
     q5: 'What keyboard shortcuts are available?',
+
     a5: 'Space = Play / Pause · Escape = Close fullscreen player. Media keys (Play/Pause, Next, Previous) work on all platforms. On Linux, use the player bar buttons for media keys. In-app shortcuts and system-wide global shortcuts can be customized in Settings → Keyboard Shortcuts / Global Shortcuts.',
+
     q6: 'What is the queue?',
+
     a6: 'The queue shows all upcoming tracks. Open it with the panel icon in the top-right header (next to the Now Playing indicator). You can reorder tracks by dragging, shuffle with the shuffle button, and save the queue as a playlist.',
+
     q7: 'How do I open the fullscreen player?',
+
     a7: 'Click the album art thumbnail in the player bar at the bottom, or the expand icon next to it. Press Escape to close it again.',
+
     q8: 'How does repeat work?',
+
     a8: 'Click the repeat button in the player bar to cycle through: Off → Repeat All → Repeat One.',
+
     s3: 'Library',
+
     q9: 'How do I download an album?',
+
     a9: 'Open an album\'s detail page and click "Download (ZIP)". The server compresses the album into a ZIP file first — for large albums or lossless files (FLAC / WAV) this can take a moment before the download actually starts. This is normal: the progress bar appears once the server finishes zipping and the transfer begins.',
+
     q10: 'How do I star / favorite tracks and albums?',
+
     a10: 'Click the star icon on any track row or on the album header. Starred items appear in the Favorites section in the sidebar.',
+
     q11: 'What is the hero carousel on the home page?',
+
     a11: 'The banner at the top of the home page randomly picks albums from your library and rotates through them every 10 seconds. Click the dots to jump to a specific one, or click the banner to open the album.',
+
     s4: 'Settings',
+
     q12: 'How do I change the theme?',
+
     a12: 'Settings → Theme. Choose from a large selection of themes across 8 groups: Psysonic Themes, Mediaplayer, Operating Systems, Games, Movies, Series, Social Media, and Open Source Classics (Catppuccin, Nord, Gruvbox, Nightfox).',
+
     q13: 'How do I change the language?',
+
     a13: 'Settings → Language. English, German, Spanish, French, Dutch, Chinese, Norwegian, and Russian are supported.',
+
     q15: 'How do I set a download folder?',
+
     a15: 'Settings → App Behavior → Download Folder. Pick any folder — downloaded albums are saved there as ZIP files. Without a custom folder, your browser\'s default downloads location is used.',
+
     s5: 'Scrobbling',
+
     q16: 'How does scrobbling work?',
+
     a16: 'Psysonic scrobbles directly to Last.fm — no Navidrome configuration needed. Connect your Last.fm account in Settings → Last.fm and enable scrobbling there.',
+
     q17: 'When is a scrobble sent?',
+
     a17: 'A scrobble is submitted after you\'ve listened to 50% of a track.',
+
     q22: 'What is the waveform in the player bar?',
+
     a22: 'The waveform seekbar replaces the classic progress slider. Click anywhere on it to jump to that position, or drag to scrub. The played portion glows with a blue-to-mauve gradient, the buffered range appears slightly brighter, and the unplayed portion is faded.',
+
     q24: 'Can I shuffle the queue?',
+
     a24: 'Yes. Open the queue panel and click the shuffle icon in the queue header. The currently playing track stays at position 1 — all remaining tracks are randomly reordered.',
+
     q25: 'Do Last.fm and Wikipedia links on artist pages open in a browser?',
+
     a25: 'Yes — they open in your default system browser. The button briefly shows a confirmation label when clicked.',
+
     s7: 'Random Mix',
+
     q26: 'What is Random Mix?',
+
     a26: 'Random Mix builds a playlist of random tracks from your entire library. Open it via "Random Mix" in the sidebar and click "New Mix". You can adjust the track count before generating.',
+
     q27: 'What is the Keyword Filter?',
+
     a27: 'The Keyword Filter excludes tracks whose genre, title, or album name contains specific words. Audiobooks are filtered automatically. Add custom keywords in Settings → Random Mix, or click any genre tag in the track list to add it instantly.',
+
     q28: 'What is the Super Genre Mix?',
+
     a28: 'The Super Genre Mix groups your library into broad categories (Rock, Metal, Electronic, Jazz, Classical, etc.) and builds a focused mix from that style. Select a category chip below the track list. Results appear progressively as each sub-genre is fetched.',
+
     s6: 'Troubleshooting',
+
     q18: 'Cover art and artist images load slowly.',
+
     a18: 'Images are fetched from your server\'s disk on first load and then cached locally for 30 days. If your server\'s storage is slow, the first visit to a page may take a moment. Subsequent visits will be instant.',
+
     q19: 'The connection test fails.',
+
     a19: 'Check the URL including the port (e.g. http://192.168.1.100:4533). Make sure no firewall blocks the connection. Try http:// instead of https:// on a local network. Also verify that your username and password are correct.',
+
     q20: 'No audio on Linux.',
+
     a20: 'Psysonic is available as .deb (Ubuntu/Debian), .rpm (Fedora/RHEL), and via AUR on Arch/CachyOS (yay -S psysonic). There is no AppImage. If audio is missing, ensure PipeWire or PulseAudio is running.',
+
     q21: 'The app shows a black screen on Linux.',
+
     a21: 'This is usually a GPU/EGL driver issue in WebKitGTK. Launch with GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. The AUR package and official .deb/.rpm installers set these automatically.',
+
     q29: 'What are Crossfade and Gapless Playback?',
+
     a29: 'Both are experimental audio features in Settings → Audio. Gapless pre-buffers the next track to eliminate silence between songs. Crossfade fades out the current track while fading in the next — adjust the duration (1–10 s) to taste.',
+
     q30: 'Does Psysonic show lyrics?',
+
     a30: 'Yes. Click the microphone icon in the player bar to open the Lyrics tab in the queue panel. Psysonic fetches lyrics automatically from LRCLIB. If synced lyrics are available, the active line is highlighted and scrolls in real time as the song plays. If only plain text is available, the full text is shown statically.',
+
     q31: 'Can I customize keyboard shortcuts?',
+
     a31: 'Yes. Settings → Keyboard Shortcuts lets you remap in-app actions (Play/Pause, Next, Previous, Volume Up/Down, Fullscreen, and more) to any key. Settings → Global Shortcuts lets you assign system-wide shortcuts that trigger even when Psysonic is in the background.',
+
     q32: 'Can I change the font?',
+
     a32: 'Yes. Settings → Font lets you choose from 10 fonts including IBM Plex Mono, Fira Code, JetBrains Mono, Courier Prime, and others. The selected font applies to the entire UI.',
+
     s8: 'Offline Mode',
+
     q34: 'What is Offline Mode?',
+
     a34: 'Offline Mode (Beta) lets you cache albums to your device so you can listen without an active server connection. Cached tracks are stored locally and played back directly from disk — no network request is made during playback.',
+
     q35: 'How do I cache an album for offline use?',
+
     a35: 'Open any album and click the download icon in the album header. Psysonic downloads all tracks in the background. Progress is shown on the button. Once cached, the icon turns green. You can view and remove cached albums in the Offline Library page (sidebar).',
+
     q36: 'How much storage can offline caching use?',
+
     a36: 'You can set a maximum cache size in Settings → Library. When the limit is reached, a warning banner appears on the album page. You can delete individual albums from the Offline Library to free up space.',
+
     q37: 'How do I rate songs, albums, and artists?',
+
     a37: 'Psysonic supports 1–5 star ratings via the OpenSubsonic API (requires Navidrome ≥ 0.53). Rate songs in the album or playlist track list using the star column, in the right-click context menu, or directly in the player bar below the artist name. Albums can be rated on their detail page; artists on their artist page. Ratings are saved to the server immediately.',
+
     q38: 'Can I remove or change a rating?',
+
     a38: 'Yes. Click the currently active star to clear the rating entirely — clicking the same star a second time removes it. To change a rating, simply click a different star.',
+
     q39: 'What is Skip-to-1★ and the rating filter?',
+
     a39: 'Skip-to-1★ automatically assigns a 1-star rating to a song after you manually skip it a configurable number of consecutive times. Enable it and set the skip threshold in Settings → Ratings. The same settings panel lets you set a minimum star rating for Random Mix and Random Albums, so only songs, albums, or artists above a certain rating are included in generated mixes.',
+
     q40: 'What is the Folder Browser?',
+
     a40: 'The Folder Browser (sidebar) lets you navigate your server\'s music directory tree using a Miller-column layout. Click a folder to drill into it; click a track or the play icon on a folder to play or enqueue its contents directly.',
+
     q41: 'What is the Theme Scheduler?',
+
     a41: 'Settings → Appearance → Auto-Switch Theme: define a day theme and a night theme with start times. Psysonic switches automatically at the configured hours. When the scheduler is active, a hint in the theme picker explains why manual theme selection has no immediate effect.',
+
     q42: 'Can I resize the interface?',
+
     a42: 'Yes. Settings → Appearance → Interface Scale lets you scale the entire UI between 80 % and 125 % without affecting your system font size.',
+
     q43: 'Can I change the seekbar style?',
+
     a43: 'Yes. Settings → Appearance → Seekbar Style offers 10 styles: Waveform, Line & Dot, Bar, Thick Bar, Segmented, Neon Glow, Pulse Wave, Particle Trail, Liquid Fill, and Retro Tape.',
+
     q44: 'What is AutoEQ?',
+
     a44: 'The 10-band EQ in Settings → Audio includes an AutoEQ lookup. Enter your headphone model and Psysonic fetches a correction profile from the AutoEQ database and applies it automatically to the equalizer bands.',
+
     q45: 'What is Replay Gain?',
+
     a45: 'Replay Gain normalizes track volume so loud and quiet albums play at a consistent level. Enable it in Settings → Audio → Replay Gain and choose Track mode (per-song normalization) or Album mode (preserves relative dynamics within an album).',
+
     q46: 'What is the Hot Cache?',
+
     a46: 'Hot Cache (Alpha, Settings → Library) preloads the next several tracks in your queue to disk so playback starts instantly with no buffering delay — especially useful on slow or remote servers. Psysonic keeps the current track and the next 5 in cache and evicts older entries when the size limit is reached. You can set the maximum cache size and a debounce delay to avoid unnecessary fetches when skipping quickly.',
+
     q47: 'Can I cache a playlist for offline use?',
+
     a47: 'Yes. Open any playlist and click the download icon in the playlist header. All tracks are downloaded in the background — progress is shown in the offline download indicator. Once fully cached, the icon changes to a red trash icon; clicking it removes the playlist from the offline cache.',
-    q48: 'What is Infinite Queue?',
-    a48: 'When the queue runs out and Repeat is off, Psysonic silently appends random tracks from your library so playback never stops. Auto-added tracks appear below a "— Added automatically —" divider in the queue. Toggle it with the infinity icon in the queue header. You can also restrict auto-added tracks to a specific genre in Settings → Queue.',
-    q49: 'Can I control Psysonic from the command line?',
-    a49: 'Yes — the Psysonic binary doubles as a remote control for the running app. Examples: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one, --player star / unstar, --player rating 1-5. You can also switch servers (--player server list / set), change the audio device (--player audio-device list / set), filter the music library (--player library list / set), trigger an Instant Mix (--player mix new / append), and search (--player search track|album|artist <query>). Run psysonic --player --help for the full list. Shell completions for bash and zsh are available via psysonic completions.',
-    q50: 'How do I manage playlists?',
-    a50: 'Open "Playlists" in the sidebar. Click "New Playlist" to create one. On a playlist detail page you can drag tracks to reorder them, remove tracks with the × button, search your library to add songs, and use "Suggestions" to get smart track recommendations based on your playlist content. Right-click any track for more options.',
-    q51: 'Can I back up and restore my settings?',
-    a51: 'Yes. Settings → Backup & Restore lets you export all your settings, server profiles, themes, and keybindings to a single JSON file. Import it on another machine or after a reinstall to restore everything at once. Passwords are included in the backup — store the file securely.',
-    q52: 'How do I change the audio output device?',
-    a52: 'Settings → Audio → Output Device. Psysonic lists all available audio outputs on your system. Select the one you want — playback switches immediately. Use the refresh button next to the list if a device was connected after the app started. On Linux this uses ALSA device names; generic entries like "default" or "sysdefault" are automatically cleaned up for readability.',
-    q53: 'What is Device Sync?',
-    a53: 'Device Sync lets you copy albums, playlists, or entire artists to a USB drive or SD card for listening on other devices. Open it via "Device Sync" in the sidebar. Select a target folder on your drive, choose sources from the browser tabs, and click "Transfer to Device". Psysonic downloads the tracks from your server and writes them in the folder structure defined by the filename template.',
-    q54: 'What is the filename template in Device Sync?',
-    a54: 'The filename template controls how tracks are named and organized on the device. Use the preset buttons (Standard, Multi-Disc, Alt. Folder) or build your own using the clickable token chips: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}, and / for folder separators. A live preview shows how an example track would be named.',
-    q55: 'Does Device Sync work across platforms?',
-    a55: 'Yes. The sync manifest (psysonic-sync.json) written to the device stores the filename template used during sync. When you open Device Sync on a different OS with a different template, Psysonic uses the stored template to correctly detect which files are already on the device — so albums don\'t show as pending when they are already synced.',
-    s9: 'Device Sync',
-    q56: 'What is Internet Radio?',
-    a56: 'The Internet Radio page (sidebar) lets you play any live stream directly in Psysonic. Stations are fetched from your Navidrome server — add them there via the Navidrome admin panel, or import a .pls / .m3u file. Playback uses the browser\'s built-in HTML5 audio engine rather than the Rust audio engine, so some EQ and Replay Gain settings do not apply to radio.',
-    q57: 'What stream formats does Internet Radio support?',
-    a57: 'Psysonic supports any format your system\'s audio stack can decode: MP3, AAC, OGG Vorbis, and most HLS streams. The stream is played via HTML5 <audio>, so codec support depends on the platform — MP3 and AAC work everywhere.',
-    s10: 'Internet Radio',
-    q58: 'Where does Psysonic fetch lyrics from?',
-    a58: 'Psysonic supports three lyrics sources, all configurable in Settings → Lyrics: your Navidrome server (embedded/OpenSubsonic lyrics), LRCLIB (community-contributed synced lyrics), and NetEase Cloud Music (large Chinese and international catalog). You can enable or disable each source and reorder their priority by dragging. Synced lyrics auto-scroll and support click-to-seek; plain-text lyrics are shown statically.',
-    q59: 'Is there a Now Playing view for other users?',
-    a59: 'Yes. Click the broadcast icon in the top-right header to open the "Now Playing" dropdown. It shows what other users on your Navidrome server are currently listening to, updated every 10 seconds. Your own entry disappears when you pause.',
+
   },
+
   queue: {
+
     title: 'Queue',
+
     savePlaylist: 'Save Playlist',
+
     updatePlaylist: 'Update Playlist',
+
     filterPlaylists: 'Filter playlists…',
+
     playlistName: 'Playlist Name',
+
     cancel: 'Cancel',
+
     save: 'Save',
+
     loadPlaylist: 'Load Playlist',
+
     loading: 'Loading…',
+
     noPlaylists: 'No playlists found.',
+
     load: 'Replace queue & play',
+
     appendToQueue: 'Append to queue',
+
     delete: 'Delete',
+
     deleteConfirm: 'Delete playlist "{{name}}"?',
+
     clear: 'Clear',
+
     shuffle: 'Shuffle queue',
+
     gapless: 'Gapless',
+
     crossfade: 'Crossfade',
+
     infiniteQueue: 'Infinite Queue',
+
     autoAdded: '— Added automatically —',
+
     radioAdded: '— Radio —',
+
     hide: 'Hide',
+
     close: 'Close',
+
     nextTracks: 'Next Tracks',
+
     emptyQueue: 'The queue is empty.',
+
     trackSingular: 'track',
+
     trackPlural: 'tracks',
+
     showRemaining: 'Show remaining time',
+
     showTotal: 'Show total time',
+
   },
+
   statistics: {
+
     title: 'Statistics',
+
     recentlyPlayed: 'Recently Played',
+
     mostPlayed: 'Most Played Albums',
+
     highestRated: 'Highest Rated Albums',
+
     genreDistribution: 'Genre Distribution (Top 20)',
+
     loadMore: 'Load more',
+
     statArtists: 'Artists',
+
     statArtistsTooltip: 'Album artists only — artists appearing only as a track-level artist (featured, guest, etc.) without their own album are not included.',
+
     statAlbums: 'Albums',
+
     statSongs: 'Songs',
+
     statGenres: 'Genres',
+
     statPlaytime: 'Total Playtime',
+
     genreInsights: 'Genre Insights',
+
     formatDistribution: 'Format Distribution',
+
     formatSample: 'Sample of {{n}} tracks',
+
     computing: 'Computing…',
+
     genreSongs: '{{count}} Songs',
+
     genreAlbums: '{{count}} Albums',
+
     recentlyAdded: 'Recently Added',
+
     decadeDistribution: 'Albums by Decade',
+
     decadeAlbums_one: '{{count}} Album',
+
     decadeAlbums_other: '{{count}} Albums',
+
     decadeUnknown: 'Unknown',
+
     lfmTitle: 'Last.fm Stats',
+
     lfmTopArtists: 'Top Artists',
+
     lfmTopAlbums: 'Top Albums',
+
     lfmTopTracks: 'Top Tracks',
+
     lfmPlays: '{{count}} plays',
+
     lfmPeriodOverall: 'All Time',
+
     lfmPeriod7day: '7 Days',
+
     lfmPeriod1month: '1 Month',
+
     lfmPeriod3month: '3 Months',
+
     lfmPeriod6month: '6 Months',
+
     lfmPeriod12month: '12 Months',
+
     lfmNotConnected: 'Connect Last.fm in Settings to see your stats.',
+
     lfmRecentTracks: 'Recent Scrobbles',
+
     lfmNowPlaying: 'Now Playing',
+
     lfmJustNow: 'just now',
+
     lfmMinutesAgo: '{{n}}m ago',
+
     lfmHoursAgo: '{{n}}h ago',
+
     lfmDaysAgo: '{{n}}d ago',
+
     topRatedSongs: 'Top Rated Songs',
+
     topRatedArtists: 'Top Rated Artists',
+
     noRatedSongs: 'No rated songs yet. Rate songs in album or playlist view.',
+
     noRatedArtists: 'No rated artists yet.',
+
   },
+
   player: {
+
     regionLabel: 'Music Player',
+
     openFullscreen: 'Open Fullscreen Player',
+
     fullscreen: 'Fullscreen Player',
+
     closeFullscreen: 'Close Fullscreen',
+
     closeTooltip: 'Close (Esc)',
+
     noTitle: 'No Title',
+
     stop: 'Stop',
+
     prev: 'Previous Track',
+
     play: 'Play',
+
     pause: 'Pause',
+
     next: 'Next Track',
+
     repeat: 'Repeat',
+
     repeatOff: 'Off',
+
     repeatAll: 'All',
+
     repeatOne: 'One',
+
     progress: 'Song Progress',
+
     volume: 'Volume',
+
     toggleQueue: 'Toggle Queue',
+
     lyrics: 'Lyrics',
+
     fsLyricsToggle: 'Lyrics in fullscreen',
+
     lyricsLoading: 'Loading lyrics…',
+
     lyricsNotFound: 'No lyrics found for this track',
+
     lyricsSourceServer: 'Source: Server',
+
     lyricsSourceLrclib: 'Source: LRCLIB',
+
     lyricsSourceNetease: 'Source: Netease',
+
   },
+
   songInfo: {
+
     title: 'Song Info',
+
     songTitle: 'Title',
+
     artist: 'Artist',
+
     album: 'Album',
+
     albumArtist: 'Album Artist',
+
     year: 'Year',
+
     genre: 'Genre',
+
     duration: 'Duration',
+
     track: 'Track',
+
     format: 'Format',
+
     bitrate: 'Bitrate',
+
     sampleRate: 'Sample Rate',
+
     bitDepth: 'Bit Depth',
+
     channels: 'Channels',
+
     fileSize: 'File Size',
+
     path: 'Path',
+
     replayGainTrack: 'RG Track Gain',
+
     replayGainAlbum: 'RG Album Gain',
+
     replayGainPeak: 'RG Track Peak',
+
     mono: 'Mono',
+
     stereo: 'Stereo',
+
   },
+
   playlists: {
+
     title: 'Playlists',
+
     newPlaylist: 'New Playlist',
+
     unnamed: 'Unnamed Playlist',
+
     createName: 'Playlist name…',
+
     create: 'Create',
+
     cancel: 'Cancel',
+
     empty: 'No playlists yet.',
+
     emptyPlaylist: 'This playlist is empty.',
+
     addFirstSong: 'Add your first song',
+
     notFound: 'Playlist not found.',
+
     songs: '{{n}} songs',
+
     playAll: 'Play All',
+
     shuffle: 'Shuffle',
+
     addToQueue: 'Add to Queue',
+
     back: 'Back to Playlists',
+
     deletePlaylist: 'Delete',
+
     confirmDelete: 'Click again to confirm',
+
     removeSong: 'Remove from playlist',
+
     addSongs: 'Add Songs',
+
     searchPlaceholder: 'Search your library…',
+
     noResults: 'No results.',
+
     suggestions: 'Suggested Songs',
+
     noSuggestions: 'No suggestions available.',
+
     titleBadge: 'Playlist',
+
     refreshSuggestions: 'New suggestions',
+
     addSong: 'Add to playlist',
+
     addSelected: 'Add selected',
+
     cacheOffline: 'Cache playlist offline',
+
     offlineCached: 'Playlist cached',
+
     removeOffline: 'Remove from offline cache',
+
     offlineDownloading: 'Caching… ({{done}}/{{total}} albums)',
+
     publicLabel: 'Public',
+
     privateLabel: 'Private',
+
     editMeta: 'Edit playlist',
+
     editNamePlaceholder: 'Playlist name…',
+
     editCommentPlaceholder: 'Add a description…',
+
     editPublic: 'Public playlist',
+
     editSave: 'Save',
+
     editCancel: 'Cancel',
+
     changeCover: 'Change cover image',
+
     changeCoverLabel: 'Change photo',
+
     removeCover: 'Remove photo',
+
     coverUpdated: 'Cover updated',
+
     metaSaved: 'Playlist updated',
+
     downloadZip: 'Download (ZIP)',
+
     // Toast notifications for multi-select
+
     addSuccess: '{{count}} songs added to {{playlist}}',
+
     addPartial: '{{added}} added, {{skipped}} skipped (duplicates)',
+
     addAllSkipped: 'All skipped ({{count}} duplicates)',
+
     addError: 'Error adding songs',
+
     createAndAddSuccess: 'Playlist "{{playlist}}" created with {{count}} songs',
+
     createError: 'Error creating playlist',
+
     deleteSuccess: '{{count}} playlists deleted',
+
     deleteFailed: 'Error deleting {{name}}',
+
     deleteSelected: 'Delete selected',
+
     mergeSuccess: '{{count}} songs merged into {{playlist}}',
+
     mergeNoNewSongs: 'No new songs to add',
+
     mergeError: 'Error merging playlists',
+
     mergeInto: 'Merge into',
+
     selectionCount: '{{count}} selected',
+
     select: 'Select',
+
     startSelect: 'Enable selection',
+
     cancelSelect: 'Cancel',
+
     loadingAlbums: 'Resolving {{count}} albums…',
+
     loadingArtists: 'Resolving {{count}} artists…',
+
     myPlaylists: 'My Playlists',
+
     noOtherPlaylists: 'No other playlists available',
+
     addToPlaylistSuccess: '{{count}} songs added to {{playlist}}',
+
     addToPlaylistNoNew: 'No new songs to add to {{playlist}}',
+
     addToPlaylistError: 'Error adding to playlist',
+
     removeSuccess: 'Song removed from playlist',
+
     removeError: 'Error removing song from playlist',
+
     importCSV: 'Import CSV',
+
     importCSVTooltip: 'Import from Spotify CSV',
+
     csvImportReport: 'CSV Import Report',
+
     csvImportTotal: 'Total',
+
     csvImportAdded: 'Added',
+
     csvImportDuplicates: 'Duplicates',
+
     csvImportNotFound: 'Not Found',
+
     csvImportNetworkErrors: 'Network Errors',
+
     csvImportDuplicatesTitle: 'Duplicate Tracks (Already in Playlist):',
+
     csvImportNotFoundTitle: 'Tracks Not Found:',
+
     csvImportNetworkErrorsTitle: 'Network Errors (may retry import):',
+
     csvImportDownloadReport: 'Download Report',
+
     csvImportClose: 'Close',
+
     csvImportNoValidTracks: 'No valid tracks found in CSV file',
+
     csvImportFailed: 'Failed to import CSV file',
+
     csvImportToast: '{{added}} added, {{notFound}} not found, {{duplicates}} duplicates',
+
   },
+
   mostPlayed: {
+
     title: 'Most Played',
+
     topArtists: 'Top Artists',
+
     topAlbums: 'Top Albums',
+
     plays: '{{n}} plays',
+
     sortMost: 'Most plays first',
+
     sortLeast: 'Fewest plays first',
+
     loadMore: 'Load more albums',
+
     noData: 'No play data yet. Start listening!',
+
     noArtists: 'All artists filtered out.',
+
     filterCompilations: 'Hide compilation artists (Various Artists, Soundtracks, etc.)',
+
     filterCompilationsShort: 'Hide compilations',
+
   },
+
   radio: {
+
     title: 'Internet Radio',
+
     empty: 'No radio stations configured.',
+
     addStation: 'Add Station',
+
     editStation: 'Edit',
+
     deleteStation: 'Delete station',
+
     confirmDelete: 'Click again to confirm',
+
     stationName: 'Station name…',
+
     streamUrl: 'Stream URL…',
+
     homepageUrl: 'Homepage URL (optional)',
+
     save: 'Save',
+
     cancel: 'Cancel',
+
     live: 'LIVE',
+
     liveStream: 'Internet Radio',
+
     openHomepage: 'Open homepage',
+
     changeCoverLabel: 'Change cover',
+
     removeCover: 'Remove cover',
+
     browseDirectory: 'Search Directory',
+
     directoryPlaceholder: 'Search stations…',
+
     noResults: 'No stations found.',
+
     stationAdded: 'Station added',
+
     filterAll: 'All',
+
     filterFavorites: 'Favorites',
+
     sortManual: 'Manual',
+
     sortAZ: 'A → Z',
+
     sortZA: 'Z → A',
+
     sortNewest: 'Newest',
+
     favorite: 'Add to favorites',
+
     unfavorite: 'Remove from favorites',
+
     noFavorites: 'No favorite stations.',
+
     listenerCount_one: '{{count}} listener',
+
     listenerCount_other: '{{count}} listeners',
+
     recentlyPlayed: 'Recently Played',
+
     upNext: 'Up Next',
+
   },
+
   folderBrowser: {
+
     empty: 'Empty folder',
+
     error: 'Failed to load',
+
   },
+
   deviceSync: {
+
     title: 'Device Sync',
+
     targetFolder: 'Target Folder',
+
     noFolderChosen: 'No folder chosen',
+
     selectDrive: 'Select a drive…',
+
     refreshDrives: 'Refresh drives',
+
     noDrivesDetected: 'No removable drives detected',
+
     browseManual: 'Browse manually…',
+
     free: 'free',
+
     notMountedVolume: 'Target is not on a mounted volume. The drive may have been disconnected.',
+
     chooseFolder: 'Choose…',
+
     filenameTemplate: 'Filename Template',
+
     targetDevice: 'Target Device',
+
     templateHint: 'Variables: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
+
     onDevice: 'Device Manager',
+
     addSources: 'Add…',
+
     colName: 'Name',
+
     colType: 'Type',
+
     colStatus: 'Status',
+
     syncResult: '{{done}} transferred, {{skipped}} already up to date ({{total}} total)',
+
     deleteFromDevice: 'Mark for deletion ({{count}})',
+
     confirmDelete: 'Delete {{count}} item(s) from the device: {{names}}?',
+
     deleteComplete: '{{count}} item(s) removed from device.',
-    manifestImported: 'Imported {{count}} source(s) from device manifest.',
+
     selectedSources: 'Selected Sources',
+
     noSourcesSelected: 'No sources selected. Click items in the browser to add them.',
+
     clearAll: 'Clear all',
+
     tabPlaylists: 'Playlists',
+
     tabAlbums: 'Albums',
+
     tabArtists: 'Artists',
+
     searchPlaceholder: 'Search…',
+
     syncButton: 'Sync to Device',
+
     actionTransfer: 'Transfer to Device',
+
     actionDelete: 'Delete from Device',
+
     actionApplyAll: 'Apply All Changes',
+
     templatePreview: 'Preview',
-    templatePresetStandard: 'Standard',
-    templatePresetMultiDisc: 'Multi-Disc',
-    templatePresetAltFolder: 'Alt. Folder',
-    tokenSlashHint: '/ = folder separator',
+
     cancel: 'Cancel',
+
     noTargetDir: 'Please choose a target folder first.',
+
     noSources: 'Please select at least one source.',
+
     noTracks: 'No tracks found in the selected sources.',
+
     fetchError: 'Failed to fetch tracks from server.',
+
     syncComplete: 'Sync complete.',
+
     dismiss: 'Dismiss',
-    cancelSync: 'Cancel',
-    syncCancelled: 'Sync cancelled ({{done}} / {{total}} transferred).',
+
     statusSynced: 'Synced',
+
     statusPending: 'Pending',
+
     statusDeletion: 'Deletion',
+
     markForDeletion: 'Mark for deletion',
+
     undoDeletion: 'Undo deletion',
+
     removeSource: 'Remove',
+
     syncInBackground: 'Sync started in background — you can navigate away.',
+
     syncInProgress: '{{done}} / {{total}} tracks…',
+
     scanningDevice: 'Scanning device…',
+
     syncSummary: 'Sync Summary',
+
     calculating: 'Calculating required payload…',
+
     filesToAdd: 'Files to Add:',
+
     filesToDelete: 'Files to Delete:',
+
     netChange: 'Net Change:',
+
     availableSpace: 'Available Disk Space:',
+
     spaceWarning: 'Warning: Target device does not have enough reported space.',
+
     proceed: 'Proceed with Sync',
+
     notEnoughSpace: 'Not enough physical disk space detected!',
+
     liveSearch: 'Live',
+
     randomAlbumsLabel: 'Random Albums',
+
   },
+
 };
+

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -542,7 +542,7 @@ export const enTranslation = {
     discordAppleCovers: 'Fetch covers from Apple Music for Discord',
     discordAppleCoversDesc: 'Sends the artist and album name to Apple\'s search API to find cover art for your Discord profile. Disabled by default for privacy.',
     discordTemplates: 'Custom text templates',
-    discordTemplatesDesc: 'Customize what information is shown on your Discord profile. Variables: {title}, {artist}, {album}, {paused}',
+    discordTemplatesDesc: 'Customize what information is shown on your Discord profile. Variables: {title}, {artist}, {album}',
     discordTemplateDetails: 'Primary line (details)',
     discordTemplateState: 'Secondary line (state)',
     discordTemplateLargeText: 'Album tooltip (largeText)',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,2268 +1,1170 @@
 export const enTranslation = {
-
   sidebar: {
-
     library: 'Library',
-
     mainstage: 'Mainstage',
-
     newReleases: 'New Releases',
-
     allAlbums: 'All Albums',
-
     randomAlbums: 'Random Albums',
-
     randomPicker: 'Build a Mix',
-
     artists: 'Artists',
-
     randomMix: 'Random Mix',
-
     favorites: 'Favorites',
-
     nowPlaying: 'Now Playing',
-
     system: 'System',
-
     statistics: 'Statistics',
-
     settings: 'Settings',
-
     help: 'Help',
-
     expand: 'Expand Sidebar',
-
     collapse: 'Collapse Sidebar',
 
-
-
     downloadingTracks: 'Caching {{n}} tracks…',
-
     syncingTracks: 'Syncing {{done}}/{{total}}…',
-
     cancelDownload: 'Cancel download',
-
     offlineLibrary: 'Offline Library',
-
     genres: 'Genres',
-
     playlists: 'Playlists',
-
     mostPlayed: 'Most Played',
-
     radio: 'Internet Radio',
-
     folderBrowser: 'Folder Browser',
-
     deviceSync: 'Device Sync',
-
     libraryScope: 'Library scope',
-
     allLibraries: 'All libraries',
-
     expandPlaylists: 'Expand playlists',
-
     collapsePlaylists: 'Collapse playlists',
-
   },
-
   home: {
-
     hero: 'Featured',
-
     starred: 'Personal Favorites',
-
     recent: 'Recently Added',
-
     mostPlayed: 'Most Played',
-
     recentlyPlayed: 'Recently Played',
-
     discover: 'Discover',
-
     loadMore: 'Load More',
-
     discoverMore: 'Discover More',
-
     discoverArtists: 'Discover Artists',
-
     discoverArtistsMore: 'All Artists'
-
   },
-
   hero: {
-
     eyebrow: 'Featured Album',
-
     playAlbum: 'Play Album',
-
     enqueue: 'Enqueue',
-
     enqueueTooltip: 'Add entire album to queue',
-
   },
-
   search: {
-
     placeholder: 'Search for artist, album or song…',
-
     noResults: 'No results for "{{query}}"',
-
     artists: 'Artists',
-
     albums: 'Albums',
-
     songs: 'Songs',
-
     clearLabel: 'Clear search',
-
     title: 'Search',
-
     resultsFor: 'Results for "{{query}}"',
-
     album: 'Album',
-
     advanced: 'Advanced Search',
-
     advancedSearchTerm: 'Search term',
-
     advancedSearchPlaceholder: 'Title, album, artist…',
-
     advancedGenre: 'Genre',
-
     advancedAllGenres: 'All genres',
-
     advancedYear: 'Year',
-
     advancedYearFrom: 'from',
-
     advancedYearTo: 'to',
-
     advancedAll: 'All',
-
     advancedSearch: 'Search',
-
     advancedEmpty: 'Enter a search term or select a filter to begin.',
-
     advancedNoResults: 'No results found.',
-
     advancedGenreNote: 'Songs are randomly selected from this genre.',
-
     recentSearches: 'Recent Searches',
-
     browse: 'Browse',
-
     emptyHint: 'What do you want to hear?',
-
     genres: 'Genres',
-
   },
-
   nowPlaying: {
-
     tooltip: 'Who is listening?',
-
     title: 'Who is listening?',
-
     loading: 'Loading…',
-
     nobody: 'Nobody is currently listening.',
-
     minutesAgo: '{{n}}m ago',
-
     nothingPlaying: 'Nothing playing yet. Start a track!',
-
     aboutArtist: 'About the Artist',
-
     fromAlbum: 'From this Album',
-
     viewAlbum: 'View Album',
-
     goToArtist: 'Go to Artist',
-
     readMore: 'Read more',
-
     showLess: 'Show less',
-
     genreInfo: 'Genre',
-
     trackInfo: 'Track Info',
-
   },
-
   contextMenu: {
-
     playNow: 'Play Now',
-
     playNext: 'Play Next',
-
     addToQueue: 'Add to Queue',
-
     enqueueAlbum: 'Enqueue Album',
-
     startRadio: 'Start Radio',
-
     instantMix: 'Instant Mix',
-
     instantMixFailed: 'Could not build Instant Mix — server or plugin error.',
-
     cliMixNeedsTrack: 'Nothing is playing — start playback first, then run the mix command again.',
-
     lfmLove: 'Love on Last.fm',
-
     lfmUnlove: 'Unlove on Last.fm',
-
     favorite: 'Favorite',
-
     favoriteArtist: 'Favorite Artist',
-
     favoriteAlbum: 'Favorite Album',
-
     unfavorite: 'Remove from Favorites',
-
     unfavoriteArtist: 'Remove Artist from Favorites',
-
     unfavoriteAlbum: 'Remove Album from Favorites',
-
     removeFromQueue: 'Remove from Queue',
-
     removeFromPlaylist: 'Remove from Playlist',
-
     openAlbum: 'Open Album',
-
     goToArtist: 'Go to Artist',
-
     download: 'Download (ZIP)',
-
     addToPlaylist: 'Add to Playlist',
-
     selectedPlaylists: '{{count}} playlists selected',
-
     selectedAlbums: '{{count}} albums selected',
-
     selectedArtists: '{{count}} artists selected',
-
     songInfo: 'Song Info',
-
   },
-
   albumDetail: {
-
     back: 'Back',
-
     playAll: 'Play All',
-
     enqueue: 'Enqueue',
-
     enqueueTooltip: 'Add entire album to queue',
-
     artistBio: 'Artist Bio',
-
     download: 'Download (ZIP)',
-
     downloading: 'Loading…',
-
     cacheOffline: 'Make available offline',
-
     offlineCached: 'Available offline',
-
     offlineDownloading: 'Caching… ({{n}}/{{total}})',
-
     removeOffline: 'Remove offline cache',
-
     offlineStorageFull: 'Offline storage full (limit: {{mb}} MB). Free up space by deleting an album from your Offline Library, or increase the limit in Settings.',
-
     offlineStorageGoToLibrary: 'Offline Library',
-
     offlineStorageGoToSettings: 'Settings',
-
     favoriteAdd: 'Add to Favorites',
-
     favoriteRemove: 'Remove from Favorites',
-
     favorite: 'Favorite',
-
     noBio: 'No biography available.',
-
     moreByArtist: 'More by {{artist}}',
-
     tracksCount: '{{n}} Tracks',
-
     goToArtist: 'Go to {{artist}}',
-
     moreLabelAlbums: 'More albums on {{label}}',
-
     trackTitle: 'Title',
-
     trackAlbum: 'Album',
-
     trackArtist: 'Artist',
-
     trackGenre: 'Genre',
-
     trackFormat: 'Format',
-
     trackFavorite: 'Favorite',
-
     trackRating: 'Rating',
-
     trackDuration: 'Duration',
-
     trackTotal: 'Total',
-
     columns: 'Columns',
-
+    resetColumns: 'Reset to defaults',
     notFound: 'Album not found.',
-
     bioModal: 'Artist Biography',
-
     bioClose: 'Close',
-
     ratingLabel: 'Rating',
-
     enlargeCover: 'Enlarge',
-
     filterSongs: 'Filter songs…',
-
     sortNatural: 'Natural',
-
     sortByTitle: 'A–Z (Title)',
-
     sortByArtist: 'A–Z (Artist)',
-
     sortByAlbum: 'A–Z (Album)',
-
   },
-
   entityRating: {
-
     albumShort: 'Album rating',
-
     artistShort: 'Artist rating',
-
     albumAriaLabel: 'Album rating',
-
     artistAriaLabel: 'Artist rating',
-
     saveFailed: 'Could not save rating.',
-
   },
-
   artistDetail: {
-
     back: 'Back',
-
     albums: 'Albums',
-
     album: 'Album',
-
     playAll: 'Play All',
-
     shuffle: 'Shuffle',
-
     radio: 'Radio',
-
     loading: 'Loading…',
-
     noRadio: 'No similar tracks found for this artist.',
-
     notFound: 'Artist not found.',
-
     albumsBy: 'Albums by {{name}}',
-
     topTracks: 'Top Tracks',
-
     noAlbums: 'No albums found.',
-
     trackTitle: 'Title',
-
     trackAlbum: 'Album',
-
     trackDuration: 'Duration',
-
     favoriteAdd: 'Add to Favorites',
-
     favoriteRemove: 'Remove from Favorites',
-
     favorite: 'Favorite',
-
     albumCount_one: '{{count}} Album',
-
     albumCount_other: '{{count}} Albums',
-
     openedInBrowser: 'Opened in browser',
-
     featuredOn: 'Also Featured On',
-
     similarArtists: 'Similar Artists',
-
     cacheOffline: 'Save discography offline',
-
     offlineCached: 'Discography cached',
-
     offlineDownloading: 'Caching… ({{done}}/{{total}} albums)',
-
     uploadImage: 'Upload artist image',
-
     uploadImageError: 'Failed to upload image',
-
   },
-
   favorites: {
-
     title: 'Favorites',
-
     empty: "You haven't saved any favorites yet.",
-
     artists: 'Artists',
-
     albums: 'Albums',
-
     songs: 'Songs',
-
     enqueueAll: 'Add all to queue',
-
     playAll: 'Play all',
-
     removeSong: 'Remove from favorites',
-
     stations: 'Radio Stations',
-
     showingFiltered: 'Showing {{filtered}} of {{total}} ({{artist}})',
-
     showingCount: 'Showing {{filtered}} of {{total}}',
-
     clearArtistFilter: 'Clear artist filter',
-
     noFilterResults: 'No results with selected filters.',
-
     allArtists: 'All Artists',
-
   },
-
   randomLanding: {
-
     title: 'Build a Mix',
-
     mixByTracks: 'Mix by Tracks',
-
     mixByTracksDesc: 'Random selection of tracks from your entire library',
-
     mixByAlbums: 'Mix by Albums',
-
     mixByAlbumsDesc: 'Random album picks for your next discovery',
-
   },
-
   randomAlbums: {
-
     title: 'Random Albums',
-
     refresh: 'Refresh',
-
   },
-
   genres: {
-
     title: 'Genres',
-
     genreCount: 'Genres',
-
     albumCount_one: '{{count}} album',
-
     albumCount_other: '{{count}} albums',
-
     loading: 'Loading genres…',
-
     empty: 'No genres found.',
-
     albumsLoading: 'Loading albums…',
-
     albumsEmpty: 'No albums found for this genre.',
-
     loadMore: 'Load more',
-
     back: 'Back',
-
   },
-
   randomMix: {
-
     title: 'Random Mix',
-
     remix: 'Remix',
-
     remixTooltip: 'Load new random songs',
-
     remixGenre: 'Remix {{genre}}',
-
     remixTooltipGenre: 'Load new {{genre}} songs',
-
     playAll: 'Play All',
-
     trackTitle: 'Title',
-
     trackArtist: 'Artist',
-
     trackAlbum: 'Album',
-
     trackFavorite: 'Favorite',
-
     trackDuration: 'Duration',
-
     favoriteAdd: 'Add to Favorites',
-
     favoriteRemove: 'Remove from Favorites',
-
     play: 'Play',
-
     trackGenre: 'Genre',
-
     excludeAudiobooks: 'Exclude audiobooks & radio plays',
-
     excludeAudiobooksDesc: 'Matches keywords against genre, title, album, and artist — e.g. Hörbuch, Audiobook, Spoken Word, …',
-
     genreBlocked: 'Keyword blocked',
-
     genreAddedToBlacklist: 'Added to filter list',
-
     genreAlreadyBlocked: 'Already blocked',
-
     artistBlocked: 'Artist blocked',
-
     artistAddedToBlacklist: 'Artist added to filter list',
-
     artistClickHint: 'Click to block this artist',
-
     blacklistToggle: 'Keyword Filter',
-
     genreMixTitle: 'Genre Mix',
-
     genreMixDesc: 'Top 20 genres by song count — click to load a random mix',
-
     genreMixAll: 'All Songs',
-
     genreMixLoadMore: 'Load 10 more',
-
     genreMixNoGenres: 'No genres found on server.',
-
     shuffleGenres: 'Show different genres',
-
     filterPanelTitle: 'Filters',
-
     filterPanelDesc: 'Click a genre tag or artist name in the tracklist below to block it from future mixes.',
-
     genreClickHint: 'Click a genre tag to add it\nas a filter keyword.\nMatches genre, title, album & artist.',
-
   },
-
   albums: {
-
     title: 'All Albums',
-
     sortByName: 'A–Z (Album)',
-
     sortByArtist: 'A–Z (Artist)',
-
     sortNewest: 'Newest first',
-
     sortRandom: 'Random',
-
     yearFrom: 'From',
-
     yearTo: 'To',
-
     yearFilterClear: 'Clear year filter',
-
     yearFilterLabel: 'Year',
-
     select: 'Multi-select',
-
     startSelect: 'Enable multi-select',
-
     cancelSelect: 'Cancel',
-
     selectionCount: '{{count}} selected',
-
     downloadZips: 'Download ZIPs',
-
     addOffline: 'Add Offline',
-
     downloadingZip: 'Downloading {{current}}/{{total}}: {{name}}',
-
     downloadZipDone: '{{count}} ZIP(s) downloaded',
-
     downloadZipFailed: 'Failed to download {{name}}',
-
     offlineQueuing: 'Queuing {{count}} album(s) for offline…',
-
     offlineFailed: 'Failed to add {{name}} offline',
-
   },
-
   artists: {
-
     title: 'Artists',
-
     search: 'Search…',
-
     all: 'All',
-
     gridView: 'Grid view',
-
     listView: 'List view',
-
     imagesOn: 'Artist images on — may increase network and system load',
-
     imagesOff: 'Artist images off — showing initials only',
-
     loadMore: 'Load more',
-
     notFound: 'No artists found.',
-
     albumCount_one: '{{count}} Album',
-
     albumCount_other: '{{count}} Albums',
-
     selectionCount: '{{count}} selected',
-
     select: 'Multi-select',
-
     startSelect: 'Enable multi-select',
-
     cancelSelect: 'Cancel',
-
     addToPlaylist: 'Add to Playlist',
-
   },
-
   login: {
-
     subtitle: 'Your Navidrome Desktop Player',
-
     serverName: 'Server Name (optional)',
-
     serverNamePlaceholder: 'My Navidrome',
-
     serverUrl: 'Server URL',
-
     serverUrlPlaceholder: '192.168.1.100:4533 or https://music.example.com',
-
     username: 'Username',
-
     usernamePlaceholder: 'admin',
-
     password: 'Password',
-
     showPassword: 'Show password',
-
     hidePassword: 'Hide password',
-
     connect: 'Connect',
-
     connecting: 'Connecting…',
-
     connected: 'Connected!',
-
     error: 'Connection failed – please check your details.',
-
     urlRequired: 'Please enter a server URL.',
-
     savedServers: 'Saved Servers',
-
     addNew: 'Or add a new server',
-
   },
-
   connection: {
-
     connected: 'Connected',
-
     connectedTo: 'Connected to {{server}}',
-
     disconnected: 'Disconnected',
-
     disconnectedFrom: 'Cannot reach {{server}} — click to check settings',
-
     checking: 'Connecting…',
-
     extern: 'Extern',
-
     offlineTitle: 'No server connection',
-
     offlineSubtitle: 'Cannot reach {{server}}. Check your network or server.',
-
     offlineModeBanner: 'Offline Mode — playing from local cache',
-
     offlineNoCacheBanner: 'No server connection — cannot reach {{server}}',
-
     offlineLibraryTitle: 'Offline Library',
-
     offlineLibraryEmpty: 'No albums cached yet. Go online, open an album and click "Make available offline".',
-
     offlineAlbumCount: '{{n}} album',
-
     offlineAlbumCount_plural: '{{n}} albums',
-
     offlineFilterAll: 'All',
-
     offlineFilterAlbums: 'Albums',
-
     offlineFilterPlaylists: 'Playlists',
-
     offlineFilterArtists: 'Discographies',
-
     retry: 'Retry',
-
     serverSettings: 'Server Settings',
-
     switchServerTitle: 'Switch server',
-
     switchServerHint: 'Click to choose another saved server.',
-
     manageServers: 'Manage servers…',
-
     switchFailed: 'Could not switch — server unreachable.',
-
     lastfmConnected: 'Last.fm connected as @{{user}}',
-
     lastfmSessionInvalid: 'Session invalid — click to re-connect',
-
   },
-
   common: {
-
     albums: 'Albums',
-
     album: 'Album',
-
     loading: 'Loading…',
-
     loadingMore: 'Loading…',
-
     loadingPlaylists: 'Loading Playlists…',
-
     noAlbums: 'No albums found.',
-
     downloading: 'Downloading…',
-
     downloadZip: 'Download (ZIP)',
-
     back: 'Back',
-
     cancel: 'Cancel',
-
     save: 'Save',
-
     delete: 'Delete',
-
     use: 'Use',
-
     add: 'Add',
-
     active: 'Active',
-
     download: 'Download',
-
     chooseDownloadFolder: 'Choose download folder',
-
     noFolderSelected: 'No folder selected',
-
     rememberDownloadFolder: 'Remember this folder',
-
     filterGenre: 'Genre Filter',
-
     filterSearchGenres: 'Search genres…',
-
     filterNoGenres: 'No genres match',
-
     filterClear: 'Clear',
-
     play: 'Play',
-
     bulkSelected: '{{count}} selected',
-
     clearSelection: 'Clear selection',
-
     bulkAddToPlaylist: 'Add to Playlist',
-
     bulkRemoveFromPlaylist: 'Remove from Playlist',
-
     bulkClear: 'Clear selection',
-
     updaterAvailable: 'Update available',
-
     updaterVersion: 'v{{version}} is available',
-
     updaterWebsite: 'Website',
-
     updaterModalTitle: 'New Version Available',
-
     updaterChangelog: "What's New",
-
     updaterDownloadBtn: 'Download Now',
-
     updaterSkipBtn: 'Skip this Version',
-
     updaterRemindBtn: 'Remind me Later',
-
     updaterDone: 'Download complete',
-
     updaterShowFolder: 'Show in Folder',
-
     updaterInstallHint: 'Close Psysonic and run the installer manually.',
-
     updaterAurHint: 'Install the update via AUR:',
-
     updaterErrorMsg: 'Download failed',
-
     updaterRetryBtn: 'Retry',
-
     durationHoursMinutes: '{{hours}}h {{minutes}}m',
-
     durationMinutesOnly: '{{minutes}}m',
-
     updaterOpenGitHub: 'Open on GitHub',
-
     filters: 'Filters',
-
     more: 'more',
-
     yearRange: 'Year Range',
-
     clearAll: 'Clear all',
-
   },
-
   settings: {
-
     title: 'Settings',
-
     language: 'Language',
-
     languageEn: 'English',
-
     languageDe: 'German',
-
     languageFr: 'French',
-
     languageNl: 'Dutch',
-
     languageZh: 'Chinese',
-
     languageNb: 'Norwegian',
-
     languageRu: 'Russian',
-
     languageEs: 'Spanish',
-
     font: 'Font',
-
     theme: 'Theme',
-
     appearance: 'Appearance',
-
     servers: 'Servers',
-
     serverName: 'Server Name',
-
     serverUrl: 'Server URL',
-
     serverUrlPlaceholder: '192.168.1.100:4533 or https://music.example.com',
-
     serverUsername: 'Username',
-
     serverPassword: 'Password',
-
     addServer: 'Add Server',
-
     addServerTitle: 'Add New Server',
-
     useServer: 'Use',
-
     deleteServer: 'Delete',
-
     noServers: 'No servers saved.',
-
     serverActive: 'Active',
-
     confirmDeleteServer: 'Delete server "{{name}}"?',
-
     serverConnecting: 'Connecting…',
-
     serverConnected: 'Connected!',
-
     serverFailed: 'Connection failed.',
-
     testBtn: 'Test Connection',
-
     testingBtn: 'Testing…',
-
     serverCompatible: 'Compatible with: Navidrome · Gonic · Airsonic · Subsonic',
-
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
-
     audiomuseDesc:
-
       'Turn on if this server has the <pluginLink>AudioMuse-AI Navidrome plugin</pluginLink> configured. Enables Instant Mix from tracks and uses server-side similar artists instead of Last.fm on artist pages.',
-
     audiomuseIssueHint:
-
       'Instant Mix failed recently — check the Navidrome plugin and AudioMuse API. Similar artists fall back to Last.fm when the server returns none.',
-
     connected: 'Connected',
-
     failed: 'Failed',
-
     eqTitle: 'Equalizer',
-
     eqEnabled: 'Enable Equalizer',
-
     eqPreset: 'Preset',
-
     eqPresetCustom: 'Custom',
-
     eqPresetBuiltin: 'Built-in Presets',
-
     eqPresetCustomGroup: 'My Presets',
-
     eqSavePreset: 'Save as Preset',
-
     eqPresetName: 'Preset name…',
-
     eqDeletePreset: 'Delete preset',
-
     eqResetBands: 'Reset to Flat',
-
     eqPreGain: 'Pre-gain',
-
     eqResetPreGain: 'Reset pre-gain',
-
     eqAutoEqTitle: 'AutoEQ Headphone Lookup',
-
     eqAutoEqPlaceholder: 'Search headphone / IEM model…',
-
     eqAutoEqSearching: 'Searching…',
-
     eqAutoEqNoResults: 'No results found',
-
     eqAutoEqError: 'Search failed',
-
     eqAutoEqRateLimit: 'GitHub rate limit reached — try again in a minute',
-
     eqAutoEqFetchError: 'Failed to fetch EQ profile',
-
     lfmTitle: 'Last.fm',
-
     lfmConnect: 'Connect with Last.fm',
-
     lfmConnecting: 'Waiting for authorisation…',
-
     lfmConfirm: 'I have authorised the app',
-
     lfmConnected: 'Connected as',
-
     lfmDisconnect: 'Disconnect',
-
     lfmConnectDesc: 'Connect your Last.fm account to enable scrobbling and Now Playing updates directly from Psysonic — no Navidrome configuration required.',
-
     lfmOpenBrowser: 'A browser window will open. Authorise Psysonic on Last.fm, then click the button below.',
-
     lfmScrobbles: '{{n}} scrobbles',
-
     lfmMemberSince: 'Member since {{year}}',
-
     scrobbleEnabled: 'Scrobbling enabled',
-
     scrobbleDesc: 'Send songs to Last.fm after 50% playtime',
-
     behavior: 'App Behavior',
-
     cacheTitle: 'Max. Storage Size',
-
     cacheDesc: 'Cover art and artist images. When full, the oldest entries are removed automatically. Offline albums are not auto-removed, but will be deleted when clearing the cache manually.',
-
     cacheUsedImages: 'Images:',
-
     cacheUsedOffline: 'Offline tracks:',
-
     cacheUsedHot: 'Size on disk:',
-
     hotCacheTrackCount: 'Tracks in cache:',
-
     cacheMaxLabel: 'Max. size',
-
     cacheClearBtn: 'Clear Cache',
-
     cacheClearWarning: 'This will also remove all offline albums from the library.',
-
     cacheClearConfirm: 'Clear Everything',
-
     cacheClearCancel: 'Cancel',
-
     offlineDirTitle: 'Offline Library (In-App)',
-
     offlineDirDesc: 'Storage location for tracks you make available offline within Psysonic.',
-
     offlineDirDefault: 'Default (App Data)',
-
     offlineDirChange: 'Change Directory',
-
     offlineDirClear: 'Reset to Default',
-
     offlineDirHint: 'New downloads will use this location. Existing downloads remain at their original path.',
-
     hotCacheTitle: 'Hot playback cache',
-
     hotCacheAlphaBadge: 'Alpha',
-
     hotCacheDisclaimer: 'Preloads upcoming queue tracks and keeps previous ones. When enabled, uses disk space and network.',
-
     hotCacheDirDefault: 'Default (App Data)',
-
     hotCacheDirChange: 'Change folder',
-
     hotCacheDirClear: 'Reset to default',
-
     hotCacheDirHint: 'Changing the folder resets the in-app index; files already on disk stay where they are until you remove them.',
-
     hotCacheEnabled: 'Enable hot playback cache',
-
     hotCacheMaxMb: 'Maximum cache size',
-
     hotCacheDebounce: 'Queue change debounce',
-
     hotCacheDebounceImmediate: 'Immediate',
-
     hotCacheDebounceSeconds: '{{n}} s',
-
     hotCacheClearBtn: 'Clear hot cache',
-
     audioOutputDevice: 'Audio Output Device',
-
     audioOutputDeviceDesc: 'Select which audio device Psysonic plays through. Changes take effect immediately and restart the current track.',
-
     audioOutputDeviceDefault: 'System Default',
-
     audioOutputDeviceRefresh: 'Refresh device list',
-
     audioOutputDeviceOsDefaultNow: 'current system output',
-
     audioOutputDeviceListError: 'Could not load the audio device list.',
-
     audioOutputDeviceNotInCurrentList: 'not in current list',
-
     hiResTitle: 'Native Hi-Res Playback',
-
     hiResEnabled: 'Enable native hi-res playback',
-
     hiResDesc: "Forces 44.1 kHz output by default for maximum stability. Enable only if your hardware and network reliably support high sample rates (88.2 kHz+).",
-
     showArtistImages: 'Show Artist Images',
-
     showArtistImagesDesc: 'Load and display artist images in the Artists overview. Disabled by default to reduce server disk I/O and network load on large libraries.',
-
     showTrayIcon: 'Show Tray Icon',
-
     showTrayIconDesc: 'Display the Psysonic icon in the system notification area / menu bar.',
-
     minimizeToTray: 'Minimize to Tray',
-
     minimizeToTrayDesc: 'When closing the window, keep Psysonic running in the system tray instead of quitting.',
-
     discordRichPresence: 'Discord Rich Presence',
-
     discordRichPresenceDesc: 'Show the currently playing track on your Discord profile. Requires Discord to be running.',
-
     useCustomTitlebar: 'Custom title bar',
-
     useCustomTitlebarDesc: 'Replace the system title bar with a built-in one that matches the app theme. Disable to use the native GNOME/GTK title bar.',
-
     discordAppleCovers: 'Fetch covers from Apple Music for Discord',
-
     discordAppleCoversDesc: 'Sends the artist and album name to Apple\'s search API to find cover art for your Discord profile. Disabled by default for privacy.',
-
     discordTemplates: 'Custom text templates',
-
     discordTemplatesDesc: 'Customize what information is shown on your Discord profile. Variables: {title}, {artist}, {album}, {paused}',
-
     discordTemplateDetails: 'Primary line (details)',
-
     discordTemplateState: 'Secondary line (state)',
-
     discordTemplateLargeText: 'Album tooltip (largeText)',
-
     nowPlayingEnabled: 'Show in Now Playing',
-
     nowPlayingEnabledDesc: 'Broadcast your currently playing track to the server\'s live listener view. Disable to stop sending playback data.',
-
     lyricsServerFirst: 'Prefer server lyrics',
-
     lyricsServerFirstDesc: 'Check server-provided lyrics (embedded tags, sidecar files) before querying LRCLIB. Disable to use LRCLIB first.',
-
     enableNeteaselyrics: 'Netease Cloud Music lyrics',
-
     enableNeteaselyricsDesc: 'Use Netease Cloud Music as a last-resort lyrics source when server and LRCLIB both return nothing. Best coverage for Asian and international music.',
-
     lyricsSourcesTitle: 'Lyrics Sources',
-
     lyricsSourcesDesc: 'Choose which sources to query for lyrics and in what order. Drag to reorder. Disabled sources are skipped entirely.',
-
     lyricsSourceServer: 'Server',
-
     lyricsSourceLrclib: 'LRCLIB',
-
     lyricsSourceNetease: 'Netease Cloud Music',
-
     downloadsTitle: 'ZIP Export & Archiving',
-
     downloadsFolderDesc: 'Destination folder for albums you download as a ZIP file to your computer.',
-
     downloadsDefault: 'Default Downloads Folder',
-
     pickFolder: 'Select',
-
     pickFolderTitle: 'Select Download Folder',
-
     clearFolder: 'Clear download folder',
-
     logout: 'Logout',
-
     aboutTitle: 'About Psysonic',
-
     aboutDesc: 'A modern desktop music player for Subsonic-compatible servers (Navidrome, Gonic, and others). Built on Tauri v2 with a native Rust audio engine — lightweight and fast, yet packed with features: waveform seekbar, synchronized lyrics, Last.fm integration, 10-band EQ, crossfade, gapless playback, Replay Gain, genre browsing, and a large library of themes.',
-
     aboutLicense: 'License',
-
     aboutLicenseText: 'GNU GPL v3 — free to use, modify, and distribute under the same license.',
-
     aboutRepo: 'Source Code on GitHub',
-
     aboutVersion: 'Version',
-
     aboutBuiltWith: 'Built with Tauri · React · TypeScript · Rust/rodio',
-
     aboutAiCredit: 'Developed with the support of Claude Code by Anthropic',
-
     aboutContributorsLabel: 'Contributors',
-
     aboutSpecialThanksLabel: 'Special Thanks',
-
     changelog: 'Changelog',
-
     showChangelogOnUpdate: "Show 'What's New' on update",
-
     showChangelogOnUpdateDesc: "Automatically show what's new when a new version is launched for the first time.",
-
     randomMixTitle: 'Random Mix',
-
     randomMixBlacklistTitle: 'Custom Filter Keywords',
-
     randomMixBlacklistDesc: 'Songs are excluded when any keyword matches their genre, title, album, or artist (active when the checkbox above is on).',
-
     randomMixBlacklistPlaceholder: 'Add keyword…',
-
     randomMixBlacklistAdd: 'Add',
-
     randomMixBlacklistEmpty: 'No custom keywords added yet.',
-
     randomMixHardcodedTitle: 'Built-in keywords (active when checkbox is on)',
-
     tabAudio: 'Audio',
-
     tabStorage: 'Storage & Downloads',
-
     tabAppearance: 'Appearance',
-
     homeCustomizerTitle: 'Home Page',
-
     sidebarTitle: 'Sidebar',
-
     sidebarReset: 'Reset to default',
-
     sidebarDrag: 'Drag to reorder',
-
     sidebarFixed: 'Always visible',
-
+    randomNavSplitTitle: 'Split Mix navigation',
+    randomNavSplitDesc: 'Show "Random Mix" and "Random Albums" as separate sidebar entries instead of the "Build a Mix" hub.',
     tabInput: 'Input',
-
     tabServer: 'Server',
-
     tabSystem: 'System',
-
     tabGeneral: 'General',
-
     ratingsSectionTitle: 'Ratings',
-
     ratingsSkipStarTitle: 'Skip for 1 star',
-
     ratingsSkipStarDesc:
-
       'After several skips in a row, set the track to 1★. Only for tracks not yet rated.',
-
     ratingsSkipStarThresholdLabel: 'Skips',
-
     ratingsMixFilterTitle: 'Filter by rating',
-
     ratingsMixFilterDesc:
-
       'Filter low-rated items in {{mix}} and {{albums}}. Click the selected star again to turn off the threshold.',
-
     ratingsMixMinSong: 'Songs',
-
     ratingsMixMinAlbum: 'Albums',
-
     ratingsMixMinArtist: 'Artists',
-
     ratingsMixMinThresholdAria: 'Minimum stars: {{label}}',
-
     backupTitle: 'Backup & Restore',
-
     backupExport: 'Export settings',
-
     backupExportDesc: 'Saves all settings, server profiles, Last.fm config, theme, EQ and keybindings to a .psybkp file. Passwords are stored in plaintext — keep the file secure.',
-
     backupImport: 'Import settings',
-
     backupImportDesc: 'Restores settings from a .psybkp file. The app will reload after import.',
-
     backupImportConfirm: 'This will overwrite all current settings. Continue?',
-
     backupSuccess: 'Backup saved',
-
     backupImportSuccess: 'Settings restored — reloading…',
-
     backupImportError: 'Invalid or corrupted backup file.',
-
     shortcutsReset: 'Reset to defaults',
-
     shortcutListening: 'Press a key…',
-
     shortcutUnbound: '—',
-
     globalShortcutsTitle: 'Global Shortcuts',
-
     globalShortcutsNote: 'Work system-wide even when Psysonic is in the background. Requires Ctrl, Alt, or Super as a modifier.',
-
     shortcutClear: 'Clear',
-
     shortcutPlayPause: 'Play / Pause',
-
     shortcutNext: 'Next track',
-
     shortcutPrev: 'Previous track',
-
     shortcutVolumeUp: 'Volume up',
-
     shortcutVolumeDown: 'Volume down',
-
     shortcutSeekForward: 'Seek forward 10s',
-
     shortcutSeekBackward: 'Seek backward 10s',
-
     shortcutToggleQueue: 'Toggle queue',
-
     shortcutOpenFolderBrowser: 'Open {{folderBrowser}}',
-
     shortcutFullscreenPlayer: 'Fullscreen player',
-
     shortcutNativeFullscreen: 'Native fullscreen',
-
     playbackTitle: 'Playback',
-
     replayGain: 'Replay Gain',
-
     replayGainDesc: 'Normalize track volume using ReplayGain metadata',
-
     replayGainMode: 'Mode',
-
     replayGainTrack: 'Track',
-
     replayGainAlbum: 'Album',
-
     replayGainPreGain: 'Pre-Gain (tagged files)',
-
     replayGainFallback: 'Fallback (untagged / radio)',
-
     crossfade: 'Crossfade',
-
     crossfadeDesc: 'Fade between tracks',
-
     crossfadeSecs: '{{n}} s',
-
     notWithGapless: 'Not available while Gapless is active',
-
     notWithCrossfade: 'Not available while Crossfade is active',
-
     gapless: 'Gapless Playback',
-
     gaplessDesc: 'Pre-buffer next track to eliminate gaps between songs',
-
     preloadMode: 'Preload Next Track',
-
     preloadModeDesc: 'When to start buffering the next track in the queue',
-
     nextTrackBufferingTitle: 'Next Track Buffering',
-
     preloadHotCacheMutualExclusive: 'Preload and Hot Cache serve the same purpose — only one can be active at a time. Enabling one will automatically disable the other.',
-
     preloadOff: 'Off',
-
     preloadBalanced: 'Balanced (30 s before end)',
-
     preloadEarly: 'Early (after 5 s of playback)',
-
     preloadCustom: 'Custom',
-
     preloadCustomSeconds: 'Seconds before end: {{n}}',
-
     infiniteQueue: 'Infinite Queue',
-
     infiniteQueueDesc: 'Automatically append random tracks when the queue runs out',
-
     experimental: 'Experimental',
-
     fsPlayerSection: 'Fullscreen Player',
-
     fsShowArtistPortrait: 'Show artist photo',
-
     fsShowArtistPortraitDesc: 'Display the artist photo (or album art) on the right side of the fullscreen player.',
-
     fsPortraitDim: 'Photo dimming',
-
     seekbarStyle: 'Seekbar Style',
-
     seekbarStyleDesc: 'Choose the look of the player seek bar',
-
     seekbarWaveform: 'Waveform',
-
     seekbarLinedot: 'Line & Dot',
-
     seekbarBar: 'Bar',
-
     seekbarThick: 'Thick Bar',
-
     seekbarSegmented: 'Segmented',
-
     seekbarNeon: 'Neon Glow',
-
     seekbarPulsewave: 'Pulse Wave',
-
     seekbarParticletrail: 'Particle Trail',
-
     seekbarLiquidfill: 'Liquid Fill',
-
     seekbarRetrotape: 'Retro Tape',
-
     themeSchedulerTitle: 'Auto-Switch Theme',
-
     themeSchedulerEnable: 'Enable Theme Scheduler',
-
     themeSchedulerEnableSub: 'Automatically switch between two themes based on the time of day',
-
     themeSchedulerDayTheme: 'Day Theme',
-
     themeSchedulerDayStart: 'Day Starts At',
-
     themeSchedulerNightTheme: 'Night Theme',
-
     themeSchedulerNightStart: 'Night Starts At',
-
     themeSchedulerActiveHint: 'Theme Scheduler is active - theme changes are managed automatically.',
-
     visualOptionsTitle: 'Visual Options',
-
     coverArtBackground: 'Cover Art Background',
-
     coverArtBackgroundSub: 'Show blurred cover art as background in album/playlist headers',
-
     playlistCoverPhoto: 'Playlist Cover Photo',
-
     playlistCoverPhotoSub: 'Show cover photo grid in playlist detail view',
-
     showBitrate: 'Show Bitrate',
-
     showBitrateSub: 'Display audio bitrate in track listings',
-
     uiScaleTitle: 'Interface Scale',
-
     uiScaleLabel: 'Zoom',
-
   },
-
   changelog: {
-
     modalTitle: "What's New",
-
     dontShowAgain: "Don't show again",
-
     close: 'Got it',
-
   },
-
   help: {
-
     title: 'Help',
-
     s1: 'Getting Started',
-
     q1: 'Which servers are compatible?',
-
     a1: 'Psysonic works with any Subsonic-compatible server: Navidrome, Gonic, Subsonic, Airsonic, and others. Navidrome is the recommended choice.',
-
     q2: 'How do I connect to my server?',
-
     a2: 'Open Settings and click "Add Server". Enter the server URL (e.g. 192.168.1.100:4533), your username, and password. Psysonic tests the connection before saving — nothing is stored if the connection fails.',
-
     q3: 'Can I use multiple servers?',
-
     a3: 'Yes. You can add as many servers as you like in Settings and switch between them at any time. Only one server is active at a time.',
-
     s2: 'Playback',
-
     q4: 'How do I play music?',
-
     a4: 'Double-click any track to play it. On album and artist pages, use "Play All" to start the whole album. You can also drag tracks into the queue panel.',
-
     q5: 'What keyboard shortcuts are available?',
-
     a5: 'Space = Play / Pause · Escape = Close fullscreen player. Media keys (Play/Pause, Next, Previous) work on all platforms. On Linux, use the player bar buttons for media keys. In-app shortcuts and system-wide global shortcuts can be customized in Settings → Keyboard Shortcuts / Global Shortcuts.',
-
     q6: 'What is the queue?',
-
     a6: 'The queue shows all upcoming tracks. Open it with the panel icon in the top-right header (next to the Now Playing indicator). You can reorder tracks by dragging, shuffle with the shuffle button, and save the queue as a playlist.',
-
     q7: 'How do I open the fullscreen player?',
-
     a7: 'Click the album art thumbnail in the player bar at the bottom, or the expand icon next to it. Press Escape to close it again.',
-
     q8: 'How does repeat work?',
-
     a8: 'Click the repeat button in the player bar to cycle through: Off → Repeat All → Repeat One.',
-
     s3: 'Library',
-
     q9: 'How do I download an album?',
-
     a9: 'Open an album\'s detail page and click "Download (ZIP)". The server compresses the album into a ZIP file first — for large albums or lossless files (FLAC / WAV) this can take a moment before the download actually starts. This is normal: the progress bar appears once the server finishes zipping and the transfer begins.',
-
     q10: 'How do I star / favorite tracks and albums?',
-
     a10: 'Click the star icon on any track row or on the album header. Starred items appear in the Favorites section in the sidebar.',
-
     q11: 'What is the hero carousel on the home page?',
-
     a11: 'The banner at the top of the home page randomly picks albums from your library and rotates through them every 10 seconds. Click the dots to jump to a specific one, or click the banner to open the album.',
-
     s4: 'Settings',
-
     q12: 'How do I change the theme?',
-
     a12: 'Settings → Theme. Choose from a large selection of themes across 8 groups: Psysonic Themes, Mediaplayer, Operating Systems, Games, Movies, Series, Social Media, and Open Source Classics (Catppuccin, Nord, Gruvbox, Nightfox).',
-
     q13: 'How do I change the language?',
-
     a13: 'Settings → Language. English, German, Spanish, French, Dutch, Chinese, Norwegian, and Russian are supported.',
-
     q15: 'How do I set a download folder?',
-
     a15: 'Settings → App Behavior → Download Folder. Pick any folder — downloaded albums are saved there as ZIP files. Without a custom folder, your browser\'s default downloads location is used.',
-
     s5: 'Scrobbling',
-
     q16: 'How does scrobbling work?',
-
     a16: 'Psysonic scrobbles directly to Last.fm — no Navidrome configuration needed. Connect your Last.fm account in Settings → Last.fm and enable scrobbling there.',
-
     q17: 'When is a scrobble sent?',
-
     a17: 'A scrobble is submitted after you\'ve listened to 50% of a track.',
-
     q22: 'What is the waveform in the player bar?',
-
     a22: 'The waveform seekbar replaces the classic progress slider. Click anywhere on it to jump to that position, or drag to scrub. The played portion glows with a blue-to-mauve gradient, the buffered range appears slightly brighter, and the unplayed portion is faded.',
-
     q24: 'Can I shuffle the queue?',
-
     a24: 'Yes. Open the queue panel and click the shuffle icon in the queue header. The currently playing track stays at position 1 — all remaining tracks are randomly reordered.',
-
     q25: 'Do Last.fm and Wikipedia links on artist pages open in a browser?',
-
     a25: 'Yes — they open in your default system browser. The button briefly shows a confirmation label when clicked.',
-
     s7: 'Random Mix',
-
     q26: 'What is Random Mix?',
-
     a26: 'Random Mix builds a playlist of random tracks from your entire library. Open it via "Random Mix" in the sidebar and click "New Mix". You can adjust the track count before generating.',
-
     q27: 'What is the Keyword Filter?',
-
     a27: 'The Keyword Filter excludes tracks whose genre, title, or album name contains specific words. Audiobooks are filtered automatically. Add custom keywords in Settings → Random Mix, or click any genre tag in the track list to add it instantly.',
-
     q28: 'What is the Super Genre Mix?',
-
     a28: 'The Super Genre Mix groups your library into broad categories (Rock, Metal, Electronic, Jazz, Classical, etc.) and builds a focused mix from that style. Select a category chip below the track list. Results appear progressively as each sub-genre is fetched.',
-
     s6: 'Troubleshooting',
-
     q18: 'Cover art and artist images load slowly.',
-
     a18: 'Images are fetched from your server\'s disk on first load and then cached locally for 30 days. If your server\'s storage is slow, the first visit to a page may take a moment. Subsequent visits will be instant.',
-
     q19: 'The connection test fails.',
-
     a19: 'Check the URL including the port (e.g. http://192.168.1.100:4533). Make sure no firewall blocks the connection. Try http:// instead of https:// on a local network. Also verify that your username and password are correct.',
-
     q20: 'No audio on Linux.',
-
     a20: 'Psysonic is available as .deb (Ubuntu/Debian), .rpm (Fedora/RHEL), and via AUR on Arch/CachyOS (yay -S psysonic). There is no AppImage. If audio is missing, ensure PipeWire or PulseAudio is running.',
-
     q21: 'The app shows a black screen on Linux.',
-
     a21: 'This is usually a GPU/EGL driver issue in WebKitGTK. Launch with GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. The AUR package and official .deb/.rpm installers set these automatically.',
-
     q29: 'What are Crossfade and Gapless Playback?',
-
     a29: 'Both are experimental audio features in Settings → Audio. Gapless pre-buffers the next track to eliminate silence between songs. Crossfade fades out the current track while fading in the next — adjust the duration (1–10 s) to taste.',
-
     q30: 'Does Psysonic show lyrics?',
-
     a30: 'Yes. Click the microphone icon in the player bar to open the Lyrics tab in the queue panel. Psysonic fetches lyrics automatically from LRCLIB. If synced lyrics are available, the active line is highlighted and scrolls in real time as the song plays. If only plain text is available, the full text is shown statically.',
-
     q31: 'Can I customize keyboard shortcuts?',
-
     a31: 'Yes. Settings → Keyboard Shortcuts lets you remap in-app actions (Play/Pause, Next, Previous, Volume Up/Down, Fullscreen, and more) to any key. Settings → Global Shortcuts lets you assign system-wide shortcuts that trigger even when Psysonic is in the background.',
-
     q32: 'Can I change the font?',
-
     a32: 'Yes. Settings → Font lets you choose from 10 fonts including IBM Plex Mono, Fira Code, JetBrains Mono, Courier Prime, and others. The selected font applies to the entire UI.',
-
     s8: 'Offline Mode',
-
     q34: 'What is Offline Mode?',
-
     a34: 'Offline Mode (Beta) lets you cache albums to your device so you can listen without an active server connection. Cached tracks are stored locally and played back directly from disk — no network request is made during playback.',
-
     q35: 'How do I cache an album for offline use?',
-
     a35: 'Open any album and click the download icon in the album header. Psysonic downloads all tracks in the background. Progress is shown on the button. Once cached, the icon turns green. You can view and remove cached albums in the Offline Library page (sidebar).',
-
     q36: 'How much storage can offline caching use?',
-
     a36: 'You can set a maximum cache size in Settings → Library. When the limit is reached, a warning banner appears on the album page. You can delete individual albums from the Offline Library to free up space.',
-
     q37: 'How do I rate songs, albums, and artists?',
-
     a37: 'Psysonic supports 1–5 star ratings via the OpenSubsonic API (requires Navidrome ≥ 0.53). Rate songs in the album or playlist track list using the star column, in the right-click context menu, or directly in the player bar below the artist name. Albums can be rated on their detail page; artists on their artist page. Ratings are saved to the server immediately.',
-
     q38: 'Can I remove or change a rating?',
-
     a38: 'Yes. Click the currently active star to clear the rating entirely — clicking the same star a second time removes it. To change a rating, simply click a different star.',
-
     q39: 'What is Skip-to-1★ and the rating filter?',
-
     a39: 'Skip-to-1★ automatically assigns a 1-star rating to a song after you manually skip it a configurable number of consecutive times. Enable it and set the skip threshold in Settings → Ratings. The same settings panel lets you set a minimum star rating for Random Mix and Random Albums, so only songs, albums, or artists above a certain rating are included in generated mixes.',
-
     q40: 'What is the Folder Browser?',
-
     a40: 'The Folder Browser (sidebar) lets you navigate your server\'s music directory tree using a Miller-column layout. Click a folder to drill into it; click a track or the play icon on a folder to play or enqueue its contents directly.',
-
     q41: 'What is the Theme Scheduler?',
-
     a41: 'Settings → Appearance → Auto-Switch Theme: define a day theme and a night theme with start times. Psysonic switches automatically at the configured hours. When the scheduler is active, a hint in the theme picker explains why manual theme selection has no immediate effect.',
-
     q42: 'Can I resize the interface?',
-
     a42: 'Yes. Settings → Appearance → Interface Scale lets you scale the entire UI between 80 % and 125 % without affecting your system font size.',
-
     q43: 'Can I change the seekbar style?',
-
     a43: 'Yes. Settings → Appearance → Seekbar Style offers 10 styles: Waveform, Line & Dot, Bar, Thick Bar, Segmented, Neon Glow, Pulse Wave, Particle Trail, Liquid Fill, and Retro Tape.',
-
     q44: 'What is AutoEQ?',
-
     a44: 'The 10-band EQ in Settings → Audio includes an AutoEQ lookup. Enter your headphone model and Psysonic fetches a correction profile from the AutoEQ database and applies it automatically to the equalizer bands.',
-
     q45: 'What is Replay Gain?',
-
     a45: 'Replay Gain normalizes track volume so loud and quiet albums play at a consistent level. Enable it in Settings → Audio → Replay Gain and choose Track mode (per-song normalization) or Album mode (preserves relative dynamics within an album).',
-
     q46: 'What is the Hot Cache?',
-
     a46: 'Hot Cache (Alpha, Settings → Library) preloads the next several tracks in your queue to disk so playback starts instantly with no buffering delay — especially useful on slow or remote servers. Psysonic keeps the current track and the next 5 in cache and evicts older entries when the size limit is reached. You can set the maximum cache size and a debounce delay to avoid unnecessary fetches when skipping quickly.',
-
     q47: 'Can I cache a playlist for offline use?',
-
     a47: 'Yes. Open any playlist and click the download icon in the playlist header. All tracks are downloaded in the background — progress is shown in the offline download indicator. Once fully cached, the icon changes to a red trash icon; clicking it removes the playlist from the offline cache.',
-
+    q48: 'What is Infinite Queue?',
+    a48: 'When the queue runs out and Repeat is off, Psysonic silently appends random tracks from your library so playback never stops. Auto-added tracks appear below a "— Added automatically —" divider in the queue. Toggle it with the infinity icon in the queue header. You can also restrict auto-added tracks to a specific genre in Settings → Queue.',
+    q49: 'Can I control Psysonic from the command line?',
+    a49: 'Yes — the Psysonic binary doubles as a remote control for the running app. Examples: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one, --player star / unstar, --player rating 1-5. You can also switch servers (--player server list / set), change the audio device (--player audio-device list / set), filter the music library (--player library list / set), trigger an Instant Mix (--player mix new / append), and search (--player search track|album|artist <query>). Run psysonic --player --help for the full list. Shell completions for bash and zsh are available via psysonic completions.',
+    q50: 'How do I manage playlists?',
+    a50: 'Open "Playlists" in the sidebar. Click "New Playlist" to create one. On a playlist detail page you can drag tracks to reorder them, remove tracks with the × button, search your library to add songs, and use "Suggestions" to get smart track recommendations based on your playlist content. Right-click any track for more options.',
+    q51: 'Can I back up and restore my settings?',
+    a51: 'Yes. Settings → Backup & Restore lets you export all your settings, server profiles, themes, and keybindings to a single JSON file. Import it on another machine or after a reinstall to restore everything at once. Passwords are included in the backup — store the file securely.',
+    q52: 'How do I change the audio output device?',
+    a52: 'Settings → Audio → Output Device. Psysonic lists all available audio outputs on your system. Select the one you want — playback switches immediately. Use the refresh button next to the list if a device was connected after the app started. On Linux this uses ALSA device names; generic entries like "default" or "sysdefault" are automatically cleaned up for readability.',
+    q53: 'What is Device Sync?',
+    a53: 'Device Sync lets you copy albums, playlists, or entire artists to a USB drive or SD card for listening on other devices. Open it via "Device Sync" in the sidebar. Select a target folder on your drive, choose sources from the browser tabs, and click "Transfer to Device". Psysonic downloads the tracks from your server and writes them in the folder structure defined by the filename template.',
+    q54: 'What is the filename template in Device Sync?',
+    a54: 'The filename template controls how tracks are named and organized on the device. Use the preset buttons (Standard, Multi-Disc, Alt. Folder) or build your own using the clickable token chips: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}, and / for folder separators. A live preview shows how an example track would be named.',
+    q55: 'Does Device Sync work across platforms?',
+    a55: 'Yes. The sync manifest (psysonic-sync.json) written to the device stores the filename template used during sync. When you open Device Sync on a different OS with a different template, Psysonic uses the stored template to correctly detect which files are already on the device — so albums don\'t show as pending when they are already synced.',
+    s9: 'Device Sync',
+    q56: 'What is Internet Radio?',
+    a56: 'The Internet Radio page (sidebar) lets you play any live stream directly in Psysonic. Stations are fetched from your Navidrome server — add them there via the Navidrome admin panel, or import a .pls / .m3u file. Playback uses the browser\'s built-in HTML5 audio engine rather than the Rust audio engine, so some EQ and Replay Gain settings do not apply to radio.',
+    q57: 'What stream formats does Internet Radio support?',
+    a57: 'Psysonic supports any format your system\'s audio stack can decode: MP3, AAC, OGG Vorbis, and most HLS streams. The stream is played via HTML5 <audio>, so codec support depends on the platform — MP3 and AAC work everywhere.',
+    s10: 'Internet Radio',
+    q58: 'Where does Psysonic fetch lyrics from?',
+    a58: 'Psysonic supports three lyrics sources, all configurable in Settings → Lyrics: your Navidrome server (embedded/OpenSubsonic lyrics), LRCLIB (community-contributed synced lyrics), and NetEase Cloud Music (large Chinese and international catalog). You can enable or disable each source and reorder their priority by dragging. Synced lyrics auto-scroll and support click-to-seek; plain-text lyrics are shown statically.',
+    q59: 'Is there a Now Playing view for other users?',
+    a59: 'Yes. Click the broadcast icon in the top-right header to open the "Now Playing" dropdown. It shows what other users on your Navidrome server are currently listening to, updated every 10 seconds. Your own entry disappears when you pause.',
   },
-
   queue: {
-
     title: 'Queue',
-
     savePlaylist: 'Save Playlist',
-
     updatePlaylist: 'Update Playlist',
-
     filterPlaylists: 'Filter playlists…',
-
     playlistName: 'Playlist Name',
-
     cancel: 'Cancel',
-
     save: 'Save',
-
     loadPlaylist: 'Load Playlist',
-
     loading: 'Loading…',
-
     noPlaylists: 'No playlists found.',
-
     load: 'Replace queue & play',
-
     appendToQueue: 'Append to queue',
-
     delete: 'Delete',
-
     deleteConfirm: 'Delete playlist "{{name}}"?',
-
     clear: 'Clear',
-
     shuffle: 'Shuffle queue',
-
     gapless: 'Gapless',
-
     crossfade: 'Crossfade',
-
     infiniteQueue: 'Infinite Queue',
-
     autoAdded: '— Added automatically —',
-
     radioAdded: '— Radio —',
-
     hide: 'Hide',
-
     close: 'Close',
-
     nextTracks: 'Next Tracks',
-
     emptyQueue: 'The queue is empty.',
-
     trackSingular: 'track',
-
     trackPlural: 'tracks',
-
     showRemaining: 'Show remaining time',
-
     showTotal: 'Show total time',
-
   },
-
   statistics: {
-
     title: 'Statistics',
-
     recentlyPlayed: 'Recently Played',
-
     mostPlayed: 'Most Played Albums',
-
     highestRated: 'Highest Rated Albums',
-
     genreDistribution: 'Genre Distribution (Top 20)',
-
     loadMore: 'Load more',
-
     statArtists: 'Artists',
-
     statArtistsTooltip: 'Album artists only — artists appearing only as a track-level artist (featured, guest, etc.) without their own album are not included.',
-
     statAlbums: 'Albums',
-
     statSongs: 'Songs',
-
     statGenres: 'Genres',
-
     statPlaytime: 'Total Playtime',
-
     genreInsights: 'Genre Insights',
-
     formatDistribution: 'Format Distribution',
-
     formatSample: 'Sample of {{n}} tracks',
-
     computing: 'Computing…',
-
     genreSongs: '{{count}} Songs',
-
     genreAlbums: '{{count}} Albums',
-
     recentlyAdded: 'Recently Added',
-
     decadeDistribution: 'Albums by Decade',
-
     decadeAlbums_one: '{{count}} Album',
-
     decadeAlbums_other: '{{count}} Albums',
-
     decadeUnknown: 'Unknown',
-
     lfmTitle: 'Last.fm Stats',
-
     lfmTopArtists: 'Top Artists',
-
     lfmTopAlbums: 'Top Albums',
-
     lfmTopTracks: 'Top Tracks',
-
     lfmPlays: '{{count}} plays',
-
     lfmPeriodOverall: 'All Time',
-
     lfmPeriod7day: '7 Days',
-
     lfmPeriod1month: '1 Month',
-
     lfmPeriod3month: '3 Months',
-
     lfmPeriod6month: '6 Months',
-
     lfmPeriod12month: '12 Months',
-
     lfmNotConnected: 'Connect Last.fm in Settings to see your stats.',
-
     lfmRecentTracks: 'Recent Scrobbles',
-
     lfmNowPlaying: 'Now Playing',
-
     lfmJustNow: 'just now',
-
     lfmMinutesAgo: '{{n}}m ago',
-
     lfmHoursAgo: '{{n}}h ago',
-
     lfmDaysAgo: '{{n}}d ago',
-
     topRatedSongs: 'Top Rated Songs',
-
     topRatedArtists: 'Top Rated Artists',
-
     noRatedSongs: 'No rated songs yet. Rate songs in album or playlist view.',
-
     noRatedArtists: 'No rated artists yet.',
-
   },
-
   player: {
-
     regionLabel: 'Music Player',
-
     openFullscreen: 'Open Fullscreen Player',
-
     fullscreen: 'Fullscreen Player',
-
     closeFullscreen: 'Close Fullscreen',
-
     closeTooltip: 'Close (Esc)',
-
     noTitle: 'No Title',
-
     stop: 'Stop',
-
     prev: 'Previous Track',
-
     play: 'Play',
-
     pause: 'Pause',
-
     next: 'Next Track',
-
     repeat: 'Repeat',
-
     repeatOff: 'Off',
-
     repeatAll: 'All',
-
     repeatOne: 'One',
-
     progress: 'Song Progress',
-
     volume: 'Volume',
-
     toggleQueue: 'Toggle Queue',
-
     lyrics: 'Lyrics',
-
     fsLyricsToggle: 'Lyrics in fullscreen',
-
     lyricsLoading: 'Loading lyrics…',
-
     lyricsNotFound: 'No lyrics found for this track',
-
     lyricsSourceServer: 'Source: Server',
-
     lyricsSourceLrclib: 'Source: LRCLIB',
-
     lyricsSourceNetease: 'Source: Netease',
-
   },
-
   songInfo: {
-
     title: 'Song Info',
-
     songTitle: 'Title',
-
     artist: 'Artist',
-
     album: 'Album',
-
     albumArtist: 'Album Artist',
-
     year: 'Year',
-
     genre: 'Genre',
-
     duration: 'Duration',
-
     track: 'Track',
-
     format: 'Format',
-
     bitrate: 'Bitrate',
-
     sampleRate: 'Sample Rate',
-
     bitDepth: 'Bit Depth',
-
     channels: 'Channels',
-
     fileSize: 'File Size',
-
     path: 'Path',
-
     replayGainTrack: 'RG Track Gain',
-
     replayGainAlbum: 'RG Album Gain',
-
     replayGainPeak: 'RG Track Peak',
-
     mono: 'Mono',
-
     stereo: 'Stereo',
-
   },
-
   playlists: {
-
     title: 'Playlists',
-
     newPlaylist: 'New Playlist',
-
     unnamed: 'Unnamed Playlist',
-
     createName: 'Playlist name…',
-
     create: 'Create',
-
     cancel: 'Cancel',
-
     empty: 'No playlists yet.',
-
     emptyPlaylist: 'This playlist is empty.',
-
     addFirstSong: 'Add your first song',
-
     notFound: 'Playlist not found.',
-
     songs: '{{n}} songs',
-
     playAll: 'Play All',
-
     shuffle: 'Shuffle',
-
     addToQueue: 'Add to Queue',
-
     back: 'Back to Playlists',
-
     deletePlaylist: 'Delete',
-
     confirmDelete: 'Click again to confirm',
-
     removeSong: 'Remove from playlist',
-
     addSongs: 'Add Songs',
-
     searchPlaceholder: 'Search your library…',
-
     noResults: 'No results.',
-
     suggestions: 'Suggested Songs',
-
     noSuggestions: 'No suggestions available.',
-
     titleBadge: 'Playlist',
-
     refreshSuggestions: 'New suggestions',
-
     addSong: 'Add to playlist',
-
     addSelected: 'Add selected',
-
     cacheOffline: 'Cache playlist offline',
-
     offlineCached: 'Playlist cached',
-
     removeOffline: 'Remove from offline cache',
-
     offlineDownloading: 'Caching… ({{done}}/{{total}} albums)',
-
     publicLabel: 'Public',
-
     privateLabel: 'Private',
-
     editMeta: 'Edit playlist',
-
     editNamePlaceholder: 'Playlist name…',
-
     editCommentPlaceholder: 'Add a description…',
-
     editPublic: 'Public playlist',
-
     editSave: 'Save',
-
     editCancel: 'Cancel',
-
     changeCover: 'Change cover image',
-
     changeCoverLabel: 'Change photo',
-
     removeCover: 'Remove photo',
-
     coverUpdated: 'Cover updated',
-
     metaSaved: 'Playlist updated',
-
     downloadZip: 'Download (ZIP)',
-
     // Toast notifications for multi-select
-
     addSuccess: '{{count}} songs added to {{playlist}}',
-
     addPartial: '{{added}} added, {{skipped}} skipped (duplicates)',
-
     addAllSkipped: 'All skipped ({{count}} duplicates)',
-
     addError: 'Error adding songs',
-
     createAndAddSuccess: 'Playlist "{{playlist}}" created with {{count}} songs',
-
     createError: 'Error creating playlist',
-
     deleteSuccess: '{{count}} playlists deleted',
-
     deleteFailed: 'Error deleting {{name}}',
-
     deleteSelected: 'Delete selected',
-
     mergeSuccess: '{{count}} songs merged into {{playlist}}',
-
     mergeNoNewSongs: 'No new songs to add',
-
     mergeError: 'Error merging playlists',
-
     mergeInto: 'Merge into',
-
     selectionCount: '{{count}} selected',
-
     select: 'Select',
-
     startSelect: 'Enable selection',
-
     cancelSelect: 'Cancel',
-
     loadingAlbums: 'Resolving {{count}} albums…',
-
     loadingArtists: 'Resolving {{count}} artists…',
-
     myPlaylists: 'My Playlists',
-
     noOtherPlaylists: 'No other playlists available',
-
     addToPlaylistSuccess: '{{count}} songs added to {{playlist}}',
-
     addToPlaylistNoNew: 'No new songs to add to {{playlist}}',
-
     addToPlaylistError: 'Error adding to playlist',
-
     removeSuccess: 'Song removed from playlist',
-
     removeError: 'Error removing song from playlist',
-
     importCSV: 'Import CSV',
-
     importCSVTooltip: 'Import from Spotify CSV',
-
     csvImportReport: 'CSV Import Report',
-
     csvImportTotal: 'Total',
-
     csvImportAdded: 'Added',
-
     csvImportDuplicates: 'Duplicates',
-
     csvImportNotFound: 'Not Found',
-
     csvImportNetworkErrors: 'Network Errors',
-
     csvImportDuplicatesTitle: 'Duplicate Tracks (Already in Playlist):',
-
     csvImportNotFoundTitle: 'Tracks Not Found:',
-
     csvImportNetworkErrorsTitle: 'Network Errors (may retry import):',
-
     csvImportDownloadReport: 'Download Report',
-
     csvImportClose: 'Close',
-
     csvImportNoValidTracks: 'No valid tracks found in CSV file',
-
     csvImportFailed: 'Failed to import CSV file',
-
     csvImportToast: '{{added}} added, {{notFound}} not found, {{duplicates}} duplicates',
-
   },
-
   mostPlayed: {
-
     title: 'Most Played',
-
     topArtists: 'Top Artists',
-
     topAlbums: 'Top Albums',
-
     plays: '{{n}} plays',
-
     sortMost: 'Most plays first',
-
     sortLeast: 'Fewest plays first',
-
     loadMore: 'Load more albums',
-
     noData: 'No play data yet. Start listening!',
-
     noArtists: 'All artists filtered out.',
-
     filterCompilations: 'Hide compilation artists (Various Artists, Soundtracks, etc.)',
-
     filterCompilationsShort: 'Hide compilations',
-
   },
-
   radio: {
-
     title: 'Internet Radio',
-
     empty: 'No radio stations configured.',
-
     addStation: 'Add Station',
-
     editStation: 'Edit',
-
     deleteStation: 'Delete station',
-
     confirmDelete: 'Click again to confirm',
-
     stationName: 'Station name…',
-
     streamUrl: 'Stream URL…',
-
     homepageUrl: 'Homepage URL (optional)',
-
     save: 'Save',
-
     cancel: 'Cancel',
-
     live: 'LIVE',
-
     liveStream: 'Internet Radio',
-
     openHomepage: 'Open homepage',
-
     changeCoverLabel: 'Change cover',
-
     removeCover: 'Remove cover',
-
     browseDirectory: 'Search Directory',
-
     directoryPlaceholder: 'Search stations…',
-
     noResults: 'No stations found.',
-
     stationAdded: 'Station added',
-
     filterAll: 'All',
-
     filterFavorites: 'Favorites',
-
     sortManual: 'Manual',
-
     sortAZ: 'A → Z',
-
     sortZA: 'Z → A',
-
     sortNewest: 'Newest',
-
     favorite: 'Add to favorites',
-
     unfavorite: 'Remove from favorites',
-
     noFavorites: 'No favorite stations.',
-
     listenerCount_one: '{{count}} listener',
-
     listenerCount_other: '{{count}} listeners',
-
     recentlyPlayed: 'Recently Played',
-
     upNext: 'Up Next',
-
   },
-
   folderBrowser: {
-
     empty: 'Empty folder',
-
     error: 'Failed to load',
-
   },
-
   deviceSync: {
-
     title: 'Device Sync',
-
     targetFolder: 'Target Folder',
-
     noFolderChosen: 'No folder chosen',
-
     selectDrive: 'Select a drive…',
-
     refreshDrives: 'Refresh drives',
-
     noDrivesDetected: 'No removable drives detected',
-
     browseManual: 'Browse manually…',
-
     free: 'free',
-
     notMountedVolume: 'Target is not on a mounted volume. The drive may have been disconnected.',
-
     chooseFolder: 'Choose…',
-
     filenameTemplate: 'Filename Template',
-
     targetDevice: 'Target Device',
-
     templateHint: 'Variables: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
-
     onDevice: 'Device Manager',
-
     addSources: 'Add…',
-
     colName: 'Name',
-
     colType: 'Type',
-
     colStatus: 'Status',
-
     syncResult: '{{done}} transferred, {{skipped}} already up to date ({{total}} total)',
-
     deleteFromDevice: 'Mark for deletion ({{count}})',
-
     confirmDelete: 'Delete {{count}} item(s) from the device: {{names}}?',
-
     deleteComplete: '{{count}} item(s) removed from device.',
-
+    manifestImported: 'Imported {{count}} source(s) from device manifest.',
     selectedSources: 'Selected Sources',
-
     noSourcesSelected: 'No sources selected. Click items in the browser to add them.',
-
     clearAll: 'Clear all',
-
     tabPlaylists: 'Playlists',
-
     tabAlbums: 'Albums',
-
     tabArtists: 'Artists',
-
     searchPlaceholder: 'Search…',
-
     syncButton: 'Sync to Device',
-
     actionTransfer: 'Transfer to Device',
-
     actionDelete: 'Delete from Device',
-
     actionApplyAll: 'Apply All Changes',
-
     templatePreview: 'Preview',
-
+    templatePresetStandard: 'Standard',
+    templatePresetMultiDisc: 'Multi-Disc',
+    templatePresetAltFolder: 'Alt. Folder',
+    tokenSlashHint: '/ = folder separator',
     cancel: 'Cancel',
-
     noTargetDir: 'Please choose a target folder first.',
-
     noSources: 'Please select at least one source.',
-
     noTracks: 'No tracks found in the selected sources.',
-
     fetchError: 'Failed to fetch tracks from server.',
-
     syncComplete: 'Sync complete.',
-
     dismiss: 'Dismiss',
-
+    cancelSync: 'Cancel',
+    syncCancelled: 'Sync cancelled ({{done}} / {{total}} transferred).',
     statusSynced: 'Synced',
-
     statusPending: 'Pending',
-
     statusDeletion: 'Deletion',
-
     markForDeletion: 'Mark for deletion',
-
     undoDeletion: 'Undo deletion',
-
     removeSource: 'Remove',
-
     syncInBackground: 'Sync started in background — you can navigate away.',
-
     syncInProgress: '{{done}} / {{total}} tracks…',
-
     scanningDevice: 'Scanning device…',
-
     syncSummary: 'Sync Summary',
-
     calculating: 'Calculating required payload…',
-
     filesToAdd: 'Files to Add:',
-
     filesToDelete: 'Files to Delete:',
-
     netChange: 'Net Change:',
-
     availableSpace: 'Available Disk Space:',
-
     spaceWarning: 'Warning: Target device does not have enough reported space.',
-
     proceed: 'Proceed with Sync',
-
     notEnoughSpace: 'Not enough physical disk space detected!',
-
     liveSearch: 'Live',
-
     randomAlbumsLabel: 'Random Albums',
-
   },
-
 };
-

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1,1169 +1,2276 @@
 export const esTranslation = {
+
   sidebar: {
+
     library: 'Biblioteca',
+
     mainstage: 'Escenario Principal',
+
     newReleases: 'Novedades',
+
     allAlbums: 'Todos los Álbumes',
+
     randomAlbums: 'Álbumes Aleatorios',
+
     artists: 'Artistas',
+
     randomMix: 'Mezcla Aleatoria',
+
     randomPicker: 'Crear Mezcla',
+
     favorites: 'Favoritos',
+
     nowPlaying: 'Reproduciendo Ahora',
+
     system: 'Sistema',
+
     statistics: 'Estadísticas',
+
     settings: 'Configuración',
+
     help: 'Ayuda',
+
     expand: 'Expandir Barra Lateral',
+
     collapse: 'Colapsar Barra Lateral',
 
+
+
     downloadingTracks: 'Descargando {{n}} pistas…',
+
     syncingTracks: 'Sincronizando {{done}}/{{total}}…',
+
     cancelDownload: 'Cancelar descarga',
+
     offlineLibrary: 'Biblioteca Offline',
+
     genres: 'Géneros',
+
     playlists: 'Listas de Reproducción',
+
     mostPlayed: 'Más Reproducidos',
+
     radio: 'Radio por Internet',
+
     folderBrowser: 'Explorar Carpetas',
+
     deviceSync: 'Sincronizar dispositivo',
+
     libraryScope: 'Ámbito de biblioteca',
+
     allLibraries: 'Todas las bibliotecas',
+
     expandPlaylists: 'Expandir listas',
+
     collapsePlaylists: 'Colapsar listas',
+
   },
+
   home: {
+
     hero: 'Destacado',
+
     starred: 'Favoritos Personales',
+
     recent: 'Agregados Recientemente',
+
     mostPlayed: 'Más Reproducidos',
+
     recentlyPlayed: 'Reproducidos Recientemente',
+
     discover: 'Descubrir',
+
     loadMore: 'Cargar Más',
+
     discoverMore: 'Descubrir Más',
+
     discoverArtists: 'Descubrir Artistas',
+
     discoverArtistsMore: 'Todos los Artistas'
+
   },
+
   hero: {
+
     eyebrow: 'Álbum Destacado',
+
     playAlbum: 'Reproducir Álbum',
+
     enqueue: 'Agregar a la Cola',
+
     enqueueTooltip: 'Agregar álbum completo a la cola',
+
   },
+
   search: {
+
     placeholder: 'Buscar artista, álbum o canción…',
+
     noResults: 'No hay resultados para "{{query}}"',
+
     artists: 'Artistas',
+
     albums: 'Álbumes',
+
     songs: 'Canciones',
+
     clearLabel: 'Limpiar búsqueda',
+
     title: 'Buscar',
+
     resultsFor: 'Resultados para "{{query}}"',
+
     album: 'Álbum',
+
     advanced: 'Búsqueda Avanzada',
+
     advancedSearchTerm: 'Término de búsqueda',
+
     advancedSearchPlaceholder: 'Título, álbum, artista…',
+
     advancedGenre: 'Género',
+
     advancedAllGenres: 'Todos los géneros',
+
     advancedYear: 'Año',
+
     advancedYearFrom: 'desde',
+
     advancedYearTo: 'hasta',
+
     advancedAll: 'Todos',
+
     advancedSearch: 'Buscar',
+
     advancedEmpty: 'Ingresa un término de búsqueda o selecciona un filtro para comenzar.',
+
     advancedNoResults: 'No se encontraron resultados.',
+
     advancedGenreNote: 'Las canciones se seleccionan aleatoriamente de este género.',
+
     recentSearches: 'Búsquedas Recientes',
+
     browse: 'Explorar',
+
     emptyHint: '¿Qué quieres escuchar?',
+
     genres: 'Géneros',
+
   },
+
   nowPlaying: {
+
     tooltip: '¿Quién está escuchando?',
+
     title: '¿Quién está escuchando?',
+
     loading: 'Cargando…',
+
     nobody: 'Nadie está escuchando actualmente.',
+
     minutesAgo: 'hace {{n}}m',
+
     nothingPlaying: 'Aún no se está reproduciendo nada. ¡Empieza una canción!',
+
     aboutArtist: 'Sobre el Artista',
+
     fromAlbum: 'De este Álbum',
+
     viewAlbum: 'Ver Álbum',
+
     goToArtist: 'Ir al Artista',
+
     readMore: 'Leer más',
+
     showLess: 'Mostrar menos',
+
     genreInfo: 'Género',
+
     trackInfo: 'Información de la Pista',
+
   },
+
   contextMenu: {
+
     playNow: 'Reproducir Ahora',
+
     playNext: 'Reproducir Siguiente',
+
     addToQueue: 'Agregar a la Cola',
+
     enqueueAlbum: 'Agregar Álbum a la Cola',
+
     startRadio: 'Iniciar Radio',
+
     instantMix: 'Mezcla Instantánea',
+
     instantMixFailed: 'No se pudo crear la Mezcla Instantánea — error del servidor o plugin.',
+
     cliMixNeedsTrack: 'No hay nada en reproducción — inicia la reproducción y vuelve a ejecutar el comando de mezcla.',
+
     lfmLove: 'Favorito en Last.fm',
+
     lfmUnlove: 'Quitar favorito de Last.fm',
+
     favorite: 'Favorito',
+
     favoriteArtist: 'Artista Favorito',
+
     favoriteAlbum: 'Álbum Favorito',
+
     unfavorite: 'Quitar de Favoritos',
+
     unfavoriteArtist: 'Quitar Artista de Favoritos',
+
     unfavoriteAlbum: 'Quitar Álbum de Favoritos',
+
     removeFromQueue: 'Quitar de la Cola',
+
     removeFromPlaylist: 'Quitar de la Playlist',
+
     openAlbum: 'Abrir Álbum',
+
     goToArtist: 'Ir al Artista',
+
     download: 'Descargar (ZIP)',
+
     addToPlaylist: 'Agregar a Lista de Reproducción',
+
     selectedPlaylists: '{{count}} listas seleccionadas',
+
     selectedAlbums: '{{count}} álbumes seleccionados',
+
     selectedArtists: '{{count}} artistas seleccionados',
+
     songInfo: 'Información de la Canción',
+
   },
+
   albumDetail: {
+
     back: 'Volver',
+
     playAll: 'Reproducir Todo',
+
     enqueue: 'Agregar a la Cola',
+
     enqueueTooltip: 'Agregar álbum completo a la cola',
+
     artistBio: 'Biografía del Artista',
+
     download: 'Descargar (ZIP)',
+
     downloading: 'Cargando…',
+
     cacheOffline: 'Disponible offline',
+
     offlineCached: 'Disponible offline',
+
     offlineDownloading: 'Descargando… ({{n}}/{{total}})',
+
     removeOffline: 'Quitar de offline',
+
     offlineStorageFull: 'Almacenamiento offline lleno (límite: {{mb}} MB). Libera espacio eliminando un álbum de tu Biblioteca Offline, o aumenta el límite en Configuración.',
+
     offlineStorageGoToLibrary: 'Biblioteca Offline',
+
     offlineStorageGoToSettings: 'Configuración',
+
     favoriteAdd: 'Agregar a Favoritos',
+
     favoriteRemove: 'Quitar de Favoritos',
+
     favorite: 'Favorito',
+
     noBio: 'No hay biografía disponible.',
+
     moreByArtist: 'Más de {{artist}}',
+
     tracksCount: '{{n}} Pistas',
+
     goToArtist: 'Ir a {{artist}}',
+
     moreLabelAlbums: 'Más álbumes en {{label}}',
+
     trackTitle: 'Título',
+
     trackAlbum: 'Álbum',
+
     trackArtist: 'Artista',
+
     trackGenre: 'Género',
+
     trackFormat: 'Formato',
+
     trackFavorite: 'Favorito',
+
     trackRating: 'Calificación',
+
     trackDuration: 'Duración',
+
     trackTotal: 'Total',
+
     columns: 'Columnas',
-    resetColumns: 'Restablecer',
+
     notFound: 'Álbum no encontrado.',
+
     bioModal: 'Biografía del Artista',
+
     bioClose: 'Cerrar',
+
     ratingLabel: 'Calificación',
+
     enlargeCover: 'Ampliar',
+
     filterSongs: 'Filtrar canciones…',
+
     sortNatural: 'Natural',
+
     sortByTitle: 'A–Z (Título)',
+
     sortByArtist: 'A–Z (Artista)',
+
     sortByAlbum: 'A–Z (Álbum)',
+
   },
+
   entityRating: {
+
     albumShort: 'Calificación del álbum',
+
     artistShort: 'Calificación del artista',
+
     albumAriaLabel: 'Calificación del álbum',
+
     artistAriaLabel: 'Calificación del artista',
+
     saveFailed: 'No se pudo guardar la calificación.',
+
   },
+
   artistDetail: {
+
     back: 'Volver',
+
     albums: 'Álbumes',
+
     album: 'Álbum',
+
     playAll: 'Reproducir Todo',
+
     shuffle: 'Aleatorio',
+
     radio: 'Radio',
+
     loading: 'Cargando…',
+
     noRadio: 'No se encontraron pistas similares para este artista.',
+
     notFound: 'Artista no encontrado.',
+
     albumsBy: 'Álbumes de {{name}}',
+
     topTracks: 'Mejores Pistas',
+
     noAlbums: 'No se encontraron álbumes.',
+
     trackTitle: 'Título',
+
     trackAlbum: 'Álbum',
+
     trackDuration: 'Duración',
+
     favoriteAdd: 'Agregar a Favoritos',
+
     favoriteRemove: 'Quitar de Favoritos',
+
     favorite: 'Favorito',
+
     albumCount_one: '{{count}} Álbum',
+
     albumCount_other: '{{count}} Álbumes',
+
     openedInBrowser: 'Abierto en navegador',
+
     featuredOn: 'También Aparece En',
+
     similarArtists: 'Artistas Similares',
+
     cacheOffline: 'Guardar discografía offline',
+
     offlineCached: 'Discografía guardada',
+
     offlineDownloading: 'Descargando… ({{done}}/{{total}} álbumes)',
+
     uploadImage: 'Subir imagen del artista',
+
     uploadImageError: 'Error al subir imagen',
+
   },
+
   favorites: {
+
     title: 'Favoritos',
+
     empty: "Aún no has guardado ningún favorito.",
+
     artists: 'Artistas',
+
     albums: 'Álbumes',
+
     songs: 'Canciones',
+
     enqueueAll: 'Agregar todo a la cola',
+
     playAll: 'Reproducir todo',
+
     removeSong: 'Quitar de favoritos',
+
     stations: 'Estaciones de Radio',
+
     showingFiltered: 'Mostrando {{filtered}} de {{total}} ({{artist}})',
+
     showingCount: 'Mostrando {{filtered}} de {{total}}',
+
     clearArtistFilter: 'Limpiar filtro de artista',
+
     noFilterResults: 'No hay resultados con los filtros seleccionados.',
+
     allArtists: 'Todos los Artistas',
+
   },
+
   randomLanding: {
+
     title: 'Crear Mezcla',
+
     mixByTracks: 'Mezcla por Canciones',
+
     mixByTracksDesc: 'Selección aleatoria de canciones de toda tu biblioteca',
+
     mixByAlbums: 'Mezcla por Álbumes',
+
     mixByAlbumsDesc: 'Álbumes aleatorios para tu próximo descubrimiento',
+
   },
+
   randomAlbums: {
+
     title: 'Álbumes Aleatorios',
+
     refresh: 'Refrescar',
+
   },
+
   genres: {
+
     title: 'Géneros',
+
     genreCount: 'Géneros',
+
     albumCount_one: '{{count}} álbum',
+
     albumCount_other: '{{count}} álbumes',
+
     loading: 'Cargando géneros…',
+
     empty: 'No se encontraron géneros.',
+
     albumsLoading: 'Cargando álbumes…',
+
     albumsEmpty: 'No se encontraron álbumes para este género.',
+
     loadMore: 'Cargar más',
+
     back: 'Volver',
+
   },
+
   randomMix: {
+
     title: 'Mezcla Aleatoria',
+
     remix: 'Remezclar',
+
     remixTooltip: 'Cargar nuevas canciones aleatorias',
+
     remixGenre: 'Remezclar {{genre}}',
+
     remixTooltipGenre: 'Cargar nuevas canciones de {{genre}}',
+
     playAll: 'Reproducir Todo',
+
     trackTitle: 'Título',
+
     trackArtist: 'Artista',
+
     trackAlbum: 'Álbum',
+
     trackFavorite: 'Favorito',
+
     trackDuration: 'Duración',
+
     favoriteAdd: 'Agregar a Favoritos',
+
     favoriteRemove: 'Quitar de Favoritos',
+
     play: 'Reproducir',
+
     trackGenre: 'Género',
+
     excludeAudiobooks: 'Excluir audiolibros y radioteatros',
+
     excludeAudiobooksDesc: 'Busca palabras clave en género, título, álbum y artista — ej. Hörbuch, Audiobook, Spoken Word, …',
+
     genreBlocked: 'Palabra clave bloqueada',
+
     genreAddedToBlacklist: 'Agregada a lista de filtros',
+
     genreAlreadyBlocked: 'Ya está bloqueada',
+
     artistBlocked: 'Artista bloqueado',
+
     artistAddedToBlacklist: 'Artista agregado a lista de filtros',
+
     artistClickHint: 'Click para bloquear este artista',
+
     blacklistToggle: 'Filtro de Palabras Clave',
+
     genreMixTitle: 'Mezcla por Género',
+
     genreMixDesc: 'Top 20 géneros por cantidad de canciones — click para cargar mezcla aleatoria',
+
     genreMixAll: 'Todas las Canciones',
+
     genreMixLoadMore: 'Cargar 10 más',
+
     genreMixNoGenres: 'No se encontraron géneros en el servidor.',
+
     shuffleGenres: 'Mostrar géneros diferentes',
+
     filterPanelTitle: 'Filtros',
+
     filterPanelDesc: 'Click en una etiqueta de género o nombre de artista en la lista para bloquearlo de futuras mezclas.',
+
     genreClickHint: 'Click en una etiqueta de género para agregarla\ncomo palabra clave filtrada.\nBusca en género, título, álbum y artista.',
+
   },
+
   albums: {
+
     title: 'Todos los Álbumes',
+
     sortByName: 'A–Z (Álbum)',
+
     sortByArtist: 'A–Z (Artista)',
+
     sortNewest: 'Más recientes primero',
+
     sortRandom: 'Aleatorio',
+
     yearFrom: 'Desde',
+
     yearTo: 'Hasta',
+
     yearFilterClear: 'Limpiar filtro de año',
+
     yearFilterLabel: 'Año',
+
     select: 'Selección múltiple',
+
     startSelect: 'Activar selección múltiple',
+
     cancelSelect: 'Cancelar',
+
     selectionCount: '{{count}} seleccionados',
+
     downloadZips: 'Descargar ZIPs',
+
     addOffline: 'Agregar Offline',
+
     downloadingZip: 'Descargando {{current}}/{{total}}: {{name}}',
+
     downloadZipDone: '{{count}} ZIP(s) descargado(s)',
+
     downloadZipFailed: 'Error al descargar {{name}}',
+
     offlineQueuing: 'Encolando {{count}} álbum(es) para offline…',
+
     offlineFailed: 'Error al agregar {{name}} offline',
+
     addToPlaylist: 'Agregar a Lista de Reproducción',
+
   },
+
   artists: {
+
     title: 'Artistas',
+
     search: 'Buscar…',
+
     all: 'Todos',
+
     gridView: 'Vista de cuadrícula',
+
     listView: 'Vista de lista',
+
     imagesOn: 'Imágenes de artistas activadas — puede aumentar la carga de red y sistema',
+
     imagesOff: 'Imágenes de artistas desactivadas — mostrando solo iniciales',
+
     loadMore: 'Cargar más',
+
     notFound: 'No se encontraron artistas.',
+
     albumCount_one: '{{count}} Álbum',
+
     albumCount_other: '{{count}} Álbumes',
+
     selectionCount: '{{count}} seleccionados',
+
     select: 'Selección múltiple',
+
     startSelect: 'Activar selección múltiple',
+
     cancelSelect: 'Cancelar',
+
     addToPlaylist: 'Agregar a Lista',
+
   },
+
   login: {
+
     subtitle: 'Tu Reproductor Navidrome para Escritorio',
+
     serverName: 'Nombre del Servidor (opcional)',
+
     serverNamePlaceholder: 'Mi Navidrome',
+
     serverUrl: 'URL del Servidor',
+
     serverUrlPlaceholder: '192.168.1.100:4533 o https://music.example.com',
+
     username: 'Usuario',
+
     usernamePlaceholder: 'admin',
+
     password: 'Contraseña',
+
     showPassword: 'Mostrar contraseña',
+
     hidePassword: 'Ocultar contraseña',
+
     connect: 'Conectar',
+
     connecting: 'Conectando…',
+
     connected: '¡Conectado!',
+
     error: 'Conexión fallida — por favor verifica tus datos.',
+
     urlRequired: 'Por favor ingresa una URL de servidor.',
+
     savedServers: 'Servidores Guardados',
+
     addNew: 'O agregar un nuevo servidor',
+
   },
+
   connection: {
+
     connected: 'Conectado',
+
     connectedTo: 'Conectado a {{server}}',
+
     disconnected: 'Desconectado',
+
     disconnectedFrom: 'No se puede alcanzar {{server}} — click para verificar configuración',
+
     checking: 'Conectando…',
+
     extern: 'Externo',
+
     offlineTitle: 'Sin conexión al servidor',
+
     offlineSubtitle: 'No se puede alcanzar {{server}}. Verifica tu red o servidor.',
+
     offlineModeBanner: 'Modo Offline — reproduciendo desde caché local',
+
     offlineNoCacheBanner: 'Sin conexión al servidor — no se puede acceder a {{server}}',
+
     offlineLibraryTitle: 'Biblioteca Offline',
+
     offlineLibraryEmpty: 'No hay álbumes en caché aún. Conéctate, abre un álbum y click en "Disponible offline".',
+
     offlineAlbumCount: '{{n}} álbum',
+
     offlineAlbumCount_plural: '{{n}} álbumes',
+
     offlineFilterAll: 'Todos',
+
     offlineFilterAlbums: 'Álbumes',
+
     offlineFilterPlaylists: 'Listas',
+
     offlineFilterArtists: 'Discografías',
+
     retry: 'Reintentar',
+
     serverSettings: 'Configuración del servidor',
+
     switchServerTitle: 'Cambiar servidor',
+
     switchServerHint: 'Clic para elegir otro servidor guardado.',
+
     manageServers: 'Gestionar servidores…',
+
     switchFailed: 'No se pudo cambiar — servidor inalcanzable.',
+
     lastfmConnected: 'Last.fm conectado como @{{user}}',
+
     lastfmSessionInvalid: 'Sesión inválida — click para reconectar',
+
   },
+
   common: {
+
     albums: 'Álbumes',
+
     album: 'Álbum',
+
     loading: 'Cargando…',
+
     loadingMore: 'Cargando…',
+
     loadingPlaylists: 'Cargando Listas…',
+
     noAlbums: 'No se encontraron álbumes.',
+
     downloading: 'Descargando…',
+
     downloadZip: 'Descargar (ZIP)',
+
     back: 'Volver',
+
     cancel: 'Cancelar',
+
     save: 'Guardar',
+
     delete: 'Eliminar',
+
     use: 'Usar',
+
     add: 'Agregar',
+
     active: 'Activo',
+
     download: 'Descargar',
+
     chooseDownloadFolder: 'Elegir carpeta de descarga',
+
     noFolderSelected: 'Ninguna carpeta seleccionada',
+
     rememberDownloadFolder: 'Recordar esta carpeta',
+
     filterGenre: 'Filtro de Género',
+
     filterSearchGenres: 'Buscar géneros…',
+
     filterNoGenres: 'Ningún género coincide',
+
     filterClear: 'Limpiar',
+
     play: 'Reproducir',
+
     bulkSelected: '{{count}} seleccionados',
+
     clearSelection: 'Limpiar selección',
+
     bulkAddToPlaylist: 'Agregar a Lista',
+
     bulkRemoveFromPlaylist: 'Quitar de Lista',
+
     bulkClear: 'Limpiar selección',
+
     updaterAvailable: 'Actualización disponible',
+
     updaterVersion: 'v{{version}} está disponible',
+
     updaterWebsite: 'Sitio web',
+
     updaterModalTitle: 'Nueva Versión Disponible',
+
     updaterChangelog: 'Novedades',
+
     updaterDownloadBtn: 'Descargar Ahora',
+
     updaterSkipBtn: 'Omitir esta Versión',
+
     updaterRemindBtn: 'Recordarme Después',
+
     updaterDone: 'Descarga completada',
+
     updaterShowFolder: 'Mostrar en Carpeta',
+
     updaterInstallHint: 'Cierra Psysonic y ejecuta el instalador manualmente.',
+
     updaterAurHint: 'Instala la actualización vía AUR:',
+
     updaterErrorMsg: 'Error de descarga',
+
     updaterRetryBtn: 'Reintentar',
+
     durationHoursMinutes: '{{hours}}h {{minutes}}m',
+
     durationMinutesOnly: '{{minutes}}m',
+
     updaterOpenGitHub: 'Abrir en GitHub',
+
     filters: 'Filtros',
+
     more: 'más',
+
     yearRange: 'Rango de años',
+
     clearAll: 'Limpiar todo',
+
   },
+
   settings: {
+
     title: 'Configuración',
+
     language: 'Idioma',
+
     languageEn: 'Inglés',
+
     languageDe: 'Alemán',
+
     languageFr: 'Francés',
+
     languageNl: 'Neerlandés',
+
     languageZh: 'Chino',
+
     languageNb: 'Noruego',
+
     languageRu: 'Ruso',
+
     languageEs: 'Español',
+
     font: 'Fuente',
+
     theme: 'Tema',
+
     appearance: 'Apariencia',
+
     servers: 'Servidores',
+
     serverName: 'Nombre del Servidor',
+
     serverUrl: 'URL del Servidor',
+
     serverUrlPlaceholder: '192.168.1.100:4533 o https://music.example.com',
+
     serverUsername: 'Usuario',
+
     serverPassword: 'Contraseña',
+
     addServer: 'Agregar Servidor',
+
     addServerTitle: 'Agregar Nuevo Servidor',
+
     useServer: 'Usar',
+
     deleteServer: 'Eliminar',
+
     noServers: 'No hay servidores guardados.',
+
     serverActive: 'Activo',
+
     confirmDeleteServer: '¿Eliminar servidor "{{name}}"?',
+
     serverConnecting: 'Conectando…',
+
     serverConnected: '¡Conectado!',
+
     serverFailed: 'Conexión fallida.',
+
     testBtn: 'Probar Conexión',
+
     testingBtn: 'Probando…',
+
     serverCompatible: 'Compatible con: Navidrome · Gonic · Airsonic · Subsonic',
+
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+
     audiomuseDesc:
+
       'Activa si este servidor tiene el plugin <pluginLink>AudioMuse-AI Navidrome</pluginLink> configurado. Habilita Mezcla Instantánea desde pistas y usa artistas similares del servidor en lugar de Last.fm en páginas de artistas.',
+
     audiomuseIssueHint:
+
       'La Mezcla Instantánea falló recientemente — verifica el plugin de Navidrome y la API de AudioMuse. Artistas similares usan Last.fm como respaldo cuando el servidor no devuelve ninguno.',
+
     connected: 'Conectado',
+
     failed: 'Fallido',
+
     eqTitle: 'Ecualizador',
+
     eqEnabled: 'Habilitar Ecualizador',
+
     eqPreset: 'Preajuste',
+
     eqPresetCustom: 'Personalizado',
+
     eqPresetBuiltin: 'Preajustes Integrados',
+
     eqPresetCustomGroup: 'Mis Preajustes',
+
     eqSavePreset: 'Guardar como Preajuste',
+
     eqPresetName: 'Nombre del preajuste…',
+
     eqDeletePreset: 'Eliminar preajuste',
+
     eqResetBands: 'Restablecer a Plano',
+
     eqPreGain: 'Pre-ganancia',
+
     eqResetPreGain: 'Restablecer pre-ganancia',
+
     eqAutoEqTitle: 'Búsqueda AutoEQ de Auriculares',
+
     eqAutoEqPlaceholder: 'Buscar modelo de auricular / IEM…',
+
     eqAutoEqSearching: 'Buscando…',
+
     eqAutoEqNoResults: 'No se encontraron resultados',
+
     eqAutoEqError: 'Error de búsqueda',
+
     eqAutoEqRateLimit: 'Límite de GitHub alcanzado — intenta de nuevo en un minuto',
+
     eqAutoEqFetchError: 'Error al obtener perfil EQ',
+
     lfmTitle: 'Last.fm',
+
     lfmConnect: 'Conectar con Last.fm',
+
     lfmConnecting: 'Esperando autorización…',
+
     lfmConfirm: 'He autorizado la aplicación',
+
     lfmConnected: 'Conectado como',
+
     lfmDisconnect: 'Desconectar',
+
     lfmConnectDesc: 'Conecta tu cuenta de Last.fm para habilitar scrobbling y actualizaciones de "Reproduciendo Ahora" directamente desde Psysonic — no requiere configuración de Navidrome.',
+
     lfmOpenBrowser: 'Se abrirá una ventana del navegador. Autoriza Psysonic en Last.fm, luego click en el botón de abajo.',
+
     lfmScrobbles: '{{n}} scrobbles',
+
     lfmMemberSince: 'Miembro desde {{year}}',
+
     scrobbleEnabled: 'Scrobbling habilitado',
+
     scrobbleDesc: 'Enviar canciones a Last.fm después del 50% de reproducción',
+
     behavior: 'Comportamiento de la App',
+
     cacheTitle: 'Tamaño Máx. de Almacenamiento',
+
     cacheDesc: 'Portadas e imágenes de artistas. Cuando está lleno, las entradas más antiguas se eliminan automáticamente. Los álbumes offline no se eliminan automáticamente, pero se borrarán al limpiar la caché manualmente.',
+
     cacheUsedImages: 'Imágenes:',
+
     cacheUsedOffline: 'Pistas offline:',
+
     cacheUsedHot: 'Tamaño en disco:',
+
     hotCacheTrackCount: 'Pistas en caché:',
+
     cacheMaxLabel: 'Tamaño máx.',
+
     cacheClearBtn: 'Limpiar Caché',
+
     cacheClearWarning: 'Esto también eliminará todos los álbumes offline de la biblioteca.',
+
     cacheClearConfirm: 'Limpiar Todo',
+
     cacheClearCancel: 'Cancelar',
+
     offlineDirTitle: 'Biblioteca Offline (En App)',
+
     offlineDirDesc: 'Ubicación de almacenamiento para pistas que haces disponibles offline dentro de Psysonic.',
+
     offlineDirDefault: 'Predeterminado (Datos de App)',
+
     offlineDirChange: 'Cambiar Directorio',
+
     offlineDirClear: 'Restablecer a Predeterminado',
+
     offlineDirHint: 'Las nuevas descargas usarán esta ubicación. Las descargas existentes permanecen en su ruta original.',
+
     hotCacheTitle: 'Caché de reproducción activa',
+
     hotCacheAlphaBadge: 'Alpha',
+
     hotCacheDisclaimer: 'Precarga las siguientes pistas en cola y mantiene las anteriores. Cuando está activado, usa espacio en disco y red.',
+
     hotCacheDirDefault: 'Predeterminado (Datos de App)',
+
     hotCacheDirChange: 'Cambiar carpeta',
+
     hotCacheDirClear: 'Restablecer a predeterminado',
+
     hotCacheDirHint: 'Cambiar la carpeta restablece el índice en-app; los archivos ya en disco permanecen donde están hasta que los elimines.',
+
     hotCacheEnabled: 'Habilitar caché de reproducción activa',
+
     hotCacheMaxMb: 'Tamaño máximo de caché',
+
     hotCacheDebounce: 'Espera de cambio de cola',
+
     hotCacheDebounceImmediate: 'Inmediato',
+
     hotCacheDebounceSeconds: '{{n}} s',
+
     hotCacheClearBtn: 'Limpiar caché activa',
+
     audioOutputDevice: 'Dispositivo de salida de audio',
+
     audioOutputDeviceDesc: 'Selecciona el dispositivo de audio que usa Psysonic. Los cambios surten efecto de inmediato y reinician la pista actual.',
+
     audioOutputDeviceDefault: 'Predeterminado del sistema',
+
     audioOutputDeviceRefresh: 'Actualizar lista de dispositivos',
+
     audioOutputDeviceOsDefaultNow: 'salida actual del sistema',
+
     audioOutputDeviceListError: 'No se pudo cargar la lista de dispositivos de audio.',
+
     audioOutputDeviceNotInCurrentList: 'no está en la lista actual',
+
     hiResTitle: 'Reproducción Nativa Hi-Res',
+
     hiResEnabled: 'Habilitar reproducción nativa hi-res',
+
     hiResDesc: "Fuerza 44.1 kHz de salida por defecto para máxima estabilidad. Habilita solo si tu hardware y red soportan confiablemente altas tasas de muestreo (88.2 kHz+).",
+
     showArtistImages: 'Mostrar Imágenes de Artistas',
+
     showArtistImagesDesc: 'Carga y muestra imágenes de artistas en el resumen de Artistas. Desactivado por defecto para reducir I/O de disco del servidor y carga de red en bibliotecas grandes.',
+
     showTrayIcon: 'Mostrar Icono en Bandeja',
+
     showTrayIconDesc: 'Muestra el icono de Psysonic en el área de notificación / barra de menú.',
+
     minimizeToTray: 'Minimizar a Bandeja',
+
     minimizeToTrayDesc: 'Al cerrar la ventana, mantener Psysonic ejecutándose en la bandeja del sistema en lugar de salir.',
+
     discordRichPresence: 'Discord Rich Presence',
+
     discordRichPresenceDesc: 'Muestra la pista actual en tu perfil de Discord. Requiere que Discord esté ejecutándose.',
+
     useCustomTitlebar: 'Barra de título personalizada',
+
     useCustomTitlebarDesc: 'Reemplaza la barra de título del sistema con una integrada que coincide con el tema de la app. Desactiva para usar la barra nativa de GNOME/GTK.',
+
     discordAppleCovers: 'Obtener portadas de Apple Music para Discord',
+
     discordAppleCoversDesc: 'Envía el artista y nombre del álbum a la API de búsqueda de Apple para encontrar portadas para tu perfil de Discord. Desactivado por defecto por privacidad.',
+
+    discordTemplates: 'Plantillas de texto personalizadas',
+
+    discordTemplatesDesc: 'Personaliza qué información se muestra en tu perfil de Discord. Variables: {title}, {artist}, {album}, {paused}',
+
+    discordTemplateDetails: 'Línea principal (details)',
+
+    discordTemplateState: 'Línea secundaria (state)',
+
+    discordTemplateLargeText: 'Tooltip del álbum (largeText)',
+
     nowPlayingEnabled: 'Mostrar en Reproduciendo Ahora',
+
     nowPlayingEnabledDesc: 'Transmite tu pista actual a la vista de oyentes en vivo del servidor. Desactiva para dejar de enviar datos de reproducción.',
+
     lyricsServerFirst: 'Preferir letras del servidor',
+
     lyricsServerFirstDesc: 'Verifica primero letras provistas por el servidor (etiquetas embebidas, archivos sidecar) antes de consultar LRCLIB. Desactiva para usar LRCLIB primero.',
+
     enableNeteaselyrics: 'Letras de Netease Cloud Music',
+
     enableNeteaselyricsDesc: 'Usa Netease Cloud Music como fuente de letras de último recurso cuando el servidor y LRCLIB no devuelvan nada. Mejor cobertura para música asiática e internacional.',
+
     lyricsSourcesTitle: 'Fuentes de Letras',
+
     lyricsSourcesDesc: 'Elige qué fuentes consultar para letras y en qué orden. Arrastra para reordenar. Las fuentes desactivadas se omiten completamente.',
+
     lyricsSourceServer: 'Servidor',
+
     lyricsSourceLrclib: 'LRCLIB',
+
     lyricsSourceNetease: 'Netease Cloud Music',
+
     downloadsTitle: 'Exportación ZIP y Archivado',
+
     downloadsFolderDesc: 'Carpeta de destino para álbumes que descargas como ZIP a tu computadora.',
+
     downloadsDefault: 'Carpeta de Descargas Predeterminada',
+
     pickFolder: 'Seleccionar',
+
     pickFolderTitle: 'Seleccionar Carpeta de Descarga',
+
     clearFolder: 'Limpiar carpeta de descarga',
+
     logout: 'Cerrar Sesión',
+
     aboutTitle: 'Acerca de Psysonic',
+
     aboutDesc: 'Un reproductor de música moderno para escritorio compatible con servidores Subsonic (Navidrome, Gonic y otros). Construido en Tauri v2 con motor de audio nativo en Rust — ligero y rápido, pero lleno de características: barra de progreso tipo onda, letras sincronizadas, integración Last.fm, ecualizador de 10 bandas, crossfade, reproducción gapless, Replay Gain, navegación por géneros, y una gran biblioteca de temas.',
+
     aboutLicense: 'Licencia',
+
     aboutLicenseText: 'GNU GPL v3 — libre para usar, modificar y distribuir bajo la misma licencia.',
+
     aboutRepo: 'Código Fuente en GitHub',
+
     aboutVersion: 'Versión',
+
     aboutBuiltWith: 'Construido con Tauri · React · TypeScript · Rust/rodio',
+
     aboutAiCredit: 'Desarrollado con el apoyo de Claude Code by Anthropic',
+
     aboutContributorsLabel: 'Contribuidores',
+
     aboutSpecialThanksLabel: 'Agradecimientos Especiales',
+
     changelog: 'Registro de Cambios',
+
     showChangelogOnUpdate: "Mostrar 'Novedades' al actualizar",
+
     showChangelogOnUpdateDesc: "Muestra automáticamente las novedades cuando se lanza una nueva versión por primera vez.",
+
     randomMixTitle: 'Mezcla Aleatoria',
+
     randomMixBlacklistTitle: 'Palabras Clave de Filtro Personalizadas',
+
     randomMixBlacklistDesc: 'Las canciones se excluyen cuando cualquier palabra clave coincide con su género, título, álbum o artista (activo cuando el checkbox de arriba está activado).',
+
     randomMixBlacklistPlaceholder: 'Agregar palabra clave…',
+
     randomMixBlacklistAdd: 'Agregar',
+
     randomMixBlacklistEmpty: 'Aún no hay palabras clave personalizadas.',
+
     randomMixHardcodedTitle: 'Palabras clave integradas (activas cuando el checkbox está activado)',
+
     tabAudio: 'Audio',
+
     tabStorage: 'Almacenamiento y Descargas',
+
     tabAppearance: 'Apariencia',
+
     homeCustomizerTitle: 'Página de Inicio',
+
     sidebarTitle: 'Barra Lateral',
+
     sidebarReset: 'Restablecer a predeterminado',
+
     sidebarDrag: 'Arrastra para reordenar',
+
     sidebarFixed: 'Siempre visible',
-    randomNavSplitTitle: 'Dividir navegación Mix',
-    randomNavSplitDesc: 'Mostrar "Mezcla Aleatoria" y "Álbumes Aleatorios" como entradas separadas en la barra lateral en lugar del hub "Crear Mezcla".',
+
     tabInput: 'Entrada',
+
     tabServer: 'Servidor',
+
     tabSystem: 'Sistema',
+
     tabGeneral: 'General',
+
     ratingsSectionTitle: 'Calificaciones',
+
     ratingsSkipStarTitle: 'Saltar para 1 estrella',
+
     ratingsSkipStarDesc:
+
       'Después de varios saltos seguidos, asigna 1 estrella a la pista. Solo para pistas aún no calificadas.',
+
     ratingsSkipStarThresholdLabel: 'Saltos',
+
     ratingsMixFilterTitle: 'Filtrar por calificación',
+
     ratingsMixFilterDesc:
+
       'Filtra elementos de baja calificación en {{mix}} y {{albums}}. Click en la estrella seleccionada nuevamente para desactivar el umbral.',
+
     ratingsMixMinSong: 'Canciones',
+
     ratingsMixMinAlbum: 'Álbumes',
+
     ratingsMixMinArtist: 'Artistas',
+
     ratingsMixMinThresholdAria: 'Estrellas mínimas: {{label}}',
+
     backupTitle: 'Respaldo y Restauración',
+
     backupExport: 'Exportar configuración',
+
     backupExportDesc: 'Guarda toda la configuración, perfiles de servidor, configuración Last.fm, tema, EQ y atajos de teclado a un archivo .psybkp. Las contraseñas se almacenan en texto plano — mantén el archivo seguro.',
+
     backupImport: 'Importar configuración',
+
     backupImportDesc: 'Restaura configuración desde un archivo .psybkp. La app se recargará después de importar.',
+
     backupImportConfirm: 'Esto sobrescribirá toda la configuración actual. ¿Continuar?',
+
     backupSuccess: 'Respaldo guardado',
+
     backupImportSuccess: 'Configuración restaurada — recargando…',
+
     backupImportError: 'Archivo de respaldo inválido o corrupto.',
+
     shortcutsReset: 'Restablecer a predeterminados',
+
     shortcutListening: 'Presiona una tecla…',
+
     shortcutUnbound: '—',
+
     globalShortcutsTitle: 'Atajos Globales',
+
     globalShortcutsNote: 'Funcionan en todo el sistema incluso cuando Psysonic está en segundo plano. Requieren Ctrl, Alt o Super como modificador.',
+
     shortcutClear: 'Limpiar',
+
     shortcutPlayPause: 'Reproducir / Pausa',
+
     shortcutNext: 'Siguiente pista',
+
     shortcutPrev: 'Pista anterior',
+
     shortcutVolumeUp: 'Subir volumen',
+
     shortcutVolumeDown: 'Bajar volumen',
+
     shortcutSeekForward: 'Avanzar 10s',
+
     shortcutSeekBackward: 'Retroceder 10s',
+
     shortcutToggleQueue: 'Alternar cola',
+
     shortcutOpenFolderBrowser: 'Abrir {{folderBrowser}}',
+
     shortcutFullscreenPlayer: 'Reproductor pantalla completa',
+
     shortcutNativeFullscreen: 'Pantalla completa nativa',
+
     playbackTitle: 'Reproducción',
+
     replayGain: 'Replay Gain',
+
     replayGainDesc: 'Normalizar volumen de pistas usando metadatos ReplayGain',
+
     replayGainMode: 'Modo',
+
     replayGainTrack: 'Pista',
+
     replayGainAlbum: 'Álbum',
+
     replayGainPreGain: 'Pre-Ganancia (archivos etiquetados)',
+
     replayGainFallback: 'Respaldo (sin etiquetar / radio)',
+
     crossfade: 'Crossfade',
+
     crossfadeDesc: 'Transición entre pistas',
+
     crossfadeSecs: '{{n}} s',
+
     notWithGapless: 'No disponible mientras Gapless está activo',
+
     notWithCrossfade: 'No disponible mientras Crossfade está activo',
+
     gapless: 'Reproducción Gapless',
+
     gaplessDesc: 'Precarga siguiente pista para eliminar silencios entre canciones',
+
     preloadMode: 'Precargar Siguiente Pista',
+
     preloadModeDesc: 'Cuándo comenzar a cargar la siguiente pista en cola',
+
     nextTrackBufferingTitle: 'Buffer de Siguiente Pista',
+
     preloadHotCacheMutualExclusive: 'Precarga y Caché Activa sirven para lo mismo — solo uno puede estar activo a la vez. Habilitar uno desactivará automáticamente el otro.',
+
     preloadOff: 'Apagado',
+
     preloadBalanced: 'Balanceado (30 s antes del final)',
+
     preloadEarly: 'Temprano (después de 5 s de reproducción)',
+
     preloadCustom: 'Personalizado',
+
     preloadCustomSeconds: 'Segundos antes del final: {{n}}',
+
     infiniteQueue: 'Cola Infinita',
+
     infiniteQueueDesc: 'Agregar automáticamente pistas aleatorias cuando la cola termina',
+
     experimental: 'Experimental',
+
     fsPlayerSection: 'Reproductor Pantalla Completa',
+
     fsShowArtistPortrait: 'Mostrar foto del artista',
+
     fsShowArtistPortraitDesc: 'Muestra la foto del artista (o portada del álbum) en el lado derecho del reproductor pantalla completa.',
+
     fsPortraitDim: 'Oscurecimiento de foto',
+
     seekbarStyle: 'Estilo de Barra de Progreso',
+
     seekbarStyleDesc: 'Elige la apariencia de la barra de progreso del reproductor',
+
     seekbarWaveform: 'Forma de Onda',
+
     seekbarLinedot: 'Línea y Punto',
+
     seekbarBar: 'Barra',
+
     seekbarThick: 'Barra Gruesa',
+
     seekbarSegmented: 'Segmentada',
+
     seekbarNeon: 'Brillo Neón',
+
     seekbarPulsewave: 'Onda Pulsante',
+
     seekbarParticletrail: 'Estela de Partículas',
+
     seekbarLiquidfill: 'Llenado Líquido',
+
     seekbarRetrotape: 'Cinta Retro',
+
     themeSchedulerTitle: 'Cambio Automático de Tema',
+
     themeSchedulerEnable: 'Habilitar Programador de Temas',
+
     themeSchedulerEnableSub: 'Cambia automáticamente entre dos temas según la hora del día',
+
     themeSchedulerDayTheme: 'Tema de Día',
+
     themeSchedulerDayStart: 'Comienza de Día A las',
+
     themeSchedulerNightTheme: 'Tema de Noche',
+
     themeSchedulerNightStart: 'Comienza de Noche A las',
+
     themeSchedulerActiveHint: 'El Programador de Temas está activo — los cambios de tema se manejan automáticamente.',
+
     visualOptionsTitle: 'Opciones Visuales',
+
     coverArtBackground: 'Fondo de Portada',
+
     coverArtBackgroundSub: 'Mostrar portada desenfocada como fondo en encabezados de álbumes y listas de reproducción',
+
     playlistCoverPhoto: 'Foto de Portada de Playlist',
+
     playlistCoverPhotoSub: 'Mostrar cuadrícula de fotos de portada en la vista detallada de playlists',
+
     showBitrate: 'Mostrar Bitrate',
+
     showBitrateSub: 'Mostrar bitrate de audio en las listas de pistas',
+
     uiScaleTitle: 'Escala de Interfaz',
+
     uiScaleLabel: 'Zoom',
+
   },
+
   changelog: {
+
     modalTitle: 'Novedades',
+
     dontShowAgain: 'No mostrar de nuevo',
+
     close: 'Entendido',
+
   },
+
   help: {
+
     title: 'Ayuda',
+
     s1: 'Primeros Pasos',
+
     q1: '¿Qué servidores son compatibles?',
+
     a1: 'Psysonic funciona con cualquier servidor compatible con Subsonic: Navidrome, Gonic, Subsonic, Airsonic y otros. Navidrome es la opción recomendada.',
+
     q2: '¿Cómo me conecto a mi servidor?',
+
     a2: 'Abre Configuración y click en "Agregar Servidor". Ingresa la URL del servidor (ej. 192.168.1.100:4533), tu usuario y contraseña. Psysonic prueba la conexión antes de guardar — nada se almacena si la conexión falla.',
+
     q3: '¿Puedo usar múltiples servidores?',
+
     a3: 'Sí. Puedes agregar tantos servidores como quieras en Configuración y cambiar entre ellos en cualquier momento. Solo un servidor está activo a la vez.',
+
     s2: 'Reproducción',
+
     q4: '¿Cómo reproduzco música?',
+
     a4: 'Doble-click en cualquier pista para reproducirla. En páginas de álbum y artista, usa "Reproducir Todo" para iniciar el álbum completo. También puedes arrastrar pistas al panel de cola.',
+
     q5: '¿Qué atajos de teclado hay disponibles?',
+
     a5: 'Espacio = Reproducir / Pausa · Escape = Cerrar reproductor pantalla completa. Las teclas multimedia (Reproducir/Pausa, Siguiente, Anterior) funcionan en todas las plataformas. En Linux, usa los botones de la barra de reproducción para teclas multimedia. Los atajos en-app y globales del sistema se pueden personalizar en Configuración → Atajos de Teclado / Atajos Globales.',
+
     q6: '¿Qué es la cola?',
+
     a6: 'La cola muestra todas las pistas siguientes. Ábrela con el icono del panel en la barra superior derecha (junto al indicador de Reproduciendo Ahora). Puedes reordenar pistas arrastrando, mezclar con el botón de mezcla, y guardar la cola como lista de reproducción.',
+
     q7: '¿Cómo abro el reproductor en pantalla completa?',
+
     a7: 'Click en la miniatura de portada en la barra de reproducción inferior, o el icono de expandir junto a ella. Presiona Escape para cerrar.',
+
     q8: '¿Cómo funciona la repetición?',
+
     a8: 'Click en el botón de repetición en la barra de reproducción para alternar: Apagado → Repetir Todo → Repetir Una.',
+
     s3: 'Biblioteca',
+
     q9: '¿Cómo descargo un álbum?',
+
     a9: 'Abre la página de detalle de un álbum y click en "Descargar (ZIP)". El servidor comprime el álbum en un archivo ZIP primero — para álbumes grandes o archivos sin pérdida (FLAC / WAV) esto puede tomar un momento antes de que comience la descarga. Esto es normal: la barra de progreso aparece una vez que el servidor termina de comprimir y comienza la transferencia.',
+
     q10: '¿Cómo marco favoritos pistas y álbumes?',
+
     a10: 'Click en el icono de estrella en cualquier fila de pista o en el encabezado del álbum. Los elementos favoritos aparecen en la sección Favoritos de la barra lateral.',
+
     q11: '¿Qué es el carrusel destacado en la página de inicio?',
+
     a11: 'El banner en la parte superior de la página de inicio selecciona álbumes aleatorios de tu biblioteca y rota entre ellos cada 10 segundos. Click en los puntos para ir a uno específico, o click en el banner para abrir el álbum.',
+
     s4: 'Configuración',
+
     q12: '¿Cómo cambio el tema?',
+
     a12: 'Configuración → Tema. Elige entre una gran selección de temas en 8 grupos: Temas Psysonic, Reproductores de Medios, Sistemas Operativos, Juegos, Películas, Series, Redes Sociales, y Clásicos Open Source (Catppuccin, Nord, Gruvbox, Nightfox).',
+
     q13: '¿Cómo cambio el idioma?',
+
     a13: 'Configuración → Idioma. Se soportan Inglés, Alemán, Francés, Neerlandés, Chino, Noruego, Ruso y Español.',
+
     q15: '¿Cómo establezco una carpeta de descarga?',
+
     a15: 'Configuración → Comportamiento de App → Carpeta de Descarga. Elige cualquier carpeta — los álbumes descargados se guardan ahí como archivos ZIP. Sin una carpeta personalizada, se usa la ubicación de descargas predeterminada del navegador.',
+
     s5: 'Scrobbling',
+
     q16: '¿Cómo funciona el scrobbling?',
+
     a16: 'Psysonic hace scrobbling directamente a Last.fm — no requiere configuración de Navidrome. Conecta tu cuenta de Last.fm en Configuración → Last.fm y habilita el scrobbling ahí.',
+
     q17: '¿Cuándo se envía un scrobble?',
+
     a17: 'Un scrobble se envía después de escuchar el 50% de una pista.',
+
     q22: '¿Qué es la forma de onda en la barra de reproducción?',
+
     a22: 'La barra de progreso tipo onda reemplaza al deslizador clásico. Click en cualquier lugar para saltar a esa posición, o arrastra para buscar. La porción reproducida brilla con un degradado azul a malva, el rango cargado aparece ligeramente más brillante, y la porción no reproducida está atenuada.',
+
     q24: '¿Puedo mezclar la cola?',
+
     a24: 'Sí. Abre el panel de cola y click en el icono de mezcla en el encabezado de la cola. La pista actual permanece en la posición 1 — todas las demás se reordenan aleatoriamente.',
+
     q25: '¿Los enlaces de Last.fm y Wikipedia en páginas de artista abren en un navegador?',
+
     a25: 'Sí — abren en tu navegador predeterminado del sistema. El botón muestra brevemente una etiqueta de confirmación al hacer click.',
+
     s7: 'Mezcla Aleatoria',
+
     q26: '¿Qué es Mezcla Aleatoria?',
+
     a26: 'Mezcla Aleatoria construye una lista de reproducción de pistas aleatorias de toda tu biblioteca. Ábrela vía "Mezcla Aleatoria" en la barra lateral y click en "Nueva Mezcla". Puedes ajustar la cantidad de pistas antes de generar.',
+
     q27: '¿Qué es el Filtro de Palabras Clave?',
+
     a27: 'El Filtro de Palabras Clave excluye pistas cuyo género, título o nombre de álbum contiene palabras específicas. Los audiolibros se filtran automáticamente. Agrega palabras clave personalizadas en Configuración → Mezcla Aleatoria, o click en cualquier etiqueta de género en la lista de pistas para agregarla instantáneamente.',
+
     q28: '¿Qué es la Mezcla por Super Género?',
+
     a28: 'La Mezcla por Super Género agrupa tu biblioteca en categorías amplias (Rock, Metal, Electrónica, Jazz, Clásica, etc.) y construye una mezcla enfocada de ese estilo. Selecciona una categoría debajo de la lista de pistas. Los resultados aparecen progresivamente a medida que se obtiene cada sub-género.',
+
     s6: 'Solución de Problemas',
+
     q18: 'Las portadas e imágenes de artistas cargan lentamente.',
+
     a18: 'Las imágenes se obtienen del disco de tu servidor al primer acceso y luego se almacenan en caché localmente por 30 días. Si el almacenamiento de tu servidor es lento, la primera visita a una página puede tomar un momento. Las visitas subsecuentes serán instantáneas.',
+
     q19: 'La prueba de conexión falla.',
+
     a19: 'Verifica la URL incluyendo el puerto (ej. http://192.168.1.100:4533). Asegúrate de que ningún firewall bloquee la conexión. Intenta http:// en lugar de https:// en una red local. También verifica que tu usuario y contraseña sean correctos.',
+
     q20: 'No hay audio en Linux.',
+
     a20: 'Psysonic está disponible como .deb (Ubuntu/Debian), .rpm (Fedora/RHEL) y vía AUR en Arch/CachyOS (yay -S psysonic). No hay AppImage. Si falta audio, asegúrate de que PipeWire o PulseAudio estén ejecutándose.',
+
     q21: 'La app muestra una pantalla negra en Linux.',
+
     a21: 'Esto suele ser un problema de GPU/EGL en WebKitGTK. Lanza con GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. El paquete AUR y los instaladores oficiales .deb/.rpm configuran esto automáticamente.',
+
     q29: '¿Qué son Crossfade y Reproducción Gapless?',
+
     a29: 'Ambas son características de audio experimentales en Configuración → Audio. Gapless precarga la siguiente pista para eliminar silencios entre canciones. Crossfade desvanece la pista actual mientras aparece la siguiente — ajusta la duración (1–10 s) a tu gusto.',
+
     q30: '¿Muestra Psysonic letras?',
+
     a30: 'Sí. Click en el icono de micrófono en la barra de reproducción para abrir la pestaña de Letras en el panel de cola. Psysonic obtiene letras automáticamente de LRCLIB. Si hay letras sincronizadas disponibles, la línea activa se resalta y desplaza en tiempo real mientras suena la canción. Si solo hay texto plano, se muestra estáticamente.',
+
     q31: '¿Puedo personalizar los atajos de teclado?',
+
     a31: 'Sí. Configuración → Atajos de Teclado te permite reasignar acciones en-app (Reproducir/Pausa, Siguiente, Anterior, Subir/Bajar Volumen, Pantalla Completa y más) a cualquier tecla. Configuración → Atajos Globales te permite asignar atajos de todo el sistema que funcionan incluso cuando Psysonic está en segundo plano.',
+
     q32: '¿Puedo cambiar la fuente?',
+
     a32: 'Sí. Configuración → Fuente te permite elegir entre 10 fuentes incluyendo IBM Plex Mono, Fira Code, JetBrains Mono, Courier Prime y otras. La fuente seleccionada se aplica a toda la interfaz.',
+
     s8: 'Modo Offline',
+
     q34: '¿Qué es el Modo Offline?',
+
     a34: 'El Modo Offline (Beta) te permite almacenar álbumes en tu dispositivo para escuchar sin una conexión activa al servidor. Las pistas en caché se almacenan localmente y se reproducen directamente desde el disco — no se hace ninguna solicitud de red durante la reproducción.',
+
     q35: '¿Cómo almaceno un álbum para uso offline?',
+
     a35: 'Abre cualquier álbum y click en el icono de descarga en el encabezado del álbum. Psysonic descarga todas las pistas en segundo plano. El progreso se muestra en el botón. Una vez completado, el icono se vuelve verde. Puedes ver y eliminar álbumes en caché en la página Biblioteca Offline (barra lateral).',
+
     q36: '¿Cuánto almacenamiento puede usar el caché offline?',
+
     a36: 'Puedes establecer un tamaño máximo de caché en Configuración → Biblioteca. Cuando se alcanza el límite, aparece un banner de advertencia en la página del álbum. Puedes eliminar álbumes individuales desde la Biblioteca Offline para liberar espacio.',
+
     q37: '¿Cómo califico canciones, álbumes y artistas?',
+
     a37: 'Psysonic soporta calificaciones de 1–5 estrellas vía la API OpenSubsonic (requiere Navidrome ≥ 0.53). Califica canciones en la lista de pistas del álbum o playlist usando la columna de estrellas, en el menú contextual derecho, o directamente en la barra de reproducción debajo del nombre del artista. Los álbumes se pueden calificar en su página de detalle; los artistas en su página de artista. Las calificaciones se guardan en el servidor inmediatamente.',
+
     q38: '¿Puedo quitar o cambiar una calificación?',
+
     a38: 'Sí. Click en la estrella actualmente activa para limpiar la calificación por completo — click en la misma estrella una segunda vez la elimina. Para cambiar una calificación, simplemente click en una estrella diferente.',
+
     q39: '¿Qué es Saltar-a-1★ y el filtro de calificación?',
+
     a39: 'Saltar-a-1★ asigna automáticamente una calificación de 1 estrella a una canción después de que la saltes manualmente una cantidad configurable de veces consecutivas. Actívalo y establece el umbral de saltos en Configuración → Calificaciones. El mismo panel te permite establecer una calificación mínima estrella para Mezcla Aleatoria y Álbumes Aleatorios, para que solo se incluyan canciones, álbumes o artistas por encima de cierta calificación en las mezclas generadas.',
+
     q40: '¿Qué es el Explorador de Carpetas?',
+
     a40: 'El Explorador de Carpetas (barra lateral) te permite navegar el árbol de directorios de música de tu servidor usando un diseño de columnas Miller. Click en una carpeta para entrar; click en una pista o el icono de reproducción en una carpeta para reproducir o agregar sus contenidos directamente.',
+
     q41: '¿Qué es el Programador de Temas?',
+
     a41: 'Configuración → Apariencia → Cambio Automático de Tema: define un tema de día y uno de noche con horas de inicio. Psysonic cambia automáticamente a las horas configuradas. Cuando el programador está activo, una sugerencia en el selector de temas explica por qué la selección manual de tema no tiene efecto inmediato.',
+
     q42: '¿Puedo cambiar el tamaño de la interfaz?',
+
     a42: 'Sí. Configuración → Apariencia → Escala de Interfaz te permite escalar toda la interfaz entre 80% y 125% sin afectar el tamaño de fuente de tu sistema.',
+
     q43: '¿Puedo cambiar el estilo de la barra de progreso?',
+
     a43: 'Sí. Configuración → Apariencia → Estilo de Barra de Progreso ofrece 10 estilos: Forma de Onda, Línea y Punto, Barra, Barra Gruesa, Segmentada, Brillo Neón, Onda Pulsante, Estela de Partículas, Llenado Líquido y Cinta Retro.',
+
     q44: '¿Qué es AutoEQ?',
+
     a44: 'El ecualizador de 10 bandas en Configuración → Audio incluye una búsqueda AutoEQ. Ingresa tu modelo de auriculares y Psysonic obtiene un perfil de corrección de la base de datos AutoEQ y lo aplica automáticamente a las bandas del ecualizador.',
+
     q45: '¿Qué es Replay Gain?',
+
     a45: 'Replay Gain normaliza el volumen de las pistas para que álbumes fuertes y silenciosos suenen a nivel consistente. Actívalo en Configuración → Audio → Replay Gain y elige modo Pista (normalización por canción) o Álbum (preserva dinámica relativa dentro de un álbum).',
+
     q46: '¿Qué es la Caché Activa?',
+
     a46: 'La Caché Activa (Alpha, Configuración → Biblioteca) precarga las siguientes varias pistas en tu cola al disco para que la reproducción comience instantáneamente sin demora de carga — especialmente útil en servidores lentos o remotos. Psysonic mantiene la pista actual y las siguientes 5 en caché y elimina entradas antiguas cuando se alcanza el límite de tamaño. Puedes establecer el tamaño máximo de caché y una demora de espera para evitar cargas innecesarias cuando saltas rápidamente.',
+
     q47: '¿Puedo almacenar una lista de reproducción para uso offline?',
+
     a47: 'Sí. Abre cualquier lista de reproducción y click en el icono de descarga en el encabezado de la lista. Todas las pistas se descargan en segundo plano — el progreso se muestra en el indicador de descarga offline. Una vez completado, el icono cambia a un ícono de basura rojo; click en él elimina la lista del caché offline.',
-    q48: '¿Qué es la Cola Infinita?',
-    a48: 'Cuando la cola se vacía y la repetición está desactivada, Psysonic añade pistas aleatorias automáticamente para que la reproducción nunca se detenga. Las pistas añadidas aparecen bajo el separador "— Añadido automáticamente —". Actívalo con el ícono de infinito en el encabezado de la cola.',
-    q49: '¿Puedo controlar Psysonic desde la línea de comandos?',
-    a49: 'Sí. Ejemplos: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one. También: cambiar servidor, dispositivo de audio, filtrar biblioteca y buscar. Ayuda completa: psysonic --player --help.',
-    q50: '¿Cómo gestiono las listas de reproducción?',
-    a50: 'A través de "Listas de reproducción" en la barra lateral. Crea una con "Nueva lista". En la vista de detalle puedes reordenar pistas arrastrando, eliminarlas con ×, añadir canciones mediante búsqueda y usar "Sugerencias" para recomendaciones inteligentes.',
-    q51: '¿Puedo hacer copia de seguridad y restaurar mis ajustes?',
-    a51: 'Sí. Ajustes → Copia de seguridad y restauración exporta todos los ajustes, perfiles de servidor, temas y atajos a un archivo JSON. Impórtalo en otro dispositivo para restaurarlo todo de una vez.',
-    q52: '¿Cómo cambio el dispositivo de salida de audio?',
-    a52: 'Ajustes → Audio → Dispositivo de salida. Psysonic lista todas las salidas disponibles. La selección surte efecto inmediatamente. Usa el botón de actualizar si conectaste un dispositivo después de iniciar la app.',
-    q53: '¿Qué es Device Sync?',
-    a53: 'Device Sync copia álbumes, listas de reproducción o artistas a un USB o tarjeta SD. Ábrelo desde "Device Sync" en la barra lateral, elige una carpeta destino, selecciona fuentes y haz clic en "Transferir al dispositivo".',
-    q54: '¿Qué es la plantilla de nombre de archivo en Device Sync?',
-    a54: 'La plantilla controla cómo se nombran y organizan las pistas. Usa los preajustes o crea el tuyo con los tokens: {artist}, {album}, {title}, {track_number}, {disc_number}, {year} y / como separador de carpeta.',
-    q55: '¿Funciona Device Sync entre plataformas?',
-    a55: 'Sí. El manifiesto guardado en el dispositivo incluye la plantilla usada. En otro SO con distinta plantilla, Psysonic detecta correctamente los archivos existentes.',
-    s9: 'Device Sync',
-    q56: '¿Qué es la Radio por Internet?',
-    a56: 'La página de Radio por Internet permite reproducir cualquier transmisión en vivo en Psysonic. Las estaciones provienen de tu servidor Navidrome. La reproducción usa audio HTML5.',
-    q57: '¿Qué formatos de transmisión admite la Radio por Internet?',
-    a57: 'MP3, AAC, OGG Vorbis y la mayoría de transmisiones HLS. MP3 y AAC funcionan en todas las plataformas.',
-    s10: 'Radio por Internet',
-    q58: '¿De dónde obtiene Psysonic las letras?',
-    a58: 'Tres fuentes configurables en Ajustes → Letras: tu servidor Navidrome, LRCLIB y NetEase Cloud Music. Cada fuente puede activarse/desactivarse y priorizarse arrastrando.',
-    q59: '¿Hay una vista de lo que escuchan otros usuarios?',
-    a59: 'Sí. Haz clic en el ícono de transmisión en la parte superior derecha para ver qué escuchan otros usuarios en tu servidor Navidrome, actualizado cada 10 segundos.',
+
   },
+
   queue: {
+
     title: 'Cola',
+
     savePlaylist: 'Guardar Lista',
+
     updatePlaylist: 'Actualizar Lista',
+
     filterPlaylists: 'Filtrar listas…',
+
     playlistName: 'Nombre de Lista',
+
     cancel: 'Cancelar',
+
     save: 'Guardar',
+
     loadPlaylist: 'Cargar Lista',
+
     loading: 'Cargando…',
+
     noPlaylists: 'No se encontraron listas.',
+
     load: 'Reemplazar cola y reproducir',
+
     appendToQueue: 'Agregar a cola',
+
     delete: 'Eliminar',
+
     deleteConfirm: '¿Eliminar lista "{{name}}"?',
+
     clear: 'Limpiar',
+
     shuffle: 'Mezclar cola',
+
     gapless: 'Gapless',
+
     crossfade: 'Crossfade',
+
     infiniteQueue: 'Cola Infinita',
+
     autoAdded: '— Agregado automáticamente —',
+
     radioAdded: '— Radio —',
+
     hide: 'Ocultar',
+
     close: 'Cerrar',
+
     nextTracks: 'Siguientes',
+
     emptyQueue: 'La cola está vacía.',
+
     trackSingular: 'pista',
+
     trackPlural: 'pistas',
+
     showRemaining: 'Mostrar tiempo restante',
+
     showTotal: 'Mostrar tiempo total',
+
   },
+
   statistics: {
+
     title: 'Estadísticas',
+
     recentlyPlayed: 'Reproducidos Recientemente',
+
     mostPlayed: 'Álbumes Más Reproducidos',
+
     highestRated: 'Álbumes Mejor Calificados',
+
     genreDistribution: 'Distribución de Géneros (Top 20)',
+
     loadMore: 'Cargar más',
+
     statArtists: 'Artistas',
+
     statArtistsTooltip: 'Solo artistas de álbum — los artistas que aparecen únicamente como artistas de pista (featuring, invitado, etc.) sin álbum propio no se cuentan.',
+
     statAlbums: 'Álbumes',
+
     statSongs: 'Canciones',
+
     statGenres: 'Géneros',
+
     statPlaytime: 'Tiempo Total de Reproducción',
+
     genreInsights: 'Información de Géneros',
+
     formatDistribution: 'Distribución de Formatos',
+
     formatSample: 'Muestra de {{n}} pistas',
+
     computing: 'Calculando…',
+
     genreSongs: '{{count}} Canciones',
+
     genreAlbums: '{{count}} Álbumes',
+
     recentlyAdded: 'Agregados Recientemente',
+
     decadeDistribution: 'Álbumes por Década',
+
     decadeAlbums_one: '{{count}} Álbum',
+
     decadeAlbums_other: '{{count}} Álbumes',
+
     decadeUnknown: 'Desconocido',
+
     lfmTitle: 'Estadísticas de Last.fm',
+
     lfmTopArtists: 'Artistas Principales',
+
     lfmTopAlbums: 'Álbumes Principales',
+
     lfmTopTracks: 'Pistas Principales',
+
     lfmPlays: '{{count}} reproducciones',
+
     lfmPeriodOverall: 'Todo el Tiempo',
+
     lfmPeriod7day: '7 Días',
+
     lfmPeriod1month: '1 Mes',
+
     lfmPeriod3month: '3 Meses',
+
     lfmPeriod6month: '6 Meses',
+
     lfmPeriod12month: '12 Meses',
+
     lfmNotConnected: 'Conecta Last.fm en Configuración para ver tus estadísticas.',
+
     lfmRecentTracks: 'Scrobbles Recientes',
+
     lfmNowPlaying: 'Reproduciendo Ahora',
+
     lfmJustNow: 'ahora mismo',
+
     lfmMinutesAgo: 'hace {{n}}m',
+
     lfmHoursAgo: 'hace {{n}}h',
+
     lfmDaysAgo: 'hace {{n}}d',
+
     topRatedSongs: 'Canciones Mejor Calificadas',
+
     topRatedArtists: 'Artistas Mejor Calificados',
+
     noRatedSongs: 'Aún no hay canciones calificadas. Califica canciones en la vista de álbum o playlist.',
+
     noRatedArtists: 'Aún no hay artistas calificados.',
+
   },
+
   player: {
+
     regionLabel: 'Reproductor de Música',
+
     openFullscreen: 'Abrir Reproductor Pantalla Completa',
+
     fullscreen: 'Reproductor Pantalla Completa',
+
     closeFullscreen: 'Cerrar Pantalla Completa',
+
     closeTooltip: 'Cerrar (Esc)',
+
     noTitle: 'Sin Título',
+
     stop: 'Detener',
+
     prev: 'Pista Anterior',
+
     play: 'Reproducir',
+
     pause: 'Pausa',
+
     next: 'Pista Siguiente',
+
     repeat: 'Repetir',
+
     repeatOff: 'Apagado',
+
     repeatAll: 'Todo',
+
     repeatOne: 'Una',
+
     progress: 'Progreso de Canción',
+
     volume: 'Volumen',
+
     toggleQueue: 'Alternar Cola',
+
     lyrics: 'Letras',
+
     fsLyricsToggle: 'Letras en pantalla completa',
+
     lyricsLoading: 'Cargando letras…',
+
     lyricsNotFound: 'No se encontraron letras para esta pista',
+
     lyricsSourceServer: 'Fuente: Servidor',
+
     lyricsSourceLrclib: 'Fuente: LRCLIB',
+
     lyricsSourceNetease: 'Fuente: Netease',
+
   },
+
   songInfo: {
+
     title: 'Información de Canción',
+
     songTitle: 'Título',
+
     artist: 'Artista',
+
     album: 'Álbum',
+
     albumArtist: 'Artista del Álbum',
+
     year: 'Año',
+
     genre: 'Género',
+
     duration: 'Duración',
+
     track: 'Pista',
+
     format: 'Formato',
+
     bitrate: 'Bitrate',
+
     sampleRate: 'Frecuencia de Muestreo',
+
     bitDepth: 'Profundidad de Bits',
+
     channels: 'Canales',
+
     fileSize: 'Tamaño de Archivo',
+
     path: 'Ruta',
+
     replayGainTrack: 'RG Ganancia de Pista',
+
     replayGainAlbum: 'RG Ganancia de Álbum',
+
     replayGainPeak: 'RG Pico de Pista',
+
     mono: 'Mono',
+
     stereo: 'Estéreo',
+
   },
+
   playlists: {
+
     title: 'Listas de Reproducción',
+
     newPlaylist: 'Nueva Lista',
+
     unnamed: 'Lista sin nombre',
+
     createName: 'Nombre de lista…',
+
     create: 'Crear',
+
     cancel: 'Cancelar',
+
     empty: 'Aún no hay listas.',
+
     emptyPlaylist: 'Esta lista está vacía.',
+
     addFirstSong: 'Agrega tu primera canción',
+
     notFound: 'Lista no encontrada.',
+
     songs: '{{n}} canciones',
+
     playAll: 'Reproducir Todo',
+
     shuffle: 'Aleatorio',
+
     addToQueue: 'Agregar a Cola',
+
     back: 'Volver a Listas',
+
     deletePlaylist: 'Eliminar',
+
     confirmDelete: 'Click de nuevo para confirmar',
+
     removeSong: 'Quitar de lista',
+
     addSongs: 'Agregar Canciones',
+
     searchPlaceholder: 'Buscar en tu biblioteca…',
+
     noResults: 'Sin resultados.',
+
     suggestions: 'Canciones Sugeridas',
+
     noSuggestions: 'No hay sugerencias disponibles.',
+
     titleBadge: 'Lista',
+
     refreshSuggestions: 'Nuevas sugerencias',
+
     addSong: 'Agregar a lista',
+
     addSelected: 'Agregar seleccionados',
+
     cacheOffline: 'Guardar lista offline',
+
     offlineCached: 'Lista guardada',
+
     removeOffline: 'Quitar de caché offline',
+
     offlineDownloading: 'Descargando… ({{done}}/{{total}} álbumes)',
+
     publicLabel: 'Pública',
+
     privateLabel: 'Privada',
+
     editMeta: 'Editar lista',
+
     editNamePlaceholder: 'Nombre de lista…',
+
     editCommentPlaceholder: 'Agregar descripción…',
+
     editPublic: 'Lista pública',
+
     editSave: 'Guardar',
+
     editCancel: 'Cancelar',
+
     changeCover: 'Cambiar imagen de portada',
+
     changeCoverLabel: 'Cambiar foto',
+
     removeCover: 'Quitar foto',
+
     coverUpdated: 'Portada actualizada',
+
     metaSaved: 'Lista actualizada',
+
     downloadZip: 'Descargar (ZIP)',
+
     // Toast notifications for multi-select
+
     addSuccess: '{{count}} canciones agregadas a {{playlist}}',
+
     addPartial: '{{added}} agregadas, {{skipped}} skippeadas por duplicadas',
+
     addAllSkipped: 'Todas skippeadas ({{count}} duplicadas)',
+
     addError: 'Error al agregar canciones',
+
     createAndAddSuccess: 'Lista "{{playlist}}" creada con {{count}} canciones',
+
     createError: 'Error al crear lista',
+
     deleteSuccess: '{{count}} listas eliminadas',
+
     deleteFailed: 'Error al eliminar {{name}}',
+
     deleteSelected: 'Eliminar seleccionadas',
+
     mergeSuccess: '{{count}} canciones unificadas en {{playlist}}',
+
     mergeNoNewSongs: 'No hay canciones nuevas para agregar',
+
     mergeError: 'Error al unificar listas',
+
     mergeInto: 'Unificar en',
+
     selectionCount: '{{count}} seleccionadas',
+
     select: 'Seleccionar',
+
     startSelect: 'Activar selección',
+
     cancelSelect: 'Cancelar',
+
     loadingAlbums: 'Resolviendo {{count}} álbumes…',
+
     loadingArtists: 'Resolviendo {{count}} artistas…',
+
     myPlaylists: 'Mis Listas',
+
     noOtherPlaylists: 'No hay otras listas disponibles',
+
     addToPlaylistSuccess: '{{count}} canciones agregadas a {{playlist}}',
+
     addToPlaylistNoNew: 'No hay canciones nuevas para agregar a {{playlist}}',
+
     addToPlaylistError: 'Error al agregar a la lista',
+
     removeSuccess: 'Canción quitada de la playlist',
+
     removeError: 'Error al quitar la canción de la playlist',
+
     importCSV: 'Importar CSV',
+
     importCSVTooltip: 'Importar desde CSV de Spotify',
+
     csvImportReport: 'Reporte de Importación CSV',
+
     csvImportTotal: 'Total',
+
     csvImportAdded: 'Agregadas',
+
     csvImportDuplicates: 'Duplicadas',
+
     csvImportNotFound: 'No Encontradas',
+
     csvImportNetworkErrors: 'Errores de Red',
+
     csvImportDuplicatesTitle: 'Canciones Duplicadas (Ya en la Lista):',
+
     csvImportNotFoundTitle: 'Canciones No Encontradas:',
+
     csvImportNetworkErrorsTitle: 'Errores de Red (puede reintentar la importación):',
+
     csvImportDownloadReport: 'Descargar Reporte',
+
     csvImportClose: 'Cerrar',
+
     csvImportNoValidTracks: 'No se encontraron canciones válidas en el archivo CSV',
+
     csvImportFailed: 'Error al importar el archivo CSV',
+
     csvImportToast: '{{added}} agregadas, {{notFound}} no encontradas, {{duplicates}} duplicadas',
+
   },
+
   mostPlayed: {
+
     title: 'Más Reproducidos',
+
     topArtists: 'Artistas Principales',
+
     topAlbums: 'Álbumes Principales',
+
     plays: '{{n}} reproducciones',
+
     sortMost: 'Más reproducciones primero',
+
     sortLeast: 'Menos reproducciones primero',
+
     loadMore: 'Cargar más álbumes',
+
     noData: 'Aún no hay datos de reproducción. ¡Empieza a escuchar!',
+
     noArtists: 'Todos los artistas filtrados.',
+
     filterCompilations: 'Ocultar artistas de compilaciones (Various Artists, Soundtracks, etc.)',
+
     filterCompilationsShort: 'Ocultar compilaciones',
+
   },
+
   radio: {
+
     title: 'Radio por Internet',
+
     empty: 'No hay estaciones de radio configuradas.',
+
     addStation: 'Agregar Estación',
+
     editStation: 'Editar',
+
     deleteStation: 'Eliminar estación',
+
     confirmDelete: 'Click de nuevo para confirmar',
+
     stationName: 'Nombre de estación…',
+
     streamUrl: 'URL de stream…',
+
     homepageUrl: 'URL de página (opcional)',
+
     save: 'Guardar',
+
     cancel: 'Cancelar',
+
     live: 'EN VIVO',
+
     liveStream: 'Radio por Internet',
+
     openHomepage: 'Abrir página',
+
     changeCoverLabel: 'Cambiar portada',
+
     removeCover: 'Quitar portada',
+
     browseDirectory: 'Buscar en Directorio',
+
     directoryPlaceholder: 'Buscar estaciones…',
+
     noResults: 'No se encontraron estaciones.',
+
     stationAdded: 'Estación agregada',
+
     filterAll: 'Todas',
+
     filterFavorites: 'Favoritos',
+
     sortManual: 'Manual',
+
     sortAZ: 'A → Z',
+
     sortZA: 'Z → A',
+
     sortNewest: 'Más recientes',
+
     favorite: 'Agregar a favoritos',
+
     unfavorite: 'Quitar de favoritos',
+
     noFavorites: 'No hay estaciones favoritas.',
+
     listenerCount_one: '{{count}} oyente',
+
     listenerCount_other: '{{count}} oyentes',
+
     recentlyPlayed: 'Reproducidos Recientemente',
+
     upNext: 'Siguientes',
+
   },
+
   folderBrowser: {
+
     empty: 'Carpeta vacía',
+
     error: 'Error al cargar',
+
   },
+
   deviceSync: {
+
     title: 'Sincronizar dispositivo',
+
     targetFolder: 'Carpeta de destino',
+
     noFolderChosen: 'Ninguna carpeta seleccionada',
+
     selectDrive: 'Seleccionar unidad…',
+
     refreshDrives: 'Actualizar unidades',
+
     noDrivesDetected: 'No se detectaron unidades extraíbles',
+
     browseManual: 'Explorar manualmente…',
+
     free: 'libre',
+
     notMountedVolume: 'El destino no está en un volumen montado. La unidad puede haberse desconectado.',
+
     chooseFolder: 'Elegir…',
+
     filenameTemplate: 'Plantilla de nombre de archivo',
+
     targetDevice: 'Dispositivo de destino',
+
     templateHint: 'Variables: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
+
     cleanupButton: 'Eliminar archivos fuera de la selección',
+
     cleanupNothingToDelete: 'Nada que eliminar — el dispositivo ya está sincronizado.',
+
     confirmCleanup: '¿Eliminar {{count}} archivo(s) del dispositivo que no están en la selección actual? ¿Continuar?',
+
     cleanupComplete: '{{count}} archivo(s) eliminado(s) del dispositivo.',
+
     selectedSources: 'Fuentes seleccionadas',
+
     noSourcesSelected: 'No hay fuentes seleccionadas. Haz clic en elementos del navegador para agregarlos.',
+
     clearAll: 'Limpiar todo',
+
     tabPlaylists: 'Listas de reproducción',
+
     tabAlbums: 'Álbumes',
+
     tabArtists: 'Artistas',
+
     searchPlaceholder: 'Buscar…',
+
     syncButton: 'Sincronizar al dispositivo',
+
     actionTransfer: 'Transferir al dispositivo',
+
     actionDelete: 'Eliminar del dispositivo',
+
     actionApplyAll: 'Aplicar todos los cambios',
+
     templatePreview: 'Vista previa',
-    templatePresetStandard: 'Estándar',
-    templatePresetMultiDisc: 'Multi-Disco',
-    templatePresetAltFolder: 'Carpeta alt.',
-    tokenSlashHint: '/ = separador de carpeta',
+
     cancel: 'Cancelar',
+
     noTargetDir: 'Por favor, elige primero una carpeta de destino.',
+
     noSources: 'Por favor, selecciona al menos una fuente.',
+
     noTracks: 'No se encontraron pistas en las fuentes seleccionadas.',
+
     fetchError: 'Error al obtener pistas del servidor.',
+
     syncComplete: 'Sincronización completada.',
+
     dismiss: 'Cerrar',
-    cancelSync: 'Cancelar',
-    syncCancelled: 'Sincronización cancelada ({{done}} / {{total}} transferidos).',
+
     colName: 'Nombre',
+
     colType: 'Tipo',
+
     colStatus: 'Estado',
+
     onDevice: 'Gestor de dispositivo',
+
     addSources: 'Agregar…',
+
     syncResult: '{{done}} transferido(s), {{skipped}} ya actualizado(s) ({{total}} total)',
+
     deleteFromDevice: 'Marcar para eliminar ({{count}})',
+
     confirmDelete: '¿Eliminar {{count}} elemento(s) del dispositivo: {{names}}?',
+
     deleteComplete: '{{count}} elemento(s) eliminado(s) del dispositivo.',
-    manifestImported: '{{count}} fuente(s) importada(s) desde el manifiesto del dispositivo.',
+
     statusSynced: 'Sincronizado',
+
     statusPending: 'Pendiente',
+
     statusDeletion: 'Eliminación',
+
     markForDeletion: 'Marcar para eliminar',
+
     removeSource: 'Eliminar',
+
     undoDeletion: 'Deshacer eliminación',
+
     syncInBackground: 'Sincronización iniciada en segundo plano — puedes navegar a otro lugar.',
+
     syncInProgress: '{{done}} / {{total}} pistas…',
+
     syncSummary: 'Resumen de sincronización',
+
     calculating: 'Calculando la carga útil requerida…',
+
     filesToAdd: 'Archivos a agregar:',
+
     filesToDelete: 'Archivos a eliminar:',
+
     netChange: 'Cambio neto:',
+
     availableSpace: 'Espacio disponible en disco:',
+
     spaceWarning: 'Advertencia: El dispositivo de destino no tiene suficiente espacio reportado.',
+
     proceed: 'Proceder con la sincronización',
+
     notEnoughSpace: '¡Espacio físico en disco insuficiente detectado!',
+
     liveSearch: 'Live',
+
     randomAlbumsLabel: 'Álbumes aleatorios',
+
   },
+
 };
+

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -543,7 +543,7 @@ export const esTranslation = {
     discordAppleCovers: 'Obtener portadas de Apple Music para Discord',
     discordAppleCoversDesc: 'Envía el artista y nombre del álbum a la API de búsqueda de Apple para encontrar portadas para tu perfil de Discord. Desactivado por defecto por privacidad.',
     discordTemplates: 'Plantillas de texto personalizadas',
-    discordTemplatesDesc: 'Personaliza qué información se muestra en tu perfil de Discord. Variables: {title}, {artist}, {album}, {paused}',
+    discordTemplatesDesc: 'Personaliza qué información se muestra en tu perfil de Discord. Variables: {title}, {artist}, {album}',
     discordTemplateDetails: 'Línea principal (details)',
     discordTemplateState: 'Línea secundaria (state)',
     discordTemplateLargeText: 'Tooltip del álbum (largeText)',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1,2276 +1,1174 @@
 export const esTranslation = {
-
   sidebar: {
-
     library: 'Biblioteca',
-
     mainstage: 'Escenario Principal',
-
     newReleases: 'Novedades',
-
     allAlbums: 'Todos los Álbumes',
-
     randomAlbums: 'Álbumes Aleatorios',
-
     artists: 'Artistas',
-
     randomMix: 'Mezcla Aleatoria',
-
     randomPicker: 'Crear Mezcla',
-
     favorites: 'Favoritos',
-
     nowPlaying: 'Reproduciendo Ahora',
-
     system: 'Sistema',
-
     statistics: 'Estadísticas',
-
     settings: 'Configuración',
-
     help: 'Ayuda',
-
     expand: 'Expandir Barra Lateral',
-
     collapse: 'Colapsar Barra Lateral',
 
-
-
     downloadingTracks: 'Descargando {{n}} pistas…',
-
     syncingTracks: 'Sincronizando {{done}}/{{total}}…',
-
     cancelDownload: 'Cancelar descarga',
-
     offlineLibrary: 'Biblioteca Offline',
-
     genres: 'Géneros',
-
     playlists: 'Listas de Reproducción',
-
     mostPlayed: 'Más Reproducidos',
-
     radio: 'Radio por Internet',
-
     folderBrowser: 'Explorar Carpetas',
-
     deviceSync: 'Sincronizar dispositivo',
-
     libraryScope: 'Ámbito de biblioteca',
-
     allLibraries: 'Todas las bibliotecas',
-
     expandPlaylists: 'Expandir listas',
-
     collapsePlaylists: 'Colapsar listas',
-
   },
-
   home: {
-
     hero: 'Destacado',
-
     starred: 'Favoritos Personales',
-
     recent: 'Agregados Recientemente',
-
     mostPlayed: 'Más Reproducidos',
-
     recentlyPlayed: 'Reproducidos Recientemente',
-
     discover: 'Descubrir',
-
     loadMore: 'Cargar Más',
-
     discoverMore: 'Descubrir Más',
-
     discoverArtists: 'Descubrir Artistas',
-
     discoverArtistsMore: 'Todos los Artistas'
-
   },
-
   hero: {
-
     eyebrow: 'Álbum Destacado',
-
     playAlbum: 'Reproducir Álbum',
-
     enqueue: 'Agregar a la Cola',
-
     enqueueTooltip: 'Agregar álbum completo a la cola',
-
   },
-
   search: {
-
     placeholder: 'Buscar artista, álbum o canción…',
-
     noResults: 'No hay resultados para "{{query}}"',
-
     artists: 'Artistas',
-
     albums: 'Álbumes',
-
     songs: 'Canciones',
-
     clearLabel: 'Limpiar búsqueda',
-
     title: 'Buscar',
-
     resultsFor: 'Resultados para "{{query}}"',
-
     album: 'Álbum',
-
     advanced: 'Búsqueda Avanzada',
-
     advancedSearchTerm: 'Término de búsqueda',
-
     advancedSearchPlaceholder: 'Título, álbum, artista…',
-
     advancedGenre: 'Género',
-
     advancedAllGenres: 'Todos los géneros',
-
     advancedYear: 'Año',
-
     advancedYearFrom: 'desde',
-
     advancedYearTo: 'hasta',
-
     advancedAll: 'Todos',
-
     advancedSearch: 'Buscar',
-
     advancedEmpty: 'Ingresa un término de búsqueda o selecciona un filtro para comenzar.',
-
     advancedNoResults: 'No se encontraron resultados.',
-
     advancedGenreNote: 'Las canciones se seleccionan aleatoriamente de este género.',
-
     recentSearches: 'Búsquedas Recientes',
-
     browse: 'Explorar',
-
     emptyHint: '¿Qué quieres escuchar?',
-
     genres: 'Géneros',
-
   },
-
   nowPlaying: {
-
     tooltip: '¿Quién está escuchando?',
-
     title: '¿Quién está escuchando?',
-
     loading: 'Cargando…',
-
     nobody: 'Nadie está escuchando actualmente.',
-
     minutesAgo: 'hace {{n}}m',
-
     nothingPlaying: 'Aún no se está reproduciendo nada. ¡Empieza una canción!',
-
     aboutArtist: 'Sobre el Artista',
-
     fromAlbum: 'De este Álbum',
-
     viewAlbum: 'Ver Álbum',
-
     goToArtist: 'Ir al Artista',
-
     readMore: 'Leer más',
-
     showLess: 'Mostrar menos',
-
     genreInfo: 'Género',
-
     trackInfo: 'Información de la Pista',
-
   },
-
   contextMenu: {
-
     playNow: 'Reproducir Ahora',
-
     playNext: 'Reproducir Siguiente',
-
     addToQueue: 'Agregar a la Cola',
-
     enqueueAlbum: 'Agregar Álbum a la Cola',
-
     startRadio: 'Iniciar Radio',
-
     instantMix: 'Mezcla Instantánea',
-
     instantMixFailed: 'No se pudo crear la Mezcla Instantánea — error del servidor o plugin.',
-
     cliMixNeedsTrack: 'No hay nada en reproducción — inicia la reproducción y vuelve a ejecutar el comando de mezcla.',
-
     lfmLove: 'Favorito en Last.fm',
-
     lfmUnlove: 'Quitar favorito de Last.fm',
-
     favorite: 'Favorito',
-
     favoriteArtist: 'Artista Favorito',
-
     favoriteAlbum: 'Álbum Favorito',
-
     unfavorite: 'Quitar de Favoritos',
-
     unfavoriteArtist: 'Quitar Artista de Favoritos',
-
     unfavoriteAlbum: 'Quitar Álbum de Favoritos',
-
     removeFromQueue: 'Quitar de la Cola',
-
     removeFromPlaylist: 'Quitar de la Playlist',
-
     openAlbum: 'Abrir Álbum',
-
     goToArtist: 'Ir al Artista',
-
     download: 'Descargar (ZIP)',
-
     addToPlaylist: 'Agregar a Lista de Reproducción',
-
     selectedPlaylists: '{{count}} listas seleccionadas',
-
     selectedAlbums: '{{count}} álbumes seleccionados',
-
     selectedArtists: '{{count}} artistas seleccionados',
-
     songInfo: 'Información de la Canción',
-
   },
-
   albumDetail: {
-
     back: 'Volver',
-
     playAll: 'Reproducir Todo',
-
     enqueue: 'Agregar a la Cola',
-
     enqueueTooltip: 'Agregar álbum completo a la cola',
-
     artistBio: 'Biografía del Artista',
-
     download: 'Descargar (ZIP)',
-
     downloading: 'Cargando…',
-
     cacheOffline: 'Disponible offline',
-
     offlineCached: 'Disponible offline',
-
     offlineDownloading: 'Descargando… ({{n}}/{{total}})',
-
     removeOffline: 'Quitar de offline',
-
     offlineStorageFull: 'Almacenamiento offline lleno (límite: {{mb}} MB). Libera espacio eliminando un álbum de tu Biblioteca Offline, o aumenta el límite en Configuración.',
-
     offlineStorageGoToLibrary: 'Biblioteca Offline',
-
     offlineStorageGoToSettings: 'Configuración',
-
     favoriteAdd: 'Agregar a Favoritos',
-
     favoriteRemove: 'Quitar de Favoritos',
-
     favorite: 'Favorito',
-
     noBio: 'No hay biografía disponible.',
-
     moreByArtist: 'Más de {{artist}}',
-
     tracksCount: '{{n}} Pistas',
-
     goToArtist: 'Ir a {{artist}}',
-
     moreLabelAlbums: 'Más álbumes en {{label}}',
-
     trackTitle: 'Título',
-
     trackAlbum: 'Álbum',
-
     trackArtist: 'Artista',
-
     trackGenre: 'Género',
-
     trackFormat: 'Formato',
-
     trackFavorite: 'Favorito',
-
     trackRating: 'Calificación',
-
     trackDuration: 'Duración',
-
     trackTotal: 'Total',
-
     columns: 'Columnas',
-
+    resetColumns: 'Restablecer',
     notFound: 'Álbum no encontrado.',
-
     bioModal: 'Biografía del Artista',
-
     bioClose: 'Cerrar',
-
     ratingLabel: 'Calificación',
-
     enlargeCover: 'Ampliar',
-
     filterSongs: 'Filtrar canciones…',
-
     sortNatural: 'Natural',
-
     sortByTitle: 'A–Z (Título)',
-
     sortByArtist: 'A–Z (Artista)',
-
     sortByAlbum: 'A–Z (Álbum)',
-
   },
-
   entityRating: {
-
     albumShort: 'Calificación del álbum',
-
     artistShort: 'Calificación del artista',
-
     albumAriaLabel: 'Calificación del álbum',
-
     artistAriaLabel: 'Calificación del artista',
-
     saveFailed: 'No se pudo guardar la calificación.',
-
   },
-
   artistDetail: {
-
     back: 'Volver',
-
     albums: 'Álbumes',
-
     album: 'Álbum',
-
     playAll: 'Reproducir Todo',
-
     shuffle: 'Aleatorio',
-
     radio: 'Radio',
-
     loading: 'Cargando…',
-
     noRadio: 'No se encontraron pistas similares para este artista.',
-
     notFound: 'Artista no encontrado.',
-
     albumsBy: 'Álbumes de {{name}}',
-
     topTracks: 'Mejores Pistas',
-
     noAlbums: 'No se encontraron álbumes.',
-
     trackTitle: 'Título',
-
     trackAlbum: 'Álbum',
-
     trackDuration: 'Duración',
-
     favoriteAdd: 'Agregar a Favoritos',
-
     favoriteRemove: 'Quitar de Favoritos',
-
     favorite: 'Favorito',
-
     albumCount_one: '{{count}} Álbum',
-
     albumCount_other: '{{count}} Álbumes',
-
     openedInBrowser: 'Abierto en navegador',
-
     featuredOn: 'También Aparece En',
-
     similarArtists: 'Artistas Similares',
-
     cacheOffline: 'Guardar discografía offline',
-
     offlineCached: 'Discografía guardada',
-
     offlineDownloading: 'Descargando… ({{done}}/{{total}} álbumes)',
-
     uploadImage: 'Subir imagen del artista',
-
     uploadImageError: 'Error al subir imagen',
-
   },
-
   favorites: {
-
     title: 'Favoritos',
-
     empty: "Aún no has guardado ningún favorito.",
-
     artists: 'Artistas',
-
     albums: 'Álbumes',
-
     songs: 'Canciones',
-
     enqueueAll: 'Agregar todo a la cola',
-
     playAll: 'Reproducir todo',
-
     removeSong: 'Quitar de favoritos',
-
     stations: 'Estaciones de Radio',
-
     showingFiltered: 'Mostrando {{filtered}} de {{total}} ({{artist}})',
-
     showingCount: 'Mostrando {{filtered}} de {{total}}',
-
     clearArtistFilter: 'Limpiar filtro de artista',
-
     noFilterResults: 'No hay resultados con los filtros seleccionados.',
-
     allArtists: 'Todos los Artistas',
-
   },
-
   randomLanding: {
-
     title: 'Crear Mezcla',
-
     mixByTracks: 'Mezcla por Canciones',
-
     mixByTracksDesc: 'Selección aleatoria de canciones de toda tu biblioteca',
-
     mixByAlbums: 'Mezcla por Álbumes',
-
     mixByAlbumsDesc: 'Álbumes aleatorios para tu próximo descubrimiento',
-
   },
-
   randomAlbums: {
-
     title: 'Álbumes Aleatorios',
-
     refresh: 'Refrescar',
-
   },
-
   genres: {
-
     title: 'Géneros',
-
     genreCount: 'Géneros',
-
     albumCount_one: '{{count}} álbum',
-
     albumCount_other: '{{count}} álbumes',
-
     loading: 'Cargando géneros…',
-
     empty: 'No se encontraron géneros.',
-
     albumsLoading: 'Cargando álbumes…',
-
     albumsEmpty: 'No se encontraron álbumes para este género.',
-
     loadMore: 'Cargar más',
-
     back: 'Volver',
-
   },
-
   randomMix: {
-
     title: 'Mezcla Aleatoria',
-
     remix: 'Remezclar',
-
     remixTooltip: 'Cargar nuevas canciones aleatorias',
-
     remixGenre: 'Remezclar {{genre}}',
-
     remixTooltipGenre: 'Cargar nuevas canciones de {{genre}}',
-
     playAll: 'Reproducir Todo',
-
     trackTitle: 'Título',
-
     trackArtist: 'Artista',
-
     trackAlbum: 'Álbum',
-
     trackFavorite: 'Favorito',
-
     trackDuration: 'Duración',
-
     favoriteAdd: 'Agregar a Favoritos',
-
     favoriteRemove: 'Quitar de Favoritos',
-
     play: 'Reproducir',
-
     trackGenre: 'Género',
-
     excludeAudiobooks: 'Excluir audiolibros y radioteatros',
-
     excludeAudiobooksDesc: 'Busca palabras clave en género, título, álbum y artista — ej. Hörbuch, Audiobook, Spoken Word, …',
-
     genreBlocked: 'Palabra clave bloqueada',
-
     genreAddedToBlacklist: 'Agregada a lista de filtros',
-
     genreAlreadyBlocked: 'Ya está bloqueada',
-
     artistBlocked: 'Artista bloqueado',
-
     artistAddedToBlacklist: 'Artista agregado a lista de filtros',
-
     artistClickHint: 'Click para bloquear este artista',
-
     blacklistToggle: 'Filtro de Palabras Clave',
-
     genreMixTitle: 'Mezcla por Género',
-
     genreMixDesc: 'Top 20 géneros por cantidad de canciones — click para cargar mezcla aleatoria',
-
     genreMixAll: 'Todas las Canciones',
-
     genreMixLoadMore: 'Cargar 10 más',
-
     genreMixNoGenres: 'No se encontraron géneros en el servidor.',
-
     shuffleGenres: 'Mostrar géneros diferentes',
-
     filterPanelTitle: 'Filtros',
-
     filterPanelDesc: 'Click en una etiqueta de género o nombre de artista en la lista para bloquearlo de futuras mezclas.',
-
     genreClickHint: 'Click en una etiqueta de género para agregarla\ncomo palabra clave filtrada.\nBusca en género, título, álbum y artista.',
-
   },
-
   albums: {
-
     title: 'Todos los Álbumes',
-
     sortByName: 'A–Z (Álbum)',
-
     sortByArtist: 'A–Z (Artista)',
-
     sortNewest: 'Más recientes primero',
-
     sortRandom: 'Aleatorio',
-
     yearFrom: 'Desde',
-
     yearTo: 'Hasta',
-
     yearFilterClear: 'Limpiar filtro de año',
-
     yearFilterLabel: 'Año',
-
     select: 'Selección múltiple',
-
     startSelect: 'Activar selección múltiple',
-
     cancelSelect: 'Cancelar',
-
     selectionCount: '{{count}} seleccionados',
-
     downloadZips: 'Descargar ZIPs',
-
     addOffline: 'Agregar Offline',
-
     downloadingZip: 'Descargando {{current}}/{{total}}: {{name}}',
-
     downloadZipDone: '{{count}} ZIP(s) descargado(s)',
-
     downloadZipFailed: 'Error al descargar {{name}}',
-
     offlineQueuing: 'Encolando {{count}} álbum(es) para offline…',
-
     offlineFailed: 'Error al agregar {{name}} offline',
-
     addToPlaylist: 'Agregar a Lista de Reproducción',
-
   },
-
   artists: {
-
     title: 'Artistas',
-
     search: 'Buscar…',
-
     all: 'Todos',
-
     gridView: 'Vista de cuadrícula',
-
     listView: 'Vista de lista',
-
     imagesOn: 'Imágenes de artistas activadas — puede aumentar la carga de red y sistema',
-
     imagesOff: 'Imágenes de artistas desactivadas — mostrando solo iniciales',
-
     loadMore: 'Cargar más',
-
     notFound: 'No se encontraron artistas.',
-
     albumCount_one: '{{count}} Álbum',
-
     albumCount_other: '{{count}} Álbumes',
-
     selectionCount: '{{count}} seleccionados',
-
     select: 'Selección múltiple',
-
     startSelect: 'Activar selección múltiple',
-
     cancelSelect: 'Cancelar',
-
     addToPlaylist: 'Agregar a Lista',
-
   },
-
   login: {
-
     subtitle: 'Tu Reproductor Navidrome para Escritorio',
-
     serverName: 'Nombre del Servidor (opcional)',
-
     serverNamePlaceholder: 'Mi Navidrome',
-
     serverUrl: 'URL del Servidor',
-
     serverUrlPlaceholder: '192.168.1.100:4533 o https://music.example.com',
-
     username: 'Usuario',
-
     usernamePlaceholder: 'admin',
-
     password: 'Contraseña',
-
     showPassword: 'Mostrar contraseña',
-
     hidePassword: 'Ocultar contraseña',
-
     connect: 'Conectar',
-
     connecting: 'Conectando…',
-
     connected: '¡Conectado!',
-
     error: 'Conexión fallida — por favor verifica tus datos.',
-
     urlRequired: 'Por favor ingresa una URL de servidor.',
-
     savedServers: 'Servidores Guardados',
-
     addNew: 'O agregar un nuevo servidor',
-
   },
-
   connection: {
-
     connected: 'Conectado',
-
     connectedTo: 'Conectado a {{server}}',
-
     disconnected: 'Desconectado',
-
     disconnectedFrom: 'No se puede alcanzar {{server}} — click para verificar configuración',
-
     checking: 'Conectando…',
-
     extern: 'Externo',
-
     offlineTitle: 'Sin conexión al servidor',
-
     offlineSubtitle: 'No se puede alcanzar {{server}}. Verifica tu red o servidor.',
-
     offlineModeBanner: 'Modo Offline — reproduciendo desde caché local',
-
     offlineNoCacheBanner: 'Sin conexión al servidor — no se puede acceder a {{server}}',
-
     offlineLibraryTitle: 'Biblioteca Offline',
-
     offlineLibraryEmpty: 'No hay álbumes en caché aún. Conéctate, abre un álbum y click en "Disponible offline".',
-
     offlineAlbumCount: '{{n}} álbum',
-
     offlineAlbumCount_plural: '{{n}} álbumes',
-
     offlineFilterAll: 'Todos',
-
     offlineFilterAlbums: 'Álbumes',
-
     offlineFilterPlaylists: 'Listas',
-
     offlineFilterArtists: 'Discografías',
-
     retry: 'Reintentar',
-
     serverSettings: 'Configuración del servidor',
-
     switchServerTitle: 'Cambiar servidor',
-
     switchServerHint: 'Clic para elegir otro servidor guardado.',
-
     manageServers: 'Gestionar servidores…',
-
     switchFailed: 'No se pudo cambiar — servidor inalcanzable.',
-
     lastfmConnected: 'Last.fm conectado como @{{user}}',
-
     lastfmSessionInvalid: 'Sesión inválida — click para reconectar',
-
   },
-
   common: {
-
     albums: 'Álbumes',
-
     album: 'Álbum',
-
     loading: 'Cargando…',
-
     loadingMore: 'Cargando…',
-
     loadingPlaylists: 'Cargando Listas…',
-
     noAlbums: 'No se encontraron álbumes.',
-
     downloading: 'Descargando…',
-
     downloadZip: 'Descargar (ZIP)',
-
     back: 'Volver',
-
     cancel: 'Cancelar',
-
     save: 'Guardar',
-
     delete: 'Eliminar',
-
     use: 'Usar',
-
     add: 'Agregar',
-
     active: 'Activo',
-
     download: 'Descargar',
-
     chooseDownloadFolder: 'Elegir carpeta de descarga',
-
     noFolderSelected: 'Ninguna carpeta seleccionada',
-
     rememberDownloadFolder: 'Recordar esta carpeta',
-
     filterGenre: 'Filtro de Género',
-
     filterSearchGenres: 'Buscar géneros…',
-
     filterNoGenres: 'Ningún género coincide',
-
     filterClear: 'Limpiar',
-
     play: 'Reproducir',
-
     bulkSelected: '{{count}} seleccionados',
-
     clearSelection: 'Limpiar selección',
-
     bulkAddToPlaylist: 'Agregar a Lista',
-
     bulkRemoveFromPlaylist: 'Quitar de Lista',
-
     bulkClear: 'Limpiar selección',
-
     updaterAvailable: 'Actualización disponible',
-
     updaterVersion: 'v{{version}} está disponible',
-
     updaterWebsite: 'Sitio web',
-
     updaterModalTitle: 'Nueva Versión Disponible',
-
     updaterChangelog: 'Novedades',
-
     updaterDownloadBtn: 'Descargar Ahora',
-
     updaterSkipBtn: 'Omitir esta Versión',
-
     updaterRemindBtn: 'Recordarme Después',
-
     updaterDone: 'Descarga completada',
-
     updaterShowFolder: 'Mostrar en Carpeta',
-
     updaterInstallHint: 'Cierra Psysonic y ejecuta el instalador manualmente.',
-
     updaterAurHint: 'Instala la actualización vía AUR:',
-
     updaterErrorMsg: 'Error de descarga',
-
     updaterRetryBtn: 'Reintentar',
-
     durationHoursMinutes: '{{hours}}h {{minutes}}m',
-
     durationMinutesOnly: '{{minutes}}m',
-
     updaterOpenGitHub: 'Abrir en GitHub',
-
     filters: 'Filtros',
-
     more: 'más',
-
     yearRange: 'Rango de años',
-
     clearAll: 'Limpiar todo',
-
   },
-
   settings: {
-
     title: 'Configuración',
-
     language: 'Idioma',
-
     languageEn: 'Inglés',
-
     languageDe: 'Alemán',
-
     languageFr: 'Francés',
-
     languageNl: 'Neerlandés',
-
     languageZh: 'Chino',
-
     languageNb: 'Noruego',
-
     languageRu: 'Ruso',
-
     languageEs: 'Español',
-
     font: 'Fuente',
-
     theme: 'Tema',
-
     appearance: 'Apariencia',
-
     servers: 'Servidores',
-
     serverName: 'Nombre del Servidor',
-
     serverUrl: 'URL del Servidor',
-
     serverUrlPlaceholder: '192.168.1.100:4533 o https://music.example.com',
-
     serverUsername: 'Usuario',
-
     serverPassword: 'Contraseña',
-
     addServer: 'Agregar Servidor',
-
     addServerTitle: 'Agregar Nuevo Servidor',
-
     useServer: 'Usar',
-
     deleteServer: 'Eliminar',
-
     noServers: 'No hay servidores guardados.',
-
     serverActive: 'Activo',
-
     confirmDeleteServer: '¿Eliminar servidor "{{name}}"?',
-
     serverConnecting: 'Conectando…',
-
     serverConnected: '¡Conectado!',
-
     serverFailed: 'Conexión fallida.',
-
     testBtn: 'Probar Conexión',
-
     testingBtn: 'Probando…',
-
     serverCompatible: 'Compatible con: Navidrome · Gonic · Airsonic · Subsonic',
-
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
-
     audiomuseDesc:
-
       'Activa si este servidor tiene el plugin <pluginLink>AudioMuse-AI Navidrome</pluginLink> configurado. Habilita Mezcla Instantánea desde pistas y usa artistas similares del servidor en lugar de Last.fm en páginas de artistas.',
-
     audiomuseIssueHint:
-
       'La Mezcla Instantánea falló recientemente — verifica el plugin de Navidrome y la API de AudioMuse. Artistas similares usan Last.fm como respaldo cuando el servidor no devuelve ninguno.',
-
     connected: 'Conectado',
-
     failed: 'Fallido',
-
     eqTitle: 'Ecualizador',
-
     eqEnabled: 'Habilitar Ecualizador',
-
     eqPreset: 'Preajuste',
-
     eqPresetCustom: 'Personalizado',
-
     eqPresetBuiltin: 'Preajustes Integrados',
-
     eqPresetCustomGroup: 'Mis Preajustes',
-
     eqSavePreset: 'Guardar como Preajuste',
-
     eqPresetName: 'Nombre del preajuste…',
-
     eqDeletePreset: 'Eliminar preajuste',
-
     eqResetBands: 'Restablecer a Plano',
-
     eqPreGain: 'Pre-ganancia',
-
     eqResetPreGain: 'Restablecer pre-ganancia',
-
     eqAutoEqTitle: 'Búsqueda AutoEQ de Auriculares',
-
     eqAutoEqPlaceholder: 'Buscar modelo de auricular / IEM…',
-
     eqAutoEqSearching: 'Buscando…',
-
     eqAutoEqNoResults: 'No se encontraron resultados',
-
     eqAutoEqError: 'Error de búsqueda',
-
     eqAutoEqRateLimit: 'Límite de GitHub alcanzado — intenta de nuevo en un minuto',
-
     eqAutoEqFetchError: 'Error al obtener perfil EQ',
-
     lfmTitle: 'Last.fm',
-
     lfmConnect: 'Conectar con Last.fm',
-
     lfmConnecting: 'Esperando autorización…',
-
     lfmConfirm: 'He autorizado la aplicación',
-
     lfmConnected: 'Conectado como',
-
     lfmDisconnect: 'Desconectar',
-
     lfmConnectDesc: 'Conecta tu cuenta de Last.fm para habilitar scrobbling y actualizaciones de "Reproduciendo Ahora" directamente desde Psysonic — no requiere configuración de Navidrome.',
-
     lfmOpenBrowser: 'Se abrirá una ventana del navegador. Autoriza Psysonic en Last.fm, luego click en el botón de abajo.',
-
     lfmScrobbles: '{{n}} scrobbles',
-
     lfmMemberSince: 'Miembro desde {{year}}',
-
     scrobbleEnabled: 'Scrobbling habilitado',
-
     scrobbleDesc: 'Enviar canciones a Last.fm después del 50% de reproducción',
-
     behavior: 'Comportamiento de la App',
-
     cacheTitle: 'Tamaño Máx. de Almacenamiento',
-
     cacheDesc: 'Portadas e imágenes de artistas. Cuando está lleno, las entradas más antiguas se eliminan automáticamente. Los álbumes offline no se eliminan automáticamente, pero se borrarán al limpiar la caché manualmente.',
-
     cacheUsedImages: 'Imágenes:',
-
     cacheUsedOffline: 'Pistas offline:',
-
     cacheUsedHot: 'Tamaño en disco:',
-
     hotCacheTrackCount: 'Pistas en caché:',
-
     cacheMaxLabel: 'Tamaño máx.',
-
     cacheClearBtn: 'Limpiar Caché',
-
     cacheClearWarning: 'Esto también eliminará todos los álbumes offline de la biblioteca.',
-
     cacheClearConfirm: 'Limpiar Todo',
-
     cacheClearCancel: 'Cancelar',
-
     offlineDirTitle: 'Biblioteca Offline (En App)',
-
     offlineDirDesc: 'Ubicación de almacenamiento para pistas que haces disponibles offline dentro de Psysonic.',
-
     offlineDirDefault: 'Predeterminado (Datos de App)',
-
     offlineDirChange: 'Cambiar Directorio',
-
     offlineDirClear: 'Restablecer a Predeterminado',
-
     offlineDirHint: 'Las nuevas descargas usarán esta ubicación. Las descargas existentes permanecen en su ruta original.',
-
     hotCacheTitle: 'Caché de reproducción activa',
-
     hotCacheAlphaBadge: 'Alpha',
-
     hotCacheDisclaimer: 'Precarga las siguientes pistas en cola y mantiene las anteriores. Cuando está activado, usa espacio en disco y red.',
-
     hotCacheDirDefault: 'Predeterminado (Datos de App)',
-
     hotCacheDirChange: 'Cambiar carpeta',
-
     hotCacheDirClear: 'Restablecer a predeterminado',
-
     hotCacheDirHint: 'Cambiar la carpeta restablece el índice en-app; los archivos ya en disco permanecen donde están hasta que los elimines.',
-
     hotCacheEnabled: 'Habilitar caché de reproducción activa',
-
     hotCacheMaxMb: 'Tamaño máximo de caché',
-
     hotCacheDebounce: 'Espera de cambio de cola',
-
     hotCacheDebounceImmediate: 'Inmediato',
-
     hotCacheDebounceSeconds: '{{n}} s',
-
     hotCacheClearBtn: 'Limpiar caché activa',
-
     audioOutputDevice: 'Dispositivo de salida de audio',
-
     audioOutputDeviceDesc: 'Selecciona el dispositivo de audio que usa Psysonic. Los cambios surten efecto de inmediato y reinician la pista actual.',
-
     audioOutputDeviceDefault: 'Predeterminado del sistema',
-
     audioOutputDeviceRefresh: 'Actualizar lista de dispositivos',
-
     audioOutputDeviceOsDefaultNow: 'salida actual del sistema',
-
     audioOutputDeviceListError: 'No se pudo cargar la lista de dispositivos de audio.',
-
     audioOutputDeviceNotInCurrentList: 'no está en la lista actual',
-
     hiResTitle: 'Reproducción Nativa Hi-Res',
-
     hiResEnabled: 'Habilitar reproducción nativa hi-res',
-
     hiResDesc: "Fuerza 44.1 kHz de salida por defecto para máxima estabilidad. Habilita solo si tu hardware y red soportan confiablemente altas tasas de muestreo (88.2 kHz+).",
-
     showArtistImages: 'Mostrar Imágenes de Artistas',
-
     showArtistImagesDesc: 'Carga y muestra imágenes de artistas en el resumen de Artistas. Desactivado por defecto para reducir I/O de disco del servidor y carga de red en bibliotecas grandes.',
-
     showTrayIcon: 'Mostrar Icono en Bandeja',
-
     showTrayIconDesc: 'Muestra el icono de Psysonic en el área de notificación / barra de menú.',
-
     minimizeToTray: 'Minimizar a Bandeja',
-
     minimizeToTrayDesc: 'Al cerrar la ventana, mantener Psysonic ejecutándose en la bandeja del sistema en lugar de salir.',
-
     discordRichPresence: 'Discord Rich Presence',
-
     discordRichPresenceDesc: 'Muestra la pista actual en tu perfil de Discord. Requiere que Discord esté ejecutándose.',
-
     useCustomTitlebar: 'Barra de título personalizada',
-
     useCustomTitlebarDesc: 'Reemplaza la barra de título del sistema con una integrada que coincide con el tema de la app. Desactiva para usar la barra nativa de GNOME/GTK.',
-
     discordAppleCovers: 'Obtener portadas de Apple Music para Discord',
-
     discordAppleCoversDesc: 'Envía el artista y nombre del álbum a la API de búsqueda de Apple para encontrar portadas para tu perfil de Discord. Desactivado por defecto por privacidad.',
-
     discordTemplates: 'Plantillas de texto personalizadas',
-
     discordTemplatesDesc: 'Personaliza qué información se muestra en tu perfil de Discord. Variables: {title}, {artist}, {album}, {paused}',
-
     discordTemplateDetails: 'Línea principal (details)',
-
     discordTemplateState: 'Línea secundaria (state)',
-
     discordTemplateLargeText: 'Tooltip del álbum (largeText)',
-
     nowPlayingEnabled: 'Mostrar en Reproduciendo Ahora',
-
     nowPlayingEnabledDesc: 'Transmite tu pista actual a la vista de oyentes en vivo del servidor. Desactiva para dejar de enviar datos de reproducción.',
-
     lyricsServerFirst: 'Preferir letras del servidor',
-
     lyricsServerFirstDesc: 'Verifica primero letras provistas por el servidor (etiquetas embebidas, archivos sidecar) antes de consultar LRCLIB. Desactiva para usar LRCLIB primero.',
-
     enableNeteaselyrics: 'Letras de Netease Cloud Music',
-
     enableNeteaselyricsDesc: 'Usa Netease Cloud Music como fuente de letras de último recurso cuando el servidor y LRCLIB no devuelvan nada. Mejor cobertura para música asiática e internacional.',
-
     lyricsSourcesTitle: 'Fuentes de Letras',
-
     lyricsSourcesDesc: 'Elige qué fuentes consultar para letras y en qué orden. Arrastra para reordenar. Las fuentes desactivadas se omiten completamente.',
-
     lyricsSourceServer: 'Servidor',
-
     lyricsSourceLrclib: 'LRCLIB',
-
     lyricsSourceNetease: 'Netease Cloud Music',
-
     downloadsTitle: 'Exportación ZIP y Archivado',
-
     downloadsFolderDesc: 'Carpeta de destino para álbumes que descargas como ZIP a tu computadora.',
-
     downloadsDefault: 'Carpeta de Descargas Predeterminada',
-
     pickFolder: 'Seleccionar',
-
     pickFolderTitle: 'Seleccionar Carpeta de Descarga',
-
     clearFolder: 'Limpiar carpeta de descarga',
-
     logout: 'Cerrar Sesión',
-
     aboutTitle: 'Acerca de Psysonic',
-
     aboutDesc: 'Un reproductor de música moderno para escritorio compatible con servidores Subsonic (Navidrome, Gonic y otros). Construido en Tauri v2 con motor de audio nativo en Rust — ligero y rápido, pero lleno de características: barra de progreso tipo onda, letras sincronizadas, integración Last.fm, ecualizador de 10 bandas, crossfade, reproducción gapless, Replay Gain, navegación por géneros, y una gran biblioteca de temas.',
-
     aboutLicense: 'Licencia',
-
     aboutLicenseText: 'GNU GPL v3 — libre para usar, modificar y distribuir bajo la misma licencia.',
-
     aboutRepo: 'Código Fuente en GitHub',
-
     aboutVersion: 'Versión',
-
     aboutBuiltWith: 'Construido con Tauri · React · TypeScript · Rust/rodio',
-
     aboutAiCredit: 'Desarrollado con el apoyo de Claude Code by Anthropic',
-
     aboutContributorsLabel: 'Contribuidores',
-
     aboutSpecialThanksLabel: 'Agradecimientos Especiales',
-
     changelog: 'Registro de Cambios',
-
     showChangelogOnUpdate: "Mostrar 'Novedades' al actualizar",
-
     showChangelogOnUpdateDesc: "Muestra automáticamente las novedades cuando se lanza una nueva versión por primera vez.",
-
     randomMixTitle: 'Mezcla Aleatoria',
-
     randomMixBlacklistTitle: 'Palabras Clave de Filtro Personalizadas',
-
     randomMixBlacklistDesc: 'Las canciones se excluyen cuando cualquier palabra clave coincide con su género, título, álbum o artista (activo cuando el checkbox de arriba está activado).',
-
     randomMixBlacklistPlaceholder: 'Agregar palabra clave…',
-
     randomMixBlacklistAdd: 'Agregar',
-
     randomMixBlacklistEmpty: 'Aún no hay palabras clave personalizadas.',
-
     randomMixHardcodedTitle: 'Palabras clave integradas (activas cuando el checkbox está activado)',
-
     tabAudio: 'Audio',
-
     tabStorage: 'Almacenamiento y Descargas',
-
     tabAppearance: 'Apariencia',
-
     homeCustomizerTitle: 'Página de Inicio',
-
     sidebarTitle: 'Barra Lateral',
-
     sidebarReset: 'Restablecer a predeterminado',
-
     sidebarDrag: 'Arrastra para reordenar',
-
     sidebarFixed: 'Siempre visible',
-
+    randomNavSplitTitle: 'Dividir navegación Mix',
+    randomNavSplitDesc: 'Mostrar "Mezcla Aleatoria" y "Álbumes Aleatorios" como entradas separadas en la barra lateral en lugar del hub "Crear Mezcla".',
     tabInput: 'Entrada',
-
     tabServer: 'Servidor',
-
     tabSystem: 'Sistema',
-
     tabGeneral: 'General',
-
     ratingsSectionTitle: 'Calificaciones',
-
     ratingsSkipStarTitle: 'Saltar para 1 estrella',
-
     ratingsSkipStarDesc:
-
       'Después de varios saltos seguidos, asigna 1 estrella a la pista. Solo para pistas aún no calificadas.',
-
     ratingsSkipStarThresholdLabel: 'Saltos',
-
     ratingsMixFilterTitle: 'Filtrar por calificación',
-
     ratingsMixFilterDesc:
-
       'Filtra elementos de baja calificación en {{mix}} y {{albums}}. Click en la estrella seleccionada nuevamente para desactivar el umbral.',
-
     ratingsMixMinSong: 'Canciones',
-
     ratingsMixMinAlbum: 'Álbumes',
-
     ratingsMixMinArtist: 'Artistas',
-
     ratingsMixMinThresholdAria: 'Estrellas mínimas: {{label}}',
-
     backupTitle: 'Respaldo y Restauración',
-
     backupExport: 'Exportar configuración',
-
     backupExportDesc: 'Guarda toda la configuración, perfiles de servidor, configuración Last.fm, tema, EQ y atajos de teclado a un archivo .psybkp. Las contraseñas se almacenan en texto plano — mantén el archivo seguro.',
-
     backupImport: 'Importar configuración',
-
     backupImportDesc: 'Restaura configuración desde un archivo .psybkp. La app se recargará después de importar.',
-
     backupImportConfirm: 'Esto sobrescribirá toda la configuración actual. ¿Continuar?',
-
     backupSuccess: 'Respaldo guardado',
-
     backupImportSuccess: 'Configuración restaurada — recargando…',
-
     backupImportError: 'Archivo de respaldo inválido o corrupto.',
-
     shortcutsReset: 'Restablecer a predeterminados',
-
     shortcutListening: 'Presiona una tecla…',
-
     shortcutUnbound: '—',
-
     globalShortcutsTitle: 'Atajos Globales',
-
     globalShortcutsNote: 'Funcionan en todo el sistema incluso cuando Psysonic está en segundo plano. Requieren Ctrl, Alt o Super como modificador.',
-
     shortcutClear: 'Limpiar',
-
     shortcutPlayPause: 'Reproducir / Pausa',
-
     shortcutNext: 'Siguiente pista',
-
     shortcutPrev: 'Pista anterior',
-
     shortcutVolumeUp: 'Subir volumen',
-
     shortcutVolumeDown: 'Bajar volumen',
-
     shortcutSeekForward: 'Avanzar 10s',
-
     shortcutSeekBackward: 'Retroceder 10s',
-
     shortcutToggleQueue: 'Alternar cola',
-
     shortcutOpenFolderBrowser: 'Abrir {{folderBrowser}}',
-
     shortcutFullscreenPlayer: 'Reproductor pantalla completa',
-
     shortcutNativeFullscreen: 'Pantalla completa nativa',
-
     playbackTitle: 'Reproducción',
-
     replayGain: 'Replay Gain',
-
     replayGainDesc: 'Normalizar volumen de pistas usando metadatos ReplayGain',
-
     replayGainMode: 'Modo',
-
     replayGainTrack: 'Pista',
-
     replayGainAlbum: 'Álbum',
-
     replayGainPreGain: 'Pre-Ganancia (archivos etiquetados)',
-
     replayGainFallback: 'Respaldo (sin etiquetar / radio)',
-
     crossfade: 'Crossfade',
-
     crossfadeDesc: 'Transición entre pistas',
-
     crossfadeSecs: '{{n}} s',
-
     notWithGapless: 'No disponible mientras Gapless está activo',
-
     notWithCrossfade: 'No disponible mientras Crossfade está activo',
-
     gapless: 'Reproducción Gapless',
-
     gaplessDesc: 'Precarga siguiente pista para eliminar silencios entre canciones',
-
     preloadMode: 'Precargar Siguiente Pista',
-
     preloadModeDesc: 'Cuándo comenzar a cargar la siguiente pista en cola',
-
     nextTrackBufferingTitle: 'Buffer de Siguiente Pista',
-
     preloadHotCacheMutualExclusive: 'Precarga y Caché Activa sirven para lo mismo — solo uno puede estar activo a la vez. Habilitar uno desactivará automáticamente el otro.',
-
     preloadOff: 'Apagado',
-
     preloadBalanced: 'Balanceado (30 s antes del final)',
-
     preloadEarly: 'Temprano (después de 5 s de reproducción)',
-
     preloadCustom: 'Personalizado',
-
     preloadCustomSeconds: 'Segundos antes del final: {{n}}',
-
     infiniteQueue: 'Cola Infinita',
-
     infiniteQueueDesc: 'Agregar automáticamente pistas aleatorias cuando la cola termina',
-
     experimental: 'Experimental',
-
     fsPlayerSection: 'Reproductor Pantalla Completa',
-
     fsShowArtistPortrait: 'Mostrar foto del artista',
-
     fsShowArtistPortraitDesc: 'Muestra la foto del artista (o portada del álbum) en el lado derecho del reproductor pantalla completa.',
-
     fsPortraitDim: 'Oscurecimiento de foto',
-
     seekbarStyle: 'Estilo de Barra de Progreso',
-
     seekbarStyleDesc: 'Elige la apariencia de la barra de progreso del reproductor',
-
     seekbarWaveform: 'Forma de Onda',
-
     seekbarLinedot: 'Línea y Punto',
-
     seekbarBar: 'Barra',
-
     seekbarThick: 'Barra Gruesa',
-
     seekbarSegmented: 'Segmentada',
-
     seekbarNeon: 'Brillo Neón',
-
     seekbarPulsewave: 'Onda Pulsante',
-
     seekbarParticletrail: 'Estela de Partículas',
-
     seekbarLiquidfill: 'Llenado Líquido',
-
     seekbarRetrotape: 'Cinta Retro',
-
     themeSchedulerTitle: 'Cambio Automático de Tema',
-
     themeSchedulerEnable: 'Habilitar Programador de Temas',
-
     themeSchedulerEnableSub: 'Cambia automáticamente entre dos temas según la hora del día',
-
     themeSchedulerDayTheme: 'Tema de Día',
-
     themeSchedulerDayStart: 'Comienza de Día A las',
-
     themeSchedulerNightTheme: 'Tema de Noche',
-
     themeSchedulerNightStart: 'Comienza de Noche A las',
-
     themeSchedulerActiveHint: 'El Programador de Temas está activo — los cambios de tema se manejan automáticamente.',
-
     visualOptionsTitle: 'Opciones Visuales',
-
     coverArtBackground: 'Fondo de Portada',
-
     coverArtBackgroundSub: 'Mostrar portada desenfocada como fondo en encabezados de álbumes y listas de reproducción',
-
     playlistCoverPhoto: 'Foto de Portada de Playlist',
-
     playlistCoverPhotoSub: 'Mostrar cuadrícula de fotos de portada en la vista detallada de playlists',
-
     showBitrate: 'Mostrar Bitrate',
-
     showBitrateSub: 'Mostrar bitrate de audio en las listas de pistas',
-
     uiScaleTitle: 'Escala de Interfaz',
-
     uiScaleLabel: 'Zoom',
-
   },
-
   changelog: {
-
     modalTitle: 'Novedades',
-
     dontShowAgain: 'No mostrar de nuevo',
-
     close: 'Entendido',
-
   },
-
   help: {
-
     title: 'Ayuda',
-
     s1: 'Primeros Pasos',
-
     q1: '¿Qué servidores son compatibles?',
-
     a1: 'Psysonic funciona con cualquier servidor compatible con Subsonic: Navidrome, Gonic, Subsonic, Airsonic y otros. Navidrome es la opción recomendada.',
-
     q2: '¿Cómo me conecto a mi servidor?',
-
     a2: 'Abre Configuración y click en "Agregar Servidor". Ingresa la URL del servidor (ej. 192.168.1.100:4533), tu usuario y contraseña. Psysonic prueba la conexión antes de guardar — nada se almacena si la conexión falla.',
-
     q3: '¿Puedo usar múltiples servidores?',
-
     a3: 'Sí. Puedes agregar tantos servidores como quieras en Configuración y cambiar entre ellos en cualquier momento. Solo un servidor está activo a la vez.',
-
     s2: 'Reproducción',
-
     q4: '¿Cómo reproduzco música?',
-
     a4: 'Doble-click en cualquier pista para reproducirla. En páginas de álbum y artista, usa "Reproducir Todo" para iniciar el álbum completo. También puedes arrastrar pistas al panel de cola.',
-
     q5: '¿Qué atajos de teclado hay disponibles?',
-
     a5: 'Espacio = Reproducir / Pausa · Escape = Cerrar reproductor pantalla completa. Las teclas multimedia (Reproducir/Pausa, Siguiente, Anterior) funcionan en todas las plataformas. En Linux, usa los botones de la barra de reproducción para teclas multimedia. Los atajos en-app y globales del sistema se pueden personalizar en Configuración → Atajos de Teclado / Atajos Globales.',
-
     q6: '¿Qué es la cola?',
-
     a6: 'La cola muestra todas las pistas siguientes. Ábrela con el icono del panel en la barra superior derecha (junto al indicador de Reproduciendo Ahora). Puedes reordenar pistas arrastrando, mezclar con el botón de mezcla, y guardar la cola como lista de reproducción.',
-
     q7: '¿Cómo abro el reproductor en pantalla completa?',
-
     a7: 'Click en la miniatura de portada en la barra de reproducción inferior, o el icono de expandir junto a ella. Presiona Escape para cerrar.',
-
     q8: '¿Cómo funciona la repetición?',
-
     a8: 'Click en el botón de repetición en la barra de reproducción para alternar: Apagado → Repetir Todo → Repetir Una.',
-
     s3: 'Biblioteca',
-
     q9: '¿Cómo descargo un álbum?',
-
     a9: 'Abre la página de detalle de un álbum y click en "Descargar (ZIP)". El servidor comprime el álbum en un archivo ZIP primero — para álbumes grandes o archivos sin pérdida (FLAC / WAV) esto puede tomar un momento antes de que comience la descarga. Esto es normal: la barra de progreso aparece una vez que el servidor termina de comprimir y comienza la transferencia.',
-
     q10: '¿Cómo marco favoritos pistas y álbumes?',
-
     a10: 'Click en el icono de estrella en cualquier fila de pista o en el encabezado del álbum. Los elementos favoritos aparecen en la sección Favoritos de la barra lateral.',
-
     q11: '¿Qué es el carrusel destacado en la página de inicio?',
-
     a11: 'El banner en la parte superior de la página de inicio selecciona álbumes aleatorios de tu biblioteca y rota entre ellos cada 10 segundos. Click en los puntos para ir a uno específico, o click en el banner para abrir el álbum.',
-
     s4: 'Configuración',
-
     q12: '¿Cómo cambio el tema?',
-
     a12: 'Configuración → Tema. Elige entre una gran selección de temas en 8 grupos: Temas Psysonic, Reproductores de Medios, Sistemas Operativos, Juegos, Películas, Series, Redes Sociales, y Clásicos Open Source (Catppuccin, Nord, Gruvbox, Nightfox).',
-
     q13: '¿Cómo cambio el idioma?',
-
     a13: 'Configuración → Idioma. Se soportan Inglés, Alemán, Francés, Neerlandés, Chino, Noruego, Ruso y Español.',
-
     q15: '¿Cómo establezco una carpeta de descarga?',
-
     a15: 'Configuración → Comportamiento de App → Carpeta de Descarga. Elige cualquier carpeta — los álbumes descargados se guardan ahí como archivos ZIP. Sin una carpeta personalizada, se usa la ubicación de descargas predeterminada del navegador.',
-
     s5: 'Scrobbling',
-
     q16: '¿Cómo funciona el scrobbling?',
-
     a16: 'Psysonic hace scrobbling directamente a Last.fm — no requiere configuración de Navidrome. Conecta tu cuenta de Last.fm en Configuración → Last.fm y habilita el scrobbling ahí.',
-
     q17: '¿Cuándo se envía un scrobble?',
-
     a17: 'Un scrobble se envía después de escuchar el 50% de una pista.',
-
     q22: '¿Qué es la forma de onda en la barra de reproducción?',
-
     a22: 'La barra de progreso tipo onda reemplaza al deslizador clásico. Click en cualquier lugar para saltar a esa posición, o arrastra para buscar. La porción reproducida brilla con un degradado azul a malva, el rango cargado aparece ligeramente más brillante, y la porción no reproducida está atenuada.',
-
     q24: '¿Puedo mezclar la cola?',
-
     a24: 'Sí. Abre el panel de cola y click en el icono de mezcla en el encabezado de la cola. La pista actual permanece en la posición 1 — todas las demás se reordenan aleatoriamente.',
-
     q25: '¿Los enlaces de Last.fm y Wikipedia en páginas de artista abren en un navegador?',
-
     a25: 'Sí — abren en tu navegador predeterminado del sistema. El botón muestra brevemente una etiqueta de confirmación al hacer click.',
-
     s7: 'Mezcla Aleatoria',
-
     q26: '¿Qué es Mezcla Aleatoria?',
-
     a26: 'Mezcla Aleatoria construye una lista de reproducción de pistas aleatorias de toda tu biblioteca. Ábrela vía "Mezcla Aleatoria" en la barra lateral y click en "Nueva Mezcla". Puedes ajustar la cantidad de pistas antes de generar.',
-
     q27: '¿Qué es el Filtro de Palabras Clave?',
-
     a27: 'El Filtro de Palabras Clave excluye pistas cuyo género, título o nombre de álbum contiene palabras específicas. Los audiolibros se filtran automáticamente. Agrega palabras clave personalizadas en Configuración → Mezcla Aleatoria, o click en cualquier etiqueta de género en la lista de pistas para agregarla instantáneamente.',
-
     q28: '¿Qué es la Mezcla por Super Género?',
-
     a28: 'La Mezcla por Super Género agrupa tu biblioteca en categorías amplias (Rock, Metal, Electrónica, Jazz, Clásica, etc.) y construye una mezcla enfocada de ese estilo. Selecciona una categoría debajo de la lista de pistas. Los resultados aparecen progresivamente a medida que se obtiene cada sub-género.',
-
     s6: 'Solución de Problemas',
-
     q18: 'Las portadas e imágenes de artistas cargan lentamente.',
-
     a18: 'Las imágenes se obtienen del disco de tu servidor al primer acceso y luego se almacenan en caché localmente por 30 días. Si el almacenamiento de tu servidor es lento, la primera visita a una página puede tomar un momento. Las visitas subsecuentes serán instantáneas.',
-
     q19: 'La prueba de conexión falla.',
-
     a19: 'Verifica la URL incluyendo el puerto (ej. http://192.168.1.100:4533). Asegúrate de que ningún firewall bloquee la conexión. Intenta http:// en lugar de https:// en una red local. También verifica que tu usuario y contraseña sean correctos.',
-
     q20: 'No hay audio en Linux.',
-
     a20: 'Psysonic está disponible como .deb (Ubuntu/Debian), .rpm (Fedora/RHEL) y vía AUR en Arch/CachyOS (yay -S psysonic). No hay AppImage. Si falta audio, asegúrate de que PipeWire o PulseAudio estén ejecutándose.',
-
     q21: 'La app muestra una pantalla negra en Linux.',
-
     a21: 'Esto suele ser un problema de GPU/EGL en WebKitGTK. Lanza con GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. El paquete AUR y los instaladores oficiales .deb/.rpm configuran esto automáticamente.',
-
     q29: '¿Qué son Crossfade y Reproducción Gapless?',
-
     a29: 'Ambas son características de audio experimentales en Configuración → Audio. Gapless precarga la siguiente pista para eliminar silencios entre canciones. Crossfade desvanece la pista actual mientras aparece la siguiente — ajusta la duración (1–10 s) a tu gusto.',
-
     q30: '¿Muestra Psysonic letras?',
-
     a30: 'Sí. Click en el icono de micrófono en la barra de reproducción para abrir la pestaña de Letras en el panel de cola. Psysonic obtiene letras automáticamente de LRCLIB. Si hay letras sincronizadas disponibles, la línea activa se resalta y desplaza en tiempo real mientras suena la canción. Si solo hay texto plano, se muestra estáticamente.',
-
     q31: '¿Puedo personalizar los atajos de teclado?',
-
     a31: 'Sí. Configuración → Atajos de Teclado te permite reasignar acciones en-app (Reproducir/Pausa, Siguiente, Anterior, Subir/Bajar Volumen, Pantalla Completa y más) a cualquier tecla. Configuración → Atajos Globales te permite asignar atajos de todo el sistema que funcionan incluso cuando Psysonic está en segundo plano.',
-
     q32: '¿Puedo cambiar la fuente?',
-
     a32: 'Sí. Configuración → Fuente te permite elegir entre 10 fuentes incluyendo IBM Plex Mono, Fira Code, JetBrains Mono, Courier Prime y otras. La fuente seleccionada se aplica a toda la interfaz.',
-
     s8: 'Modo Offline',
-
     q34: '¿Qué es el Modo Offline?',
-
     a34: 'El Modo Offline (Beta) te permite almacenar álbumes en tu dispositivo para escuchar sin una conexión activa al servidor. Las pistas en caché se almacenan localmente y se reproducen directamente desde el disco — no se hace ninguna solicitud de red durante la reproducción.',
-
     q35: '¿Cómo almaceno un álbum para uso offline?',
-
     a35: 'Abre cualquier álbum y click en el icono de descarga en el encabezado del álbum. Psysonic descarga todas las pistas en segundo plano. El progreso se muestra en el botón. Una vez completado, el icono se vuelve verde. Puedes ver y eliminar álbumes en caché en la página Biblioteca Offline (barra lateral).',
-
     q36: '¿Cuánto almacenamiento puede usar el caché offline?',
-
     a36: 'Puedes establecer un tamaño máximo de caché en Configuración → Biblioteca. Cuando se alcanza el límite, aparece un banner de advertencia en la página del álbum. Puedes eliminar álbumes individuales desde la Biblioteca Offline para liberar espacio.',
-
     q37: '¿Cómo califico canciones, álbumes y artistas?',
-
     a37: 'Psysonic soporta calificaciones de 1–5 estrellas vía la API OpenSubsonic (requiere Navidrome ≥ 0.53). Califica canciones en la lista de pistas del álbum o playlist usando la columna de estrellas, en el menú contextual derecho, o directamente en la barra de reproducción debajo del nombre del artista. Los álbumes se pueden calificar en su página de detalle; los artistas en su página de artista. Las calificaciones se guardan en el servidor inmediatamente.',
-
     q38: '¿Puedo quitar o cambiar una calificación?',
-
     a38: 'Sí. Click en la estrella actualmente activa para limpiar la calificación por completo — click en la misma estrella una segunda vez la elimina. Para cambiar una calificación, simplemente click en una estrella diferente.',
-
     q39: '¿Qué es Saltar-a-1★ y el filtro de calificación?',
-
     a39: 'Saltar-a-1★ asigna automáticamente una calificación de 1 estrella a una canción después de que la saltes manualmente una cantidad configurable de veces consecutivas. Actívalo y establece el umbral de saltos en Configuración → Calificaciones. El mismo panel te permite establecer una calificación mínima estrella para Mezcla Aleatoria y Álbumes Aleatorios, para que solo se incluyan canciones, álbumes o artistas por encima de cierta calificación en las mezclas generadas.',
-
     q40: '¿Qué es el Explorador de Carpetas?',
-
     a40: 'El Explorador de Carpetas (barra lateral) te permite navegar el árbol de directorios de música de tu servidor usando un diseño de columnas Miller. Click en una carpeta para entrar; click en una pista o el icono de reproducción en una carpeta para reproducir o agregar sus contenidos directamente.',
-
     q41: '¿Qué es el Programador de Temas?',
-
     a41: 'Configuración → Apariencia → Cambio Automático de Tema: define un tema de día y uno de noche con horas de inicio. Psysonic cambia automáticamente a las horas configuradas. Cuando el programador está activo, una sugerencia en el selector de temas explica por qué la selección manual de tema no tiene efecto inmediato.',
-
     q42: '¿Puedo cambiar el tamaño de la interfaz?',
-
     a42: 'Sí. Configuración → Apariencia → Escala de Interfaz te permite escalar toda la interfaz entre 80% y 125% sin afectar el tamaño de fuente de tu sistema.',
-
     q43: '¿Puedo cambiar el estilo de la barra de progreso?',
-
     a43: 'Sí. Configuración → Apariencia → Estilo de Barra de Progreso ofrece 10 estilos: Forma de Onda, Línea y Punto, Barra, Barra Gruesa, Segmentada, Brillo Neón, Onda Pulsante, Estela de Partículas, Llenado Líquido y Cinta Retro.',
-
     q44: '¿Qué es AutoEQ?',
-
     a44: 'El ecualizador de 10 bandas en Configuración → Audio incluye una búsqueda AutoEQ. Ingresa tu modelo de auriculares y Psysonic obtiene un perfil de corrección de la base de datos AutoEQ y lo aplica automáticamente a las bandas del ecualizador.',
-
     q45: '¿Qué es Replay Gain?',
-
     a45: 'Replay Gain normaliza el volumen de las pistas para que álbumes fuertes y silenciosos suenen a nivel consistente. Actívalo en Configuración → Audio → Replay Gain y elige modo Pista (normalización por canción) o Álbum (preserva dinámica relativa dentro de un álbum).',
-
     q46: '¿Qué es la Caché Activa?',
-
     a46: 'La Caché Activa (Alpha, Configuración → Biblioteca) precarga las siguientes varias pistas en tu cola al disco para que la reproducción comience instantáneamente sin demora de carga — especialmente útil en servidores lentos o remotos. Psysonic mantiene la pista actual y las siguientes 5 en caché y elimina entradas antiguas cuando se alcanza el límite de tamaño. Puedes establecer el tamaño máximo de caché y una demora de espera para evitar cargas innecesarias cuando saltas rápidamente.',
-
     q47: '¿Puedo almacenar una lista de reproducción para uso offline?',
-
     a47: 'Sí. Abre cualquier lista de reproducción y click en el icono de descarga en el encabezado de la lista. Todas las pistas se descargan en segundo plano — el progreso se muestra en el indicador de descarga offline. Una vez completado, el icono cambia a un ícono de basura rojo; click en él elimina la lista del caché offline.',
-
+    q48: '¿Qué es la Cola Infinita?',
+    a48: 'Cuando la cola se vacía y la repetición está desactivada, Psysonic añade pistas aleatorias automáticamente para que la reproducción nunca se detenga. Las pistas añadidas aparecen bajo el separador "— Añadido automáticamente —". Actívalo con el ícono de infinito en el encabezado de la cola.',
+    q49: '¿Puedo controlar Psysonic desde la línea de comandos?',
+    a49: 'Sí. Ejemplos: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one. También: cambiar servidor, dispositivo de audio, filtrar biblioteca y buscar. Ayuda completa: psysonic --player --help.',
+    q50: '¿Cómo gestiono las listas de reproducción?',
+    a50: 'A través de "Listas de reproducción" en la barra lateral. Crea una con "Nueva lista". En la vista de detalle puedes reordenar pistas arrastrando, eliminarlas con ×, añadir canciones mediante búsqueda y usar "Sugerencias" para recomendaciones inteligentes.',
+    q51: '¿Puedo hacer copia de seguridad y restaurar mis ajustes?',
+    a51: 'Sí. Ajustes → Copia de seguridad y restauración exporta todos los ajustes, perfiles de servidor, temas y atajos a un archivo JSON. Impórtalo en otro dispositivo para restaurarlo todo de una vez.',
+    q52: '¿Cómo cambio el dispositivo de salida de audio?',
+    a52: 'Ajustes → Audio → Dispositivo de salida. Psysonic lista todas las salidas disponibles. La selección surte efecto inmediatamente. Usa el botón de actualizar si conectaste un dispositivo después de iniciar la app.',
+    q53: '¿Qué es Device Sync?',
+    a53: 'Device Sync copia álbumes, listas de reproducción o artistas a un USB o tarjeta SD. Ábrelo desde "Device Sync" en la barra lateral, elige una carpeta destino, selecciona fuentes y haz clic en "Transferir al dispositivo".',
+    q54: '¿Qué es la plantilla de nombre de archivo en Device Sync?',
+    a54: 'La plantilla controla cómo se nombran y organizan las pistas. Usa los preajustes o crea el tuyo con los tokens: {artist}, {album}, {title}, {track_number}, {disc_number}, {year} y / como separador de carpeta.',
+    q55: '¿Funciona Device Sync entre plataformas?',
+    a55: 'Sí. El manifiesto guardado en el dispositivo incluye la plantilla usada. En otro SO con distinta plantilla, Psysonic detecta correctamente los archivos existentes.',
+    s9: 'Device Sync',
+    q56: '¿Qué es la Radio por Internet?',
+    a56: 'La página de Radio por Internet permite reproducir cualquier transmisión en vivo en Psysonic. Las estaciones provienen de tu servidor Navidrome. La reproducción usa audio HTML5.',
+    q57: '¿Qué formatos de transmisión admite la Radio por Internet?',
+    a57: 'MP3, AAC, OGG Vorbis y la mayoría de transmisiones HLS. MP3 y AAC funcionan en todas las plataformas.',
+    s10: 'Radio por Internet',
+    q58: '¿De dónde obtiene Psysonic las letras?',
+    a58: 'Tres fuentes configurables en Ajustes → Letras: tu servidor Navidrome, LRCLIB y NetEase Cloud Music. Cada fuente puede activarse/desactivarse y priorizarse arrastrando.',
+    q59: '¿Hay una vista de lo que escuchan otros usuarios?',
+    a59: 'Sí. Haz clic en el ícono de transmisión en la parte superior derecha para ver qué escuchan otros usuarios en tu servidor Navidrome, actualizado cada 10 segundos.',
   },
-
   queue: {
-
     title: 'Cola',
-
     savePlaylist: 'Guardar Lista',
-
     updatePlaylist: 'Actualizar Lista',
-
     filterPlaylists: 'Filtrar listas…',
-
     playlistName: 'Nombre de Lista',
-
     cancel: 'Cancelar',
-
     save: 'Guardar',
-
     loadPlaylist: 'Cargar Lista',
-
     loading: 'Cargando…',
-
     noPlaylists: 'No se encontraron listas.',
-
     load: 'Reemplazar cola y reproducir',
-
     appendToQueue: 'Agregar a cola',
-
     delete: 'Eliminar',
-
     deleteConfirm: '¿Eliminar lista "{{name}}"?',
-
     clear: 'Limpiar',
-
     shuffle: 'Mezclar cola',
-
     gapless: 'Gapless',
-
     crossfade: 'Crossfade',
-
     infiniteQueue: 'Cola Infinita',
-
     autoAdded: '— Agregado automáticamente —',
-
     radioAdded: '— Radio —',
-
     hide: 'Ocultar',
-
     close: 'Cerrar',
-
     nextTracks: 'Siguientes',
-
     emptyQueue: 'La cola está vacía.',
-
     trackSingular: 'pista',
-
     trackPlural: 'pistas',
-
     showRemaining: 'Mostrar tiempo restante',
-
     showTotal: 'Mostrar tiempo total',
-
   },
-
   statistics: {
-
     title: 'Estadísticas',
-
     recentlyPlayed: 'Reproducidos Recientemente',
-
     mostPlayed: 'Álbumes Más Reproducidos',
-
     highestRated: 'Álbumes Mejor Calificados',
-
     genreDistribution: 'Distribución de Géneros (Top 20)',
-
     loadMore: 'Cargar más',
-
     statArtists: 'Artistas',
-
     statArtistsTooltip: 'Solo artistas de álbum — los artistas que aparecen únicamente como artistas de pista (featuring, invitado, etc.) sin álbum propio no se cuentan.',
-
     statAlbums: 'Álbumes',
-
     statSongs: 'Canciones',
-
     statGenres: 'Géneros',
-
     statPlaytime: 'Tiempo Total de Reproducción',
-
     genreInsights: 'Información de Géneros',
-
     formatDistribution: 'Distribución de Formatos',
-
     formatSample: 'Muestra de {{n}} pistas',
-
     computing: 'Calculando…',
-
     genreSongs: '{{count}} Canciones',
-
     genreAlbums: '{{count}} Álbumes',
-
     recentlyAdded: 'Agregados Recientemente',
-
     decadeDistribution: 'Álbumes por Década',
-
     decadeAlbums_one: '{{count}} Álbum',
-
     decadeAlbums_other: '{{count}} Álbumes',
-
     decadeUnknown: 'Desconocido',
-
     lfmTitle: 'Estadísticas de Last.fm',
-
     lfmTopArtists: 'Artistas Principales',
-
     lfmTopAlbums: 'Álbumes Principales',
-
     lfmTopTracks: 'Pistas Principales',
-
     lfmPlays: '{{count}} reproducciones',
-
     lfmPeriodOverall: 'Todo el Tiempo',
-
     lfmPeriod7day: '7 Días',
-
     lfmPeriod1month: '1 Mes',
-
     lfmPeriod3month: '3 Meses',
-
     lfmPeriod6month: '6 Meses',
-
     lfmPeriod12month: '12 Meses',
-
     lfmNotConnected: 'Conecta Last.fm en Configuración para ver tus estadísticas.',
-
     lfmRecentTracks: 'Scrobbles Recientes',
-
     lfmNowPlaying: 'Reproduciendo Ahora',
-
     lfmJustNow: 'ahora mismo',
-
     lfmMinutesAgo: 'hace {{n}}m',
-
     lfmHoursAgo: 'hace {{n}}h',
-
     lfmDaysAgo: 'hace {{n}}d',
-
     topRatedSongs: 'Canciones Mejor Calificadas',
-
     topRatedArtists: 'Artistas Mejor Calificados',
-
     noRatedSongs: 'Aún no hay canciones calificadas. Califica canciones en la vista de álbum o playlist.',
-
     noRatedArtists: 'Aún no hay artistas calificados.',
-
   },
-
   player: {
-
     regionLabel: 'Reproductor de Música',
-
     openFullscreen: 'Abrir Reproductor Pantalla Completa',
-
     fullscreen: 'Reproductor Pantalla Completa',
-
     closeFullscreen: 'Cerrar Pantalla Completa',
-
     closeTooltip: 'Cerrar (Esc)',
-
     noTitle: 'Sin Título',
-
     stop: 'Detener',
-
     prev: 'Pista Anterior',
-
     play: 'Reproducir',
-
     pause: 'Pausa',
-
     next: 'Pista Siguiente',
-
     repeat: 'Repetir',
-
     repeatOff: 'Apagado',
-
     repeatAll: 'Todo',
-
     repeatOne: 'Una',
-
     progress: 'Progreso de Canción',
-
     volume: 'Volumen',
-
     toggleQueue: 'Alternar Cola',
-
     lyrics: 'Letras',
-
     fsLyricsToggle: 'Letras en pantalla completa',
-
     lyricsLoading: 'Cargando letras…',
-
     lyricsNotFound: 'No se encontraron letras para esta pista',
-
     lyricsSourceServer: 'Fuente: Servidor',
-
     lyricsSourceLrclib: 'Fuente: LRCLIB',
-
     lyricsSourceNetease: 'Fuente: Netease',
-
   },
-
   songInfo: {
-
     title: 'Información de Canción',
-
     songTitle: 'Título',
-
     artist: 'Artista',
-
     album: 'Álbum',
-
     albumArtist: 'Artista del Álbum',
-
     year: 'Año',
-
     genre: 'Género',
-
     duration: 'Duración',
-
     track: 'Pista',
-
     format: 'Formato',
-
     bitrate: 'Bitrate',
-
     sampleRate: 'Frecuencia de Muestreo',
-
     bitDepth: 'Profundidad de Bits',
-
     channels: 'Canales',
-
     fileSize: 'Tamaño de Archivo',
-
     path: 'Ruta',
-
     replayGainTrack: 'RG Ganancia de Pista',
-
     replayGainAlbum: 'RG Ganancia de Álbum',
-
     replayGainPeak: 'RG Pico de Pista',
-
     mono: 'Mono',
-
     stereo: 'Estéreo',
-
   },
-
   playlists: {
-
     title: 'Listas de Reproducción',
-
     newPlaylist: 'Nueva Lista',
-
     unnamed: 'Lista sin nombre',
-
     createName: 'Nombre de lista…',
-
     create: 'Crear',
-
     cancel: 'Cancelar',
-
     empty: 'Aún no hay listas.',
-
     emptyPlaylist: 'Esta lista está vacía.',
-
     addFirstSong: 'Agrega tu primera canción',
-
     notFound: 'Lista no encontrada.',
-
     songs: '{{n}} canciones',
-
     playAll: 'Reproducir Todo',
-
     shuffle: 'Aleatorio',
-
     addToQueue: 'Agregar a Cola',
-
     back: 'Volver a Listas',
-
     deletePlaylist: 'Eliminar',
-
     confirmDelete: 'Click de nuevo para confirmar',
-
     removeSong: 'Quitar de lista',
-
     addSongs: 'Agregar Canciones',
-
     searchPlaceholder: 'Buscar en tu biblioteca…',
-
     noResults: 'Sin resultados.',
-
     suggestions: 'Canciones Sugeridas',
-
     noSuggestions: 'No hay sugerencias disponibles.',
-
     titleBadge: 'Lista',
-
     refreshSuggestions: 'Nuevas sugerencias',
-
     addSong: 'Agregar a lista',
-
     addSelected: 'Agregar seleccionados',
-
     cacheOffline: 'Guardar lista offline',
-
     offlineCached: 'Lista guardada',
-
     removeOffline: 'Quitar de caché offline',
-
     offlineDownloading: 'Descargando… ({{done}}/{{total}} álbumes)',
-
     publicLabel: 'Pública',
-
     privateLabel: 'Privada',
-
     editMeta: 'Editar lista',
-
     editNamePlaceholder: 'Nombre de lista…',
-
     editCommentPlaceholder: 'Agregar descripción…',
-
     editPublic: 'Lista pública',
-
     editSave: 'Guardar',
-
     editCancel: 'Cancelar',
-
     changeCover: 'Cambiar imagen de portada',
-
     changeCoverLabel: 'Cambiar foto',
-
     removeCover: 'Quitar foto',
-
     coverUpdated: 'Portada actualizada',
-
     metaSaved: 'Lista actualizada',
-
     downloadZip: 'Descargar (ZIP)',
-
     // Toast notifications for multi-select
-
     addSuccess: '{{count}} canciones agregadas a {{playlist}}',
-
     addPartial: '{{added}} agregadas, {{skipped}} skippeadas por duplicadas',
-
     addAllSkipped: 'Todas skippeadas ({{count}} duplicadas)',
-
     addError: 'Error al agregar canciones',
-
     createAndAddSuccess: 'Lista "{{playlist}}" creada con {{count}} canciones',
-
     createError: 'Error al crear lista',
-
     deleteSuccess: '{{count}} listas eliminadas',
-
     deleteFailed: 'Error al eliminar {{name}}',
-
     deleteSelected: 'Eliminar seleccionadas',
-
     mergeSuccess: '{{count}} canciones unificadas en {{playlist}}',
-
     mergeNoNewSongs: 'No hay canciones nuevas para agregar',
-
     mergeError: 'Error al unificar listas',
-
     mergeInto: 'Unificar en',
-
     selectionCount: '{{count}} seleccionadas',
-
     select: 'Seleccionar',
-
     startSelect: 'Activar selección',
-
     cancelSelect: 'Cancelar',
-
     loadingAlbums: 'Resolviendo {{count}} álbumes…',
-
     loadingArtists: 'Resolviendo {{count}} artistas…',
-
     myPlaylists: 'Mis Listas',
-
     noOtherPlaylists: 'No hay otras listas disponibles',
-
     addToPlaylistSuccess: '{{count}} canciones agregadas a {{playlist}}',
-
     addToPlaylistNoNew: 'No hay canciones nuevas para agregar a {{playlist}}',
-
     addToPlaylistError: 'Error al agregar a la lista',
-
     removeSuccess: 'Canción quitada de la playlist',
-
     removeError: 'Error al quitar la canción de la playlist',
-
     importCSV: 'Importar CSV',
-
     importCSVTooltip: 'Importar desde CSV de Spotify',
-
     csvImportReport: 'Reporte de Importación CSV',
-
     csvImportTotal: 'Total',
-
     csvImportAdded: 'Agregadas',
-
     csvImportDuplicates: 'Duplicadas',
-
     csvImportNotFound: 'No Encontradas',
-
     csvImportNetworkErrors: 'Errores de Red',
-
     csvImportDuplicatesTitle: 'Canciones Duplicadas (Ya en la Lista):',
-
     csvImportNotFoundTitle: 'Canciones No Encontradas:',
-
     csvImportNetworkErrorsTitle: 'Errores de Red (puede reintentar la importación):',
-
     csvImportDownloadReport: 'Descargar Reporte',
-
     csvImportClose: 'Cerrar',
-
     csvImportNoValidTracks: 'No se encontraron canciones válidas en el archivo CSV',
-
     csvImportFailed: 'Error al importar el archivo CSV',
-
     csvImportToast: '{{added}} agregadas, {{notFound}} no encontradas, {{duplicates}} duplicadas',
-
   },
-
   mostPlayed: {
-
     title: 'Más Reproducidos',
-
     topArtists: 'Artistas Principales',
-
     topAlbums: 'Álbumes Principales',
-
     plays: '{{n}} reproducciones',
-
     sortMost: 'Más reproducciones primero',
-
     sortLeast: 'Menos reproducciones primero',
-
     loadMore: 'Cargar más álbumes',
-
     noData: 'Aún no hay datos de reproducción. ¡Empieza a escuchar!',
-
     noArtists: 'Todos los artistas filtrados.',
-
     filterCompilations: 'Ocultar artistas de compilaciones (Various Artists, Soundtracks, etc.)',
-
     filterCompilationsShort: 'Ocultar compilaciones',
-
   },
-
   radio: {
-
     title: 'Radio por Internet',
-
     empty: 'No hay estaciones de radio configuradas.',
-
     addStation: 'Agregar Estación',
-
     editStation: 'Editar',
-
     deleteStation: 'Eliminar estación',
-
     confirmDelete: 'Click de nuevo para confirmar',
-
     stationName: 'Nombre de estación…',
-
     streamUrl: 'URL de stream…',
-
     homepageUrl: 'URL de página (opcional)',
-
     save: 'Guardar',
-
     cancel: 'Cancelar',
-
     live: 'EN VIVO',
-
     liveStream: 'Radio por Internet',
-
     openHomepage: 'Abrir página',
-
     changeCoverLabel: 'Cambiar portada',
-
     removeCover: 'Quitar portada',
-
     browseDirectory: 'Buscar en Directorio',
-
     directoryPlaceholder: 'Buscar estaciones…',
-
     noResults: 'No se encontraron estaciones.',
-
     stationAdded: 'Estación agregada',
-
     filterAll: 'Todas',
-
     filterFavorites: 'Favoritos',
-
     sortManual: 'Manual',
-
     sortAZ: 'A → Z',
-
     sortZA: 'Z → A',
-
     sortNewest: 'Más recientes',
-
     favorite: 'Agregar a favoritos',
-
     unfavorite: 'Quitar de favoritos',
-
     noFavorites: 'No hay estaciones favoritas.',
-
     listenerCount_one: '{{count}} oyente',
-
     listenerCount_other: '{{count}} oyentes',
-
     recentlyPlayed: 'Reproducidos Recientemente',
-
     upNext: 'Siguientes',
-
   },
-
   folderBrowser: {
-
     empty: 'Carpeta vacía',
-
     error: 'Error al cargar',
-
   },
-
   deviceSync: {
-
     title: 'Sincronizar dispositivo',
-
     targetFolder: 'Carpeta de destino',
-
     noFolderChosen: 'Ninguna carpeta seleccionada',
-
     selectDrive: 'Seleccionar unidad…',
-
     refreshDrives: 'Actualizar unidades',
-
     noDrivesDetected: 'No se detectaron unidades extraíbles',
-
     browseManual: 'Explorar manualmente…',
-
     free: 'libre',
-
     notMountedVolume: 'El destino no está en un volumen montado. La unidad puede haberse desconectado.',
-
     chooseFolder: 'Elegir…',
-
     filenameTemplate: 'Plantilla de nombre de archivo',
-
     targetDevice: 'Dispositivo de destino',
-
     templateHint: 'Variables: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
-
     cleanupButton: 'Eliminar archivos fuera de la selección',
-
     cleanupNothingToDelete: 'Nada que eliminar — el dispositivo ya está sincronizado.',
-
     confirmCleanup: '¿Eliminar {{count}} archivo(s) del dispositivo que no están en la selección actual? ¿Continuar?',
-
     cleanupComplete: '{{count}} archivo(s) eliminado(s) del dispositivo.',
-
     selectedSources: 'Fuentes seleccionadas',
-
     noSourcesSelected: 'No hay fuentes seleccionadas. Haz clic en elementos del navegador para agregarlos.',
-
     clearAll: 'Limpiar todo',
-
     tabPlaylists: 'Listas de reproducción',
-
     tabAlbums: 'Álbumes',
-
     tabArtists: 'Artistas',
-
     searchPlaceholder: 'Buscar…',
-
     syncButton: 'Sincronizar al dispositivo',
-
     actionTransfer: 'Transferir al dispositivo',
-
     actionDelete: 'Eliminar del dispositivo',
-
     actionApplyAll: 'Aplicar todos los cambios',
-
     templatePreview: 'Vista previa',
-
+    templatePresetStandard: 'Estándar',
+    templatePresetMultiDisc: 'Multi-Disco',
+    templatePresetAltFolder: 'Carpeta alt.',
+    tokenSlashHint: '/ = separador de carpeta',
     cancel: 'Cancelar',
-
     noTargetDir: 'Por favor, elige primero una carpeta de destino.',
-
     noSources: 'Por favor, selecciona al menos una fuente.',
-
     noTracks: 'No se encontraron pistas en las fuentes seleccionadas.',
-
     fetchError: 'Error al obtener pistas del servidor.',
-
     syncComplete: 'Sincronización completada.',
-
     dismiss: 'Cerrar',
-
+    cancelSync: 'Cancelar',
+    syncCancelled: 'Sincronización cancelada ({{done}} / {{total}} transferidos).',
     colName: 'Nombre',
-
     colType: 'Tipo',
-
     colStatus: 'Estado',
-
     onDevice: 'Gestor de dispositivo',
-
     addSources: 'Agregar…',
-
     syncResult: '{{done}} transferido(s), {{skipped}} ya actualizado(s) ({{total}} total)',
-
     deleteFromDevice: 'Marcar para eliminar ({{count}})',
-
     confirmDelete: '¿Eliminar {{count}} elemento(s) del dispositivo: {{names}}?',
-
     deleteComplete: '{{count}} elemento(s) eliminado(s) del dispositivo.',
-
+    manifestImported: '{{count}} fuente(s) importada(s) desde el manifiesto del dispositivo.',
     statusSynced: 'Sincronizado',
-
     statusPending: 'Pendiente',
-
     statusDeletion: 'Eliminación',
-
     markForDeletion: 'Marcar para eliminar',
-
     removeSource: 'Eliminar',
-
     undoDeletion: 'Deshacer eliminación',
-
     syncInBackground: 'Sincronización iniciada en segundo plano — puedes navegar a otro lugar.',
-
     syncInProgress: '{{done}} / {{total}} pistas…',
-
     syncSummary: 'Resumen de sincronización',
-
     calculating: 'Calculando la carga útil requerida…',
-
     filesToAdd: 'Archivos a agregar:',
-
     filesToDelete: 'Archivos a eliminar:',
-
     netChange: 'Cambio neto:',
-
     availableSpace: 'Espacio disponible en disco:',
-
     spaceWarning: 'Advertencia: El dispositivo de destino no tiene suficiente espacio reportado.',
-
     proceed: 'Proceder con la sincronización',
-
     notEnoughSpace: '¡Espacio físico en disco insuficiente detectado!',
-
     liveSearch: 'Live',
-
     randomAlbumsLabel: 'Álbumes aleatorios',
-
   },
-
 };
-

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -1,1164 +1,2266 @@
 export const frTranslation = {
+
   sidebar: {
+
     library: 'Bibliothèque',
+
     mainstage: 'Scène principale',
+
     newReleases: 'Nouveautés',
+
     allAlbums: 'Tous les albums',
+
     randomAlbums: 'Albums aléatoires',
+
     randomPicker: 'Créer un mix',
+
     artists: 'Artistes',
+
     randomMix: 'Mix aléatoire',
+
     favorites: 'Favoris',
+
     nowPlaying: 'En cours',
+
     system: 'Système',
+
     statistics: 'Statistiques',
+
     settings: 'Paramètres',
+
     help: 'Aide',
+
     expand: 'Développer la barre latérale',
+
     collapse: 'Réduire la barre latérale',
+
     downloadingTracks: '{{n}} pistes en cache…',
+
     syncingTracks: 'Synchro {{done}}/{{total}}…',
+
     cancelDownload: 'Annuler le téléchargement',
+
     offlineLibrary: 'Bibliothèque hors ligne',
+
     genres: 'Genres',
+
     playlists: 'Playlists',
+
     mostPlayed: 'Les plus joués',
+
     radio: 'Radio Internet',
+
     folderBrowser: 'Explorateur de dossiers',
+
     deviceSync: 'Sync appareil',
+
     libraryScope: 'Portée de la bibliothèque',
+
     allLibraries: 'Toutes les bibliothèques',
+
     expandPlaylists: 'Développer les playlists',
+
     collapsePlaylists: 'Réduire les playlists',
+
   },
+
   home: {
+
     hero: 'En vedette',
+
     starred: 'Favoris personnels',
+
     recent: 'Ajoutés récemment',
+
     mostPlayed: 'Les plus écoutés',
+
     recentlyPlayed: 'Récemment écoutés',
+
     discover: 'Découvrir',
+
     loadMore: 'Charger plus',
+
     discoverMore: 'Découvrir plus',
+
     discoverArtists: 'Découvrir des artistes',
+
     discoverArtistsMore: 'Tous les artistes'
+
   },
+
   hero: {
+
     eyebrow: 'Album en vedette',
+
     playAlbum: 'Lire l\'album',
+
     enqueue: 'Mettre en file',
+
     enqueueTooltip: 'Ajouter l\'album entier à la file d\'attente',
+
   },
+
   search: {
+
     placeholder: 'Rechercher un artiste, album ou morceau…',
+
     noResults: 'Aucun résultat pour « {{query}} »',
+
     artists: 'Artistes',
+
     albums: 'Albums',
+
     songs: 'Morceaux',
+
     clearLabel: 'Effacer la recherche',
+
     title: 'Recherche',
+
     resultsFor: 'Résultats pour « {{query}} »',
+
     album: 'Album',
+
     advanced: 'Recherche avancée',
+
     advancedSearchTerm: 'Terme de recherche',
+
     advancedSearchPlaceholder: 'Titre, album, artiste…',
+
     advancedGenre: 'Genre',
+
     advancedAllGenres: 'Tous les genres',
+
     advancedYear: 'Année',
+
     advancedYearFrom: 'de',
+
     advancedYearTo: 'à',
+
     advancedAll: 'Tous',
+
     advancedSearch: 'Rechercher',
+
     advancedEmpty: 'Entrez un terme de recherche ou sélectionnez un filtre.',
+
     advancedNoResults: 'Aucun résultat trouvé.',
+
     advancedGenreNote: 'Les morceaux sont sélectionnés aléatoirement dans ce genre.',
+
     recentSearches: 'Recherches récentes',
+
     browse: 'Parcourir',
+
     emptyHint: 'Que veux-tu écouter ?',
+
     genres: 'Genres',
+
   },
+
   nowPlaying: {
+
     tooltip: 'Qui écoute ?',
+
     title: 'Qui écoute ?',
+
     loading: 'Chargement…',
+
     nobody: 'Personne n\'écoute en ce moment.',
+
     minutesAgo: 'il y a {{n}} min',
+
     nothingPlaying: 'Rien en cours. Lancez un morceau !',
+
     aboutArtist: "À propos de l'artiste",
+
     fromAlbum: 'De cet album',
+
     viewAlbum: "Voir l'album",
+
     goToArtist: "Aller à l'artiste",
+
     readMore: 'Lire la suite',
+
     showLess: 'Réduire',
+
     genreInfo: 'Genre',
+
     trackInfo: 'Infos piste',
+
   },
+
   contextMenu: {
+
     playNow: 'Lire maintenant',
+
     playNext: 'Lire ensuite',
+
     addToQueue: 'Ajouter à la file',
+
     enqueueAlbum: 'Mettre l\'album en file',
+
     startRadio: 'Démarrer la radio',
+
     instantMix: 'Mix instantané',
+
     instantMixFailed: 'Impossible de créer le mix instantané — erreur serveur ou plugin.',
+
     cliMixNeedsTrack: 'Aucune lecture en cours — lancez d’abord la lecture, puis relancez la commande de mix.',
+
     lfmLove: 'Aimer sur Last.fm',
+
     lfmUnlove: 'Ne plus aimer sur Last.fm',
+
     favorite: 'Favori',
+
     favoriteArtist: 'Artiste favori',
+
     favoriteAlbum: 'Album favori',
+
     unfavorite: 'Retirer des favoris',
+
     unfavoriteArtist: 'Retirer l\'artiste des favoris',
+
     unfavoriteAlbum: 'Retirer l\'album des favoris',
+
     removeFromQueue: 'Retirer de la file',
+
     removeFromPlaylist: 'Retirer de la playlist',
+
     openAlbum: 'Ouvrir l\'album',
+
     goToArtist: 'Aller à l\'artiste',
+
     download: 'Télécharger (ZIP)',
+
     addToPlaylist: 'Ajouter à la playlist',
+
     selectedPlaylists: '{{count}} playlists sélectionnées',
+
     selectedAlbums: '{{count}} albums sélectionnés',
+
     selectedArtists: '{{count}} artistes sélectionnés',
+
     songInfo: 'Infos du morceau',
+
   },
+
   albumDetail: {
+
     back: 'Retour',
+
     playAll: 'Tout lire',
+
     enqueue: 'Mettre en file',
+
     enqueueTooltip: 'Ajouter l\'album entier à la file d\'attente',
+
     artistBio: 'Biographie',
+
     download: 'Télécharger (ZIP)',
+
     downloading: 'Chargement…',
+
     cacheOffline: 'Rendre disponible hors ligne',
+
     offlineCached: 'Disponible hors ligne',
+
     offlineDownloading: 'Mise en cache… ({{n}}/{{total}})',
+
     removeOffline: 'Supprimer le cache hors ligne',
+
     offlineStorageFull: 'Stockage hors ligne plein (limite : {{mb}} Mo). Supprimez un album de votre bibliothèque hors ligne ou augmentez la limite dans les paramètres.',
+
     offlineStorageGoToSettings: 'Paramètres',
+
     offlineStorageGoToLibrary: 'Bibliothèque hors ligne',
+
     favoriteAdd: 'Ajouter aux favoris',
+
     favoriteRemove: 'Retirer des favoris',
+
     favorite: 'Favori',
+
     noBio: 'Aucune biographie disponible.',
+
     moreByArtist: 'Plus de {{artist}}',
+
     tracksCount: '{{n}} pistes',
+
     goToArtist: 'Aller à {{artist}}',
+
     moreLabelAlbums: 'Plus d\'albums sur {{label}}',
+
     trackTitle: 'Titre',
+
     trackAlbum: 'Album',
+
     trackArtist: 'Artiste',
+
     trackGenre: 'Genre',
+
     trackFormat: 'Format',
+
     trackFavorite: 'Favori',
+
     trackRating: 'Note',
+
     trackDuration: 'Durée',
+
     trackTotal: 'Total',
+
     columns: 'Colonnes',
-    resetColumns: 'Réinitialiser',
+
     notFound: 'Album introuvable.',
+
     bioModal: 'Biographie de l\'artiste',
+
     bioClose: 'Fermer',
+
     ratingLabel: 'Note',
+
     enlargeCover: 'Agrandir',
+
     filterSongs: 'Filtrer…',
+
     sortNatural: 'Naturel',
+
     sortByTitle: 'A–Z (Titre)',
+
     sortByArtist: 'A–Z (Artiste)',
+
     sortByAlbum: 'A–Z (Album)',
+
   },
+
   entityRating: {
+
     albumShort: 'Note de l’album',
+
     artistShort: 'Note de l’artiste',
+
     albumAriaLabel: 'Note de l’album',
+
     artistAriaLabel: 'Note de l’artiste',
+
     saveFailed: 'Impossible d’enregistrer la note.',
+
   },
+
   artistDetail: {
+
     back: 'Retour',
+
     albums: 'Albums',
+
     album: 'Album',
+
     playAll: 'Tout lire',
+
     shuffle: 'Aléatoire',
+
     radio: 'Radio',
+
     loading: 'Chargement…',
+
     noRadio: 'Aucun morceau similaire trouvé pour cet artiste.',
+
     notFound: 'Artiste introuvable.',
+
     albumsBy: 'Albums de {{name}}',
+
     topTracks: 'Morceaux populaires',
+
     noAlbums: 'Aucun album trouvé.',
+
     trackTitle: 'Titre',
+
     trackAlbum: 'Album',
+
     trackDuration: 'Durée',
+
     favoriteAdd: 'Ajouter aux favoris',
+
     favoriteRemove: 'Retirer des favoris',
+
     favorite: 'Favori',
+
     albumCount_one: '{{count}} album',
+
     albumCount_other: '{{count}} albums',
+
     openedInBrowser: 'Ouvert dans le navigateur',
+
     featuredOn: 'Également sur',
+
     similarArtists: 'Artistes similaires',
+
     cacheOffline: 'Enregistrer la discographie hors ligne',
+
     offlineCached: 'Discographie en cache',
+
     offlineDownloading: 'En cache… ({{done}}/{{total}} albums)',
+
     uploadImage: "Téléverser l'image de l'artiste",
+
     uploadImageError: "Échec du téléversement de l'image",
+
   },
+
   favorites: {
+
     title: 'Favoris',
+
     empty: 'Vous n\'avez pas encore de favoris.',
+
     artists: 'Artistes',
+
     albums: 'Albums',
+
     songs: 'Morceaux',
+
     enqueueAll: 'Tout ajouter à la file',
+
     playAll: 'Tout lire',
+
     removeSong: 'Retirer des favoris',
+
     stations: 'Stations de radio',
+
     showingFiltered: 'Affichage de {{filtered}} sur {{total}} ({{artist}})',
+
     showingCount: 'Affichage de {{filtered}} sur {{total}}',
+
     clearArtistFilter: 'Effacer le filtre artiste',
+
     noFilterResults: 'Aucun résultat avec les filtres sélectionnés.',
+
     allArtists: 'Tous les artistes',
+
   },
+
   randomLanding: {
+
     title: 'Créer un mix',
+
     mixByTracks: 'Mix par pistes',
+
     mixByTracksDesc: 'Sélection aléatoire de titres depuis toute votre médiathèque',
+
     mixByAlbums: 'Mix par albums',
+
     mixByAlbumsDesc: 'Albums aléatoires pour vos prochaines découvertes',
+
   },
+
   randomAlbums: {
+
     title: 'Albums aléatoires',
+
     refresh: 'Actualiser',
+
   },
+
   genres: {
+
     title: 'Genres',
+
     genreCount: 'genres',
+
     albumCount_one: '{{count}} album',
+
     albumCount_other: '{{count}} albums',
+
     loading: 'Chargement des genres…',
+
     empty: 'Aucun genre trouvé.',
+
     albumsLoading: 'Chargement des albums…',
+
     albumsEmpty: 'Aucun album trouvé pour ce genre.',
+
     loadMore: 'Charger plus',
+
     back: 'Retour',
+
   },
+
   randomMix: {
+
     title: 'Mix aléatoire',
+
     remix: 'Remixer',
+
     remixTooltip: 'Charger de nouveaux morceaux aléatoires',
+
     remixGenre: 'Remixer {{genre}}',
+
     remixTooltipGenre: 'Charger de nouveaux morceaux {{genre}}',
+
     playAll: 'Tout lire',
+
     trackTitle: 'Titre',
+
     trackArtist: 'Artiste',
+
     trackAlbum: 'Album',
+
     trackFavorite: 'Favori',
+
     trackDuration: 'Durée',
+
     favoriteAdd: 'Ajouter aux favoris',
+
     favoriteRemove: 'Retirer des favoris',
+
     play: 'Lire',
+
     trackGenre: 'Genre',
+
     excludeAudiobooks: 'Exclure les livres audio et pièces radiophoniques',
+
     excludeAudiobooksDesc: 'Correspond aux mots-clés dans le genre, le titre, l\'album et l\'artiste — ex. Hörbuch, Audiobook, Spoken Word, …',
+
     genreBlocked: 'Mot-clé bloqué',
+
     genreAddedToBlacklist: 'Ajouté à la liste de filtres',
+
     genreAlreadyBlocked: 'Déjà bloqué',
+
     artistBlocked: 'Artiste bloqué',
+
     artistAddedToBlacklist: 'Artiste ajouté à la liste de filtres',
+
     artistClickHint: 'Cliquer pour bloquer cet artiste',
+
     blacklistToggle: 'Filtre par mot-clé',
+
     genreMixTitle: 'Mix par genre',
+
     genreMixDesc: 'Top 20 genres par nombre de morceaux — cliquer pour un mix aléatoire',
+
     genreMixAll: 'Tous les morceaux',
+
     genreMixLoadMore: 'Charger 10 de plus',
+
     genreMixNoGenres: 'Aucun genre trouvé sur le serveur.',
+
     shuffleGenres: 'Afficher d\'autres genres',
+
     filterPanelTitle: 'Filtres',
+
     filterPanelDesc: 'Cliquez sur un tag de genre ou un nom d\'artiste dans la liste pour l\'exclure des futurs mix.',
+
     genreClickHint: 'Cliquez sur un tag de genre pour l\'ajouter\ncomme mot-clé de filtre.\nCorrespond au genre, titre, album et artiste.',
+
   },
+
   albums: {
+
     title: 'Tous les albums',
+
     sortByName: 'A–Z (Album)',
+
     sortByArtist: 'A–Z (Artiste)',
+
     sortNewest: 'Plus récents',
+
     sortRandom: 'Aléatoire',
+
     yearFrom: 'De',
+
     yearTo: 'À',
+
     yearFilterClear: 'Effacer le filtre année',
+
     yearFilterLabel: 'Année',
+
     select: 'Sélection multiple',
+
     startSelect: 'Activer la sélection multiple',
+
     cancelSelect: 'Annuler',
+
     selectionCount: '{{count}} sélectionnés',
+
     downloadZips: 'Télécharger les ZIPs',
+
     addOffline: 'Ajouter hors ligne',
+
     downloadingZip: 'Téléchargement {{current}}/{{total}} : {{name}}',
+
     downloadZipDone: '{{count}} ZIP(s) téléchargé(s)',
+
     downloadZipFailed: 'Échec du téléchargement de {{name}}',
+
     offlineQueuing: 'Mise en file d\'attente de {{count}} album(s) hors ligne…',
+
     offlineFailed: 'Échec de l\'ajout de {{name}} hors ligne',
+
   },
+
   artists: {
+
     title: 'Artistes',
+
     search: 'Rechercher…',
+
     all: 'Tous',
+
     gridView: 'Vue en grille',
+
     listView: 'Vue en liste',
+
     imagesOn: 'Images d\'artistes activées — peut augmenter la charge réseau et système',
+
     imagesOff: 'Images d\'artistes désactivées — affichage des initiales uniquement',
+
     loadMore: 'Charger plus',
+
     notFound: 'Aucun artiste trouvé.',
+
     albumCount_one: '{{count}} album',
+
     albumCount_other: '{{count}} albums',
+
     selectionCount: '{{count}} sélectionnés',
+
     select: 'Sélection multiple',
+
     startSelect: 'Activer la sélection multiple',
+
     cancelSelect: 'Annuler',
+
     addToPlaylist: 'Ajouter à la playlist',
+
   },
+
   login: {
+
     subtitle: 'Votre lecteur de bureau Navidrome',
+
     serverName: 'Nom du serveur (facultatif)',
+
     serverNamePlaceholder: 'Mon Navidrome',
+
     serverUrl: 'URL du serveur',
+
     serverUrlPlaceholder: '192.168.1.100:4533 ou https://music.exemple.com',
+
     username: 'Nom d\'utilisateur',
+
     usernamePlaceholder: 'admin',
+
     password: 'Mot de passe',
+
     showPassword: 'Afficher le mot de passe',
+
     hidePassword: 'Masquer le mot de passe',
+
     connect: 'Se connecter',
+
     connecting: 'Connexion…',
+
     connected: 'Connecté !',
+
     error: 'Connexion échouée — vérifiez vos informations.',
+
     urlRequired: 'Veuillez saisir une URL de serveur.',
+
     savedServers: 'Serveurs enregistrés',
+
     addNew: 'Ou ajouter un nouveau serveur',
+
   },
+
   connection: {
+
     connected: 'Connecté',
+
     connectedTo: 'Connecté à {{server}}',
+
     disconnected: 'Déconnecté',
+
     disconnectedFrom: 'Impossible d\'atteindre {{server}} — cliquez pour vérifier les paramètres',
+
     checking: 'Connexion…',
+
     extern: 'Externe',
+
     offlineTitle: 'Pas de connexion au serveur',
+
     offlineSubtitle: 'Impossible d\'atteindre {{server}}. Vérifiez votre réseau ou le serveur.',
+
     offlineModeBanner: 'Mode hors ligne — lecture depuis le cache local',
+
     offlineNoCacheBanner: 'Pas de connexion au serveur — {{server}} inaccessible',
+
     offlineLibraryTitle: 'Bibliothèque hors ligne',
+
     offlineLibraryEmpty: 'Aucun album en cache. Connectez-vous, ouvrez un album et cliquez sur "Rendre disponible hors ligne".',
+
     offlineAlbumCount: '{{n}} album',
+
     offlineAlbumCount_plural: '{{n}} albums',
+
     offlineFilterAll: 'Tout',
+
     offlineFilterAlbums: 'Albums',
+
     offlineFilterPlaylists: 'Playlists',
+
     offlineFilterArtists: 'Discographies',
+
     retry: 'Réessayer',
+
     serverSettings: 'Paramètres serveur',
+
     switchServerTitle: 'Changer de serveur',
+
     switchServerHint: 'Cliquez pour choisir un autre serveur enregistré.',
+
     manageServers: 'Gérer les serveurs…',
+
     switchFailed: 'Impossible de changer — serveur injoignable.',
+
     lastfmConnected: 'Last.fm connecté en tant que @{{user}}',
+
     lastfmSessionInvalid: 'Session invalide — cliquez pour vous reconnecter',
+
   },
+
   common: {
+
     albums: 'Albums',
+
     album: 'Album',
+
     loading: 'Chargement…',
+
     loadingMore: 'Chargement…',
+
     loadingPlaylists: 'Chargement des listes…',
+
     noAlbums: 'Aucun album trouvé.',
+
     downloading: 'Téléchargement…',
+
     downloadZip: 'Télécharger (ZIP)',
+
     back: 'Retour',
+
     cancel: 'Annuler',
+
     save: 'Enregistrer',
+
     delete: 'Supprimer',
+
     use: 'Utiliser',
+
     add: 'Ajouter',
+
     active: 'Actif',
+
     download: 'Télécharger',
+
     chooseDownloadFolder: 'Choisir le dossier de téléchargement',
+
     noFolderSelected: 'Aucun dossier sélectionné',
+
     rememberDownloadFolder: 'Mémoriser ce dossier',
+
     filterGenre: 'Filtre genre',
+
     filterSearchGenres: 'Rechercher des genres…',
+
     filterNoGenres: 'Aucun genre trouvé',
+
     filterClear: 'Effacer',
+
     play: 'Lire',
+
     bulkSelected: '{{count}} sélectionné(s)',
+
     clearSelection: 'Effacer la sélection',
+
     bulkAddToPlaylist: 'Ajouter à la playlist',
+
     bulkRemoveFromPlaylist: 'Retirer de la playlist',
+
     bulkClear: 'Désélectionner',
+
     updaterAvailable: 'Mise à jour disponible',
+
     updaterVersion: 'v{{version}} est disponible',
+
     updaterWebsite: 'Site Web',
+
     updaterModalTitle: 'Nouvelle version disponible',
+
     updaterChangelog: 'Nouveautés',
+
     updaterDownloadBtn: 'Télécharger maintenant',
+
     updaterSkipBtn: 'Ignorer cette version',
+
     updaterRemindBtn: 'Me rappeler plus tard',
+
     updaterDone: 'Téléchargement terminé',
+
     updaterShowFolder: 'Afficher dans le dossier',
+
     updaterInstallHint: 'Fermez Psysonic et lancez le programme d\'installation manuellement.',
+
     updaterAurHint: 'Installer la mise à jour via AUR :',
+
     updaterErrorMsg: 'Échec du téléchargement',
+
     updaterRetryBtn: 'Réessayer',
+
     durationHoursMinutes: '{{hours}} h {{minutes}} min',
+
     durationMinutesOnly: '{{minutes}} min',
+
     updaterOpenGitHub: 'Ouvrir sur GitHub',
+
     filters: 'Filtres',
+
     more: 'plus',
+
     yearRange: 'Plage d\'années',
+
     clearAll: 'Tout effacer',
+
   },
+
   settings: {
+
     title: 'Paramètres',
+
     language: 'Langue',
+
     languageEn: 'Anglais',
+
     languageDe: 'Allemand',
+
     languageFr: 'Français',
+
     languageNl: 'Néerlandais',
+
     languageZh: 'Chinois',
+
     languageNb: 'Norvégien',
+
     languageRu: 'Russe',
+
     font: 'Police',
+
     theme: 'Thème',
+
     appearance: 'Apparence',
+
     servers: 'Serveurs',
+
     serverName: 'Nom du serveur',
+
     serverUrl: 'URL du serveur',
+
     serverUrlPlaceholder: '192.168.1.100:4533 ou https://music.exemple.com',
+
     serverUsername: 'Nom d\'utilisateur',
+
     serverPassword: 'Mot de passe',
+
     addServer: 'Ajouter un serveur',
+
     addServerTitle: 'Ajouter un nouveau serveur',
+
     useServer: 'Utiliser',
+
     deleteServer: 'Supprimer',
+
     noServers: 'Aucun serveur enregistré.',
+
     serverActive: 'Actif',
+
     confirmDeleteServer: 'Supprimer le serveur « {{name}} » ?',
+
     serverConnecting: 'Connexion…',
+
     serverConnected: 'Connecté !',
+
     serverFailed: 'Connexion échouée.',
+
     testBtn: 'Tester la connexion',
+
     testingBtn: 'Test en cours…',
+
     serverCompatible: 'Compatible avec : Navidrome · Gonic · Airsonic · Subsonic',
+
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+
     audiomuseDesc:
+
       'Activez si ce serveur utilise le <pluginLink>plugin Navidrome AudioMuse-AI</pluginLink>. Active le mix instantané depuis un morceau et affiche les artistes similaires côté serveur au lieu de Last.fm sur les pages artiste.',
+
     audiomuseIssueHint:
+
       'Le mix instantané a échoué récemment — vérifiez le plugin Navidrome et l’API AudioMuse. Les artistes similaires utilisent Last.fm si le serveur ne renvoie rien.',
+
     connected: 'Connecté',
+
     failed: 'Échec',
+
     eqTitle: 'Égaliseur',
+
     eqEnabled: 'Activer l\'égaliseur',
+
     eqPreset: 'Préréglage',
+
     eqPresetCustom: 'Personnalisé',
+
     eqPresetBuiltin: 'Préréglages intégrés',
+
     eqPresetCustomGroup: 'Mes préréglages',
+
     eqSavePreset: 'Enregistrer comme préréglage',
+
     eqPresetName: 'Nom du préréglage…',
+
     eqDeletePreset: 'Supprimer le préréglage',
+
     eqResetBands: 'Réinitialiser à plat',
+
     eqPreGain: 'Pré-amplification',
+
     eqResetPreGain: 'Réinitialiser la pré-amplification',
+
     eqAutoEqTitle: 'Recherche AutoEQ',
+
     eqAutoEqPlaceholder: 'Rechercher un casque / IEM…',
+
     eqAutoEqSearching: 'Recherche…',
+
     eqAutoEqNoResults: 'Aucun résultat',
+
     eqAutoEqError: 'Échec de la recherche',
+
     eqAutoEqRateLimit: 'Limite GitHub atteinte — réessayez dans une minute',
+
     eqAutoEqFetchError: 'Impossible de charger le profil EQ',
+
     lfmTitle: 'Last.fm',
+
     lfmConnect: 'Connecter avec Last.fm',
+
     lfmConnecting: 'En attente d\'autorisation…',
+
     lfmConfirm: 'J\'ai autorisé l\'application',
+
     lfmConnected: 'Connecté en tant que',
+
     lfmDisconnect: 'Déconnecter',
+
     lfmConnectDesc: 'Connectez votre compte Last.fm pour activer le scrobbling et les mises à jour « En cours de lecture » depuis Psysonic — aucune configuration Navidrome requise.',
+
     lfmOpenBrowser: 'Une fenêtre de navigateur s\'ouvrira. Autorisez Psysonic sur Last.fm, puis cliquez sur le bouton ci-dessous.',
+
     lfmScrobbles: '{{n}} scrobbles',
+
     lfmMemberSince: 'Membre depuis {{year}}',
+
     scrobbleEnabled: 'Scrobbling activé',
+
     scrobbleDesc: 'Envoyer les morceaux à Last.fm après 50% d\'écoute',
+
     behavior: 'Comportement de l\'application',
+
     cacheTitle: 'Taille max. du stockage',
+
     cacheDesc: 'Pochettes et images d\'artistes. Quand le cache est plein, les entrées les plus anciennes sont supprimées automatiquement. Les albums hors ligne ne sont pas supprimés automatiquement, mais le seront lors d\'un nettoyage manuel.',
+
     cacheUsedImages: 'Images :',
+
     cacheUsedOffline: 'Pistes hors ligne :',
+
     cacheUsedHot: 'Espace disque :',
+
     hotCacheTrackCount: 'Pistes en cache :',
+
     cacheMaxLabel: 'Taille max.',
+
     cacheClearBtn: 'Vider le cache',
+
     cacheClearWarning: 'Cela supprimera aussi tous les albums hors ligne de la bibliothèque.',
+
     cacheClearConfirm: 'Tout supprimer',
+
     cacheClearCancel: 'Annuler',
+
     offlineDirTitle: 'Bibliothèque hors ligne (intégrée)',
+
     offlineDirDesc: 'Emplacement de stockage des titres rendus disponibles hors ligne dans Psysonic.',
+
     offlineDirDefault: 'Par défaut (données d\'application)',
+
     offlineDirChange: 'Changer le dossier',
+
     offlineDirClear: 'Réinitialiser',
+
     offlineDirHint: 'Les nouveaux téléchargements utiliseront cet emplacement. Les téléchargements existants restent à leur emplacement d\'origine.',
+
     hotCacheTitle: 'Cache de lecture à chaud',
+
     hotCacheAlphaBadge: 'Alpha',
+
     hotCacheDisclaimer: 'Précharge les titres à venir dans la file et conserve les précédents. Si activé : espace disque et réseau.',
+
     hotCacheDirDefault: 'Par défaut (données d\'application)',
+
     hotCacheDirChange: 'Changer le dossier',
+
     hotCacheDirClear: 'Réinitialiser',
+
     hotCacheDirHint: 'Changer de dossier réinitialise l’index dans l’app ; les fichiers déjà écrits restent à l’ancien emplacement.',
+
     hotCacheEnabled: 'Activer le cache de lecture à chaud',
+
     hotCacheMaxMb: 'Taille maximale du cache',
+
     hotCacheDebounce: 'Délai après changement de file',
+
     hotCacheDebounceImmediate: 'Immédiat',
+
     hotCacheDebounceSeconds: '{{n}} s',
+
     hotCacheClearBtn: 'Vider le cache à chaud',
+
     audioOutputDevice: 'Périphérique de sortie audio',
+
     audioOutputDeviceDesc: 'Choisissez le périphérique audio utilisé par Psysonic. Les changements sont immédiats et relancent la piste en cours.',
+
     audioOutputDeviceDefault: 'Défaut système',
+
     audioOutputDeviceRefresh: 'Actualiser la liste',
+
     audioOutputDeviceOsDefaultNow: 'sortie système actuelle',
+
     audioOutputDeviceListError: 'Impossible de charger la liste des périphériques audio.',
+
     audioOutputDeviceNotInCurrentList: 'absent de la liste actuelle',
+
     hiResTitle: 'Lecture haute résolution native',
+
     hiResEnabled: 'Activer la lecture haute résolution native',
+
     hiResDesc: "Force une sortie à 44,1 kHz par défaut pour une stabilité maximale. N'activer que si le matériel et le réseau prennent en charge les hautes fréquences d'échantillonnage (88,2 kHz+).",
+
     showArtistImages: 'Afficher les images d\'artistes',
+
     showArtistImagesDesc: 'Charge et affiche les images d\'artistes dans la vue d\'ensemble. Désactivé par défaut pour réduire les E/S disque serveur et la charge réseau sur les grandes bibliothèques.',
+
     showTrayIcon: 'Afficher l\'icône dans la barre système',
+
     showTrayIconDesc: 'Affiche l\'icône Psysonic dans la zone de notification / barre des menus.',
+
     minimizeToTray: 'Réduire dans la barre système',
+
     minimizeToTrayDesc: 'Lors de la fermeture, Psysonic continue de fonctionner dans la barre système au lieu de se fermer.',
+
     discordRichPresence: 'Discord Rich Presence',
+
     discordRichPresenceDesc: 'Affiche le titre en cours de lecture sur votre profil Discord. Discord doit être ouvert.',
+
     discordAppleCovers: 'Récupérer les pochettes via Apple Music pour Discord',
+
     discordAppleCoversDesc: 'Envoie le nom de l\'artiste et de l\'album à l\'API Apple pour trouver une pochette pour votre profil Discord. Désactivé par défaut pour des raisons de confidentialité.',
+
+    discordTemplates: 'Modèles de texte personnalisés',
+
+    discordTemplatesDesc: 'Personnalise les informations affichées sur votre profil Discord. Variables : {title}, {artist}, {album}, {paused}',
+
+    discordTemplateDetails: 'Ligne principale (details)',
+
+    discordTemplateState: 'Ligne secondaire (state)',
+
+    discordTemplateLargeText: 'Info-bulle album (largeText)',
+
     nowPlayingEnabled: 'Afficher dans la fenêtre live',
+
     nowPlayingEnabledDesc: 'Diffuse le titre en cours de lecture vers la vue des auditeurs en direct du serveur. Désactiver pour ne pas envoyer de données de lecture.',
+
     lyricsServerFirst: 'Préférer les paroles du serveur',
+
     lyricsServerFirstDesc: 'Consulter d\'abord les paroles fournies par le serveur (tags intégrés, fichiers sidecar) avant LRCLIB. Désactiver pour utiliser LRCLIB en priorité.',
+
     enableNeteaselyrics: 'Paroles Netease Cloud Music',
+
     enableNeteaselyricsDesc: 'Utiliser Netease Cloud Music en dernier recours lorsque le serveur et LRCLIB ne retournent rien. Meilleure couverture pour la musique asiatique et internationale.',
+
     lyricsSourcesTitle: 'Sources de paroles',
+
     lyricsSourcesDesc: 'Choisissez quelles sources interroger et dans quel ordre. Glissez pour réordonner. Les sources désactivées sont ignorées.',
+
     lyricsSourceServer: 'Serveur',
+
     lyricsSourceLrclib: 'LRCLIB',
+
     lyricsSourceNetease: 'Netease Cloud Music',
+
     downloadsTitle: 'Export ZIP & Archivage',
+
     downloadsFolderDesc: 'Dossier de destination pour les albums téléchargés en tant que fichier ZIP sur votre ordinateur.',
+
     downloadsDefault: 'Dossier de téléchargement par défaut',
+
     pickFolder: 'Sélectionner',
+
     pickFolderTitle: 'Sélectionner le dossier de téléchargement',
+
     clearFolder: 'Effacer le dossier',
+
     logout: 'Se déconnecter',
+
     aboutTitle: 'À propos de Psysonic',
+
     aboutDesc: 'Un lecteur de musique de bureau moderne pour les serveurs compatibles Subsonic (Navidrome, Gonic, et autres). Construit sur Tauri v2 avec un moteur audio Rust natif — léger et rapide, mais riche en fonctionnalités : barre waveform, paroles synchronisées, intégration Last.fm, égaliseur 10 bandes, crossfade, lecture sans blanc, Replay Gain, navigation par genre et une grande bibliothèque de thèmes.',
+
     aboutLicense: 'Licence',
+
     aboutLicenseText: 'GNU GPL v3 — libre d\'utilisation, de modification et de distribution sous la même licence.',
+
     aboutRepo: 'Code source sur GitHub',
+
     aboutVersion: 'Version',
+
     aboutBuiltWith: 'Construit avec Tauri · React · TypeScript · Rust/rodio',
+
     aboutAiCredit: 'Développé avec le soutien de Claude Code par Anthropic',
+
     aboutContributorsLabel: 'Contributeurs',
+
     aboutSpecialThanksLabel: 'Remerciements spéciaux',
+
     changelog: 'Journal des modifications',
+
     showChangelogOnUpdate: "Afficher 'Quoi de neuf' lors des mises à jour",
+
     showChangelogOnUpdateDesc: 'Affiche automatiquement les nouveautés au premier lancement d\'une nouvelle version.',
+
     randomMixTitle: 'Mix aléatoire',
+
     randomMixBlacklistTitle: 'Mots-clés de filtre personnalisés',
+
     randomMixBlacklistDesc: 'Les morceaux sont exclus si un mot-clé correspond à leur genre, titre, album ou artiste (actif quand la case ci-dessus est cochée).',
+
     randomMixBlacklistPlaceholder: 'Ajouter un mot-clé…',
+
     randomMixBlacklistAdd: 'Ajouter',
+
     randomMixBlacklistEmpty: 'Aucun mot-clé personnalisé ajouté.',
+
     randomMixHardcodedTitle: 'Mots-clés intégrés (actifs quand la case est cochée)',
+
     tabAudio: 'Audio',
+
     tabStorage: 'Stockage & Téléchargements',
+
     tabAppearance: 'Apparence',
+
     homeCustomizerTitle: 'Page d\'accueil',
+
     sidebarTitle: 'Barre latérale',
+
     sidebarReset: 'Réinitialiser',
+
     sidebarDrag: 'Glisser pour réorganiser',
+
     sidebarFixed: 'Toujours visible',
-    randomNavSplitTitle: 'Diviser la navigation Mix',
-    randomNavSplitDesc: 'Afficher "Mix Aléatoire" et "Albums Aléatoires" comme entrées séparées dans la barre latérale plutôt que le hub "Créer un Mix".',
+
     tabInput: 'Entrée',
+
     tabServer: 'Serveur',
+
     shortcutsReset: 'Réinitialiser',
+
     shortcutListening: 'Appuyez sur une touche…',
+
     shortcutUnbound: '—',
+
     shortcutClear: 'Effacer',
+
     globalShortcutsTitle: 'Raccourcis globaux',
+
     globalShortcutsNote: 'Fonctionnent à l\'échelle du système, même quand Psysonic est en arrière-plan. Nécessite Ctrl, Alt ou Super comme modificateur.',
+
     shortcutPlayPause: 'Lecture / Pause',
+
     shortcutNext: 'Piste suivante',
+
     shortcutPrev: 'Piste précédente',
+
     shortcutVolumeUp: 'Volume +',
+
     shortcutVolumeDown: 'Volume -',
+
     shortcutSeekForward: 'Avancer de 10s',
+
     shortcutSeekBackward: 'Reculer de 10s',
+
     shortcutToggleQueue: 'Afficher/masquer la file',
+
     shortcutOpenFolderBrowser: 'Ouvrir {{folderBrowser}}',
+
     shortcutFullscreenPlayer: 'Lecteur plein écran',
+
     shortcutNativeFullscreen: 'Plein écran natif',
+
     tabSystem: 'Système',
+
     tabGeneral: 'Général',
+
     ratingsSectionTitle: 'Notes',
+
     ratingsSkipStarTitle: 'Passer pour 1 étoile',
+
     ratingsSkipStarDesc:
+
       "Après plusieurs sauts d’affilée, le morceau passe à 1 étoile. Uniquement s’il n’était pas encore noté.",
+
     ratingsSkipStarThresholdLabel: 'Sauts',
+
     ratingsMixFilterTitle: 'Filtrage par note',
+
     ratingsMixFilterDesc:
+
       "Filtrer le contenu peu noté dans {{mix}} et {{albums}}. Cliquer de nouveau sur l’étoile choisie désactive le seuil.",
+
     ratingsMixMinSong: 'Morceaux',
+
     ratingsMixMinAlbum: 'Albums',
+
     ratingsMixMinArtist: 'Artistes',
+
     ratingsMixMinThresholdAria: 'Étoiles minimum : {{label}}',
+
     backupTitle: 'Sauvegarde & Restauration',
+
     backupExport: 'Exporter les paramètres',
+
     backupExportDesc: 'Enregistre tous les paramètres, profils serveur, configuration Last.fm, thème, EQ et raccourcis dans un fichier .psybkp. Les mots de passe sont stockés en clair — conservez le fichier en sécurité.',
+
     backupImport: 'Importer les paramètres',
+
     backupImportDesc: 'Restaure les paramètres depuis un fichier .psybkp. L\'application sera rechargée après l\'import.',
+
     backupImportConfirm: 'Tous les paramètres actuels seront écrasés. Continuer ?',
+
     backupSuccess: 'Sauvegarde enregistrée',
+
     backupImportSuccess: 'Paramètres restaurés — rechargement…',
+
     backupImportError: 'Fichier de sauvegarde invalide ou corrompu.',
+
     playbackTitle: 'Lecture',
+
     replayGain: 'Replay Gain',
+
     replayGainDesc: 'Normaliser le volume des pistes avec les métadonnées ReplayGain',
+
     replayGainMode: 'Mode',
+
     replayGainTrack: 'Piste',
+
     replayGainAlbum: 'Album',
+
     replayGainPreGain: 'Pré-Gain (fichiers taggés)',
+
     replayGainFallback: 'Repli (sans tags / radio)',
+
     crossfade: 'Fondu enchaîné',
+
     crossfadeDesc: 'Fondu entre les pistes',
+
     crossfadeSecs: '{{n}} s',
+
     notWithGapless: 'Non disponible quand la lecture sans blanc est active',
+
     notWithCrossfade: 'Non disponible quand le fondu enchaîné est actif',
+
     gapless: 'Lecture sans blanc',
+
     gaplessDesc: 'Préparer la piste suivante pour éliminer les silences entre les morceaux',
+
     preloadMode: 'Précharger la piste suivante',
+
     preloadModeDesc: 'Quand commencer à mettre en mémoire tampon la piste suivante',
+
     nextTrackBufferingTitle: 'Piste suivante – mise en mémoire tampon',
+
     preloadHotCacheMutualExclusive: "Preload et Hot Cache remplissent le même rôle — un seul peut être actif à la fois. Activer l'un désactive automatiquement l'autre.",
+
     preloadOff: 'Désactivé',
+
     preloadBalanced: 'Équilibré (30 s avant la fin)',
+
     preloadEarly: 'Tôt (après 5 s de lecture)',
+
     preloadCustom: 'Personnalisé',
+
     preloadCustomSeconds: 'Secondes avant la fin : {{n}}',
+
     infiniteQueue: 'File infinie',
+
     infiniteQueueDesc: 'Ajouter automatiquement des morceaux aléatoires quand la file est épuisée',
+
     experimental: 'Expérimental',
+
     fsPlayerSection: 'Lecteur plein écran',
+
     fsShowArtistPortrait: "Afficher la photo de l'artiste",
+
     fsShowArtistPortraitDesc: "Afficher la photo de l'artiste (ou la pochette) sur le côté droit du lecteur plein écran.",
+
     fsPortraitDim: "Assombrissement de la photo",
+
     seekbarStyle: 'Style de la barre de lecture',
+
     seekbarStyleDesc: 'Choisir l\'apparence de la barre de progression',
+
     seekbarWaveform: 'Forme d\'onde',
+
     seekbarLinedot: 'Ligne & point',
+
     seekbarBar: 'Barre',
+
     seekbarThick: 'Barre épaisse',
+
     seekbarSegmented: 'Segmentée',
+
     seekbarNeon: 'Néon',
+
     seekbarPulsewave: 'Onde pulsée',
+
     seekbarParticletrail: 'Traînée de particules',
+
     seekbarLiquidfill: 'Tube liquide',
+
     seekbarRetrotape: 'Bande rétro',
+
     themeSchedulerTitle: 'Planificateur de thème',
+
     themeSchedulerEnable: 'Activer le planificateur de thème',
+
     themeSchedulerEnableSub: 'Bascule automatiquement entre deux thèmes selon l\'heure',
+
     themeSchedulerDayTheme: 'Thème de jour',
+
     themeSchedulerDayStart: 'Début du jour',
+
     themeSchedulerNightTheme: 'Thème de nuit',
+
     themeSchedulerNightStart: 'Début de la nuit',
+
     themeSchedulerActiveHint: 'Le planificateur de thème est actif - les thèmes changent automatiquement.',
+
     visualOptionsTitle: 'Options Visuelles',
+
     coverArtBackground: "Fond d'Art de Poche",
+
     coverArtBackgroundSub: "Afficher la pochette floutée comme fond dans les en-têtes d'albums et de playlists",
+
     playlistCoverPhoto: 'Photo de Couverture de Playlist',
+
     playlistCoverPhotoSub: 'Afficher la grille de photos de couverture dans la vue détaillée des playlists',
+
     showBitrate: 'Afficher le Débit',
+
     showBitrateSub: 'Afficher le débit audio dans les listes de pistes',
+
     uiScaleTitle: "Mise à l'échelle de l'interface",
+
     uiScaleLabel: 'Zoom',
+
   },
+
   changelog: {
+
     modalTitle: 'Quoi de neuf',
+
     dontShowAgain: 'Ne plus afficher',
+
     close: 'Compris',
+
   },
+
   help: {
+
     title: 'Aide',
+
     s1: 'Démarrage',
+
     q1: 'Quels serveurs sont compatibles ?',
+
     a1: 'Psysonic fonctionne avec tout serveur compatible Subsonic : Navidrome, Gonic, Subsonic, Airsonic, et autres. Navidrome est recommandé.',
+
     q2: 'Comment me connecter à mon serveur ?',
+
     a2: 'Ouvrez les Paramètres et cliquez sur « Ajouter un serveur ». Saisissez l\'URL du serveur (ex. 192.168.1.100:4533), votre nom d\'utilisateur et mot de passe. Psysonic teste la connexion avant d\'enregistrer.',
+
     q3: 'Puis-je utiliser plusieurs serveurs ?',
+
     a3: 'Oui. Vous pouvez ajouter autant de serveurs que vous le souhaitez dans les Paramètres et basculer entre eux à tout moment. Un seul serveur est actif à la fois.',
+
     s2: 'Lecture',
+
     q4: 'Comment lire de la musique ?',
+
     a4: 'Double-cliquez sur une piste pour la lire. Sur les pages d\'album et d\'artiste, utilisez « Tout lire » pour démarrer l\'album entier. Vous pouvez aussi glisser des pistes dans la file d\'attente.',
+
     q5: 'Quels raccourcis clavier sont disponibles ?',
+
     a5: 'Espace = Lecture / Pause · Échap = Fermer le lecteur plein écran. Les touches multimédia fonctionnent sur toutes les plateformes. Sur Linux, utilisez les boutons de la barre du lecteur. Les raccourcis in-app et les raccourcis système peuvent être personnalisés dans Paramètres → Raccourcis / Raccourcis globaux.',
+
     q6: 'Qu\'est-ce que la file d\'attente ?',
+
     a6: 'La file d\'attente affiche toutes les pistes à venir. Ouvrez-la avec l\'icône de panneau en haut à droite. Vous pouvez réorganiser les pistes par glisser-déposer, les mélanger et enregistrer la file comme liste de lecture.',
+
     q7: 'Comment ouvrir le lecteur plein écran ?',
+
     a7: 'Cliquez sur la pochette dans la barre du lecteur en bas, ou sur l\'icône d\'agrandissement à côté. Appuyez sur Échap pour fermer.',
+
     q8: 'Comment fonctionne la répétition ?',
+
     a8: 'Cliquez sur le bouton répéter pour alterner : Désactivé → Répéter tout → Répéter un.',
+
     s3: 'Bibliothèque',
+
     q9: 'Comment télécharger un album ?',
+
     a9: 'Ouvrez la page de détail d\'un album et cliquez sur « Télécharger (ZIP) ». Le serveur compresse d\'abord l\'album en ZIP — pour les grands albums ou les fichiers sans perte (FLAC / WAV), cela peut prendre un moment avant que le téléchargement ne démarre réellement. La barre de progression n\'apparaît qu\'une fois la compression terminée.',
+
     q10: 'Comment mettre des pistes et albums en favoris ?',
+
     a10: 'Cliquez sur l\'icône étoile sur une piste ou dans l\'en-tête de l\'album. Les éléments favoris apparaissent dans la section Favoris de la barre latérale.',
+
     q11: 'Qu\'est-ce que le carousel hero sur la page d\'accueil ?',
+
     a11: 'La bannière en haut de la page d\'accueil sélectionne aléatoirement des albums de votre bibliothèque et les fait défiler toutes les 10 secondes. Cliquez sur les points pour accéder à un album spécifique.',
+
     s4: 'Paramètres',
+
     q12: 'Comment changer le thème ?',
+
     a12: 'Paramètres → Thème. Un grand choix de thèmes en 8 groupes : Psysonic Themes, Mediaplayer, Systèmes d\'exploitation, Jeux, Films, Séries, Réseaux sociaux et Open Source Classics (Catppuccin, Nord, Gruvbox, Nightfox).',
+
     q13: 'Comment changer la langue ?',
+
     a13: 'Paramètres → Langue. L\'anglais, l\'allemand, le français, le néerlandais et le chinois sont pris en charge.',
+
     q15: 'Comment définir un dossier de téléchargement ?',
+
     a15: 'Paramètres → Comportement → Dossier de téléchargement. Les albums téléchargés y sont enregistrés en ZIP.',
+
     s5: 'Scrobbling',
+
     q16: 'Comment fonctionne le scrobbling ?',
+
     a16: 'Psysonic envoie les scrobbles directement à Last.fm — aucune configuration Navidrome nécessaire. Connectez votre compte dans Paramètres → Last.fm et activez le scrobbling.',
+
     q17: 'Quand un scrobble est-il envoyé ?',
+
     a17: 'Un scrobble est soumis après avoir écouté 50% d\'une piste.',
+
     q22: 'Qu\'est-ce que la forme d\'onde dans la barre du lecteur ?',
+
     a22: 'La barre de forme d\'onde remplace le curseur de progression classique. Cliquez n\'importe où pour sauter à cette position, ou faites glisser pour naviguer.',
+
     q24: 'Puis-je mélanger la file d\'attente ?',
+
     a24: 'Oui. Ouvrez le panneau de file et cliquez sur l\'icône de mélange. La piste en cours reste en position 1 — les autres sont réorganisées aléatoirement.',
+
     q25: 'Les liens Last.fm et Wikipédia s\'ouvrent-ils dans un navigateur ?',
+
     a25: 'Oui — ils s\'ouvrent dans votre navigateur système par défaut. Le bouton affiche brièvement une confirmation au clic.',
+
     s7: 'Mix aléatoire',
+
     q26: 'Qu\'est-ce que le Mix aléatoire ?',
+
     a26: 'Le Mix aléatoire crée une liste de morceaux aléatoires depuis toute votre bibliothèque. Ouvrez-le via « Mix aléatoire » dans la barre latérale et cliquez sur « Nouveau mix ».',
+
     q27: 'Qu\'est-ce que le Filtre par mot-clé ?',
+
     a27: 'Le Filtre par mot-clé exclut les pistes dont le genre, le titre ou l\'album contient des mots spécifiques. Les livres audio sont filtrés automatiquement. Ajoutez des mots-clés dans Paramètres → Mix aléatoire.',
+
     q28: 'Qu\'est-ce que le Mix par super-genre ?',
+
     a28: 'Le Mix par super-genre regroupe votre bibliothèque en grandes catégories (Rock, Métal, Électronique, Jazz, Classique, etc.) et crée un mix ciblé. Sélectionnez une catégorie dans les puces sous la liste.',
+
     s6: 'Dépannage',
+
     q18: 'Les pochettes et images d\'artistes chargent lentement.',
+
     a18: 'Les images sont récupérées depuis le disque de votre serveur au premier chargement, puis mises en cache localement pendant 30 jours. Les visites suivantes seront instantanées.',
+
     q19: 'Le test de connexion échoue.',
+
     a19: 'Vérifiez l\'URL avec le port (ex. http://192.168.1.100:4533). Assurez-vous qu\'aucun pare-feu ne bloque la connexion. Essayez http:// au lieu de https:// sur un réseau local.',
+
     q20: 'Pas d\'audio sur Linux.',
+
     a20: 'Psysonic est disponible en .deb (Ubuntu/Debian), .rpm (Fedora/RHEL) et via AUR sur Arch/CachyOS (yay -S psysonic). Il n\'y a pas d\'AppImage. Si l\'audio ne fonctionne pas, vérifiez que PipeWire ou PulseAudio est actif.',
+
     q21: 'L\'application affiche un écran noir sur Linux.',
+
     a21: 'Cela est généralement dû à des problèmes de pilote GPU/EGL dans WebKitGTK. Lancez avec GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. Les paquets AUR et installateurs .deb/.rpm officiels le configurent automatiquement.',
+
     q29: 'Que sont le fondu enchaîné et la lecture sans blanc ?',
+
     a29: 'Ce sont des fonctionnalités audio expérimentales dans Paramètres → Audio. La lecture sans blanc pré-charge la piste suivante pour éliminer les silences. Le fondu enchaîné effectue un fondu sortant de la piste en cours tout en faisant un fondu entrant de la suivante — durée réglable (1–10 s).',
+
     q30: 'Psysonic affiche-t-il les paroles ?',
+
     a30: 'Oui. Cliquez sur l\'icône microphone dans la barre du lecteur pour ouvrir l\'onglet Paroles. Psysonic récupère automatiquement les paroles depuis LRCLIB. Si des paroles synchronisées sont disponibles, la ligne active est mise en évidence et défile en temps réel. Sinon, le texte complet est affiché statiquement.',
+
     q31: 'Puis-je personnaliser les raccourcis clavier ?',
+
     a31: 'Oui. Paramètres → Raccourcis clavier permet de réattribuer les actions in-app (Lecture/Pause, Suivant, Précédent, Volume, Plein écran, etc.). Paramètres → Raccourcis globaux permet d\'assigner des raccourcis système actifs même quand l\'application est en arrière-plan.',
+
     q32: 'Puis-je changer la police ?',
+
     a32: 'Oui. Paramètres → Police propose 10 polices dont IBM Plex Mono, Fira Code, JetBrains Mono et Courier Prime. La police choisie s\'applique à toute l\'interface.',
+
     s8: 'Mode hors ligne',
+
     q34: 'Qu\'est-ce que le mode hors ligne ?',
+
     a34: 'Le mode hors ligne (Bêta) permet de mettre des albums en cache sur l\'appareil afin d\'écouter de la musique sans connexion serveur active. Les pistes mises en cache sont stockées localement et lues directement depuis le disque — sans requête réseau.',
+
     q35: 'Comment mettre un album en cache pour une utilisation hors ligne ?',
+
     a35: 'Ouvrez un album et cliquez sur l\'icône de téléchargement dans l\'en-tête de l\'album. Psysonic télécharge toutes les pistes en arrière-plan. La progression est affichée sur le bouton. Une fois en cache, l\'icône devient verte. Les albums mis en cache peuvent être consultés et supprimés dans la page Bibliothèque hors ligne (barre latérale).',
+
     q36: 'Quelle quantité de stockage le cache hors ligne peut-il utiliser ?',
+
     a36: 'Vous pouvez définir une taille de cache maximale dans Paramètres → Bibliothèque. Lorsque la limite est atteinte, une bannière d\'avertissement s\'affiche sur la page de l\'album. Vous pouvez supprimer des albums individuels dans la Bibliothèque hors ligne pour libérer de l\'espace.',
+
     q37: 'Comment noter des morceaux, albums et artistes ?',
+
     a37: 'Psysonic prend en charge les notes de 1 à 5 étoiles via l\'API OpenSubsonic (Navidrome ≥ 0.53 requis). Notez les morceaux dans la liste de pistes d\'un album ou d\'une playlist, via le menu contextuel ou directement dans la barre du lecteur. Les albums sont notés sur leur page de détail, les artistes sur leur page.',
+
     q38: 'Puis-je supprimer ou modifier une note ?',
+
     a38: 'Oui. Cliquer à nouveau sur l\'étoile active supprime entièrement la note — un second clic sur la même étoile l\'efface. Pour modifier une note, cliquez simplement sur une étoile différente.',
+
     q39: 'Qu\'est-ce que Skip-to-1★ et le filtre de notes ?',
+
     a39: 'Skip-to-1★ attribue automatiquement une note d\'une étoile à un morceau après un certain nombre de sauts consécutifs. Activez-le dans Paramètres → Notes. Vous pouvez également y définir une note minimale pour les mix aléatoires.',
+
     q40: 'Qu\'est-ce que le Navigateur de dossiers ?',
+
     a40: 'Le Navigateur de dossiers (barre latérale) permet de parcourir l\'arborescence musicale du serveur en colonnes Miller. Cliquez sur un dossier pour l\'explorer ; utilisez l\'icône lecture pour jouer ou ajouter son contenu à la file.',
+
     q41: 'Qu\'est-ce que le planificateur de thème ?',
+
     a41: 'Paramètres → Apparence → Changer de thème automatiquement : définissez un thème de jour et un thème de nuit avec des heures de début. Psysonic bascule automatiquement à l\'heure configurée.',
+
     q42: 'Puis-je redimensionner l\'interface ?',
+
     a42: 'Oui. Paramètres → Apparence → Échelle de l\'interface permet de régler l\'interface entre 80 % et 125 %.',
+
     q43: 'Puis-je changer le style de la barre de progression ?',
+
     a43: 'Oui. Paramètres → Apparence → Style de la barre de progression offre 10 styles : Waveform, Ligne & Point, Barre, Barre épaisse, Segmenté, Neon Glow, Pulse Wave, Particle Trail, Liquid Fill et Retro Tape.',
+
     q44: 'Qu\'est-ce qu\'AutoEQ ?',
+
     a44: 'L\'égaliseur 10 bandes dans Paramètres → Audio comprend une recherche AutoEQ. Saisissez le modèle de votre casque pour charger automatiquement le profil de correction.',
+
     q45: 'Qu\'est-ce que le Replay Gain ?',
+
     a45: 'Le Replay Gain normalise le volume afin que les albums forts et doux soient lus à un niveau cohérent. Activez-le dans Paramètres → Audio → Replay Gain ; mode Piste ou Album.',
+
     q46: 'Qu\'est-ce que le Hot Cache ?',
+
     a46: 'Le Hot Cache (Alpha, Paramètres → Bibliothèque) précharge les prochains morceaux de la file sur le disque pour une lecture instantanée. Psysonic conserve le morceau actuel et les 5 suivants et évince les anciens quand la limite est atteinte.',
+
     q47: 'Puis-je mettre en cache une playlist hors ligne ?',
+
     a47: 'Oui. Dans les détails d\'une playlist, cliquez sur l\'icône de téléchargement. Une fois entièrement mis en cache, l\'icône se transforme en corbeille rouge ; cliquer dessus supprime la playlist du cache hors ligne.',
-    q48: 'Qu\'est-ce que la file infinie ?',
-    a48: 'Lorsque la file se vide et que la répétition est désactivée, Psysonic ajoute silencieusement des pistes aléatoires pour que la lecture ne s\'arrête jamais. Les pistes ajoutées automatiquement apparaissent sous le séparateur « — Ajouté automatiquement — ». Activez/désactivez via l\'icône infini dans l\'en-tête de la file.',
-    q49: 'Puis-je contrôler Psysonic en ligne de commande ?',
-    a49: 'Oui. Exemples : psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one, --player star / unstar, --player rating 1-5. Aussi : changer de serveur, d\'appareil audio, filtrer la bibliothèque, lancer un mix instantané et rechercher. Aide complète : psysonic --player --help.',
-    q50: 'Comment gérer les playlists ?',
-    a50: 'Via « Playlists » dans la barre latérale. Créez une playlist avec « Nouvelle playlist ». Dans la vue détaillée, réorganisez les pistes par glisser-déposer, supprimez-les avec le bouton ×, ajoutez des chansons via la recherche et consultez les « Suggestions » pour des recommandations intelligentes.',
-    q51: 'Puis-je sauvegarder et restaurer mes paramètres ?',
-    a51: 'Oui. Paramètres → Sauvegarde & Restauration permet d\'exporter tous les paramètres, profils de serveur, thèmes et raccourcis clavier dans un fichier JSON. Importez-le sur une autre machine pour tout restaurer d\'un coup. Les mots de passe sont inclus — conservez le fichier en lieu sûr.',
-    q52: 'Comment changer le périphérique de sortie audio ?',
-    a52: 'Paramètres → Audio → Périphérique de sortie. Psysonic liste tous les périphériques disponibles. La sélection prend effet immédiatement. Utilisez le bouton d\'actualisation si un périphérique a été branché après le démarrage de l\'application.',
-    q53: 'Qu\'est-ce que Device Sync ?',
-    a53: 'Device Sync copie des albums, playlists ou artistes sur une clé USB ou une carte SD. Ouvrez-le via « Device Sync » dans la barre latérale, choisissez un dossier cible, sélectionnez vos sources et cliquez sur « Transférer vers l\'appareil ».',
-    q54: 'Qu\'est-ce que le modèle de nom de fichier dans Device Sync ?',
-    a54: 'Le modèle contrôle comment les pistes sont nommées et organisées. Utilisez les préréglages ou créez le vôtre avec les jetons cliquables : {artist}, {album}, {title}, {track_number}, {disc_number}, {year} et / comme séparateur de dossier. Un aperçu en direct est affiché.',
-    q55: 'Device Sync fonctionne-t-il entre plateformes ?',
-    a55: 'Oui. Le manifeste écrit sur l\'appareil contient le modèle utilisé lors de la synchronisation. Sur un autre OS avec un modèle différent, Psysonic détecte correctement les fichiers existants.',
-    s9: 'Device Sync',
-    q56: 'Qu\'est-ce que la radio Internet ?',
-    a56: 'La page Radio Internet permet de lire n\'importe quel flux en direct dans Psysonic. Les stations proviennent de votre serveur Navidrome — ajoutez-les via le panneau d\'administration ou importez un fichier .pls/.m3u. La lecture utilise l\'audio HTML5.',
-    q57: 'Quels formats de flux la radio Internet supporte-t-elle ?',
-    a57: 'MP3, AAC, OGG Vorbis et la plupart des flux HLS. La prise en charge des codecs dépend de la plateforme — MP3 et AAC fonctionnent partout.',
-    s10: 'Radio Internet',
-    q58: 'D\'où Psysonic récupère-t-il les paroles ?',
-    a58: 'Trois sources configurables dans Paramètres → Paroles : votre serveur Navidrome (paroles intégrées/OpenSubsonic), LRCLIB (paroles synchronisées communautaires) et NetEase Cloud Music. Chaque source peut être activée/désactivée et priorisée par glisser-déposer.',
-    q59: 'Y a-t-il une vue de ce qu\'écoutent les autres utilisateurs ?',
-    a59: 'Oui. Cliquez sur l\'icône de diffusion en haut à droite pour voir ce que les autres utilisateurs écoutent actuellement sur votre serveur Navidrome, mis à jour toutes les 10 secondes.',
+
   },
+
   queue: {
+
     title: 'File d\'attente',
+
     savePlaylist: 'Enregistrer la liste',
+
     updatePlaylist: 'Mettre à jour la liste',
+
     filterPlaylists: 'Filtrer les listes…',
+
     playlistName: 'Nom de la liste',
+
     cancel: 'Annuler',
+
     save: 'Enregistrer',
+
     loadPlaylist: 'Charger une liste',
+
     loading: 'Chargement…',
+
     noPlaylists: 'Aucune liste trouvée.',
+
     load: 'Remplacer la file et lire',
+
     appendToQueue: 'Ajouter à la file',
+
     delete: 'Supprimer',
+
     deleteConfirm: 'Supprimer la liste « {{name}} » ?',
+
     clear: 'Vider',
+
     shuffle: 'Mélanger la file',
+
     gapless: 'Sans blanc',
+
     crossfade: 'Fondu',
+
     infiniteQueue: 'File infinie',
+
     autoAdded: '— Ajouté automatiquement —',
+
     radioAdded: '— Radio —',
+
     hide: 'Masquer',
+
     close: 'Fermer',
+
     nextTracks: 'Pistes suivantes',
+
     emptyQueue: 'La file d\'attente est vide.',
+
     trackSingular: 'piste',
+
     trackPlural: 'pistes',
+
     showRemaining: 'Afficher le temps restant',
+
     showTotal: 'Afficher la durée totale',
+
   },
+
   statistics: {
+
     title: 'Statistiques',
+
     recentlyPlayed: 'Écoutés récemment',
+
     mostPlayed: 'Albums les plus écoutés',
+
     highestRated: 'Albums les mieux notés',
+
     genreDistribution: 'Répartition par genre (Top 20)',
+
     loadMore: 'Charger plus',
+
     statArtists: 'Artistes',
+
     statArtistsTooltip: 'Artistes d\'album uniquement — les artistes apparaissant seulement sur des pistes (featuring, invité, etc.) sans album propre ne sont pas comptés.',
+
     statAlbums: 'Albums',
+
     statSongs: 'Morceaux',
+
     statGenres: 'Genres',
+
     statPlaytime: 'Durée totale',
+
     genreInsights: 'Aperçu des genres',
+
     formatDistribution: 'Distribution des formats',
+
     formatSample: 'Échantillon de {{n}} pistes',
+
     computing: 'Calcul en cours…',
+
     genreSongs: '{{count}} morceaux',
+
     genreAlbums: '{{count}} albums',
+
     recentlyAdded: 'Ajoutés récemment',
+
     decadeDistribution: 'Albums par décennie',
+
     decadeAlbums_one: '{{count}} album',
+
     decadeAlbums_other: '{{count}} albums',
+
     decadeUnknown: 'Inconnu',
+
     lfmTitle: 'Stats Last.fm',
+
     lfmTopArtists: 'Artistes favoris',
+
     lfmTopAlbums: 'Albums favoris',
+
     lfmTopTracks: 'Morceaux favoris',
+
     lfmPlays: '{{count}} écoutes',
+
     lfmPeriodOverall: 'Tout le temps',
+
     lfmPeriod7day: '7 jours',
+
     lfmPeriod1month: '1 mois',
+
     lfmPeriod3month: '3 mois',
+
     lfmPeriod6month: '6 mois',
+
     lfmPeriod12month: '12 mois',
+
     lfmNotConnected: 'Connectez Last.fm dans les Paramètres pour voir vos stats.',
+
     lfmRecentTracks: 'Scrobbles récents',
+
     lfmNowPlaying: 'En cours de lecture',
+
     lfmJustNow: 'à l\'instant',
+
     lfmMinutesAgo: 'il y a {{n}} min',
+
     lfmHoursAgo: 'il y a {{n}}h',
+
     lfmDaysAgo: 'il y a {{n}}j',
+
     topRatedSongs: 'Morceaux les mieux notés',
+
     topRatedArtists: 'Artistes les mieux notés',
+
     noRatedSongs: 'Aucun morceau noté. Notez des morceaux dans la vue album ou playlist.',
+
     noRatedArtists: 'Aucun artiste noté.',
+
   },
+
   player: {
+
     regionLabel: 'Lecteur de musique',
+
     openFullscreen: 'Ouvrir le lecteur plein écran',
+
     fullscreen: 'Lecteur plein écran',
+
     closeFullscreen: 'Fermer le plein écran',
+
     closeTooltip: 'Fermer (Échap)',
+
     noTitle: 'Sans titre',
+
     stop: 'Arrêter',
+
     prev: 'Piste précédente',
+
     play: 'Lecture',
+
     pause: 'Pause',
+
     next: 'Piste suivante',
+
     repeat: 'Répéter',
+
     repeatOff: 'Désactivé',
+
     repeatAll: 'Tout',
+
     repeatOne: 'Un',
+
     progress: 'Progression',
+
     volume: 'Volume',
+
     toggleQueue: 'Afficher/masquer la file',
+
     lyrics: 'Paroles',
+
     fsLyricsToggle: 'Paroles en plein écran',
+
     lyricsLoading: 'Chargement des paroles…',
+
     lyricsNotFound: 'Aucune parole trouvée pour ce titre',
+
     lyricsSourceServer: 'Source : Serveur',
+
     lyricsSourceLrclib: 'Source : LRCLIB',
+
     lyricsSourceNetease: 'Source : Netease',
+
   },
+
   songInfo: {
+
     title: 'Infos du morceau',
+
     songTitle: 'Titre',
+
     artist: 'Artiste',
+
     album: 'Album',
+
     albumArtist: 'Artiste de l\'album',
+
     year: 'Année',
+
     genre: 'Genre',
+
     duration: 'Durée',
+
     track: 'Piste',
+
     format: 'Format',
+
     bitrate: 'Débit',
+
     sampleRate: 'Fréquence d\'échantillonnage',
+
     bitDepth: 'Profondeur de bits',
+
     channels: 'Canaux',
+
     fileSize: 'Taille du fichier',
+
     path: 'Emplacement',
+
     replayGainTrack: 'RG Gain de piste',
+
     replayGainAlbum: 'RG Gain d\'album',
+
     replayGainPeak: 'RG Crête de piste',
+
     mono: 'Mono',
+
     stereo: 'Stéréo',
+
   },
+
   playlists: {
+
     title: 'Playlists',
+
     newPlaylist: 'Nouvelle playlist',
+
     unnamed: 'Playlist sans nom',
+
     createName: 'Nom de la playlist…',
+
     create: 'Créer',
+
     cancel: 'Annuler',
+
     empty: 'Aucune playlist pour l\'instant.',
+
     emptyPlaylist: 'Cette playlist est vide.',
+
     addFirstSong: 'Ajouter votre premier titre',
+
     notFound: 'Playlist introuvable.',
+
     songs: '{{n}} titres',
+
     playAll: 'Tout lire',
+
     shuffle: 'Aléatoire',
+
     addToQueue: 'Ajouter à la file',
+
     back: 'Retour aux playlists',
+
     deletePlaylist: 'Supprimer',
+
     confirmDelete: 'Cliquer à nouveau pour confirmer',
+
     removeSong: 'Retirer de la playlist',
+
     addSongs: 'Ajouter des titres',
+
     searchPlaceholder: 'Rechercher dans la bibliothèque…',
+
     noResults: 'Aucun résultat.',
+
     suggestions: 'Titres suggérés',
+
     noSuggestions: 'Aucune suggestion disponible.',
+
     titleBadge: 'Playlist',
+
     refreshSuggestions: 'Nouvelles suggestions',
+
     addSong: 'Ajouter à la playlist',
+
     addSelected: 'Ajouter la sélection',
+
     cacheOffline: 'Mettre la playlist hors ligne',
+
     offlineCached: 'Playlist en cache',
+
     removeOffline: 'Retirer du cache hors ligne',
+
     offlineDownloading: 'En cache… ({{done}}/{{total}} albums)',
+
     publicLabel: 'Publique',
+
     privateLabel: 'Privée',
+
     editMeta: 'Modifier la playlist',
+
     editNamePlaceholder: 'Nom de la playlist…',
+
     editCommentPlaceholder: 'Ajouter une description…',
+
     editPublic: 'Playlist publique',
+
     editSave: 'Enregistrer',
+
     editCancel: 'Annuler',
+
     changeCover: 'Changer la pochette',
+
     changeCoverLabel: 'Changer la photo',
+
     removeCover: 'Supprimer la photo',
+
     coverUpdated: 'Pochette mise à jour',
+
     metaSaved: 'Playlist mise à jour',
+
     downloadZip: 'Télécharger (ZIP)',
+
     // Toast notifications for multi-select
+
     addSuccess: '{{count}} morceaux ajoutés à {{playlist}}',
+
     addPartial: '{{added}} ajoutés, {{skipped}} ignorés (doublons)',
+
     addAllSkipped: 'Tous ignorés ({{count}} doublons)',
+
     addError: 'Erreur lors de l\'ajout des morceaux',
+
     createAndAddSuccess: 'Playlist "{{playlist}}" créée avec {{count}} morceaux',
+
     createError: 'Erreur lors de la création de la playlist',
+
     deleteSuccess: '{{count}} playlists supprimées',
+
     deleteFailed: 'Erreur lors de la suppression de {{name}}',
+
     deleteSelected: 'Supprimer la sélection',
+
     mergeSuccess: '{{count}} morceaux fusionnés dans {{playlist}}',
+
     mergeNoNewSongs: 'Aucun nouveau morceau à ajouter',
+
     mergeError: 'Erreur lors de la fusion des playlists',
+
     mergeInto: 'Fusionner dans',
+
     selectionCount: '{{count}} sélectionnés',
+
     select: 'Sélectionner',
+
     startSelect: 'Activer la sélection',
+
     cancelSelect: 'Annuler',
+
     loadingAlbums: 'Résolution de {{count}} albums…',
+
     loadingArtists: 'Résolution de {{count}} artistes…',
+
     myPlaylists: 'Mes Playlists',
+
     noOtherPlaylists: 'Aucune autre playlist disponible',
+
     addToPlaylistSuccess: '{{count}} morceaux ajoutés à {{playlist}}',
+
     addToPlaylistNoNew: 'Aucun nouveau morceau pour {{playlist}}',
+
     addToPlaylistError: 'Erreur lors de l\'ajout à la playlist',
+
     removeSuccess: 'Morceau retiré de la playlist',
+
     removeError: 'Erreur lors du retrait de la playlist',
+
     importCSV: 'Importer CSV',
+
     importCSVTooltip: 'Importer depuis CSV Spotify',
+
     csvImportReport: 'Rapport d\'Import CSV',
+
     csvImportTotal: 'Total',
+
     csvImportAdded: 'Ajoutés',
+
     csvImportDuplicates: 'Doublons',
+
     csvImportNotFound: 'Non Trouvés',
+
     csvImportNetworkErrors: 'Erreurs Réseau',
+
     csvImportDuplicatesTitle: 'Titres en Doublon (Déjà dans la Playlist):',
+
     csvImportNotFoundTitle: 'Titres Non Trouvés:',
+
     csvImportNetworkErrorsTitle: 'Erreurs Réseau (peut réessayer l\'import):',
+
     csvImportDownloadReport: 'Télécharger le Rapport',
+
     csvImportClose: 'Fermer',
+
     csvImportNoValidTracks: 'Aucun titre valide trouvé dans le fichier CSV',
+
     csvImportFailed: 'Échec de l\'import CSV',
+
     csvImportToast: '{{added}} ajoutés, {{notFound}} non trouvés, {{duplicates}} doublons',
+
   },
+
   mostPlayed: {
+
     title: 'Les plus joués',
+
     topArtists: 'Artistes populaires',
+
     topAlbums: 'Albums populaires',
+
     plays: '{{n}} écoutes',
+
     sortMost: 'Plus joués en premier',
+
     sortLeast: 'Moins joués en premier',
+
     loadMore: 'Charger plus d\'albums',
+
     noData: 'Aucune donnée d\'écoute. Commencez à écouter !',
+
     noArtists: 'Tous les artistes filtrés.',
+
     filterCompilations: 'Masquer les artistes de compilations (Various Artists, Soundtracks, etc.)',
+
     filterCompilationsShort: 'Masquer les compilations',
+
   },
+
   radio: {
+
     title: 'Radio Internet',
+
     empty: 'Aucune station radio configurée.',
+
     addStation: 'Ajouter une station',
+
     editStation: 'Modifier',
+
     deleteStation: 'Supprimer la station',
+
     confirmDelete: 'Cliquer à nouveau pour confirmer',
+
     stationName: 'Nom de la station…',
+
     streamUrl: 'URL du flux…',
+
     homepageUrl: 'URL de la page d\'accueil (optionnel)',
+
     save: 'Enregistrer',
+
     cancel: 'Annuler',
+
     live: 'LIVE',
+
     liveStream: 'Radio Internet',
+
     openHomepage: 'Ouvrir la page d\'accueil',
+
     changeCoverLabel: 'Changer la pochette',
+
     removeCover: 'Supprimer la pochette',
+
     browseDirectory: 'Parcourir l\'annuaire',
+
     directoryPlaceholder: 'Rechercher des stations…',
+
     noResults: 'Aucune station trouvée.',
+
     stationAdded: 'Station ajoutée',
+
     filterAll: 'Toutes',
+
     filterFavorites: 'Favoris',
+
     sortManual: 'Manuel',
+
     sortAZ: 'A → Z',
+
     sortZA: 'Z → A',
+
     sortNewest: 'Plus récentes',
+
     favorite: 'Ajouter aux favoris',
+
     unfavorite: 'Retirer des favoris',
+
     noFavorites: 'Aucune station favorite.',
+
     listenerCount_one: '{{count}} auditeur',
+
     listenerCount_other: '{{count}} auditeurs',
+
     recentlyPlayed: 'Récemment joués',
+
     upNext: 'À suivre',
+
   },
+
   folderBrowser: {
+
     empty: 'Dossier vide',
+
     error: 'Échec du chargement',
+
   },
+
   deviceSync: {
+
     title: 'Sync appareil',
+
     targetFolder: 'Dossier cible',
+
     noFolderChosen: 'Aucun dossier sélectionné',
+
     selectDrive: 'Sélectionner un lecteur…',
+
     refreshDrives: 'Actualiser les lecteurs',
+
     noDrivesDetected: 'Aucun lecteur amovible détecté',
+
     browseManual: 'Parcourir manuellement…',
+
     free: 'libre',
+
     notMountedVolume: 'La cible n\u0027est pas sur un volume monté. Le lecteur a peut-être été déconnecté.',
+
     chooseFolder: 'Choisir…',
+
     filenameTemplate: 'Modèle de nom de fichier',
+
     targetDevice: 'Appareil cible',
+
     templateHint: 'Variables : {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
+
     cleanupButton: 'Supprimer les fichiers absents',
+
     cleanupNothingToDelete: 'Rien à supprimer — l\'appareil est déjà synchronisé.',
+
     confirmCleanup: 'Supprimer {{count}} fichier(s) de l\'appareil qui ne font pas partie de la sélection actuelle. Continuer ?',
+
     cleanupComplete: '{{count}} fichier(s) supprimé(s) de l\'appareil.',
+
     selectedSources: 'Sources sélectionnées',
+
     noSourcesSelected: 'Aucune source sélectionnée. Cliquez sur des éléments dans le navigateur pour les ajouter.',
+
     clearAll: 'Tout effacer',
+
     tabPlaylists: 'Listes de lecture',
+
     tabAlbums: 'Albums',
+
     tabArtists: 'Artistes',
+
     searchPlaceholder: 'Rechercher…',
+
     syncButton: 'Synchroniser vers l\'appareil',
+
     actionTransfer: 'Transférer vers l\'appareil',
+
     actionDelete: 'Supprimer de l\'appareil',
+
     actionApplyAll: 'Appliquer toutes les modifications',
+
     templatePreview: 'Aperçu',
-    templatePresetStandard: 'Standard',
-    templatePresetMultiDisc: 'Multi-Disc',
-    templatePresetAltFolder: 'Dossier alt.',
-    tokenSlashHint: '/ = séparateur de dossier',
+
     cancel: 'Annuler',
+
     noTargetDir: 'Veuillez d\'abord choisir un dossier cible.',
+
     noSources: 'Veuillez sélectionner au moins une source.',
+
     noTracks: 'Aucune piste trouvée dans les sources sélectionnées.',
+
     fetchError: 'Échec du chargement des pistes depuis le serveur.',
+
     syncComplete: 'Synchronisation terminée.',
+
     dismiss: 'Fermer',
-    cancelSync: 'Annuler',
-    syncCancelled: 'Synchronisation annulée ({{done}} / {{total}} transférés).',
+
     colName: 'Nom',
+
     colType: 'Type',
+
     colStatus: 'Statut',
+
     onDevice: 'Gestionnaire d\'appareil',
+
     addSources: 'Ajouter…',
+
     syncResult: '{{done}} transféré(s), {{skipped}} déjà à jour ({{total}} au total)',
+
     deleteFromDevice: 'Marquer pour suppression ({{count}})',
+
     confirmDelete: 'Supprimer {{count}} élément(s) du périphérique : {{names}} ?',
+
     deleteComplete: '{{count}} élément(s) supprimé(s) du périphérique.',
-    manifestImported: '{{count}} source(s) importée(s) depuis le manifeste du périphérique.',
+
     statusSynced: 'Synchronisé',
+
     statusPending: 'En attente',
+
     statusDeletion: 'Suppression',
+
     markForDeletion: 'Marquer pour suppression',
+
     removeSource: 'Supprimer',
+
     undoDeletion: 'Annuler la suppression',
+
     syncInBackground: 'Sync démarré en arrière-plan — vous pouvez naviguer ailleurs.',
+
     syncInProgress: '{{done}} / {{total}} pistes…',
+
     syncSummary: 'Résumé de la synchronisation',
+
     calculating: 'Calcul de la charge utile…',
+
     filesToAdd: 'Fichiers à ajouter :',
+
     filesToDelete: 'Fichiers à supprimer :',
+
     netChange: 'Variation nette :',
+
     availableSpace: 'Espace disque disponible :',
+
     spaceWarning: 'Attention : L\'appareil cible ne dispose pas d\'assez d\'espace signalé.',
+
     proceed: 'Procéder à la synchronisation',
+
     notEnoughSpace: 'Espace disque physique insuffisant détecté !',
+
     liveSearch: 'Live',
+
     randomAlbumsLabel: 'Albums aléatoires',
+
   },
+
 };
+

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -538,7 +538,7 @@ export const frTranslation = {
     discordAppleCovers: 'Récupérer les pochettes via Apple Music pour Discord',
     discordAppleCoversDesc: 'Envoie le nom de l\'artiste et de l\'album à l\'API Apple pour trouver une pochette pour votre profil Discord. Désactivé par défaut pour des raisons de confidentialité.',
     discordTemplates: 'Modèles de texte personnalisés',
-    discordTemplatesDesc: 'Personnalisez les informations affichées sur votre profil Discord. Variables : {title}, {artist}, {album}, {paused}',
+    discordTemplatesDesc: 'Personnalisez les informations affichées sur votre profil Discord. Variables : {title}, {artist}, {album}',
     discordTemplateDetails: 'Ligne principale (details)',
     discordTemplateState: 'Ligne secondaire (state)',
     discordTemplateLargeText: 'Info-bulle album (largeText)',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -1,2266 +1,1169 @@
 export const frTranslation = {
-
   sidebar: {
-
     library: 'Bibliothèque',
-
     mainstage: 'Scène principale',
-
     newReleases: 'Nouveautés',
-
     allAlbums: 'Tous les albums',
-
     randomAlbums: 'Albums aléatoires',
-
     randomPicker: 'Créer un mix',
-
     artists: 'Artistes',
-
     randomMix: 'Mix aléatoire',
-
     favorites: 'Favoris',
-
     nowPlaying: 'En cours',
-
     system: 'Système',
-
     statistics: 'Statistiques',
-
     settings: 'Paramètres',
-
     help: 'Aide',
-
     expand: 'Développer la barre latérale',
-
     collapse: 'Réduire la barre latérale',
-
     downloadingTracks: '{{n}} pistes en cache…',
-
     syncingTracks: 'Synchro {{done}}/{{total}}…',
-
     cancelDownload: 'Annuler le téléchargement',
-
     offlineLibrary: 'Bibliothèque hors ligne',
-
     genres: 'Genres',
-
     playlists: 'Playlists',
-
     mostPlayed: 'Les plus joués',
-
     radio: 'Radio Internet',
-
     folderBrowser: 'Explorateur de dossiers',
-
     deviceSync: 'Sync appareil',
-
     libraryScope: 'Portée de la bibliothèque',
-
     allLibraries: 'Toutes les bibliothèques',
-
     expandPlaylists: 'Développer les playlists',
-
     collapsePlaylists: 'Réduire les playlists',
-
   },
-
   home: {
-
     hero: 'En vedette',
-
     starred: 'Favoris personnels',
-
     recent: 'Ajoutés récemment',
-
     mostPlayed: 'Les plus écoutés',
-
     recentlyPlayed: 'Récemment écoutés',
-
     discover: 'Découvrir',
-
     loadMore: 'Charger plus',
-
     discoverMore: 'Découvrir plus',
-
     discoverArtists: 'Découvrir des artistes',
-
     discoverArtistsMore: 'Tous les artistes'
-
   },
-
   hero: {
-
     eyebrow: 'Album en vedette',
-
     playAlbum: 'Lire l\'album',
-
     enqueue: 'Mettre en file',
-
     enqueueTooltip: 'Ajouter l\'album entier à la file d\'attente',
-
   },
-
   search: {
-
     placeholder: 'Rechercher un artiste, album ou morceau…',
-
     noResults: 'Aucun résultat pour « {{query}} »',
-
     artists: 'Artistes',
-
     albums: 'Albums',
-
     songs: 'Morceaux',
-
     clearLabel: 'Effacer la recherche',
-
     title: 'Recherche',
-
     resultsFor: 'Résultats pour « {{query}} »',
-
     album: 'Album',
-
     advanced: 'Recherche avancée',
-
     advancedSearchTerm: 'Terme de recherche',
-
     advancedSearchPlaceholder: 'Titre, album, artiste…',
-
     advancedGenre: 'Genre',
-
     advancedAllGenres: 'Tous les genres',
-
     advancedYear: 'Année',
-
     advancedYearFrom: 'de',
-
     advancedYearTo: 'à',
-
     advancedAll: 'Tous',
-
     advancedSearch: 'Rechercher',
-
     advancedEmpty: 'Entrez un terme de recherche ou sélectionnez un filtre.',
-
     advancedNoResults: 'Aucun résultat trouvé.',
-
     advancedGenreNote: 'Les morceaux sont sélectionnés aléatoirement dans ce genre.',
-
     recentSearches: 'Recherches récentes',
-
     browse: 'Parcourir',
-
     emptyHint: 'Que veux-tu écouter ?',
-
     genres: 'Genres',
-
   },
-
   nowPlaying: {
-
     tooltip: 'Qui écoute ?',
-
     title: 'Qui écoute ?',
-
     loading: 'Chargement…',
-
     nobody: 'Personne n\'écoute en ce moment.',
-
     minutesAgo: 'il y a {{n}} min',
-
     nothingPlaying: 'Rien en cours. Lancez un morceau !',
-
     aboutArtist: "À propos de l'artiste",
-
     fromAlbum: 'De cet album',
-
     viewAlbum: "Voir l'album",
-
     goToArtist: "Aller à l'artiste",
-
     readMore: 'Lire la suite',
-
     showLess: 'Réduire',
-
     genreInfo: 'Genre',
-
     trackInfo: 'Infos piste',
-
   },
-
   contextMenu: {
-
     playNow: 'Lire maintenant',
-
     playNext: 'Lire ensuite',
-
     addToQueue: 'Ajouter à la file',
-
     enqueueAlbum: 'Mettre l\'album en file',
-
     startRadio: 'Démarrer la radio',
-
     instantMix: 'Mix instantané',
-
     instantMixFailed: 'Impossible de créer le mix instantané — erreur serveur ou plugin.',
-
     cliMixNeedsTrack: 'Aucune lecture en cours — lancez d’abord la lecture, puis relancez la commande de mix.',
-
     lfmLove: 'Aimer sur Last.fm',
-
     lfmUnlove: 'Ne plus aimer sur Last.fm',
-
     favorite: 'Favori',
-
     favoriteArtist: 'Artiste favori',
-
     favoriteAlbum: 'Album favori',
-
     unfavorite: 'Retirer des favoris',
-
     unfavoriteArtist: 'Retirer l\'artiste des favoris',
-
     unfavoriteAlbum: 'Retirer l\'album des favoris',
-
     removeFromQueue: 'Retirer de la file',
-
     removeFromPlaylist: 'Retirer de la playlist',
-
     openAlbum: 'Ouvrir l\'album',
-
     goToArtist: 'Aller à l\'artiste',
-
     download: 'Télécharger (ZIP)',
-
     addToPlaylist: 'Ajouter à la playlist',
-
     selectedPlaylists: '{{count}} playlists sélectionnées',
-
     selectedAlbums: '{{count}} albums sélectionnés',
-
     selectedArtists: '{{count}} artistes sélectionnés',
-
     songInfo: 'Infos du morceau',
-
   },
-
   albumDetail: {
-
     back: 'Retour',
-
     playAll: 'Tout lire',
-
     enqueue: 'Mettre en file',
-
     enqueueTooltip: 'Ajouter l\'album entier à la file d\'attente',
-
     artistBio: 'Biographie',
-
     download: 'Télécharger (ZIP)',
-
     downloading: 'Chargement…',
-
     cacheOffline: 'Rendre disponible hors ligne',
-
     offlineCached: 'Disponible hors ligne',
-
     offlineDownloading: 'Mise en cache… ({{n}}/{{total}})',
-
     removeOffline: 'Supprimer le cache hors ligne',
-
     offlineStorageFull: 'Stockage hors ligne plein (limite : {{mb}} Mo). Supprimez un album de votre bibliothèque hors ligne ou augmentez la limite dans les paramètres.',
-
     offlineStorageGoToSettings: 'Paramètres',
-
     offlineStorageGoToLibrary: 'Bibliothèque hors ligne',
-
     favoriteAdd: 'Ajouter aux favoris',
-
     favoriteRemove: 'Retirer des favoris',
-
     favorite: 'Favori',
-
     noBio: 'Aucune biographie disponible.',
-
     moreByArtist: 'Plus de {{artist}}',
-
     tracksCount: '{{n}} pistes',
-
     goToArtist: 'Aller à {{artist}}',
-
     moreLabelAlbums: 'Plus d\'albums sur {{label}}',
-
     trackTitle: 'Titre',
-
     trackAlbum: 'Album',
-
     trackArtist: 'Artiste',
-
     trackGenre: 'Genre',
-
     trackFormat: 'Format',
-
     trackFavorite: 'Favori',
-
     trackRating: 'Note',
-
     trackDuration: 'Durée',
-
     trackTotal: 'Total',
-
     columns: 'Colonnes',
-
+    resetColumns: 'Réinitialiser',
     notFound: 'Album introuvable.',
-
     bioModal: 'Biographie de l\'artiste',
-
     bioClose: 'Fermer',
-
     ratingLabel: 'Note',
-
     enlargeCover: 'Agrandir',
-
     filterSongs: 'Filtrer…',
-
     sortNatural: 'Naturel',
-
     sortByTitle: 'A–Z (Titre)',
-
     sortByArtist: 'A–Z (Artiste)',
-
     sortByAlbum: 'A–Z (Album)',
-
   },
-
   entityRating: {
-
     albumShort: 'Note de l’album',
-
     artistShort: 'Note de l’artiste',
-
     albumAriaLabel: 'Note de l’album',
-
     artistAriaLabel: 'Note de l’artiste',
-
     saveFailed: 'Impossible d’enregistrer la note.',
-
   },
-
   artistDetail: {
-
     back: 'Retour',
-
     albums: 'Albums',
-
     album: 'Album',
-
     playAll: 'Tout lire',
-
     shuffle: 'Aléatoire',
-
     radio: 'Radio',
-
     loading: 'Chargement…',
-
     noRadio: 'Aucun morceau similaire trouvé pour cet artiste.',
-
     notFound: 'Artiste introuvable.',
-
     albumsBy: 'Albums de {{name}}',
-
     topTracks: 'Morceaux populaires',
-
     noAlbums: 'Aucun album trouvé.',
-
     trackTitle: 'Titre',
-
     trackAlbum: 'Album',
-
     trackDuration: 'Durée',
-
     favoriteAdd: 'Ajouter aux favoris',
-
     favoriteRemove: 'Retirer des favoris',
-
     favorite: 'Favori',
-
     albumCount_one: '{{count}} album',
-
     albumCount_other: '{{count}} albums',
-
     openedInBrowser: 'Ouvert dans le navigateur',
-
     featuredOn: 'Également sur',
-
     similarArtists: 'Artistes similaires',
-
     cacheOffline: 'Enregistrer la discographie hors ligne',
-
     offlineCached: 'Discographie en cache',
-
     offlineDownloading: 'En cache… ({{done}}/{{total}} albums)',
-
     uploadImage: "Téléverser l'image de l'artiste",
-
     uploadImageError: "Échec du téléversement de l'image",
-
   },
-
   favorites: {
-
     title: 'Favoris',
-
     empty: 'Vous n\'avez pas encore de favoris.',
-
     artists: 'Artistes',
-
     albums: 'Albums',
-
     songs: 'Morceaux',
-
     enqueueAll: 'Tout ajouter à la file',
-
     playAll: 'Tout lire',
-
     removeSong: 'Retirer des favoris',
-
     stations: 'Stations de radio',
-
     showingFiltered: 'Affichage de {{filtered}} sur {{total}} ({{artist}})',
-
     showingCount: 'Affichage de {{filtered}} sur {{total}}',
-
     clearArtistFilter: 'Effacer le filtre artiste',
-
     noFilterResults: 'Aucun résultat avec les filtres sélectionnés.',
-
     allArtists: 'Tous les artistes',
-
   },
-
   randomLanding: {
-
     title: 'Créer un mix',
-
     mixByTracks: 'Mix par pistes',
-
     mixByTracksDesc: 'Sélection aléatoire de titres depuis toute votre médiathèque',
-
     mixByAlbums: 'Mix par albums',
-
     mixByAlbumsDesc: 'Albums aléatoires pour vos prochaines découvertes',
-
   },
-
   randomAlbums: {
-
     title: 'Albums aléatoires',
-
     refresh: 'Actualiser',
-
   },
-
   genres: {
-
     title: 'Genres',
-
     genreCount: 'genres',
-
     albumCount_one: '{{count}} album',
-
     albumCount_other: '{{count}} albums',
-
     loading: 'Chargement des genres…',
-
     empty: 'Aucun genre trouvé.',
-
     albumsLoading: 'Chargement des albums…',
-
     albumsEmpty: 'Aucun album trouvé pour ce genre.',
-
     loadMore: 'Charger plus',
-
     back: 'Retour',
-
   },
-
   randomMix: {
-
     title: 'Mix aléatoire',
-
     remix: 'Remixer',
-
     remixTooltip: 'Charger de nouveaux morceaux aléatoires',
-
     remixGenre: 'Remixer {{genre}}',
-
     remixTooltipGenre: 'Charger de nouveaux morceaux {{genre}}',
-
     playAll: 'Tout lire',
-
     trackTitle: 'Titre',
-
     trackArtist: 'Artiste',
-
     trackAlbum: 'Album',
-
     trackFavorite: 'Favori',
-
     trackDuration: 'Durée',
-
     favoriteAdd: 'Ajouter aux favoris',
-
     favoriteRemove: 'Retirer des favoris',
-
     play: 'Lire',
-
     trackGenre: 'Genre',
-
     excludeAudiobooks: 'Exclure les livres audio et pièces radiophoniques',
-
     excludeAudiobooksDesc: 'Correspond aux mots-clés dans le genre, le titre, l\'album et l\'artiste — ex. Hörbuch, Audiobook, Spoken Word, …',
-
     genreBlocked: 'Mot-clé bloqué',
-
     genreAddedToBlacklist: 'Ajouté à la liste de filtres',
-
     genreAlreadyBlocked: 'Déjà bloqué',
-
     artistBlocked: 'Artiste bloqué',
-
     artistAddedToBlacklist: 'Artiste ajouté à la liste de filtres',
-
     artistClickHint: 'Cliquer pour bloquer cet artiste',
-
     blacklistToggle: 'Filtre par mot-clé',
-
     genreMixTitle: 'Mix par genre',
-
     genreMixDesc: 'Top 20 genres par nombre de morceaux — cliquer pour un mix aléatoire',
-
     genreMixAll: 'Tous les morceaux',
-
     genreMixLoadMore: 'Charger 10 de plus',
-
     genreMixNoGenres: 'Aucun genre trouvé sur le serveur.',
-
     shuffleGenres: 'Afficher d\'autres genres',
-
     filterPanelTitle: 'Filtres',
-
     filterPanelDesc: 'Cliquez sur un tag de genre ou un nom d\'artiste dans la liste pour l\'exclure des futurs mix.',
-
     genreClickHint: 'Cliquez sur un tag de genre pour l\'ajouter\ncomme mot-clé de filtre.\nCorrespond au genre, titre, album et artiste.',
-
   },
-
   albums: {
-
     title: 'Tous les albums',
-
     sortByName: 'A–Z (Album)',
-
     sortByArtist: 'A–Z (Artiste)',
-
     sortNewest: 'Plus récents',
-
     sortRandom: 'Aléatoire',
-
     yearFrom: 'De',
-
     yearTo: 'À',
-
     yearFilterClear: 'Effacer le filtre année',
-
     yearFilterLabel: 'Année',
-
     select: 'Sélection multiple',
-
     startSelect: 'Activer la sélection multiple',
-
     cancelSelect: 'Annuler',
-
     selectionCount: '{{count}} sélectionnés',
-
     downloadZips: 'Télécharger les ZIPs',
-
     addOffline: 'Ajouter hors ligne',
-
     downloadingZip: 'Téléchargement {{current}}/{{total}} : {{name}}',
-
     downloadZipDone: '{{count}} ZIP(s) téléchargé(s)',
-
     downloadZipFailed: 'Échec du téléchargement de {{name}}',
-
     offlineQueuing: 'Mise en file d\'attente de {{count}} album(s) hors ligne…',
-
     offlineFailed: 'Échec de l\'ajout de {{name}} hors ligne',
-
   },
-
   artists: {
-
     title: 'Artistes',
-
     search: 'Rechercher…',
-
     all: 'Tous',
-
     gridView: 'Vue en grille',
-
     listView: 'Vue en liste',
-
     imagesOn: 'Images d\'artistes activées — peut augmenter la charge réseau et système',
-
     imagesOff: 'Images d\'artistes désactivées — affichage des initiales uniquement',
-
     loadMore: 'Charger plus',
-
     notFound: 'Aucun artiste trouvé.',
-
     albumCount_one: '{{count}} album',
-
     albumCount_other: '{{count}} albums',
-
     selectionCount: '{{count}} sélectionnés',
-
     select: 'Sélection multiple',
-
     startSelect: 'Activer la sélection multiple',
-
     cancelSelect: 'Annuler',
-
     addToPlaylist: 'Ajouter à la playlist',
-
   },
-
   login: {
-
     subtitle: 'Votre lecteur de bureau Navidrome',
-
     serverName: 'Nom du serveur (facultatif)',
-
     serverNamePlaceholder: 'Mon Navidrome',
-
     serverUrl: 'URL du serveur',
-
     serverUrlPlaceholder: '192.168.1.100:4533 ou https://music.exemple.com',
-
     username: 'Nom d\'utilisateur',
-
     usernamePlaceholder: 'admin',
-
     password: 'Mot de passe',
-
     showPassword: 'Afficher le mot de passe',
-
     hidePassword: 'Masquer le mot de passe',
-
     connect: 'Se connecter',
-
     connecting: 'Connexion…',
-
     connected: 'Connecté !',
-
     error: 'Connexion échouée — vérifiez vos informations.',
-
     urlRequired: 'Veuillez saisir une URL de serveur.',
-
     savedServers: 'Serveurs enregistrés',
-
     addNew: 'Ou ajouter un nouveau serveur',
-
   },
-
   connection: {
-
     connected: 'Connecté',
-
     connectedTo: 'Connecté à {{server}}',
-
     disconnected: 'Déconnecté',
-
     disconnectedFrom: 'Impossible d\'atteindre {{server}} — cliquez pour vérifier les paramètres',
-
     checking: 'Connexion…',
-
     extern: 'Externe',
-
     offlineTitle: 'Pas de connexion au serveur',
-
     offlineSubtitle: 'Impossible d\'atteindre {{server}}. Vérifiez votre réseau ou le serveur.',
-
     offlineModeBanner: 'Mode hors ligne — lecture depuis le cache local',
-
     offlineNoCacheBanner: 'Pas de connexion au serveur — {{server}} inaccessible',
-
     offlineLibraryTitle: 'Bibliothèque hors ligne',
-
     offlineLibraryEmpty: 'Aucun album en cache. Connectez-vous, ouvrez un album et cliquez sur "Rendre disponible hors ligne".',
-
     offlineAlbumCount: '{{n}} album',
-
     offlineAlbumCount_plural: '{{n}} albums',
-
     offlineFilterAll: 'Tout',
-
     offlineFilterAlbums: 'Albums',
-
     offlineFilterPlaylists: 'Playlists',
-
     offlineFilterArtists: 'Discographies',
-
     retry: 'Réessayer',
-
     serverSettings: 'Paramètres serveur',
-
     switchServerTitle: 'Changer de serveur',
-
     switchServerHint: 'Cliquez pour choisir un autre serveur enregistré.',
-
     manageServers: 'Gérer les serveurs…',
-
     switchFailed: 'Impossible de changer — serveur injoignable.',
-
     lastfmConnected: 'Last.fm connecté en tant que @{{user}}',
-
     lastfmSessionInvalid: 'Session invalide — cliquez pour vous reconnecter',
-
   },
-
   common: {
-
     albums: 'Albums',
-
     album: 'Album',
-
     loading: 'Chargement…',
-
     loadingMore: 'Chargement…',
-
     loadingPlaylists: 'Chargement des listes…',
-
     noAlbums: 'Aucun album trouvé.',
-
     downloading: 'Téléchargement…',
-
     downloadZip: 'Télécharger (ZIP)',
-
     back: 'Retour',
-
     cancel: 'Annuler',
-
     save: 'Enregistrer',
-
     delete: 'Supprimer',
-
     use: 'Utiliser',
-
     add: 'Ajouter',
-
     active: 'Actif',
-
     download: 'Télécharger',
-
     chooseDownloadFolder: 'Choisir le dossier de téléchargement',
-
     noFolderSelected: 'Aucun dossier sélectionné',
-
     rememberDownloadFolder: 'Mémoriser ce dossier',
-
     filterGenre: 'Filtre genre',
-
     filterSearchGenres: 'Rechercher des genres…',
-
     filterNoGenres: 'Aucun genre trouvé',
-
     filterClear: 'Effacer',
-
     play: 'Lire',
-
     bulkSelected: '{{count}} sélectionné(s)',
-
     clearSelection: 'Effacer la sélection',
-
     bulkAddToPlaylist: 'Ajouter à la playlist',
-
     bulkRemoveFromPlaylist: 'Retirer de la playlist',
-
     bulkClear: 'Désélectionner',
-
     updaterAvailable: 'Mise à jour disponible',
-
     updaterVersion: 'v{{version}} est disponible',
-
     updaterWebsite: 'Site Web',
-
     updaterModalTitle: 'Nouvelle version disponible',
-
     updaterChangelog: 'Nouveautés',
-
     updaterDownloadBtn: 'Télécharger maintenant',
-
     updaterSkipBtn: 'Ignorer cette version',
-
     updaterRemindBtn: 'Me rappeler plus tard',
-
     updaterDone: 'Téléchargement terminé',
-
     updaterShowFolder: 'Afficher dans le dossier',
-
     updaterInstallHint: 'Fermez Psysonic et lancez le programme d\'installation manuellement.',
-
     updaterAurHint: 'Installer la mise à jour via AUR :',
-
     updaterErrorMsg: 'Échec du téléchargement',
-
     updaterRetryBtn: 'Réessayer',
-
     durationHoursMinutes: '{{hours}} h {{minutes}} min',
-
     durationMinutesOnly: '{{minutes}} min',
-
     updaterOpenGitHub: 'Ouvrir sur GitHub',
-
     filters: 'Filtres',
-
     more: 'plus',
-
     yearRange: 'Plage d\'années',
-
     clearAll: 'Tout effacer',
-
   },
-
   settings: {
-
     title: 'Paramètres',
-
     language: 'Langue',
-
     languageEn: 'Anglais',
-
     languageDe: 'Allemand',
-
     languageFr: 'Français',
-
     languageNl: 'Néerlandais',
-
     languageZh: 'Chinois',
-
     languageNb: 'Norvégien',
-
     languageRu: 'Russe',
-
     font: 'Police',
-
     theme: 'Thème',
-
     appearance: 'Apparence',
-
     servers: 'Serveurs',
-
     serverName: 'Nom du serveur',
-
     serverUrl: 'URL du serveur',
-
     serverUrlPlaceholder: '192.168.1.100:4533 ou https://music.exemple.com',
-
     serverUsername: 'Nom d\'utilisateur',
-
     serverPassword: 'Mot de passe',
-
     addServer: 'Ajouter un serveur',
-
     addServerTitle: 'Ajouter un nouveau serveur',
-
     useServer: 'Utiliser',
-
     deleteServer: 'Supprimer',
-
     noServers: 'Aucun serveur enregistré.',
-
     serverActive: 'Actif',
-
     confirmDeleteServer: 'Supprimer le serveur « {{name}} » ?',
-
     serverConnecting: 'Connexion…',
-
     serverConnected: 'Connecté !',
-
     serverFailed: 'Connexion échouée.',
-
     testBtn: 'Tester la connexion',
-
     testingBtn: 'Test en cours…',
-
     serverCompatible: 'Compatible avec : Navidrome · Gonic · Airsonic · Subsonic',
-
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
-
     audiomuseDesc:
-
       'Activez si ce serveur utilise le <pluginLink>plugin Navidrome AudioMuse-AI</pluginLink>. Active le mix instantané depuis un morceau et affiche les artistes similaires côté serveur au lieu de Last.fm sur les pages artiste.',
-
     audiomuseIssueHint:
-
       'Le mix instantané a échoué récemment — vérifiez le plugin Navidrome et l’API AudioMuse. Les artistes similaires utilisent Last.fm si le serveur ne renvoie rien.',
-
     connected: 'Connecté',
-
     failed: 'Échec',
-
     eqTitle: 'Égaliseur',
-
     eqEnabled: 'Activer l\'égaliseur',
-
     eqPreset: 'Préréglage',
-
     eqPresetCustom: 'Personnalisé',
-
     eqPresetBuiltin: 'Préréglages intégrés',
-
     eqPresetCustomGroup: 'Mes préréglages',
-
     eqSavePreset: 'Enregistrer comme préréglage',
-
     eqPresetName: 'Nom du préréglage…',
-
     eqDeletePreset: 'Supprimer le préréglage',
-
     eqResetBands: 'Réinitialiser à plat',
-
     eqPreGain: 'Pré-amplification',
-
     eqResetPreGain: 'Réinitialiser la pré-amplification',
-
     eqAutoEqTitle: 'Recherche AutoEQ',
-
     eqAutoEqPlaceholder: 'Rechercher un casque / IEM…',
-
     eqAutoEqSearching: 'Recherche…',
-
     eqAutoEqNoResults: 'Aucun résultat',
-
     eqAutoEqError: 'Échec de la recherche',
-
     eqAutoEqRateLimit: 'Limite GitHub atteinte — réessayez dans une minute',
-
     eqAutoEqFetchError: 'Impossible de charger le profil EQ',
-
     lfmTitle: 'Last.fm',
-
     lfmConnect: 'Connecter avec Last.fm',
-
     lfmConnecting: 'En attente d\'autorisation…',
-
     lfmConfirm: 'J\'ai autorisé l\'application',
-
     lfmConnected: 'Connecté en tant que',
-
     lfmDisconnect: 'Déconnecter',
-
     lfmConnectDesc: 'Connectez votre compte Last.fm pour activer le scrobbling et les mises à jour « En cours de lecture » depuis Psysonic — aucune configuration Navidrome requise.',
-
     lfmOpenBrowser: 'Une fenêtre de navigateur s\'ouvrira. Autorisez Psysonic sur Last.fm, puis cliquez sur le bouton ci-dessous.',
-
     lfmScrobbles: '{{n}} scrobbles',
-
     lfmMemberSince: 'Membre depuis {{year}}',
-
     scrobbleEnabled: 'Scrobbling activé',
-
     scrobbleDesc: 'Envoyer les morceaux à Last.fm après 50% d\'écoute',
-
     behavior: 'Comportement de l\'application',
-
     cacheTitle: 'Taille max. du stockage',
-
     cacheDesc: 'Pochettes et images d\'artistes. Quand le cache est plein, les entrées les plus anciennes sont supprimées automatiquement. Les albums hors ligne ne sont pas supprimés automatiquement, mais le seront lors d\'un nettoyage manuel.',
-
     cacheUsedImages: 'Images :',
-
     cacheUsedOffline: 'Pistes hors ligne :',
-
     cacheUsedHot: 'Espace disque :',
-
     hotCacheTrackCount: 'Pistes en cache :',
-
     cacheMaxLabel: 'Taille max.',
-
     cacheClearBtn: 'Vider le cache',
-
     cacheClearWarning: 'Cela supprimera aussi tous les albums hors ligne de la bibliothèque.',
-
     cacheClearConfirm: 'Tout supprimer',
-
     cacheClearCancel: 'Annuler',
-
     offlineDirTitle: 'Bibliothèque hors ligne (intégrée)',
-
     offlineDirDesc: 'Emplacement de stockage des titres rendus disponibles hors ligne dans Psysonic.',
-
     offlineDirDefault: 'Par défaut (données d\'application)',
-
     offlineDirChange: 'Changer le dossier',
-
     offlineDirClear: 'Réinitialiser',
-
     offlineDirHint: 'Les nouveaux téléchargements utiliseront cet emplacement. Les téléchargements existants restent à leur emplacement d\'origine.',
-
     hotCacheTitle: 'Cache de lecture à chaud',
-
     hotCacheAlphaBadge: 'Alpha',
-
     hotCacheDisclaimer: 'Précharge les titres à venir dans la file et conserve les précédents. Si activé : espace disque et réseau.',
-
     hotCacheDirDefault: 'Par défaut (données d\'application)',
-
     hotCacheDirChange: 'Changer le dossier',
-
     hotCacheDirClear: 'Réinitialiser',
-
     hotCacheDirHint: 'Changer de dossier réinitialise l’index dans l’app ; les fichiers déjà écrits restent à l’ancien emplacement.',
-
     hotCacheEnabled: 'Activer le cache de lecture à chaud',
-
     hotCacheMaxMb: 'Taille maximale du cache',
-
     hotCacheDebounce: 'Délai après changement de file',
-
     hotCacheDebounceImmediate: 'Immédiat',
-
     hotCacheDebounceSeconds: '{{n}} s',
-
     hotCacheClearBtn: 'Vider le cache à chaud',
-
     audioOutputDevice: 'Périphérique de sortie audio',
-
     audioOutputDeviceDesc: 'Choisissez le périphérique audio utilisé par Psysonic. Les changements sont immédiats et relancent la piste en cours.',
-
     audioOutputDeviceDefault: 'Défaut système',
-
     audioOutputDeviceRefresh: 'Actualiser la liste',
-
     audioOutputDeviceOsDefaultNow: 'sortie système actuelle',
-
     audioOutputDeviceListError: 'Impossible de charger la liste des périphériques audio.',
-
     audioOutputDeviceNotInCurrentList: 'absent de la liste actuelle',
-
     hiResTitle: 'Lecture haute résolution native',
-
     hiResEnabled: 'Activer la lecture haute résolution native',
-
     hiResDesc: "Force une sortie à 44,1 kHz par défaut pour une stabilité maximale. N'activer que si le matériel et le réseau prennent en charge les hautes fréquences d'échantillonnage (88,2 kHz+).",
-
     showArtistImages: 'Afficher les images d\'artistes',
-
     showArtistImagesDesc: 'Charge et affiche les images d\'artistes dans la vue d\'ensemble. Désactivé par défaut pour réduire les E/S disque serveur et la charge réseau sur les grandes bibliothèques.',
-
     showTrayIcon: 'Afficher l\'icône dans la barre système',
-
     showTrayIconDesc: 'Affiche l\'icône Psysonic dans la zone de notification / barre des menus.',
-
     minimizeToTray: 'Réduire dans la barre système',
-
     minimizeToTrayDesc: 'Lors de la fermeture, Psysonic continue de fonctionner dans la barre système au lieu de se fermer.',
-
     discordRichPresence: 'Discord Rich Presence',
-
     discordRichPresenceDesc: 'Affiche le titre en cours de lecture sur votre profil Discord. Discord doit être ouvert.',
-
     discordAppleCovers: 'Récupérer les pochettes via Apple Music pour Discord',
-
     discordAppleCoversDesc: 'Envoie le nom de l\'artiste et de l\'album à l\'API Apple pour trouver une pochette pour votre profil Discord. Désactivé par défaut pour des raisons de confidentialité.',
-
     discordTemplates: 'Modèles de texte personnalisés',
-
-    discordTemplatesDesc: 'Personnalise les informations affichées sur votre profil Discord. Variables : {title}, {artist}, {album}, {paused}',
-
+    discordTemplatesDesc: 'Personnalisez les informations affichées sur votre profil Discord. Variables : {title}, {artist}, {album}, {paused}',
     discordTemplateDetails: 'Ligne principale (details)',
-
     discordTemplateState: 'Ligne secondaire (state)',
-
     discordTemplateLargeText: 'Info-bulle album (largeText)',
-
     nowPlayingEnabled: 'Afficher dans la fenêtre live',
-
     nowPlayingEnabledDesc: 'Diffuse le titre en cours de lecture vers la vue des auditeurs en direct du serveur. Désactiver pour ne pas envoyer de données de lecture.',
-
     lyricsServerFirst: 'Préférer les paroles du serveur',
-
     lyricsServerFirstDesc: 'Consulter d\'abord les paroles fournies par le serveur (tags intégrés, fichiers sidecar) avant LRCLIB. Désactiver pour utiliser LRCLIB en priorité.',
-
     enableNeteaselyrics: 'Paroles Netease Cloud Music',
-
     enableNeteaselyricsDesc: 'Utiliser Netease Cloud Music en dernier recours lorsque le serveur et LRCLIB ne retournent rien. Meilleure couverture pour la musique asiatique et internationale.',
-
     lyricsSourcesTitle: 'Sources de paroles',
-
     lyricsSourcesDesc: 'Choisissez quelles sources interroger et dans quel ordre. Glissez pour réordonner. Les sources désactivées sont ignorées.',
-
     lyricsSourceServer: 'Serveur',
-
     lyricsSourceLrclib: 'LRCLIB',
-
     lyricsSourceNetease: 'Netease Cloud Music',
-
     downloadsTitle: 'Export ZIP & Archivage',
-
     downloadsFolderDesc: 'Dossier de destination pour les albums téléchargés en tant que fichier ZIP sur votre ordinateur.',
-
     downloadsDefault: 'Dossier de téléchargement par défaut',
-
     pickFolder: 'Sélectionner',
-
     pickFolderTitle: 'Sélectionner le dossier de téléchargement',
-
     clearFolder: 'Effacer le dossier',
-
     logout: 'Se déconnecter',
-
     aboutTitle: 'À propos de Psysonic',
-
     aboutDesc: 'Un lecteur de musique de bureau moderne pour les serveurs compatibles Subsonic (Navidrome, Gonic, et autres). Construit sur Tauri v2 avec un moteur audio Rust natif — léger et rapide, mais riche en fonctionnalités : barre waveform, paroles synchronisées, intégration Last.fm, égaliseur 10 bandes, crossfade, lecture sans blanc, Replay Gain, navigation par genre et une grande bibliothèque de thèmes.',
-
     aboutLicense: 'Licence',
-
     aboutLicenseText: 'GNU GPL v3 — libre d\'utilisation, de modification et de distribution sous la même licence.',
-
     aboutRepo: 'Code source sur GitHub',
-
     aboutVersion: 'Version',
-
     aboutBuiltWith: 'Construit avec Tauri · React · TypeScript · Rust/rodio',
-
     aboutAiCredit: 'Développé avec le soutien de Claude Code par Anthropic',
-
     aboutContributorsLabel: 'Contributeurs',
-
     aboutSpecialThanksLabel: 'Remerciements spéciaux',
-
     changelog: 'Journal des modifications',
-
     showChangelogOnUpdate: "Afficher 'Quoi de neuf' lors des mises à jour",
-
     showChangelogOnUpdateDesc: 'Affiche automatiquement les nouveautés au premier lancement d\'une nouvelle version.',
-
     randomMixTitle: 'Mix aléatoire',
-
     randomMixBlacklistTitle: 'Mots-clés de filtre personnalisés',
-
     randomMixBlacklistDesc: 'Les morceaux sont exclus si un mot-clé correspond à leur genre, titre, album ou artiste (actif quand la case ci-dessus est cochée).',
-
     randomMixBlacklistPlaceholder: 'Ajouter un mot-clé…',
-
     randomMixBlacklistAdd: 'Ajouter',
-
     randomMixBlacklistEmpty: 'Aucun mot-clé personnalisé ajouté.',
-
     randomMixHardcodedTitle: 'Mots-clés intégrés (actifs quand la case est cochée)',
-
     tabAudio: 'Audio',
-
     tabStorage: 'Stockage & Téléchargements',
-
     tabAppearance: 'Apparence',
-
     homeCustomizerTitle: 'Page d\'accueil',
-
     sidebarTitle: 'Barre latérale',
-
     sidebarReset: 'Réinitialiser',
-
     sidebarDrag: 'Glisser pour réorganiser',
-
     sidebarFixed: 'Toujours visible',
-
+    randomNavSplitTitle: 'Diviser la navigation Mix',
+    randomNavSplitDesc: 'Afficher "Mix Aléatoire" et "Albums Aléatoires" comme entrées séparées dans la barre latérale plutôt que le hub "Créer un Mix".',
     tabInput: 'Entrée',
-
     tabServer: 'Serveur',
-
     shortcutsReset: 'Réinitialiser',
-
     shortcutListening: 'Appuyez sur une touche…',
-
     shortcutUnbound: '—',
-
     shortcutClear: 'Effacer',
-
     globalShortcutsTitle: 'Raccourcis globaux',
-
     globalShortcutsNote: 'Fonctionnent à l\'échelle du système, même quand Psysonic est en arrière-plan. Nécessite Ctrl, Alt ou Super comme modificateur.',
-
     shortcutPlayPause: 'Lecture / Pause',
-
     shortcutNext: 'Piste suivante',
-
     shortcutPrev: 'Piste précédente',
-
     shortcutVolumeUp: 'Volume +',
-
     shortcutVolumeDown: 'Volume -',
-
     shortcutSeekForward: 'Avancer de 10s',
-
     shortcutSeekBackward: 'Reculer de 10s',
-
     shortcutToggleQueue: 'Afficher/masquer la file',
-
     shortcutOpenFolderBrowser: 'Ouvrir {{folderBrowser}}',
-
     shortcutFullscreenPlayer: 'Lecteur plein écran',
-
     shortcutNativeFullscreen: 'Plein écran natif',
-
     tabSystem: 'Système',
-
     tabGeneral: 'Général',
-
     ratingsSectionTitle: 'Notes',
-
     ratingsSkipStarTitle: 'Passer pour 1 étoile',
-
     ratingsSkipStarDesc:
-
       "Après plusieurs sauts d’affilée, le morceau passe à 1 étoile. Uniquement s’il n’était pas encore noté.",
-
     ratingsSkipStarThresholdLabel: 'Sauts',
-
     ratingsMixFilterTitle: 'Filtrage par note',
-
     ratingsMixFilterDesc:
-
       "Filtrer le contenu peu noté dans {{mix}} et {{albums}}. Cliquer de nouveau sur l’étoile choisie désactive le seuil.",
-
     ratingsMixMinSong: 'Morceaux',
-
     ratingsMixMinAlbum: 'Albums',
-
     ratingsMixMinArtist: 'Artistes',
-
     ratingsMixMinThresholdAria: 'Étoiles minimum : {{label}}',
-
     backupTitle: 'Sauvegarde & Restauration',
-
     backupExport: 'Exporter les paramètres',
-
     backupExportDesc: 'Enregistre tous les paramètres, profils serveur, configuration Last.fm, thème, EQ et raccourcis dans un fichier .psybkp. Les mots de passe sont stockés en clair — conservez le fichier en sécurité.',
-
     backupImport: 'Importer les paramètres',
-
     backupImportDesc: 'Restaure les paramètres depuis un fichier .psybkp. L\'application sera rechargée après l\'import.',
-
     backupImportConfirm: 'Tous les paramètres actuels seront écrasés. Continuer ?',
-
     backupSuccess: 'Sauvegarde enregistrée',
-
     backupImportSuccess: 'Paramètres restaurés — rechargement…',
-
     backupImportError: 'Fichier de sauvegarde invalide ou corrompu.',
-
     playbackTitle: 'Lecture',
-
     replayGain: 'Replay Gain',
-
     replayGainDesc: 'Normaliser le volume des pistes avec les métadonnées ReplayGain',
-
     replayGainMode: 'Mode',
-
     replayGainTrack: 'Piste',
-
     replayGainAlbum: 'Album',
-
     replayGainPreGain: 'Pré-Gain (fichiers taggés)',
-
     replayGainFallback: 'Repli (sans tags / radio)',
-
     crossfade: 'Fondu enchaîné',
-
     crossfadeDesc: 'Fondu entre les pistes',
-
     crossfadeSecs: '{{n}} s',
-
     notWithGapless: 'Non disponible quand la lecture sans blanc est active',
-
     notWithCrossfade: 'Non disponible quand le fondu enchaîné est actif',
-
     gapless: 'Lecture sans blanc',
-
     gaplessDesc: 'Préparer la piste suivante pour éliminer les silences entre les morceaux',
-
     preloadMode: 'Précharger la piste suivante',
-
     preloadModeDesc: 'Quand commencer à mettre en mémoire tampon la piste suivante',
-
     nextTrackBufferingTitle: 'Piste suivante – mise en mémoire tampon',
-
     preloadHotCacheMutualExclusive: "Preload et Hot Cache remplissent le même rôle — un seul peut être actif à la fois. Activer l'un désactive automatiquement l'autre.",
-
     preloadOff: 'Désactivé',
-
     preloadBalanced: 'Équilibré (30 s avant la fin)',
-
     preloadEarly: 'Tôt (après 5 s de lecture)',
-
     preloadCustom: 'Personnalisé',
-
     preloadCustomSeconds: 'Secondes avant la fin : {{n}}',
-
     infiniteQueue: 'File infinie',
-
     infiniteQueueDesc: 'Ajouter automatiquement des morceaux aléatoires quand la file est épuisée',
-
     experimental: 'Expérimental',
-
     fsPlayerSection: 'Lecteur plein écran',
-
     fsShowArtistPortrait: "Afficher la photo de l'artiste",
-
     fsShowArtistPortraitDesc: "Afficher la photo de l'artiste (ou la pochette) sur le côté droit du lecteur plein écran.",
-
     fsPortraitDim: "Assombrissement de la photo",
-
     seekbarStyle: 'Style de la barre de lecture',
-
     seekbarStyleDesc: 'Choisir l\'apparence de la barre de progression',
-
     seekbarWaveform: 'Forme d\'onde',
-
     seekbarLinedot: 'Ligne & point',
-
     seekbarBar: 'Barre',
-
     seekbarThick: 'Barre épaisse',
-
     seekbarSegmented: 'Segmentée',
-
     seekbarNeon: 'Néon',
-
     seekbarPulsewave: 'Onde pulsée',
-
     seekbarParticletrail: 'Traînée de particules',
-
     seekbarLiquidfill: 'Tube liquide',
-
     seekbarRetrotape: 'Bande rétro',
-
     themeSchedulerTitle: 'Planificateur de thème',
-
     themeSchedulerEnable: 'Activer le planificateur de thème',
-
     themeSchedulerEnableSub: 'Bascule automatiquement entre deux thèmes selon l\'heure',
-
     themeSchedulerDayTheme: 'Thème de jour',
-
     themeSchedulerDayStart: 'Début du jour',
-
     themeSchedulerNightTheme: 'Thème de nuit',
-
     themeSchedulerNightStart: 'Début de la nuit',
-
     themeSchedulerActiveHint: 'Le planificateur de thème est actif - les thèmes changent automatiquement.',
-
     visualOptionsTitle: 'Options Visuelles',
-
     coverArtBackground: "Fond d'Art de Poche",
-
     coverArtBackgroundSub: "Afficher la pochette floutée comme fond dans les en-têtes d'albums et de playlists",
-
     playlistCoverPhoto: 'Photo de Couverture de Playlist',
-
     playlistCoverPhotoSub: 'Afficher la grille de photos de couverture dans la vue détaillée des playlists',
-
     showBitrate: 'Afficher le Débit',
-
     showBitrateSub: 'Afficher le débit audio dans les listes de pistes',
-
     uiScaleTitle: "Mise à l'échelle de l'interface",
-
     uiScaleLabel: 'Zoom',
-
   },
-
   changelog: {
-
     modalTitle: 'Quoi de neuf',
-
     dontShowAgain: 'Ne plus afficher',
-
     close: 'Compris',
-
   },
-
   help: {
-
     title: 'Aide',
-
     s1: 'Démarrage',
-
     q1: 'Quels serveurs sont compatibles ?',
-
     a1: 'Psysonic fonctionne avec tout serveur compatible Subsonic : Navidrome, Gonic, Subsonic, Airsonic, et autres. Navidrome est recommandé.',
-
     q2: 'Comment me connecter à mon serveur ?',
-
     a2: 'Ouvrez les Paramètres et cliquez sur « Ajouter un serveur ». Saisissez l\'URL du serveur (ex. 192.168.1.100:4533), votre nom d\'utilisateur et mot de passe. Psysonic teste la connexion avant d\'enregistrer.',
-
     q3: 'Puis-je utiliser plusieurs serveurs ?',
-
     a3: 'Oui. Vous pouvez ajouter autant de serveurs que vous le souhaitez dans les Paramètres et basculer entre eux à tout moment. Un seul serveur est actif à la fois.',
-
     s2: 'Lecture',
-
     q4: 'Comment lire de la musique ?',
-
     a4: 'Double-cliquez sur une piste pour la lire. Sur les pages d\'album et d\'artiste, utilisez « Tout lire » pour démarrer l\'album entier. Vous pouvez aussi glisser des pistes dans la file d\'attente.',
-
     q5: 'Quels raccourcis clavier sont disponibles ?',
-
     a5: 'Espace = Lecture / Pause · Échap = Fermer le lecteur plein écran. Les touches multimédia fonctionnent sur toutes les plateformes. Sur Linux, utilisez les boutons de la barre du lecteur. Les raccourcis in-app et les raccourcis système peuvent être personnalisés dans Paramètres → Raccourcis / Raccourcis globaux.',
-
     q6: 'Qu\'est-ce que la file d\'attente ?',
-
     a6: 'La file d\'attente affiche toutes les pistes à venir. Ouvrez-la avec l\'icône de panneau en haut à droite. Vous pouvez réorganiser les pistes par glisser-déposer, les mélanger et enregistrer la file comme liste de lecture.',
-
     q7: 'Comment ouvrir le lecteur plein écran ?',
-
     a7: 'Cliquez sur la pochette dans la barre du lecteur en bas, ou sur l\'icône d\'agrandissement à côté. Appuyez sur Échap pour fermer.',
-
     q8: 'Comment fonctionne la répétition ?',
-
     a8: 'Cliquez sur le bouton répéter pour alterner : Désactivé → Répéter tout → Répéter un.',
-
     s3: 'Bibliothèque',
-
     q9: 'Comment télécharger un album ?',
-
     a9: 'Ouvrez la page de détail d\'un album et cliquez sur « Télécharger (ZIP) ». Le serveur compresse d\'abord l\'album en ZIP — pour les grands albums ou les fichiers sans perte (FLAC / WAV), cela peut prendre un moment avant que le téléchargement ne démarre réellement. La barre de progression n\'apparaît qu\'une fois la compression terminée.',
-
     q10: 'Comment mettre des pistes et albums en favoris ?',
-
     a10: 'Cliquez sur l\'icône étoile sur une piste ou dans l\'en-tête de l\'album. Les éléments favoris apparaissent dans la section Favoris de la barre latérale.',
-
     q11: 'Qu\'est-ce que le carousel hero sur la page d\'accueil ?',
-
     a11: 'La bannière en haut de la page d\'accueil sélectionne aléatoirement des albums de votre bibliothèque et les fait défiler toutes les 10 secondes. Cliquez sur les points pour accéder à un album spécifique.',
-
     s4: 'Paramètres',
-
     q12: 'Comment changer le thème ?',
-
     a12: 'Paramètres → Thème. Un grand choix de thèmes en 8 groupes : Psysonic Themes, Mediaplayer, Systèmes d\'exploitation, Jeux, Films, Séries, Réseaux sociaux et Open Source Classics (Catppuccin, Nord, Gruvbox, Nightfox).',
-
     q13: 'Comment changer la langue ?',
-
     a13: 'Paramètres → Langue. L\'anglais, l\'allemand, le français, le néerlandais et le chinois sont pris en charge.',
-
     q15: 'Comment définir un dossier de téléchargement ?',
-
     a15: 'Paramètres → Comportement → Dossier de téléchargement. Les albums téléchargés y sont enregistrés en ZIP.',
-
     s5: 'Scrobbling',
-
     q16: 'Comment fonctionne le scrobbling ?',
-
     a16: 'Psysonic envoie les scrobbles directement à Last.fm — aucune configuration Navidrome nécessaire. Connectez votre compte dans Paramètres → Last.fm et activez le scrobbling.',
-
     q17: 'Quand un scrobble est-il envoyé ?',
-
     a17: 'Un scrobble est soumis après avoir écouté 50% d\'une piste.',
-
     q22: 'Qu\'est-ce que la forme d\'onde dans la barre du lecteur ?',
-
     a22: 'La barre de forme d\'onde remplace le curseur de progression classique. Cliquez n\'importe où pour sauter à cette position, ou faites glisser pour naviguer.',
-
     q24: 'Puis-je mélanger la file d\'attente ?',
-
     a24: 'Oui. Ouvrez le panneau de file et cliquez sur l\'icône de mélange. La piste en cours reste en position 1 — les autres sont réorganisées aléatoirement.',
-
     q25: 'Les liens Last.fm et Wikipédia s\'ouvrent-ils dans un navigateur ?',
-
     a25: 'Oui — ils s\'ouvrent dans votre navigateur système par défaut. Le bouton affiche brièvement une confirmation au clic.',
-
     s7: 'Mix aléatoire',
-
     q26: 'Qu\'est-ce que le Mix aléatoire ?',
-
     a26: 'Le Mix aléatoire crée une liste de morceaux aléatoires depuis toute votre bibliothèque. Ouvrez-le via « Mix aléatoire » dans la barre latérale et cliquez sur « Nouveau mix ».',
-
     q27: 'Qu\'est-ce que le Filtre par mot-clé ?',
-
     a27: 'Le Filtre par mot-clé exclut les pistes dont le genre, le titre ou l\'album contient des mots spécifiques. Les livres audio sont filtrés automatiquement. Ajoutez des mots-clés dans Paramètres → Mix aléatoire.',
-
     q28: 'Qu\'est-ce que le Mix par super-genre ?',
-
     a28: 'Le Mix par super-genre regroupe votre bibliothèque en grandes catégories (Rock, Métal, Électronique, Jazz, Classique, etc.) et crée un mix ciblé. Sélectionnez une catégorie dans les puces sous la liste.',
-
     s6: 'Dépannage',
-
     q18: 'Les pochettes et images d\'artistes chargent lentement.',
-
     a18: 'Les images sont récupérées depuis le disque de votre serveur au premier chargement, puis mises en cache localement pendant 30 jours. Les visites suivantes seront instantanées.',
-
     q19: 'Le test de connexion échoue.',
-
     a19: 'Vérifiez l\'URL avec le port (ex. http://192.168.1.100:4533). Assurez-vous qu\'aucun pare-feu ne bloque la connexion. Essayez http:// au lieu de https:// sur un réseau local.',
-
     q20: 'Pas d\'audio sur Linux.',
-
     a20: 'Psysonic est disponible en .deb (Ubuntu/Debian), .rpm (Fedora/RHEL) et via AUR sur Arch/CachyOS (yay -S psysonic). Il n\'y a pas d\'AppImage. Si l\'audio ne fonctionne pas, vérifiez que PipeWire ou PulseAudio est actif.',
-
     q21: 'L\'application affiche un écran noir sur Linux.',
-
     a21: 'Cela est généralement dû à des problèmes de pilote GPU/EGL dans WebKitGTK. Lancez avec GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. Les paquets AUR et installateurs .deb/.rpm officiels le configurent automatiquement.',
-
     q29: 'Que sont le fondu enchaîné et la lecture sans blanc ?',
-
     a29: 'Ce sont des fonctionnalités audio expérimentales dans Paramètres → Audio. La lecture sans blanc pré-charge la piste suivante pour éliminer les silences. Le fondu enchaîné effectue un fondu sortant de la piste en cours tout en faisant un fondu entrant de la suivante — durée réglable (1–10 s).',
-
     q30: 'Psysonic affiche-t-il les paroles ?',
-
     a30: 'Oui. Cliquez sur l\'icône microphone dans la barre du lecteur pour ouvrir l\'onglet Paroles. Psysonic récupère automatiquement les paroles depuis LRCLIB. Si des paroles synchronisées sont disponibles, la ligne active est mise en évidence et défile en temps réel. Sinon, le texte complet est affiché statiquement.',
-
     q31: 'Puis-je personnaliser les raccourcis clavier ?',
-
     a31: 'Oui. Paramètres → Raccourcis clavier permet de réattribuer les actions in-app (Lecture/Pause, Suivant, Précédent, Volume, Plein écran, etc.). Paramètres → Raccourcis globaux permet d\'assigner des raccourcis système actifs même quand l\'application est en arrière-plan.',
-
     q32: 'Puis-je changer la police ?',
-
     a32: 'Oui. Paramètres → Police propose 10 polices dont IBM Plex Mono, Fira Code, JetBrains Mono et Courier Prime. La police choisie s\'applique à toute l\'interface.',
-
     s8: 'Mode hors ligne',
-
     q34: 'Qu\'est-ce que le mode hors ligne ?',
-
     a34: 'Le mode hors ligne (Bêta) permet de mettre des albums en cache sur l\'appareil afin d\'écouter de la musique sans connexion serveur active. Les pistes mises en cache sont stockées localement et lues directement depuis le disque — sans requête réseau.',
-
     q35: 'Comment mettre un album en cache pour une utilisation hors ligne ?',
-
     a35: 'Ouvrez un album et cliquez sur l\'icône de téléchargement dans l\'en-tête de l\'album. Psysonic télécharge toutes les pistes en arrière-plan. La progression est affichée sur le bouton. Une fois en cache, l\'icône devient verte. Les albums mis en cache peuvent être consultés et supprimés dans la page Bibliothèque hors ligne (barre latérale).',
-
     q36: 'Quelle quantité de stockage le cache hors ligne peut-il utiliser ?',
-
     a36: 'Vous pouvez définir une taille de cache maximale dans Paramètres → Bibliothèque. Lorsque la limite est atteinte, une bannière d\'avertissement s\'affiche sur la page de l\'album. Vous pouvez supprimer des albums individuels dans la Bibliothèque hors ligne pour libérer de l\'espace.',
-
     q37: 'Comment noter des morceaux, albums et artistes ?',
-
     a37: 'Psysonic prend en charge les notes de 1 à 5 étoiles via l\'API OpenSubsonic (Navidrome ≥ 0.53 requis). Notez les morceaux dans la liste de pistes d\'un album ou d\'une playlist, via le menu contextuel ou directement dans la barre du lecteur. Les albums sont notés sur leur page de détail, les artistes sur leur page.',
-
     q38: 'Puis-je supprimer ou modifier une note ?',
-
     a38: 'Oui. Cliquer à nouveau sur l\'étoile active supprime entièrement la note — un second clic sur la même étoile l\'efface. Pour modifier une note, cliquez simplement sur une étoile différente.',
-
     q39: 'Qu\'est-ce que Skip-to-1★ et le filtre de notes ?',
-
     a39: 'Skip-to-1★ attribue automatiquement une note d\'une étoile à un morceau après un certain nombre de sauts consécutifs. Activez-le dans Paramètres → Notes. Vous pouvez également y définir une note minimale pour les mix aléatoires.',
-
     q40: 'Qu\'est-ce que le Navigateur de dossiers ?',
-
     a40: 'Le Navigateur de dossiers (barre latérale) permet de parcourir l\'arborescence musicale du serveur en colonnes Miller. Cliquez sur un dossier pour l\'explorer ; utilisez l\'icône lecture pour jouer ou ajouter son contenu à la file.',
-
     q41: 'Qu\'est-ce que le planificateur de thème ?',
-
     a41: 'Paramètres → Apparence → Changer de thème automatiquement : définissez un thème de jour et un thème de nuit avec des heures de début. Psysonic bascule automatiquement à l\'heure configurée.',
-
     q42: 'Puis-je redimensionner l\'interface ?',
-
     a42: 'Oui. Paramètres → Apparence → Échelle de l\'interface permet de régler l\'interface entre 80 % et 125 %.',
-
     q43: 'Puis-je changer le style de la barre de progression ?',
-
     a43: 'Oui. Paramètres → Apparence → Style de la barre de progression offre 10 styles : Waveform, Ligne & Point, Barre, Barre épaisse, Segmenté, Neon Glow, Pulse Wave, Particle Trail, Liquid Fill et Retro Tape.',
-
     q44: 'Qu\'est-ce qu\'AutoEQ ?',
-
     a44: 'L\'égaliseur 10 bandes dans Paramètres → Audio comprend une recherche AutoEQ. Saisissez le modèle de votre casque pour charger automatiquement le profil de correction.',
-
     q45: 'Qu\'est-ce que le Replay Gain ?',
-
     a45: 'Le Replay Gain normalise le volume afin que les albums forts et doux soient lus à un niveau cohérent. Activez-le dans Paramètres → Audio → Replay Gain ; mode Piste ou Album.',
-
     q46: 'Qu\'est-ce que le Hot Cache ?',
-
     a46: 'Le Hot Cache (Alpha, Paramètres → Bibliothèque) précharge les prochains morceaux de la file sur le disque pour une lecture instantanée. Psysonic conserve le morceau actuel et les 5 suivants et évince les anciens quand la limite est atteinte.',
-
     q47: 'Puis-je mettre en cache une playlist hors ligne ?',
-
     a47: 'Oui. Dans les détails d\'une playlist, cliquez sur l\'icône de téléchargement. Une fois entièrement mis en cache, l\'icône se transforme en corbeille rouge ; cliquer dessus supprime la playlist du cache hors ligne.',
-
+    q48: 'Qu\'est-ce que la file infinie ?',
+    a48: 'Lorsque la file se vide et que la répétition est désactivée, Psysonic ajoute silencieusement des pistes aléatoires pour que la lecture ne s\'arrête jamais. Les pistes ajoutées automatiquement apparaissent sous le séparateur « — Ajouté automatiquement — ». Activez/désactivez via l\'icône infini dans l\'en-tête de la file.',
+    q49: 'Puis-je contrôler Psysonic en ligne de commande ?',
+    a49: 'Oui. Exemples : psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one, --player star / unstar, --player rating 1-5. Aussi : changer de serveur, d\'appareil audio, filtrer la bibliothèque, lancer un mix instantané et rechercher. Aide complète : psysonic --player --help.',
+    q50: 'Comment gérer les playlists ?',
+    a50: 'Via « Playlists » dans la barre latérale. Créez une playlist avec « Nouvelle playlist ». Dans la vue détaillée, réorganisez les pistes par glisser-déposer, supprimez-les avec le bouton ×, ajoutez des chansons via la recherche et consultez les « Suggestions » pour des recommandations intelligentes.',
+    q51: 'Puis-je sauvegarder et restaurer mes paramètres ?',
+    a51: 'Oui. Paramètres → Sauvegarde & Restauration permet d\'exporter tous les paramètres, profils de serveur, thèmes et raccourcis clavier dans un fichier JSON. Importez-le sur une autre machine pour tout restaurer d\'un coup. Les mots de passe sont inclus — conservez le fichier en lieu sûr.',
+    q52: 'Comment changer le périphérique de sortie audio ?',
+    a52: 'Paramètres → Audio → Périphérique de sortie. Psysonic liste tous les périphériques disponibles. La sélection prend effet immédiatement. Utilisez le bouton d\'actualisation si un périphérique a été branché après le démarrage de l\'application.',
+    q53: 'Qu\'est-ce que Device Sync ?',
+    a53: 'Device Sync copie des albums, playlists ou artistes sur une clé USB ou une carte SD. Ouvrez-le via « Device Sync » dans la barre latérale, choisissez un dossier cible, sélectionnez vos sources et cliquez sur « Transférer vers l\'appareil ».',
+    q54: 'Qu\'est-ce que le modèle de nom de fichier dans Device Sync ?',
+    a54: 'Le modèle contrôle comment les pistes sont nommées et organisées. Utilisez les préréglages ou créez le vôtre avec les jetons cliquables : {artist}, {album}, {title}, {track_number}, {disc_number}, {year} et / comme séparateur de dossier. Un aperçu en direct est affiché.',
+    q55: 'Device Sync fonctionne-t-il entre plateformes ?',
+    a55: 'Oui. Le manifeste écrit sur l\'appareil contient le modèle utilisé lors de la synchronisation. Sur un autre OS avec un modèle différent, Psysonic détecte correctement les fichiers existants.',
+    s9: 'Device Sync',
+    q56: 'Qu\'est-ce que la radio Internet ?',
+    a56: 'La page Radio Internet permet de lire n\'importe quel flux en direct dans Psysonic. Les stations proviennent de votre serveur Navidrome — ajoutez-les via le panneau d\'administration ou importez un fichier .pls/.m3u. La lecture utilise l\'audio HTML5.',
+    q57: 'Quels formats de flux la radio Internet supporte-t-elle ?',
+    a57: 'MP3, AAC, OGG Vorbis et la plupart des flux HLS. La prise en charge des codecs dépend de la plateforme — MP3 et AAC fonctionnent partout.',
+    s10: 'Radio Internet',
+    q58: 'D\'où Psysonic récupère-t-il les paroles ?',
+    a58: 'Trois sources configurables dans Paramètres → Paroles : votre serveur Navidrome (paroles intégrées/OpenSubsonic), LRCLIB (paroles synchronisées communautaires) et NetEase Cloud Music. Chaque source peut être activée/désactivée et priorisée par glisser-déposer.',
+    q59: 'Y a-t-il une vue de ce qu\'écoutent les autres utilisateurs ?',
+    a59: 'Oui. Cliquez sur l\'icône de diffusion en haut à droite pour voir ce que les autres utilisateurs écoutent actuellement sur votre serveur Navidrome, mis à jour toutes les 10 secondes.',
   },
-
   queue: {
-
     title: 'File d\'attente',
-
     savePlaylist: 'Enregistrer la liste',
-
     updatePlaylist: 'Mettre à jour la liste',
-
     filterPlaylists: 'Filtrer les listes…',
-
     playlistName: 'Nom de la liste',
-
     cancel: 'Annuler',
-
     save: 'Enregistrer',
-
     loadPlaylist: 'Charger une liste',
-
     loading: 'Chargement…',
-
     noPlaylists: 'Aucune liste trouvée.',
-
     load: 'Remplacer la file et lire',
-
     appendToQueue: 'Ajouter à la file',
-
     delete: 'Supprimer',
-
     deleteConfirm: 'Supprimer la liste « {{name}} » ?',
-
     clear: 'Vider',
-
     shuffle: 'Mélanger la file',
-
     gapless: 'Sans blanc',
-
     crossfade: 'Fondu',
-
     infiniteQueue: 'File infinie',
-
     autoAdded: '— Ajouté automatiquement —',
-
     radioAdded: '— Radio —',
-
     hide: 'Masquer',
-
     close: 'Fermer',
-
     nextTracks: 'Pistes suivantes',
-
     emptyQueue: 'La file d\'attente est vide.',
-
     trackSingular: 'piste',
-
     trackPlural: 'pistes',
-
     showRemaining: 'Afficher le temps restant',
-
     showTotal: 'Afficher la durée totale',
-
   },
-
   statistics: {
-
     title: 'Statistiques',
-
     recentlyPlayed: 'Écoutés récemment',
-
     mostPlayed: 'Albums les plus écoutés',
-
     highestRated: 'Albums les mieux notés',
-
     genreDistribution: 'Répartition par genre (Top 20)',
-
     loadMore: 'Charger plus',
-
     statArtists: 'Artistes',
-
     statArtistsTooltip: 'Artistes d\'album uniquement — les artistes apparaissant seulement sur des pistes (featuring, invité, etc.) sans album propre ne sont pas comptés.',
-
     statAlbums: 'Albums',
-
     statSongs: 'Morceaux',
-
     statGenres: 'Genres',
-
     statPlaytime: 'Durée totale',
-
     genreInsights: 'Aperçu des genres',
-
     formatDistribution: 'Distribution des formats',
-
     formatSample: 'Échantillon de {{n}} pistes',
-
     computing: 'Calcul en cours…',
-
     genreSongs: '{{count}} morceaux',
-
     genreAlbums: '{{count}} albums',
-
     recentlyAdded: 'Ajoutés récemment',
-
     decadeDistribution: 'Albums par décennie',
-
     decadeAlbums_one: '{{count}} album',
-
     decadeAlbums_other: '{{count}} albums',
-
     decadeUnknown: 'Inconnu',
-
     lfmTitle: 'Stats Last.fm',
-
     lfmTopArtists: 'Artistes favoris',
-
     lfmTopAlbums: 'Albums favoris',
-
     lfmTopTracks: 'Morceaux favoris',
-
     lfmPlays: '{{count}} écoutes',
-
     lfmPeriodOverall: 'Tout le temps',
-
     lfmPeriod7day: '7 jours',
-
     lfmPeriod1month: '1 mois',
-
     lfmPeriod3month: '3 mois',
-
     lfmPeriod6month: '6 mois',
-
     lfmPeriod12month: '12 mois',
-
     lfmNotConnected: 'Connectez Last.fm dans les Paramètres pour voir vos stats.',
-
     lfmRecentTracks: 'Scrobbles récents',
-
     lfmNowPlaying: 'En cours de lecture',
-
     lfmJustNow: 'à l\'instant',
-
     lfmMinutesAgo: 'il y a {{n}} min',
-
     lfmHoursAgo: 'il y a {{n}}h',
-
     lfmDaysAgo: 'il y a {{n}}j',
-
     topRatedSongs: 'Morceaux les mieux notés',
-
     topRatedArtists: 'Artistes les mieux notés',
-
     noRatedSongs: 'Aucun morceau noté. Notez des morceaux dans la vue album ou playlist.',
-
     noRatedArtists: 'Aucun artiste noté.',
-
   },
-
   player: {
-
     regionLabel: 'Lecteur de musique',
-
     openFullscreen: 'Ouvrir le lecteur plein écran',
-
     fullscreen: 'Lecteur plein écran',
-
     closeFullscreen: 'Fermer le plein écran',
-
     closeTooltip: 'Fermer (Échap)',
-
     noTitle: 'Sans titre',
-
     stop: 'Arrêter',
-
     prev: 'Piste précédente',
-
     play: 'Lecture',
-
     pause: 'Pause',
-
     next: 'Piste suivante',
-
     repeat: 'Répéter',
-
     repeatOff: 'Désactivé',
-
     repeatAll: 'Tout',
-
     repeatOne: 'Un',
-
     progress: 'Progression',
-
     volume: 'Volume',
-
     toggleQueue: 'Afficher/masquer la file',
-
     lyrics: 'Paroles',
-
     fsLyricsToggle: 'Paroles en plein écran',
-
     lyricsLoading: 'Chargement des paroles…',
-
     lyricsNotFound: 'Aucune parole trouvée pour ce titre',
-
     lyricsSourceServer: 'Source : Serveur',
-
     lyricsSourceLrclib: 'Source : LRCLIB',
-
     lyricsSourceNetease: 'Source : Netease',
-
   },
-
   songInfo: {
-
     title: 'Infos du morceau',
-
     songTitle: 'Titre',
-
     artist: 'Artiste',
-
     album: 'Album',
-
     albumArtist: 'Artiste de l\'album',
-
     year: 'Année',
-
     genre: 'Genre',
-
     duration: 'Durée',
-
     track: 'Piste',
-
     format: 'Format',
-
     bitrate: 'Débit',
-
     sampleRate: 'Fréquence d\'échantillonnage',
-
     bitDepth: 'Profondeur de bits',
-
     channels: 'Canaux',
-
     fileSize: 'Taille du fichier',
-
     path: 'Emplacement',
-
     replayGainTrack: 'RG Gain de piste',
-
     replayGainAlbum: 'RG Gain d\'album',
-
     replayGainPeak: 'RG Crête de piste',
-
     mono: 'Mono',
-
     stereo: 'Stéréo',
-
   },
-
   playlists: {
-
     title: 'Playlists',
-
     newPlaylist: 'Nouvelle playlist',
-
     unnamed: 'Playlist sans nom',
-
     createName: 'Nom de la playlist…',
-
     create: 'Créer',
-
     cancel: 'Annuler',
-
     empty: 'Aucune playlist pour l\'instant.',
-
     emptyPlaylist: 'Cette playlist est vide.',
-
     addFirstSong: 'Ajouter votre premier titre',
-
     notFound: 'Playlist introuvable.',
-
     songs: '{{n}} titres',
-
     playAll: 'Tout lire',
-
     shuffle: 'Aléatoire',
-
     addToQueue: 'Ajouter à la file',
-
     back: 'Retour aux playlists',
-
     deletePlaylist: 'Supprimer',
-
     confirmDelete: 'Cliquer à nouveau pour confirmer',
-
     removeSong: 'Retirer de la playlist',
-
     addSongs: 'Ajouter des titres',
-
     searchPlaceholder: 'Rechercher dans la bibliothèque…',
-
     noResults: 'Aucun résultat.',
-
     suggestions: 'Titres suggérés',
-
     noSuggestions: 'Aucune suggestion disponible.',
-
     titleBadge: 'Playlist',
-
     refreshSuggestions: 'Nouvelles suggestions',
-
     addSong: 'Ajouter à la playlist',
-
     addSelected: 'Ajouter la sélection',
-
     cacheOffline: 'Mettre la playlist hors ligne',
-
     offlineCached: 'Playlist en cache',
-
     removeOffline: 'Retirer du cache hors ligne',
-
     offlineDownloading: 'En cache… ({{done}}/{{total}} albums)',
-
     publicLabel: 'Publique',
-
     privateLabel: 'Privée',
-
     editMeta: 'Modifier la playlist',
-
     editNamePlaceholder: 'Nom de la playlist…',
-
     editCommentPlaceholder: 'Ajouter une description…',
-
     editPublic: 'Playlist publique',
-
     editSave: 'Enregistrer',
-
     editCancel: 'Annuler',
-
     changeCover: 'Changer la pochette',
-
     changeCoverLabel: 'Changer la photo',
-
     removeCover: 'Supprimer la photo',
-
     coverUpdated: 'Pochette mise à jour',
-
     metaSaved: 'Playlist mise à jour',
-
     downloadZip: 'Télécharger (ZIP)',
-
     // Toast notifications for multi-select
-
     addSuccess: '{{count}} morceaux ajoutés à {{playlist}}',
-
     addPartial: '{{added}} ajoutés, {{skipped}} ignorés (doublons)',
-
     addAllSkipped: 'Tous ignorés ({{count}} doublons)',
-
     addError: 'Erreur lors de l\'ajout des morceaux',
-
     createAndAddSuccess: 'Playlist "{{playlist}}" créée avec {{count}} morceaux',
-
     createError: 'Erreur lors de la création de la playlist',
-
     deleteSuccess: '{{count}} playlists supprimées',
-
     deleteFailed: 'Erreur lors de la suppression de {{name}}',
-
     deleteSelected: 'Supprimer la sélection',
-
     mergeSuccess: '{{count}} morceaux fusionnés dans {{playlist}}',
-
     mergeNoNewSongs: 'Aucun nouveau morceau à ajouter',
-
     mergeError: 'Erreur lors de la fusion des playlists',
-
     mergeInto: 'Fusionner dans',
-
     selectionCount: '{{count}} sélectionnés',
-
     select: 'Sélectionner',
-
     startSelect: 'Activer la sélection',
-
     cancelSelect: 'Annuler',
-
     loadingAlbums: 'Résolution de {{count}} albums…',
-
     loadingArtists: 'Résolution de {{count}} artistes…',
-
     myPlaylists: 'Mes Playlists',
-
     noOtherPlaylists: 'Aucune autre playlist disponible',
-
     addToPlaylistSuccess: '{{count}} morceaux ajoutés à {{playlist}}',
-
     addToPlaylistNoNew: 'Aucun nouveau morceau pour {{playlist}}',
-
     addToPlaylistError: 'Erreur lors de l\'ajout à la playlist',
-
     removeSuccess: 'Morceau retiré de la playlist',
-
     removeError: 'Erreur lors du retrait de la playlist',
-
     importCSV: 'Importer CSV',
-
     importCSVTooltip: 'Importer depuis CSV Spotify',
-
     csvImportReport: 'Rapport d\'Import CSV',
-
     csvImportTotal: 'Total',
-
     csvImportAdded: 'Ajoutés',
-
     csvImportDuplicates: 'Doublons',
-
     csvImportNotFound: 'Non Trouvés',
-
     csvImportNetworkErrors: 'Erreurs Réseau',
-
     csvImportDuplicatesTitle: 'Titres en Doublon (Déjà dans la Playlist):',
-
     csvImportNotFoundTitle: 'Titres Non Trouvés:',
-
     csvImportNetworkErrorsTitle: 'Erreurs Réseau (peut réessayer l\'import):',
-
     csvImportDownloadReport: 'Télécharger le Rapport',
-
     csvImportClose: 'Fermer',
-
     csvImportNoValidTracks: 'Aucun titre valide trouvé dans le fichier CSV',
-
     csvImportFailed: 'Échec de l\'import CSV',
-
     csvImportToast: '{{added}} ajoutés, {{notFound}} non trouvés, {{duplicates}} doublons',
-
   },
-
   mostPlayed: {
-
     title: 'Les plus joués',
-
     topArtists: 'Artistes populaires',
-
     topAlbums: 'Albums populaires',
-
     plays: '{{n}} écoutes',
-
     sortMost: 'Plus joués en premier',
-
     sortLeast: 'Moins joués en premier',
-
     loadMore: 'Charger plus d\'albums',
-
     noData: 'Aucune donnée d\'écoute. Commencez à écouter !',
-
     noArtists: 'Tous les artistes filtrés.',
-
     filterCompilations: 'Masquer les artistes de compilations (Various Artists, Soundtracks, etc.)',
-
     filterCompilationsShort: 'Masquer les compilations',
-
   },
-
   radio: {
-
     title: 'Radio Internet',
-
     empty: 'Aucune station radio configurée.',
-
     addStation: 'Ajouter une station',
-
     editStation: 'Modifier',
-
     deleteStation: 'Supprimer la station',
-
     confirmDelete: 'Cliquer à nouveau pour confirmer',
-
     stationName: 'Nom de la station…',
-
     streamUrl: 'URL du flux…',
-
     homepageUrl: 'URL de la page d\'accueil (optionnel)',
-
     save: 'Enregistrer',
-
     cancel: 'Annuler',
-
     live: 'LIVE',
-
     liveStream: 'Radio Internet',
-
     openHomepage: 'Ouvrir la page d\'accueil',
-
     changeCoverLabel: 'Changer la pochette',
-
     removeCover: 'Supprimer la pochette',
-
     browseDirectory: 'Parcourir l\'annuaire',
-
     directoryPlaceholder: 'Rechercher des stations…',
-
     noResults: 'Aucune station trouvée.',
-
     stationAdded: 'Station ajoutée',
-
     filterAll: 'Toutes',
-
     filterFavorites: 'Favoris',
-
     sortManual: 'Manuel',
-
     sortAZ: 'A → Z',
-
     sortZA: 'Z → A',
-
     sortNewest: 'Plus récentes',
-
     favorite: 'Ajouter aux favoris',
-
     unfavorite: 'Retirer des favoris',
-
     noFavorites: 'Aucune station favorite.',
-
     listenerCount_one: '{{count}} auditeur',
-
     listenerCount_other: '{{count}} auditeurs',
-
     recentlyPlayed: 'Récemment joués',
-
     upNext: 'À suivre',
-
   },
-
   folderBrowser: {
-
     empty: 'Dossier vide',
-
     error: 'Échec du chargement',
-
   },
-
   deviceSync: {
-
     title: 'Sync appareil',
-
     targetFolder: 'Dossier cible',
-
     noFolderChosen: 'Aucun dossier sélectionné',
-
     selectDrive: 'Sélectionner un lecteur…',
-
     refreshDrives: 'Actualiser les lecteurs',
-
     noDrivesDetected: 'Aucun lecteur amovible détecté',
-
     browseManual: 'Parcourir manuellement…',
-
     free: 'libre',
-
     notMountedVolume: 'La cible n\u0027est pas sur un volume monté. Le lecteur a peut-être été déconnecté.',
-
     chooseFolder: 'Choisir…',
-
     filenameTemplate: 'Modèle de nom de fichier',
-
     targetDevice: 'Appareil cible',
-
     templateHint: 'Variables : {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
-
     cleanupButton: 'Supprimer les fichiers absents',
-
     cleanupNothingToDelete: 'Rien à supprimer — l\'appareil est déjà synchronisé.',
-
     confirmCleanup: 'Supprimer {{count}} fichier(s) de l\'appareil qui ne font pas partie de la sélection actuelle. Continuer ?',
-
     cleanupComplete: '{{count}} fichier(s) supprimé(s) de l\'appareil.',
-
     selectedSources: 'Sources sélectionnées',
-
     noSourcesSelected: 'Aucune source sélectionnée. Cliquez sur des éléments dans le navigateur pour les ajouter.',
-
     clearAll: 'Tout effacer',
-
     tabPlaylists: 'Listes de lecture',
-
     tabAlbums: 'Albums',
-
     tabArtists: 'Artistes',
-
     searchPlaceholder: 'Rechercher…',
-
     syncButton: 'Synchroniser vers l\'appareil',
-
     actionTransfer: 'Transférer vers l\'appareil',
-
     actionDelete: 'Supprimer de l\'appareil',
-
     actionApplyAll: 'Appliquer toutes les modifications',
-
     templatePreview: 'Aperçu',
-
+    templatePresetStandard: 'Standard',
+    templatePresetMultiDisc: 'Multi-Disc',
+    templatePresetAltFolder: 'Dossier alt.',
+    tokenSlashHint: '/ = séparateur de dossier',
     cancel: 'Annuler',
-
     noTargetDir: 'Veuillez d\'abord choisir un dossier cible.',
-
     noSources: 'Veuillez sélectionner au moins une source.',
-
     noTracks: 'Aucune piste trouvée dans les sources sélectionnées.',
-
     fetchError: 'Échec du chargement des pistes depuis le serveur.',
-
     syncComplete: 'Synchronisation terminée.',
-
     dismiss: 'Fermer',
-
+    cancelSync: 'Annuler',
+    syncCancelled: 'Synchronisation annulée ({{done}} / {{total}} transférés).',
     colName: 'Nom',
-
     colType: 'Type',
-
     colStatus: 'Statut',
-
     onDevice: 'Gestionnaire d\'appareil',
-
     addSources: 'Ajouter…',
-
     syncResult: '{{done}} transféré(s), {{skipped}} déjà à jour ({{total}} au total)',
-
     deleteFromDevice: 'Marquer pour suppression ({{count}})',
-
     confirmDelete: 'Supprimer {{count}} élément(s) du périphérique : {{names}} ?',
-
     deleteComplete: '{{count}} élément(s) supprimé(s) du périphérique.',
-
+    manifestImported: '{{count}} source(s) importée(s) depuis le manifeste du périphérique.',
     statusSynced: 'Synchronisé',
-
     statusPending: 'En attente',
-
     statusDeletion: 'Suppression',
-
     markForDeletion: 'Marquer pour suppression',
-
     removeSource: 'Supprimer',
-
     undoDeletion: 'Annuler la suppression',
-
     syncInBackground: 'Sync démarré en arrière-plan — vous pouvez naviguer ailleurs.',
-
     syncInProgress: '{{done}} / {{total}} pistes…',
-
     syncSummary: 'Résumé de la synchronisation',
-
     calculating: 'Calcul de la charge utile…',
-
     filesToAdd: 'Fichiers à ajouter :',
-
     filesToDelete: 'Fichiers à supprimer :',
-
     netChange: 'Variation nette :',
-
     availableSpace: 'Espace disque disponible :',
-
     spaceWarning: 'Attention : L\'appareil cible ne dispose pas d\'assez d\'espace signalé.',
-
     proceed: 'Procéder à la synchronisation',
-
     notEnoughSpace: 'Espace disque physique insuffisant détecté !',
-
     liveSearch: 'Live',
-
     randomAlbumsLabel: 'Albums aléatoires',
-
   },
-
 };
-

--- a/src/locales/nb.ts
+++ b/src/locales/nb.ts
@@ -1,1163 +1,2264 @@
 export const nbTranslation = {
+
   sidebar: {
+
     library: 'Bibliotek',
+
     mainstage: 'Hovedscene',
+
     newReleases: 'Nye utgivelser',
+
     allAlbums: 'Alle album',
+
     randomAlbums: 'Tilfeldige album',
+
     randomPicker: 'Lag en miks',
+
     artists: 'Artister',
+
     randomMix: 'Tilfeldig miks',
+
     favorites: 'Favoritter',
+
     nowPlaying: 'Spilles nå',
+
     system: 'System',
+
     statistics: 'Statistikk',
+
     settings: 'Innstillinger',
+
     help: 'Hjelp',
+
     expand: 'Utvid sidefelt',
+
     collapse: 'Skjul sidefelt',
+
     downloadingTracks: 'Bufre {{n}} spor…',
+
     syncingTracks: 'Synkroniserer {{done}}/{{total}}…',
+
     cancelDownload: 'Avbryt nedlasting',
+
     offlineLibrary: 'Frakoblet bibliotek',
+
     genres: 'Sjangere',
+
     playlists: 'Spillelister',
+
     mostPlayed: 'Mest spilt',
+
     radio: 'Internettradio',
+
     folderBrowser: 'Mappeleser',
+
     deviceSync: 'Enhetssynk',
+
     libraryScope: 'Biblioteksomfang',
+
     allLibraries: 'Alle biblioteker',
+
     expandPlaylists: 'Utvid spillelister',
+
     collapsePlaylists: 'Skjul spillelister',
+
   },
+
   home: {
+
     hero: 'Utvalgt',
+
     starred: 'Personlige favoritter',
+
     recent: 'Nylig lagt til',
+
     mostPlayed: 'Mest spilt',
+
     recentlyPlayed: 'Nylig spilt',
+
     discover: 'Oppdag',
+
     loadMore: 'Last inn flere',
+
     discoverMore: 'Oppdag flere',
+
     discoverArtists: 'Oppdag artister',
+
     discoverArtistsMore: 'Alle artister'
+
   },
+
   hero: {
+
     eyebrow: 'Utvalgt album',
+
     playAlbum: 'Spill av album',
+
     enqueue: 'Legg til i kø',
+
     enqueueTooltip: 'Legg til hele albumet i køen',
+
   },
+
   search: {
+
     placeholder: 'Søk etter artist, album eller sang…',
+
     noResults: 'Ingen resultater funnet for "{{query}}"',
+
     artists: 'Artister',
+
     albums: 'Album',
+
     songs: 'Sanger',
+
     clearLabel: 'Fjern søk',
+
     title: 'Søk',
+
     resultsFor: 'Resultater for "{{query}}"',
+
     album: 'Album',
+
     advanced: 'Avansert søk',
+
     advancedSearchTerm: 'Søkeord',
+
     advancedSearchPlaceholder: 'Tittel, album, artist…',
+
     advancedGenre: 'Sjanger',
+
     advancedAllGenres: 'Alle sjangre',
+
     advancedYear: 'År',
+
     advancedYearFrom: 'fra',
+
     advancedYearTo: 'til',
+
     advancedAll: 'Alle',
+
     advancedSearch: 'Søk',
+
     advancedEmpty: 'Skriv inn et søkeord eller velg ett filter for å begynne.',
+
     advancedNoResults: 'Ingen resultater funnet.',
+
     advancedGenreNote: 'Sanger er tilfeldig valgt fra denne sjangeren.',
+
     recentSearches: 'Siste søk',
+
     browse: 'Utforsk',
+
     emptyHint: 'Hva vil du høre?',
+
     genres: 'Sjangre',
+
   },
+
   nowPlaying: {
+
     tooltip: 'Hvem lytter?',
+
     title: 'Hvem lytter?',
+
     loading: 'Laster…',
+
     nobody: 'Ingen lyttere for øyeblikket.',
+
     minutesAgo: '{{n}}m siden',
+
     nothingPlaying: 'Ingenting spiller akkurat å. Start et spor!',
+
     aboutArtist: 'Om artisten',
+
     fromAlbum: 'Fra dette albumet',
+
     viewAlbum: 'Se album',
+
     goToArtist: 'Gå til artist',
+
     readMore: 'Les mer',
+
     showLess: 'Vis mindre',
+
     genreInfo: 'Sjanger',
+
     trackInfo: 'Sporinfo',
+
   },
+
   contextMenu: {
+
     playNow: 'Spill nå',
+
     playNext: 'Spill neste',
+
     addToQueue: 'Legg til i kø',
+
     enqueueAlbum: 'Legg albumet i kø',
+
     startRadio: 'Start radio',
+
     instantMix: 'Instant Mix',
+
     instantMixFailed: 'Kunne ikke lage Instant Mix — server- eller pluginfeil.',
+
     cliMixNeedsTrack: 'Ingenting spilles — start avspilling først, og kjør mix-kommandoen på nytt.',
+
     lfmLove: 'Lik på Last.fm',
+
     lfmUnlove: 'Fjern fra likte på Last.fm',
+
     favorite: 'Favoritt',
+
     favoriteArtist: 'Favorittartist',
+
     favoriteAlbum: 'Favorittalbum',
+
     unfavorite: 'Fjern fra favoritter',
+
     unfavoriteArtist: 'Fjern artist fra favoritter',
+
     unfavoriteAlbum: 'Fjern album fra favoritter',
+
     removeFromQueue: 'Fjern fra kø',
+
     removeFromPlaylist: 'Fjern fra spilleliste',
+
     openAlbum: 'Åpne album',
+
     goToArtist: 'Gå til artist',
+
     download: 'Last ned (ZIP)',
+
     addToPlaylist: 'Legg til i spilleliste',
+
     selectedPlaylists: '{{count}} spillelister valgt',
+
     selectedAlbums: '{{count}} album valgt',
+
     selectedArtists: '{{count}} artister valgt',
+
     songInfo: 'Sanginfo',
+
   },
+
   albumDetail: {
+
     back: 'Tilbake',
+
     playAll: 'Spill alt',
+
     enqueue: 'Legg i kø',
+
     enqueueTooltip: 'Legg hele albumet i kø',
+
     artistBio: 'Artistbiografi',
+
     download: 'Last ned (ZIP)',
+
     downloading: 'Laster…',
+
     cacheOffline: 'Gjør tilgjengelig som frakoblet',
+
     offlineCached: 'Tilgjengelig frakoblet',
+
     offlineDownloading: 'Bufrer… ({{n}}/{{total}})',
+
     removeOffline: 'Fjern frakoblet hurtigbuffer',
+
     offlineStorageFull: 'Frakoblet lagring er full (lagringsgrense: {{mb}} MB). Frigjør plass, ved å slette et album fra ditt frakoblede bibliotek, eller øk lagringsgrensen i Innstillinger.',
+
     offlineStorageGoToLibrary: 'Frakoblet bibliotek',
+
     offlineStorageGoToSettings: 'Innstillinger',
+
     favoriteAdd: 'Legg til i favoritter',
+
     favoriteRemove: 'Fjern fra favoritter',
+
     favorite: 'Favoritt',
+
     noBio: 'Ingen biografi er tilgjengelig.',
+
     moreByArtist: 'Mer av {{artist}}',
+
     tracksCount: '{{n}} spor',
+
     goToArtist: 'Gå til {{artist}}',
+
     moreLabelAlbums: 'Flere album på {{label}}',
+
     trackTitle: 'Tittel',
+
     trackAlbum: 'Album',
+
     trackArtist: 'Artist',
+
     trackGenre: 'Sjanger',
+
     trackFormat: 'Format',
+
     trackFavorite: 'Favoritt',
+
     trackRating: 'Vurdering',
+
     trackDuration: 'Varighet',
+
     trackTotal: 'Totalt',
+
     columns: 'Kolonner',
-    resetColumns: 'Tilbakestill',
+
     notFound: 'Album ble ikke funnet.',
+
     bioModal: 'Artistbiografi',
+
     bioClose: 'Lukk',
+
     ratingLabel: 'Vurdering',
+
     enlargeCover: 'Forstørr',
+
     filterSongs: 'Filtrer sanger…',
+
     sortNatural: 'Naturlig',
+
     sortByTitle: 'A–Å (Tittel)',
+
     sortByArtist: 'A–Å (Artist)',
+
     sortByAlbum: 'A–Å (Album)',
+
   },
+
   entityRating: {
+
     albumShort: 'Albumvurdering',
+
     artistShort: 'Artistvurdering',
+
     albumAriaLabel: 'Albumvurdering',
+
     artistAriaLabel: 'Artistvurdering',
+
     saveFailed: 'Kunne ikke lagre vurderingen.',
+
   },
+
   artistDetail: {
+
     back: 'Tilbake',
+
     albums: 'Album',
+
     album: 'Album',
+
     playAll: 'Spill alt',
+
     shuffle: 'Tilfeldig rekkefølge',
+
     radio: 'Radio',
+
     loading: 'Laster…',
+
     noRadio: 'Ingen lignende spor funnet for denne artisten.',
+
     notFound: 'Artisten ble ikke funnet.',
+
     albumsBy: 'Album fra {{name}}',
+
     topTracks: 'Toppspor',
+
     noAlbums: 'Ingen album funnet.',
+
     trackTitle: 'Tittel',
+
     trackAlbum: 'Album',
+
     trackDuration: 'Varighet',
+
     favoriteAdd: 'Legg til i favoritter',
+
     favoriteRemove: 'Fjern fra favoritter',
+
     favorite: 'Favoritt',
+
     albumCount_one: '{{count}} album',
+
     albumCount_other: '{{count}} album',
+
     openedInBrowser: 'Åpnet i nettleser',
+
     featuredOn: 'Også en del av',
+
     similarArtists: 'Lignende artister',
+
     cacheOffline: 'Lagre diskografi som frakoblet',
+
     offlineCached: 'Diskografi bufret',
+
     offlineDownloading: 'Bufrer… ({{done}}/{{total}} album)',
+
     uploadImage: 'Last opp artistbilde',
+
     uploadImageError: 'Kunne ikke laste opp bildet',
+
   },
+
   favorites: {
+
     title: 'Favoritter',
+
     empty: "Du har ikke lagret noen favoritter ennå.",
+
     artists: 'Artister',
+
     albums: 'Album',
+
     songs: 'Sanger',
+
     enqueueAll: 'Legg alle i kø',
+
     playAll: 'Spill alle',
+
     removeSong: 'Fjern fra favoritter',
+
     stations: 'Radiostasjoner',
+
     showingFiltered: 'Viser {{filtered}} av {{total}} ({{artist}})',
+
     showingCount: 'Viser {{filtered}} av {{total}}',
+
     clearArtistFilter: 'Tøm artistfilter',
+
     noFilterResults: 'Ingen resultater med valgte filtre.',
+
     allArtists: 'Alle artister',
+
   },
+
   randomLanding: {
+
     title: 'Lag en miks',
+
     mixByTracks: 'Miks etter spor',
+
     mixByTracksDesc: 'Tilfeldig utvalg av spor fra hele biblioteket ditt',
+
     mixByAlbums: 'Miks etter album',
+
     mixByAlbumsDesc: 'Tilfeldige album for nye oppdagelser',
+
   },
+
   randomAlbums: {
+
     title: 'Tilfeldige album',
+
     refresh: 'Oppdater',
+
   },
+
   genres: {
+
     title: 'Sjangre',
+
     genreCount: 'Sjangre',
+
     albumCount_one: '{{count}} album',
+
     albumCount_other: '{{count}} album',
+
     loading: 'Laster sjangre…',
+
     empty: 'Ingen sjangre funnet.',
+
     albumsLoading: 'Laster album…',
+
     albumsEmpty: 'Ingen album funnet for denne sjangeren.',
+
     loadMore: 'Last mer',
+
     back: 'Tilbake',
+
   },
+
   randomMix: {
+
     title: 'Tilfeldig miks',
+
     remix: 'Remiks',
+
     remixTooltip: 'Last inn nye tilfeldige sanger',
+
     remixGenre: 'Remiks {{genre}}',
+
     remixTooltipGenre: 'Last inn nye {{genre}}-sanger',
+
     playAll: 'Spill alt',
+
     trackTitle: 'Tittel',
+
     trackArtist: 'Artist',
+
     trackAlbum: 'Album',
+
     trackFavorite: 'Favoritt',
+
     trackDuration: 'Varighet',
+
     favoriteAdd: 'Legg til i favoritter',
+
     favoriteRemove: 'Fjern fra favoritter',
+
     play: 'Spill',
+
     trackGenre: 'Sjanger',
+
     excludeAudiobooks: 'Ekskluder lydbøker og hørespill',
+
     excludeAudiobooksDesc: 'Samsvarer nøkkelord mot sjanger, tittel, album og artist - f.eks. Hørespill, Lydbok, Spoken Word, …',
+
     genreBlocked: 'Nøkkelord blokkert',
+
     genreAddedToBlacklist: 'Lagt til i filterliste',
+
     genreAlreadyBlocked: 'Allerede blokkert',
+
     artistBlocked: 'Artisten er blokkert',
+
     artistAddedToBlacklist: 'Artist er lagt til i filterliste',
+
     artistClickHint: 'Klikk for å blokkere denne artisten',
+
     blacklistToggle: 'Nøkkelordfilter',
+
     genreMixTitle: 'Sjangermiks',
+
     genreMixDesc: 'Topp 20 sjangre etter antall sanger - klikk for å laste en tilfeldig miks',
+
     genreMixAll: 'Alle sanger',
+
     genreMixLoadMore: 'Last 10 til',
+
     genreMixNoGenres: 'Ingen sjangre funnet på tjeneren.',
+
     shuffleGenres: 'Vis andre sjangre',
+
     filterPanelTitle: 'Filtre',
+
     filterPanelDesc: 'Klikk på en sjanger-tag eller på artistnavnet i sporlisten nedenfor, for å blokkere den fra fremtidige mikser.',
+
     genreClickHint: 'Klikk på en sjanger-tag for å legge den til\nsom et filternøkkelord.\nSamsvarer med sjanger, tittel, album og artist.',
+
   },
+
   albums: {
+
     title: 'Alle album',
+
     sortByName: 'A–Å (Album)',
+
     sortByArtist: 'A–Å (Artist)',
+
     sortNewest: 'Vis nyeste først',
+
     sortRandom: 'Tilfeldig',
+
 	yearFrom: 'Fra',
+
     yearTo: 'Til',
+
     yearFilterClear: 'Tøm år filteret',
+
     yearFilterLabel: 'År',
+
     select: 'Multivalg',
+
     startSelect: 'Aktiver multivalg',
+
     cancelSelect: 'Avbryt',
+
     selectionCount: '{{count}} valgt',
+
     downloadZips: 'Last ned ZIPs',
+
     addOffline: 'Legg til offline',
+
     downloadingZip: 'Laster ned {{current}}/{{total}}: {{name}}',
+
     downloadZipDone: '{{count}} ZIP(s) lastet ned',
+
     downloadZipFailed: 'Kunne ikke laste ned {{name}}',
+
     offlineQueuing: 'Legger {{count}} album i kø for offline…',
+
     offlineFailed: 'Kunne ikke legge til {{name}} offline',
+
   },
+
   artists: {
+
     title: 'Artister',
+
     search: 'Søk…',
+
     all: 'Alle',
+
     gridView: 'Rutenettvisning',
+
     listView: 'Listevisning',
+
     imagesOn: 'Artistbilder på - kan øke belastningen på nettverket og applikasjonen',
+
     imagesOff: 'Artistbilder av - viser kun initialer',
+
     loadMore: 'Last flere',
+
     notFound: 'Ingen artister funnet.',
+
     albumCount_one: '{{count}} album',
+
     albumCount_other: '{{count}} album',
+
     selectionCount: '{{count}} valgt',
+
     select: 'Multivalg',
+
     startSelect: 'Aktiver multivalg',
+
     cancelSelect: 'Avbryt',
+
     addToPlaylist: 'Legg til i spilleliste',
+
   },
+
   login: {
+
     subtitle: 'Din Navidrome-mediaspiller',
+
     serverName: 'Tjenernavn (valgfritt)',
+
     serverNamePlaceholder: 'Mitt mediabibliotek',
+
     serverUrl: 'Tjener-URL',
+
     serverUrlPlaceholder: '192.168.1.100:4533 eller https://musikk.eksempel.com',
+
     username: 'Brukernavn',
+
     usernamePlaceholder: 'admin',
+
     password: 'Passord',
+
     showPassword: 'Vis passord',
+
     hidePassword: 'Skjul passord',
+
     connect: 'Koble til',
+
     connecting: 'Kobler til…',
+
     connected: 'Tilkoblet!',
+
     error: 'Tilkoblingen mislyktes – vennligst sjekk instillingene.',
+
     urlRequired: 'Vennligst skriv inn en tjeneer-URL.',
+
     savedServers: 'Lagrede servere',
+
     addNew: 'Eller legg til en ny tjener',
+
   },
+
   connection: {
+
     connected: 'Tilkoblet',
+
     connectedTo: 'Tilkoblet til {{server}}',
+
     disconnected: 'Frakoblet',
+
     disconnectedFrom: 'Kan ikke nå {{server}} - klikk for å sjekke innstillinger',
+
     checking: 'Kobler til…',
+
     extern: 'Ekstern',
+
     offlineTitle: 'Ingen tjenertilkobling',
+
     offlineSubtitle: 'Kan ikke nå {{server}}. Sjekk nettverket eller tjeneren din.',
+
     offlineModeBanner: 'Frakoblet modus - spiller fra lokal hurtigbuffer',
+
     offlineNoCacheBanner: 'Ingen servertilkobling — kan ikke nå {{server}}',
+
     offlineLibraryTitle: 'Frakoblet bibliotek',
+
     offlineLibraryEmpty: 'Ingen album bufret ennå. Kobl deg til nettverket, åpne et album og klikk "Gjør tilgjengelig frakoblet".',
+
     offlineAlbumCount: '{{n}} album',
+
     offlineAlbumCount_plural: '{{n}} album',
+
     offlineFilterAll: 'Alle',
+
     offlineFilterAlbums: 'Album',
+
     offlineFilterPlaylists: 'Spillelister',
+
     offlineFilterArtists: 'Diskografier',
+
     retry: 'Prøv igjen',
+
     serverSettings: 'Serverinnstillinger',
+
     switchServerTitle: 'Bytt server',
+
     switchServerHint: 'Klikk for å velge en annen lagret server.',
+
     manageServers: 'Administrer servere…',
+
     switchFailed: 'Klarte ikke å bytte — serveren er utilgjengelig.',
+
     lastfmConnected: 'Last.fm tilkoblet som bruker @{{user}}',
+
     lastfmSessionInvalid: 'Sesjonen er ugyldig - klikk her for å koble til på nytt',
+
   },
+
   common: {
+
     albums: 'Album',
+
     album: 'Album',
+
     loading: 'Laster…',
+
     loadingMore: 'Laster…',
+
     loadingPlaylists: 'Laster spillelister…',
+
     noAlbums: 'Ingen album funnet.',
+
     downloading: 'Laster ned…',
+
     downloadZip: 'Last ned (ZIP)',
+
     back: 'Tilbake',
+
     cancel: 'Avbryt',
+
     save: 'Lagre',
+
     delete: 'Slett',
+
     use: 'Bruk',
+
     add: 'Legg til',
+
     active: 'Aktiv',
+
     download: 'Last ned',
+
     chooseDownloadFolder: 'Velg nedlastingsmappe',
+
     noFolderSelected: 'Ingen mappe valgt',
+
     rememberDownloadFolder: 'Husk denne mappen',
+
     filterGenre: 'Sjangerfilter',
+
     filterSearchGenres: 'Søk i sjangre…',
+
     filterNoGenres: 'Ingen sjangre samsvarer',
+
     filterClear: 'Tøm',
+
     play: 'Spill',
+
     bulkSelected: '{{count}} valgt',
+
     clearSelection: 'Fjern utvalg',
+
     bulkAddToPlaylist: 'Legg til i spilleliste',
+
     bulkRemoveFromPlaylist: 'Fjern fra spilleliste',
+
     bulkClear: 'Tøm utvalg',
+
     updaterAvailable: 'Ny versjon er tilgjengelig',
+
     updaterVersion: 'v{{version}} er tilgjengelig',
+
     updaterWebsite: 'Nettsted',
+
     updaterModalTitle: 'Ny versjon tilgjengelig',
+
     updaterChangelog: 'Hva er nytt',
+
     updaterDownloadBtn: 'Last ned nå',
+
     updaterSkipBtn: 'Hopp over denne versjonen',
+
     updaterRemindBtn: 'Påminn meg senere',
+
     updaterDone: 'Nedlasting fullført',
+
     updaterShowFolder: 'Vis i mappe',
+
     updaterInstallHint: 'Lukk Psysonic og kjør installasjonsprogrammet manuelt.',
+
     updaterAurHint: 'Installer oppdateringen via AUR:',
+
     updaterErrorMsg: 'Nedlasting mislyktes',
+
     updaterRetryBtn: 'Prøv igjen',
+
     durationHoursMinutes: '{{hours}} t {{minutes}} min',
+
     durationMinutesOnly: '{{minutes}} min',
+
     updaterOpenGitHub: 'Åpne på GitHub',
+
     filters: 'Filter',
+
     more: 'mer',
+
     yearRange: 'Årsspenn',
+
     clearAll: 'Tøm alt',
+
   },
+
   settings: {
+
     title: 'Innstillinger',
+
     language: 'Språk',
+
     languageEn: 'Engelsk',
+
     languageDe: 'Tysk',
+
     languageFr: 'Fransk',
+
     languageNl: 'Nederlandsk',
+
     languageZh: 'Kinesisk',
+
     languageNb: 'Norsk',
+
     languageRu: 'Russisk',
+
     font: 'Skrifttype',
+
     theme: 'Tema',
+
     appearance: 'Utseende',
+
     servers: 'Tjenere',
+
     serverName: 'Tjenernavn',
+
     serverUrl: 'Tjener-URL',
+
     serverUrlPlaceholder: '192.168.1.100:4533 eller https://musikk.eksempel.com',
+
     serverUsername: 'Brukernavn',
+
     serverPassword: 'Passord',
+
     addServer: 'Legg til tjener',
+
     addServerTitle: 'Legg til ny tjener',
+
     useServer: 'Bruk',
+
     deleteServer: 'Slett',
+
     noServers: 'Ingen tjenere lagret.',
+
     serverActive: 'Aktiv',
+
     confirmDeleteServer: 'Slett tjener "{{name}}"?',
+
     serverConnecting: 'Kobler til…',
+
     serverConnected: 'Tilkoblet!',
+
     serverFailed: 'Tilkobling mislyktes.',
+
     testBtn: 'Test tilkobling',
+
     testingBtn: 'Tester…',
+
     serverCompatible: 'Kompatibel med: Navidrome · Gonic · Airsonic · Subsonic',
+
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+
     audiomuseDesc:
+
       'Slå på hvis denne serveren bruker <pluginLink>AudioMuse-AI Navidrome-plugin</pluginLink>. Aktiverer Instant Mix fra spor og henter lignende artister fra serveren i stedet for Last.fm på artistsider.',
+
     audiomuseIssueHint:
+
       'Instant Mix feilet nylig — sjekk Navidrome-plugin og AudioMuse API. Lignende artister hentes fra Last.fm hvis serveren ikke returnerer noe.',
+
     connected: 'Tilkoblet',
+
     failed: 'Mislyktes',
+
     eqTitle: 'Jevnstiller',
+
     eqEnabled: 'Aktiver jevnstiller',
+
     eqPreset: 'Forhåndsinnstilling',
+
     eqPresetCustom: 'Egendefinert',
+
     eqPresetBuiltin: 'Innebygde forhåndsinnstillinger',
+
     eqPresetCustomGroup: 'Mine forhåndsinnstillinger',
+
     eqSavePreset: 'Lagre som forhåndsinnstilling',
+
     eqPresetName: 'Navn på forhåndsinnstilling…',
+
     eqDeletePreset: 'Slett forhåndsinnstilling',
+
     eqResetBands: 'Tilbakestill til standard',
+
     eqPreGain: 'Forforsterkning',
+
     eqResetPreGain: 'Tilbakestill forforsterkning',
+
     eqAutoEqTitle: 'AutoEQ hodetelefonoppslag',
+
     eqAutoEqPlaceholder: 'Søk etter hodetelefon- / IEM-modell…',
+
     eqAutoEqSearching: 'Søker…',
+
     eqAutoEqNoResults: 'Ingen resultater funnet',
+
     eqAutoEqError: 'Søk mislyktes',
+
     eqAutoEqRateLimit: 'GitHub-hastighetsgrense nådd - prøv igjen om ett minutt',
+
     eqAutoEqFetchError: 'Kunne ikke hente EQ-profil',
+
     lfmTitle: 'Last.fm',
+
     lfmConnect: 'Koble til med Last.fm',
+
     lfmConnecting: 'Venter på autorisasjon…',
+
     lfmConfirm: 'Jeg har autorisert appen',
+
     lfmConnected: 'Tilkoblet som',
+
     lfmDisconnect: 'Koble fra',
+
     lfmConnectDesc: 'Koble til din Last.fm-konto for å aktivere scrobbling og få "Nå spiller"-oppdateringer direkte fra Psysonic - ingen Navidrome-konfigurasjon kreves.',
+
     lfmOpenBrowser: 'Et nettleservindu vil åpne seg. Autoriser Psysonic via Last.fm, og klikk deretter på knappen nedenfor.',
+
     lfmScrobbles: '{{n}} scrobbles',
+
     lfmMemberSince: 'Medlem siden {{year}}',
+
     scrobbleEnabled: 'Scrobbling er aktivert',
+
     scrobbleDesc: 'Send sanger til Last.fm etter 50 % avspilling',
+
     behavior: 'App-oppførsel',
+
     cacheTitle: 'Maks. lagringsstørrelse',
+
     cacheDesc: 'Plateomslag og artistbilder. Når den er full, fjernes de eldste oppføringene automatisk. Frakoblede album fjernes ikke automatisk, men slettes når hurtigbufferen tømmes manuelt.',
+
     cacheUsed: 'Brukt: {{images}} bilder · {{offline}} frakoblede spor',
+
 	cacheUsedImages: 'Bilder:',
+
     cacheUsedOffline: 'Frakoblede spor:',
+
     cacheUsedHot: 'Plass brukt:',
+
     hotCacheTrackCount: 'Spor i buffer:',
+
     cacheMaxLabel: 'Maks størrelse',															   
+
     cacheClearBtn: 'Tøm hurtigbuffer',
+
     cacheClearWarning: 'Dette vil også fjerne alle frakoblede album fra biblioteket.',
+
     cacheClearConfirm: 'Tøm alt',
+
     cacheClearCancel: 'Avbryt',
+
 	offlineDirTitle: 'Frakoblet bibliotek (In-App)',
+
 	offlineDirDesc: 'Lagringsplassering for spor som du gjør tilgjengelige som frakoblet i Psysonic.',
+
 	offlineDirDefault: 'Standard (App-data)',
+
 	offlineDirChange: 'Endre katalog',
+
 	offlineDirClear: 'Tilbakestill til standard',
+
 	offlineDirHint: 'Nye nedlastinger vil bruke denne plasseringen. Eksisterende nedlastinger forblir på sin opprinnelige lokasjon.',	
+
     hotCacheTitle: 'Varm avspillingsbuffer',
+
     hotCacheAlphaBadge: 'Alfa',
+
     hotCacheDisclaimer: 'Forhåndshenter neste spor i køen og beholder tidligere. Når aktivert: diskplass og nettverk.',
+
     hotCacheDirDefault: 'Standard (App-data)',
+
     hotCacheDirChange: 'Endre mappe',
+
     hotCacheDirClear: 'Tilbakestill til standard',
+
     hotCacheDirHint: 'Bytte mappe nullstiller indeksen i appen; gamle filer blir liggende til du sletter dem.',
+
     hotCacheEnabled: 'Aktiver varm avspillingsbuffer',
+
     hotCacheMaxMb: 'Maks bufferstørrelse',
+
     hotCacheDebounce: 'Utsettelse ved køendring',
+
     hotCacheDebounceImmediate: 'Umiddelbart',
+
     hotCacheDebounceSeconds: '{{n}} sek',
+
     hotCacheClearBtn: 'Tøm varm buffer',
+
     audioOutputDevice: 'Lydutgangsenhet',
+
     audioOutputDeviceDesc: 'Velg hvilken lydenhet Psysonic spiller gjennom. Endringer trer i kraft umiddelbart og starter gjeldende spor på nytt.',
+
     audioOutputDeviceDefault: 'Systemstandard',
+
     audioOutputDeviceRefresh: 'Oppdater enhetsliste',
+
     audioOutputDeviceOsDefaultNow: 'gjeldende systemutgang',
+
     audioOutputDeviceListError: 'Kunne ikke laste listen over lydenheter.',
+
     audioOutputDeviceNotInCurrentList: 'ikke i gjeldende liste',
+
     hiResTitle: 'Innebygd hi-res-avspilling',
+
     hiResEnabled: 'Aktiver innebygd hi-res-avspilling',
+
     hiResDesc: "Begrenser utdata til 44,1 kHz som standard for maksimal stabilitet. Aktiver kun hvis maskinvare og nettverk støtter høye samplingsrater (88,2 kHz+) pålitelig.",
+
     showArtistImages: 'Vis artistbilder',
+
     showArtistImagesDesc: 'Last inn og vis artistbilder i artistoversikten. Denne er deaktivert som standard, for å redusere disk-I/O og nettverksbelastningen på store biblioteker.',
+
     minimizeToTray: 'Minimer til oppgavelinjen',
+
     minimizeToTrayDesc: 'Når vinduet lukkes, vil Psysonic bli kjørende i oppgavelinjen fremfor å bli avsluttet.',
+
     discordRichPresence: 'Discord Rich Presence',
+
     discordRichPresenceDesc: 'Vis sporet som spilles i din Discord-profil. Krever at Discord kjører.',
+
     discordAppleCovers: 'Hent covere fra Apple Music til Discord',
+
     discordAppleCoversDesc: 'Sender artist- og albumnavn til Apples søke-API for å finne cover til Discord-profilen din. Deaktivert som standard av personvernhensyn.',
+
+    discordTemplates: 'Egendefinerte tekstmaler',
+
+    discordTemplatesDesc: 'Tilpass hvilken informasjon som vises på Discord-profilen din. Variabler: {title}, {artist}, {album}, {paused}',
+
+    discordTemplateDetails: 'Primærlinje (details)',
+
+    discordTemplateState: 'Sekundærlinje (state)',
+
+    discordTemplateLargeText: 'Album-tooltip (largeText)',
+
     nowPlayingEnabled: 'Vis i "Nå spiller"',
+
     nowPlayingEnabledDesc: 'Send sporet som spilles av til tjenerens live-lyttervisning. Deaktiver for å stoppe sending av avspillingsdata.',
+
     lyricsServerFirst: 'Foretrekk server-sangtekst',
+
     lyricsServerFirstDesc: 'Sjekk tjenerlevererte sangtekster (innebygde tagger, sidecar-filer) før LRCLIB. Deaktiver for å bruke LRCLIB først.',
+
     enableNeteaselyrics: 'Netease Cloud Music sangtekster',
+
     enableNeteaselyricsDesc: 'Bruk Netease Cloud Music som siste utvei når server og LRCLIB ikke finner noe. Best dekning for asiatisk og internasjonal musikk.',
+
     lyricsSourcesTitle: 'Sangtekstkilder',
+
     lyricsSourcesDesc: 'Velg hvilke kilder som skal brukes og i hvilken rekkefølge. Dra for å sortere. Deaktiverte kilder hoppes over.',
+
     lyricsSourceServer: 'Tjener',
+
     lyricsSourceLrclib: 'LRCLIB',
+
     lyricsSourceNetease: 'Netease Cloud Music',
+
     downloadsTitle: 'ZIP Eksport & Arkivering',
+
 	downloadsFolderDesc: 'Målmappe for album du laster ned som en ZIP-fil til datamaskinen din.',												  
+
     downloadsDefault: 'Standard nedlastingsmappe',
+
     pickFolder: 'Velg',
+
     pickFolderTitle: 'Velg nedlastingsmappe',
+
     clearFolder: 'Tøm nedlastingsmappe',
+
     logout: 'Logg ut',
+
     aboutTitle: 'Om Psysonic',
+
     aboutDesc: 'En moderne musikkspiller for Subsonic-kompatible tjenere (Navidrome, Gonic og andre). Bygget på Tauri v2 med en innebygd Rust-lydmotor - lett og rask, men fullpakket med funksjoner: bølgeform-søkelinje, synkroniserte sangtekster, Last.fm-integrasjon, 10-bånds jevnstiller, crossfade, gapless-avspilling, Replay Gain, sjangerlesing og et stort bibliotek med temaer.',
+
     aboutLicense: 'Lisens',
+
     aboutLicenseText: 'GNU GPL v3 - gratis å bruke, endre og distribuere under samme lisens.',
+
     aboutRepo: 'Kildekode på GitHub',
+
     aboutVersion: 'Versjon',
+
     aboutBuiltWith: 'Bygget med Tauri · React · TypeScript · Rust/rodio',
+
     aboutAiCredit: 'Utviklet med støtte fra Claude Code laget av Anthropic',
+
     aboutContributorsLabel: 'Bidragsytere',
+
     aboutSpecialThanksLabel: 'Spesiell takk',
+
     changelog: 'Endringslogg',
+
     showChangelogOnUpdate: "Vis 'Hva er nytt' ved oppdatering til ny versjon",
+
     showChangelogOnUpdateDesc: "Vis automatisk hva som er nytt når en ny versjon lanseres for første gang.",
+
     randomMixTitle: 'Tilfeldig miks',
+
     randomMixBlacklistTitle: 'Egendefinerte filternøkkelord',
+
     randomMixBlacklistDesc: 'Sanger ekskluderes når et nøkkelord samsvarer med sjanger, tittel, album eller artist (aktiv når avkrysningsboksen ovenfor er på).',
+
     randomMixBlacklistPlaceholder: 'Legg til nøkkelord…',
+
     randomMixBlacklistAdd: 'Legg til',
+
     randomMixBlacklistEmpty: 'Ingen egendefinerte nøkkelord lagt til ennå.',
+
     randomMixHardcodedTitle: 'Innebygde nøkkelord (aktiv når avkrysningsboksen er på)',
+
     tabPlayback: 'Avspilling',
+
     tabLibrary: 'Bibliotek',
+
     tabAppearance: 'Utseende',
+
     homeCustomizerTitle: 'Hjemmeside',
+
     sidebarTitle: 'Sidefelt',
+
     sidebarReset: 'Tilbakestill til standard',
+
     sidebarDrag: 'Dra for å endre rekkefølge',
+
     sidebarFixed: 'Alltid synlig',
-    randomNavSplitTitle: 'Del Mix-navigasjon',
-    randomNavSplitDesc: 'Vis "Tilfeldig miks" og "Tilfeldige album" som separate sidefeltsoppføringer i stedet for "Lag en miks"-huben.',
+
     tabShortcuts: 'Snarveier',
+
     tabServer: 'Tjener',
+
     tabSystem: 'System',
+
     tabGeneral: 'Generelt',
+
     ratingsSectionTitle: 'Vurderinger',
+
     ratingsSkipStarTitle: 'Hopp for 1 stjerne',
+
     ratingsSkipStarDesc:
+
       'Etter flere hopp på rad: sett sporet til 1 stjerne. Bare for spor som ikke var vurdert før.',
+
     ratingsSkipStarThresholdLabel: 'Hopp',
+
     ratingsMixFilterTitle: 'Filtrering etter vurdering',
+
     ratingsMixFilterDesc:
+
       'Filtrer innhold med lav vurdering i {{mix}} og {{albums}}. Klikk på den valgte stjerna igjen for å slå av terskelen.',
+
     ratingsMixMinSong: 'Spor',
+
     ratingsMixMinAlbum: 'Album',
+
     ratingsMixMinArtist: 'Artister',
+
     ratingsMixMinThresholdAria: 'Minimum stjerner: {{label}}',
+
     backupTitle: 'Sikkerhetskopiering og gjenoppretting',
+
     backupExport: 'Eksporter innstillinger',
+
     backupExportDesc: 'Lagrer alle innstillinger, tjenerprofiler, Last.fm-konfigurasjon, tema, jevnstiller og tastebindinger til en .psybkp-fil. Passordet lagres i klartekst – hold filen sikker.',
+
     backupImport: 'Importer innstillinger',
+
     backupImportDesc: 'Gjenoppretter innstillinger fra en .psybkp-fil. Applikasjonen starter på nytt etter import.',
+
     backupImportConfirm: 'Dette vil overskrive alle gjeldende innstillinger. Vil du fortsette?',
+
     backupSuccess: 'Sikkerhetskopiering lagret',
+
     backupImportSuccess: 'Innstillinger gjenopprettet – laster inn data på nytt…',
+
     backupImportError: 'Ugyldig eller ødelagt fil for sikkerhetskopi.',
+
     shortcutsReset: 'Tilbakestill til standardinnstillinger',
+
     shortcutListening: 'Trykk på en tast…',
+
     shortcutUnbound: '-',
+
     globalShortcutsTitle: 'Globale snarveier',
+
     globalShortcutsNote: 'Arbeid systemomfattende selv når Psysonic er i bakgrunnen. Krever Ctrl, Alt eller Super som modifikator.',
+
     shortcutClear: 'Fjern',
+
     shortcutPlayPause: 'Spill av / Pause',
+
     shortcutNext: 'Neste spor',
+
     shortcutPrev: 'Forrige spor',
+
     shortcutVolumeUp: 'Volum opp',
+
     shortcutVolumeDown: 'Volum ned',
+
     shortcutSeekForward: 'Søk fremover 10 sekunder',
+
     shortcutSeekBackward: 'Søk bakover 10 sekunder',
+
     shortcutToggleQueue: 'Veksle kø',
+
     shortcutOpenFolderBrowser: 'Åpne {{folderBrowser}}',
+
     shortcutFullscreenPlayer: 'Fullskjermsspiller',
+
     shortcutNativeFullscreen: 'Naturlig fullskjerm',
+
     playbackTitle: 'Avspilling',
+
     replayGain: 'Replay Gain',
+
     replayGainDesc: 'Normaliser sporvolumet ved hjelp av ReplayGain-metadata',
+
     replayGainMode: 'Modus',
+
     replayGainTrack: 'Spor',
+
     replayGainAlbum: 'Album',
+
     replayGainPreGain: 'Pre-Gain (taggede filer)',
+
     replayGainFallback: 'Reserveverdi (uten tagger / radio)',
+
     crossfade: 'Crossfade',
+
     crossfadeDesc: 'Tone mellom spor',
+
     crossfadeSecs: '{{n}}s',
+
     notWithGapless: 'Ikke tilgjengelig mens Gapless er aktiv',
+
     notWithCrossfade: 'Ikke tilgjengelig mens Crossfade er aktiv',
+
     gapless: 'Gapless avspilling',
+
     gaplessDesc: 'Forhåndsbuffer neste spor for å eliminere mellomrom mellom sanger',
+
     infiniteQueue: 'Uendelig kø',
+
     infiniteQueueDesc: 'Legg automatisk til tilfeldige spor når køen går tom',
+
     experimental: 'Eksperimentell',
+
     preloadMode: 'Forhåndslast neste spor',
+
     preloadModeDesc: 'Når buffering av neste spor i køen skal starte',
+
     nextTrackBufferingTitle: 'Neste spor – bufring',
+
     preloadHotCacheMutualExclusive: 'Forhåndslasting og Hot Cache tjener samme formål – bare én kan være aktiv om gangen. Å aktivere den ene deaktiverer automatisk den andre.',
+
     preloadOff: 'Av',
+
     preloadBalanced: 'Balansert (30 s før slutt)',
+
     preloadEarly: 'Tidlig (etter 5 s avspilling)',
+
     preloadCustom: 'Egendefinert',
+
     preloadCustomSeconds: 'Sekunder før slutt: {{n}}',
+
     fsPlayerSection: 'Fullskjermspiller',
+
     fsShowArtistPortrait: 'Vis artistbilde',
+
     fsShowArtistPortraitDesc: 'Vis artistbilde (eller albumomslag) på høyre side av fullskjermspilleren.',
+
     fsPortraitDim: 'Mørklegging av bilde',
+
     seekbarStyle: 'Søkefelt-stil',
+
     seekbarStyleDesc: 'Velg utseendet på avspillingssøkefeltet',
+
     seekbarWaveform: 'Bølgeform',
+
     seekbarLinedot: 'Linje & punkt',
+
     seekbarBar: 'Linje',
+
     seekbarThick: 'Tykk linje',
+
     seekbarSegmented: 'Segmentert',
+
     seekbarNeon: 'Neon',
+
     seekbarPulsewave: 'Pulsbølge',
+
     seekbarParticletrail: 'Partikkelspor',
+
     seekbarLiquidfill: 'Væskerør',
+
     seekbarRetrotape: 'Retrotape',
+
     themeSchedulerTitle: 'Tidsplanlagt tema',
+
     themeSchedulerEnable: 'Aktiver temaplanlegger',
+
     themeSchedulerEnableSub: 'Bytter automatisk mellom to temaer basert på tidspunkt',
+
     themeSchedulerDayTheme: 'Dagtema',
+
     themeSchedulerDayStart: 'Dag starter kl.',
+
     themeSchedulerNightTheme: 'Natttema',
+
     themeSchedulerNightStart: 'Natt starter kl.',
+
     themeSchedulerActiveHint: 'Temaplanlegger er aktiv - temaer byttes automatisk.',
+
     visualOptionsTitle: 'Visuelle Alternativer',
+
     coverArtBackground: 'Cover-bakgrunn',
+
     coverArtBackgroundSub: 'Vis uskarpt cover som bakgrunn i album/playlist-overskrifter',
+
     playlistCoverPhoto: 'Playlist-coverfoto',
+
     playlistCoverPhotoSub: 'Vis coverfoto-rutenett i playlist-detailedvisning',
+
     showBitrate: 'Vis Bitrate',
+
     showBitrateSub: 'Vis audio-bitrate i sporlister',
+
     uiScaleTitle: 'Grensesnittskala',
+
     uiScaleLabel: 'Zoom',
+
   },
+
   changelog: {
+
     modalTitle: "Nyheter",
+
     dontShowAgain: "Ikke vis igjen",
+
     close: 'Forstått',
+
   },
+
   help: {
+
     title: 'Hjelp',
+
     s1: 'Komme i gang',
+
     q1: 'Hvilke servere er kompatible?',
+
     a1: 'Psysonic fungerer med alle Subsonic-kompatible servere: Navidrome, Gonic, Subsonic, Airsonic og andre. Navidrome er det anbefalte valget.',
+
     q2: 'Hvordan kobler jeg til serveren min?',
+
     a2: 'Åpne Innstillinger og klikk på "Legg til server". Skriv inn server-URL-en (f.eks. 192.168.1.100:4533), brukernavn og passord. Psysonic tester tilkoblingen før den lagrer – ingenting lagres hvis tilkoblingen mislykkes.',
+
     q3: 'Kan jeg bruke flere servere?',
+
     a3: 'Ja. Du kan legge til så mange servere du vil i Innstillinger og bytte mellom dem når som helst. Bare én server er aktiv om gangen.',
+
     s2: 'Avspilling',
+
     q4: 'Hvordan spiller jeg musikk?',
+
     a4: 'Dobbeltklikk på et spor for å spille det av. På album- og artistsider bruker du "Spill av alle" for å starte hele albumet. Du kan også dra spor inn i køpanelet.',
+
     q5: 'Hvilke hurtigtaster er tilgjengelige?',
+
     a5: 'Mellomrom = Spill av / Pause · Escape = Lukk fullskjermsspiller. Medietaster (Spill av / Pause, Neste, Forrige) fungerer på alle plattformer. På Linux bruker du knappene i spillerlinjen for medietaster. Snarveier i appen og systemomfattende globale snarveier kan tilpasses i Innstillinger → Tastatursnarveier / Globale snarveier.',
+
     q6: 'Hva er køen?',
+
     a6: 'Køen viser alle kommende spor. Åpne den med panelikonet øverst til høyre (ved siden av Spilles nå-indikatoren). Du kan endre rekkefølgen på sporene ved å dra, spille av i tilfeldig rekkefølge med tilfeldig-knappen og lagre køen som en spilleliste.',
+
     q7: 'Hvordan åpner jeg fullskjermsspilleren?',
+
     a7: 'Klikk på miniatyrbildet av albumcoveret i spillerlinjen nederst, eller på utvid-ikonet ved siden av. Trykk på Escape for å lukke det igjen.',
+
     q8: 'Hvordan fungerer gjentakelse?',
+
     a8: 'Klikk på gjentakelsesknappen i spillerlinjen for å bla gjennom: Av → Gjenta alle → Gjenta én.',
+
     s3: 'Bibliotek',
+
     q9: 'Hvordan laster jeg ned et album?',
+
     a9: 'Åpne detaljsiden for et album og klikk på "Last ned (ZIP)". Serveren komprimerer albumet til en ZIP-fil først – for store album eller filer uten tap (FLAC/WAV) kan dette ta et øyeblikk før nedlastingen faktisk starter. Dette er normalt: fremdriftslinjen vises når serveren er ferdig med å zippe og overføringen starter.',
+
     q10: 'Hvordan stjernemerker/favoritterer jeg spor og album?',
+
     a10: 'Klikk på stjerneikonet på en hvilken som helst sporrad eller i albumoverskriften. Stjernemerkede elementer vises i Favoritter-delen i sidefeltet.',
+
     q11: 'Hva er hovedkarusellen på hjemmesiden?',
+
     a11: 'Banneret øverst på hjemmesiden velger tilfeldig album fra biblioteket ditt og roterer gjennom dem hvert 10. sekund. Klikk på prikkene for å hoppe til et bestemt album, eller klikk på banneret for å åpne albumet.',
+
     s4: 'Innstillinger',
+
     q12: 'Hvordan endrer jeg temaet?',
+
     a12: 'Innstillinger → Tema. Velg fra et stort utvalg av temaer på tvers av 8 grupper: Psysonic-temaer, mediaspiller, operativsystemer, spill, filmer, serier, sosiale medier og åpen kildekode-klassikere (Catppuccin, Nord, Gruvbox).',
+
     q13: 'Hvordan endrer jeg språket?',
+
     a13: 'Innstillinger → Språk. Engelsk, tysk, fransk, nederlandsk og kinesisk støttes.',
+
     q15: 'Hvordan angir jeg en nedlastingsmappe?',
+
     a15: 'Innstillinger → App-oppførsel → Nedlastingsmappe. Velg en hvilken som helst mappe – nedlastede album lagres der som ZIP-filer. Uten en tilpasset mappe brukes nettleserens standard nedlastingsplassering.',
+
     s5: 'Scrobbling',
+
     q16: 'Hvordan fungerer scrobbling?',
+
     a16: 'Psysonic scrobbler direkte til Last.fm - ingen Navidrome-konfigurasjon nødvendig. Koble til Last.fm-kontoen din i Innstillinger → Last.fm og aktiver scrobbling der.',
+
     q17: 'Når sendes en scrobble?',
+
     a17: 'En scrobble sendes etter at du har lyttet til 50 % av et spor.',
+
     q22: 'Hva er bølgeformen i avspillerlinjen?',
+
     a22: 'Bølgeformsøkelinjen erstatter den klassiske fremdriftsglidebryteren. Klikk hvor som helst på den for å hoppe til den posisjonen, eller dra for å skrubbe. Den avspilte delen lyser med en blå-til-lilla gradient, det bufrede området vises litt lysere, og den uavspilte delen er falmet.',
+
     q24: 'Kan jeg blande køen?',
+
     a24: 'Ja. Åpne køpanelet og klikk på blandeikonet i køoverskriften. Sporet som spilles av for øyeblikket forblir på posisjon 1 – alle gjenværende spor blir tilfeldig omorganisert.',
+
     q25: 'Åpnes Last.fm- og Wikipedia-lenker på artistsider i en nettleser?',
+
     a25: 'Ja – de åpnes i standardnettleseren din. Knappen viser kort en bekreftelsesetikett når du klikker på den.',
+
     s7: 'Tilfeldig miks',
+
     q26: 'Hva er tilfeldig miks?',
+
     a26: 'Tilfeldig miks bygger en spilleliste med tilfeldige spor fra hele biblioteket ditt. Åpne den via "Tilfeldig miks" i sidefeltet og klikk på "Ny miks". Du kan justere antall spor før generering.',
+
     q27: 'Hva er nøkkelordfilteret?',
+
     a27: 'Nøkkelordfilteret ekskluderer spor der sjanger, tittel eller albumnavn inneholder spesifikke ord. Lydbøker filtreres automatisk. Legg til egendefinerte nøkkelord i Innstillinger → Tilfeldig miks, eller klikk på en hvilken som helst sjangertagg i sporlisten for å legge den til umiddelbart.',
+
     q28: 'Hva er Super Genre Mix?',
+
     a28: 'Super Genre Mix grupperer biblioteket ditt i brede kategorier (rock, metal, elektronisk, jazz, klassisk osv.) og bygger en fokusert miks fra den stilen. Velg en kategoribrikke under sporlisten. Resultatene vises gradvis etter hvert som hver undersjanger hentes.',
+
     s6: 'Feilsøking',
+
     q18: 'Omslagsbilder og artistbilder lastes sakte.',
+
     a18: 'Bilder hentes fra serverens disk ved første innlasting og bufres deretter lokalt i 30 dager. Hvis serverens lagring er treg, kan det ta et øyeblikk før det første besøket på en side. Senere besøk vil være umiddelbare.',
+
     q19: 'Tilkoblingstesten mislykkes.',
+
     a19: 'Sjekk URL-en inkludert porten (f.eks. http://192.168.1.100:4533). Sørg for at ingen brannmur blokkerer tilkoblingen. Prøv http:// i stedet for https:// på et lokalt nettverk. Bekreft også at brukernavnet og passordet ditt er riktig.',
+
     q20: 'Ingen lyd på Linux.',
+
     a20: 'Psysonic er tilgjengelig som .deb (Ubuntu/Debian), .rpm (Fedora/RHEL), og via AUR på Arch/CachyOS (yay -S psysonic). Det finnes ingen AppImage. Hvis lyd mangler, sørg for at PipeWire eller PulseAudio kjører.',
+
     q21: 'Appen viser en svart skjerm på Linux.',
+
     a21: 'Dette er vanligvis et GPU/EGL-driverproblem i WebKitGTK. Start med GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. AUR-pakken og offisielle .deb/.rpm-installasjonsprogrammer setter disse automatisk.',
+
     q29: 'Hva er Crossfade og Gapless Playback?',
+
     a29: 'Begge er eksperimentelle lydfunksjoner i Innstillinger → Lyd. Gapless forhåndsbuffer neste spor for å eliminere stillhet mellom sanger. Crossfade fader ut gjeldende spor mens det fader inn det neste – juster varigheten (1–10 s) etter smak.',
+
     q30: 'Viser Psysonic sangtekst?',
+
     a30: 'Ja. Klikk på mikrofonikonet i spillerlinjen, for å åpne Sangtekst-fanen i køpanelet. Psysonic henter tekst automatisk fra LRCLIB. Hvis synkroniserte tekster er tilgjengelige, utheves den aktive linjen og ruller i sanntid mens sangen spilles av. Hvis bare ren tekst er tilgjengelig, vises fullteksten statisk.',
+
     q31: 'Kan jeg tilpasse hurtigtaster?',
+
     a31: 'Ja. Innstillinger → Tastatursnarveier lar deg tilordne handlinger i appen (Spill av/pause, Neste, Forrige, Volum opp/ned, Fullskjerm og mer) til en hvilken som helst tast. Innstillinger → Globale snarveier lar deg tilordne systemomfattende snarveier som utløses selv når Psysonic er i bakgrunnen.',
+
     q32: 'Kan jeg endre skrifttypen?',
+
     a32: 'Ja. Innstillinger → Skrifttype lar deg velge mellom 10 skrifttyper, inkludert IBM Plex Mono, Fira Code, JetBrains Mono, Courier Prime og andre. Den valgte skrifttypen gjelder for hele brukergrensesnittet.',
+
     s8: 'Frakoblet modus',
+
     q34: 'Hva er frakoblet modus?',
+
     a34: 'Frakoblet modus (beta) lar deg mellomlagre album til enheten din, slik at du kan lytte uten en aktiv servertilkobling. Bufrede spor lagres lokalt og spilles av direkte fra harddisken – ingen nettverksforespørsel gjøres under avspilling.',
+
     q35: 'Hvordan bufrer jeg et album for å bruke det offline?',
+
     a35: 'Åpne et hvilket som helst album og klikk på nedlastingsikonet i albumoverskriften. Psysonic laster ned alle spor i bakgrunnen. Fremdrift vises på knappen. Når bufren er lagret, blir ikonet grønt. Du kan vise og fjerne bufrede album på siden Offline bibliotek (sidefelt).',                                               
+
     q36: 'Hvor mye lagringsplass kan frakoblet mellomlagring bruke?',
+
     a36: 'Du kan angi en maksimal mellomlagringsstørrelse i Innstillinger → Bibliotek. Når grensen er nådd, vises et advarselsbanner på albumsiden. Du kan slette individuelle album fra frakoblet bibliotek for å frigjøre plass.',
+
     q37: 'Hvordan vurderer jeg sanger, album og artister?',
+
     a37: 'Psysonic støtter 1–5 stjernevurderinger via OpenSubsonic API (krever Navidrome ≥ 0.53). Vurder sanger i sporlistene, via høyreklikk-menyen eller i spillerlinjen. Album vurderes på detaljsiden, artister på artistsiden.',
+
     q38: 'Kan jeg fjerne eller endre en vurdering?',
+
     a38: 'Ja. Klikk på den aktive stjernen igjen for å slette vurderingen — et andre klikk på samme stjerne fjerner den. Klikk på en annen stjerne for å endre vurderingen.',
+
     q39: 'Hva er Skip-to-1★ og vurderingsfilter?',
+
     a39: 'Skip-to-1★ tildeler automatisk en 1-stjernevurdering etter et visst antall påfølgende manuelle hopp. Aktiver det i Innstillinger → Vurderinger. Der kan du også angi minimum stjerner for tilfeldige mikser.',
+
     q40: 'Hva er mappebrowseren?',
+
     a40: 'Mappebrowseren (sidepanel) lar deg navigere i serverens musikkmappe med Miller-kolonner. Klikk på en mappe for å utforske innholdet; bruk avspillingsikonen for å spille eller legge til i køen.',
+
     q41: 'Hva er temaplanleggeren?',
+
     a41: 'Innstillinger → Utseende → Bytt tema automatisk: angi et dagstema og et nattstema med starttider. Psysonic bytter automatisk på de angitte tidspunktene.',
+
     q42: 'Kan jeg skalere grensesnittet?',
+
     a42: 'Ja. Innstillinger → Utseende → Grensesnittskala lar deg skalere hele grensesnittet mellom 80 % og 125 %.',
+
     q43: 'Kan jeg endre søkelinjesstilen?',
+
     a43: 'Ja. Innstillinger → Utseende → Søkelinjestil tilbyr 10 stiler: Bølgeform, Linje & Punkt, Stolpe, Tykk stolpe, Segmentert, Neon Glow, Pulsbølge, Partikkelspor, Væskefylling og Retro Tape.',
+
     q44: 'Hva er AutoEQ?',
+
     a44: '10-bånds equalizer i Innstillinger → Lyd inkluderer AutoEQ-oppslag. Skriv inn hodetelefon-modellen for å laste inn en korreksjonsprofil automatisk.',
+
     q45: 'Hva er Replay Gain?',
+
     a45: 'Replay Gain normaliserer volumet slik at høye og stille album spilles av på et konsistent nivå. Aktiver det i Innstillinger → Lyd → Replay Gain; velg modus Spor eller Album.',
+
     q46: 'Hva er hurtigbufferen?',
+
     a46: 'Hurtigbuffer (Alpha, Innstillinger → Bibliotek) forhåndslaster de neste sporene i køen til disk for umiddelbar avspilling. Psysonic beholder gjeldende spor og de neste 5 og fjerner eldre innslag når grensen nås.',
+
     q47: 'Kan jeg mellomlagre en spilleliste frakoblet?',
+
     a47: 'Ja. Åpne spillelistedetaljene og klikk på nedlastingsikonen. Når alle spor er mellomlagret, endres ikonet til en rød søppelbøtte; klikk på den for å fjerne spillelisten fra frakoblet hurtigbuffer.',
-    q48: 'Hva er Infinite Queue?',
-    a48: 'Når køen tømmes og gjentakelse er deaktivert, legger Psysonic automatisk til tilfeldige spor så avspillingen aldri stopper. Automatisk tillagte spor vises under skillelinjen "— Lagt til automatisk —".',
-    q49: 'Kan jeg styre Psysonic fra kommandolinjen?',
-    a49: 'Ja. Eksempler: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one. Også: bytt server, lydenhet, filtrer bibliotek og søk. Full hjelp: psysonic --player --help.',
-    q50: 'Hvordan administrerer jeg spillelister?',
-    a50: 'Via "Spillelister" i sidefeltet. Opprett en med "Ny spilleliste". I detaljvisningen kan du dra spor for å sortere, fjerne dem med ×, legge til sanger via søk og bruke "Forslag" for smarte anbefalinger.',
-    q51: 'Kan jeg sikkerhetskopiere og gjenopprette innstillingene mine?',
-    a51: 'Ja. Innstillinger → Sikkerhetskopi og gjenoppretting eksporterer alle innstillinger, serverprofiler, temaer og snarveier til en JSON-fil.',
-    q52: 'Hvordan endrer jeg lydutgangsenheten?',
-    a52: 'Innstillinger → Lyd → Utgangsenhet. Psysonic viser alle tilgjengelige utganger. Valget trer i kraft umiddelbart.',
-    q53: 'Hva er Device Sync?',
-    a53: 'Device Sync kopierer album, spillelister eller artister til en USB-pinne eller SD-kort. Åpne via "Device Sync" i sidefeltet, velg en målmappe, velg kilder og klikk "Overfør til enhet".',
-    q54: 'Hva er filnavnmalen i Device Sync?',
-    a54: 'Malen styrer hvordan spor navngis og organiseres. Bruk forhåndsinnstillinger eller bygg din egen med klikkbare tokens: {artist}, {album}, {title}, {track_number}, {disc_number}, {year} og / som mappeskiller.',
-    q55: 'Fungerer Device Sync på tvers av plattformer?',
-    a55: 'Ja. Manifestet på enheten inneholder malen som ble brukt. På et annet OS gjenkjenner Psysonic eksisterende filer korrekt.',
-    s9: 'Device Sync',
-    q56: 'Hva er internettradio?',
-    a56: 'Internettradiosiden lar deg spille av direkte strømmer i Psysonic. Stasjoner hentes fra Navidrome-serveren din. Avspilling bruker HTML5-lyd.',
-    q57: 'Hvilke strømformater støtter internettradio?',
-    a57: 'MP3, AAC, OGG Vorbis og de fleste HLS-strømmer. MP3 og AAC fungerer på alle plattformer.',
-    s10: 'Internettradio',
-    q58: 'Hvor henter Psysonic sangtekster fra?',
-    a58: 'Tre konfigurerbare kilder i Innstillinger → Sangtekster: Navidrome-serveren din, LRCLIB og NetEase Cloud Music. Hver kilde kan aktiveres/deaktiveres og prioriteres ved dra-og-slipp.',
-    q59: 'Finnes det en visning av hva andre brukere hører på?',
-    a59: 'Ja. Klikk på kringkastingsikonet øverst til høyre for å se hva andre brukere på Navidrome-serveren din hører på, oppdatert hvert 10. sekund.',
+
   },
+
   queue: {
+
     title: 'Kø',
+
     savePlaylist: 'Lagre spilleliste',
+
     updatePlaylist: 'Oppdater spilleliste',
+
     filterPlaylists: 'Filtrer spillelister…',
+
     playlistName: 'Spillelistenavn',
+
     cancel: 'Avbryt',
+
     save: 'Lagre',
+
     loadPlaylist: 'Last inn spilleliste',
+
     loading: 'Laster…',
+
     noPlaylists: 'Ingen spillelister funnet.',
+
     load: 'Erstatt kø og spill av',
+
     appendToQueue: 'Legg til i kø',
+
     delete: 'Slett',
+
     deleteConfirm: 'Slett spillelisten "{{name}}"?',
+
     clear: 'Fjern',
+
     shuffle: 'Bland kø',
+
     gapless: 'Uten mellomrom',
+
     crossfade: 'Crossfade',
+
     infiniteQueue: 'Uendelig kø',
+
     autoAdded: '- Lagt til automatisk -',
+
     radioAdded: '- Radio -',
+
     hide: 'Skjul',
+
     close: 'Lukk',
+
     nextTracks: 'Neste spor',
+
     emptyQueue: 'Køen er tom.',
+
     trackSingular: 'spor',
+
     trackPlural: 'spor',
+
     showRemaining: 'Vis gjenværende tid',
+
     showTotal: 'Vis total tid',
+
   },
+
   statistics: {
+
     title: 'Statistikk',
+
     recentlyPlayed: 'Nylig spilt',
+
     mostPlayed: 'Mest spilte album',
+
     highestRated: 'Høyest rangerte album',
+
     genreDistribution: 'Sjangerfordeling (Topp 20)',
+
     loadMore: 'Last inn mer',
+
     statArtists: 'Artister',
+
     statArtistsTooltip: 'Kun albumartister — artister som bare opptrer som sporartist (featuring, gjest, osv.) uten eget album telles ikke med.',
+
     statAlbums: 'Album',
+
     statSongs: 'Sanger',
+
     statGenres: 'Sjangere',
+
     statPlaytime: 'Total spilletid',
+
     genreInsights: 'Sjangerinnsikt',
+
     formatDistribution: 'Formatdistribusjon',
+
     formatSample: 'Utvalg av {{n}} spor',
+
     computing: 'Utregner…',								   
+
     genreSongs: '{{count}} Sanger',
+
     genreAlbums: '{{count}} Album',
+
     recentlyAdded: 'Nylig lagt til',
+
     decadeDistribution: 'Album etter tiår',
+
     decadeAlbums_one: '{{count}} Album',
+
     decadeAlbums_other: '{{count}} Album',
+
     decadeUnknown: 'Ukjent',
+
     lfmTitle: 'Last.fm Statistikk',
+
     lfmTopArtists: 'Toppartister',
+
     lfmTopAlbums: 'Toppalbum',
+
     lfmTopTracks: 'Toppspor',
+
     lfmPlays: '{{count}} avspillinger',
+
     lfmPeriodOverall: 'Alltid',
+
     lfmPeriod7day: '7 dager',
+
     lfmPeriod1month: '1 måned',
+
     lfmPeriod3month: '3 måneder',
+
     lfmPeriod6month: '6 måneder',
+
     lfmPeriod12month: '12 måneder',
+
     lfmNotConnected: 'Koble til Last.fm i Innstillinger for å se statistikken din.',
+
     lfmRecentTracks: 'Siste Scrobble-innslag',
+
     lfmNowPlaying: 'Spilles nå',
+
     lfmJustNow: 'akkurat nå',
+
     lfmMinutesAgo: 'For {{n}}m siden',
+
     lfmHoursAgo: 'For {{n}}t siden',
+
     lfmDaysAgo: 'For {{n}}d siden',
+
     topRatedSongs: 'Høyest vurderte spor',
+
     topRatedArtists: 'Høyest vurderte artister',
+
     noRatedSongs: 'Ingen vurderte spor ennå. Vurder spor i album- eller spillelistevisning.',
+
     noRatedArtists: 'Ingen vurderte artister ennå.',
+
   },
+
   player: {
+
     regionLabel: 'Musikkspiller',
+
     openFullscreen: 'Åpne fullskjermsspiller',
+
     fullscreen: 'Fullskjermsspiller',
+
     closeFullscreen: 'Lukk fullskjerm',
+
     closeTooltip: 'Lukk (Esc)',
+
     noTitle: 'Ingen tittel',
+
     stop: 'Stopp',
+
     prev: 'Forrige spor',
+
     play: 'Spill av',
+
     pause: 'Pause',
+
     next: 'Neste spor',
+
     repeat: 'Gjenta',
+
     repeatOff: 'Av',
+
     repeatAll: 'Alle',
+
     repeatOne: 'Én',
+
     progress: 'Sangfremdrift',
+
     volume: 'Volum',
+
     toggleQueue: 'Veksle kø',
+
     lyrics: 'Sangtekst',
+
     fsLyricsToggle: 'Sangtekst i fullskjerm',
+
     lyricsLoading: 'Laster sangtekst…',
+
     lyricsNotFound: 'Ingen sangtekst funnet for dette sporet',
+
     lyricsSourceServer: 'Kilde: Server',
+
     lyricsSourceLrclib: 'Kilde: LRCLIB',
+
     lyricsSourceNetease: 'Kilde: Netease',
+
   },
+
   songInfo: {
+
     title: 'Sanginfo',
+
     songTitle: 'Tittel',
+
     artist: 'Artist',
+
     album: 'Album',
+
     albumArtist: 'Albumartist',
+
     year: 'År',
+
     genre: 'Sjanger',
+
     duration: 'Varighet',
+
     track: 'Spor',
+
     format: 'Format',
+
     bitrate: 'Bitrate',
+
     sampleRate: 'Samplingfrekvens',
+
     bitDepth: 'Bitdybde',
+
     channels: 'Kanaler',
+
     fileSize: 'Filstørrelse',
+
     path: 'Sti',
+
     replayGainTrack: 'RG-sporforsterkning',
+
     replayGainAlbum: 'RG-albumforsterkning',
+
     replayGainPeak: 'RG-sportopp',
+
     mono: 'Mono',
+
     stereo: 'Stereo',
+
   },
+
   playlists: {
+
     title: 'Spillelister',
+
     newPlaylist: 'Ny spilleliste',
+
     unnamed: 'Navnløs spilleliste',
+
     createName: 'Spillelistenavn…',
+
     create: 'Opprett',
+
     cancel: 'Avbryt',
+
     empty: 'Ingen spillelister ennå.',
+
     emptyPlaylist: 'Denne spillelisten er tom.',
+
     addFirstSong: 'Legg til din første sang',
+
     notFound: 'Spillelisten ble ikke funnet.',
+
     songs: '{{n}} sanger',
+
     playAll: 'Spill alle',
+
     shuffle: 'Bland',
+
     addToQueue: 'Legg til i kø',
+
     back: 'Tilbake til spillelister',
+
     deletePlaylist: 'Slett',
+
     confirmDelete: 'Klikk igjen for å bekrefte',
+
     removeSong: 'Fjern fra spilleliste',
+
     addSongs: 'Legg til sanger',
+
     searchPlaceholder: 'Søk i biblioteket ditt…',
+
     noResults: 'Ingen resultater.',
+
     suggestions: 'Foreslåtte sanger',
+
     noSuggestions: 'Ingen forslag tilgjengelig.',
+
     titleBadge: 'Spilleliste',
+
     refreshSuggestions: 'Nye forslag',
+
     addSong: 'Legg til i spilleliste',
+
     addSelected: 'Legg til valgte',
+
     cacheOffline: 'Bufre spilleliste offline',
+
     offlineCached: 'Spilleliste bufret',
+
     removeOffline: 'Fjern fra offline-buffer',
+
     offlineDownloading: 'Bufre… ({{done}}/{{total}} album)',
+
     publicLabel: 'Offentlig',
+
     privateLabel: 'Privat',
+
     editMeta: 'Rediger spilleliste',
+
     editNamePlaceholder: 'Spillelistenavn…',
+
     editCommentPlaceholder: 'Legg til en beskrivelse…',
+
     editPublic: 'Offentlig spilleliste',
+
     editSave: 'Lagre',
+
     editCancel: 'Avbryt',
+
     changeCover: 'Endre omslagsbilde',
+
     changeCoverLabel: 'Endre bilde',
+
     removeCover: 'Fjern bilde',
+
     coverUpdated: 'Omslag oppdatert',
+
     metaSaved: 'Spillelisten er oppdatert',
+
     downloadZip: 'Last ned (ZIP)',
+
     // Toast notifications for multi-select
+
     addSuccess: '{{count}} sanger lagt til i {{playlist}}',
+
     addPartial: '{{added}} lagt til, {{skipped}} hoppet over (duplikater)',
+
     addAllSkipped: 'Alle hoppet over ({{count}} duplikater)',
+
     addError: 'Feil ved å legge til sanger',
+
     createAndAddSuccess: 'Spilleliste "{{playlist}}" opprettet med {{count}} sanger',
+
     createError: 'Feil ved oppretting av spilleliste',
+
     deleteSuccess: '{{count}} spillelister slettet',
+
     deleteFailed: 'Feil ved sletting av {{name}}',
+
     deleteSelected: 'Slett valgte',
+
     mergeSuccess: '{{count}} sanger slått sammen i {{playlist}}',
+
     mergeNoNewSongs: 'Ingen nye sanger å legge til',
+
     mergeError: 'Feil ved sammenslåing av spillelister',
+
     mergeInto: 'Slå sammen i',
+
     selectionCount: '{{count}} valgt',
+
     select: 'Velg',
+
     startSelect: 'Aktiver valg',
+
     cancelSelect: 'Avbryt',
+
     loadingAlbums: 'Løser {{count}} album…',
+
     loadingArtists: 'Løser {{count}} artister…',
+
     myPlaylists: 'Mine spillelister',
+
     noOtherPlaylists: 'Ingen andre spillelister tilgjengelig',
+
     addToPlaylistSuccess: '{{count}} sanger lagt til i {{playlist}}',
+
     addToPlaylistNoNew: 'Ingen nye sanger for {{playlist}}',
+
     addToPlaylistError: 'Feil ved å legge til i spilleliste',
+
     removeSuccess: 'Sang fjernet fra spilleliste',
+
     removeError: 'Feil ved fjerning fra spilleliste',
+
     importCSV: 'Importer CSV',
+
     importCSVTooltip: 'Importer fra Spotify CSV',
+
     csvImportReport: 'CSV-importrapport',
+
     csvImportTotal: 'Totalt',
+
     csvImportAdded: 'Lagt til',
+
     csvImportDuplicates: 'Duplikater',
+
     csvImportNotFound: 'Ikke funnet',
+
     csvImportNetworkErrors: 'Nettverksfeil',
+
     csvImportDuplicatesTitle: 'Duplikater (allerede i spillelisten):',
+
     csvImportNotFoundTitle: 'Ikke funnet spor:',
+
     csvImportNetworkErrorsTitle: 'Nettverksfeil (kan prøve import på nytt):',
+
     csvImportDownloadReport: 'Last ned rapport',
+
     csvImportClose: 'Lukk',
+
     csvImportNoValidTracks: 'Ingen gyldige spor funnet i CSV-filen',
+
     csvImportFailed: 'Kunne ikke importere CSV-fil',
+
     csvImportToast: '{{added}} lagt til, {{notFound}} ikke funnet, {{duplicates}} duplikater',
+
   },
+
   mostPlayed: {
+
     title: 'Mest spilt',
+
     topArtists: 'Toppkunstnere',
+
     topAlbums: 'Toppalbum',
+
     plays: '{{n}} avspillinger',
+
     sortMost: 'Mest spilt først',
+
     sortLeast: 'Minst spilt først',
+
     loadMore: 'Last inn flere album',
+
     noData: 'Ingen avspillingsdata ennå. Begynn å høre!',
+
     noArtists: 'Alle artister filtrert bort.',
+
     filterCompilations: 'Skjul kompilasjonsartister (Various Artists, Soundtracks, etc.)',
+
     filterCompilationsShort: 'Skjul kompilasjoner',
+
   },
+
   radio: {
+
     title: 'Internettradio',
+
     empty: 'Ingen radiostasjoner konfigurert.',
+
     addStation: 'Legg til radio stasjon',
+
     editStation: 'Rediger',
+
     deleteStation: 'Slett stasjon',
+
     confirmDelete: 'Klikk igjen for å bekrefte',
+
     stationName: 'Stasjonsnavn…',
+
     streamUrl: 'Strøm-URL…',
+
     homepageUrl: 'Hjemmeside-URL (valgfritt)',
+
     save: 'Lagre',
+
     cancel: 'Avbryt',
+
     live: 'LIVE',
+
     liveStream: 'Internettradio',
+
     openHomepage: 'Åpne hjemmesiden',
+
     changeCoverLabel: 'Endre omslag',
+
     removeCover: 'Fjern omslag',
+
     browseDirectory: 'Søk i katalogen',
+
     directoryPlaceholder: 'Søk i stasjoner…',
+
     noResults: 'Ingen stasjoner funnet.',
+
     stationAdded: 'Stasjon lagt til',
+
     filterAll: 'Alle',
+
     filterFavorites: 'Favoritter',
+
     sortManual: 'Manuell',
+
     sortAZ: 'A → Å',
+
     sortZA: 'Å → A',
+
     sortNewest: 'Nyeste',
+
     favorite: 'Legg til i favoritter',
+
     unfavorite: 'Fjern fra favoritter',
+
     noFavorites: 'Ingen favorittstasjoner.',
+
     listenerCount_one: '{{count}} lytter',
+
     listenerCount_other: '{{count}} lyttere',
+
     recentlyPlayed: 'Nylig spilt',
+
     upNext: 'Neste ut',
+
   },
+
   folderBrowser: {
+
     empty: 'Tom mappe',
+
     error: 'Kunne ikke laste',
+
   },
+
   deviceSync: {
+
     title: 'Enhetssynk',
+
     targetFolder: 'Målmappe',
+
     noFolderChosen: 'Ingen mappe valgt',
+
     selectDrive: 'Velg en stasjon…',
+
     refreshDrives: 'Oppdater stasjoner',
+
     noDrivesDetected: 'Ingen flyttbare stasjoner oppdaget',
+
     browseManual: 'Bla manuelt…',
+
     free: 'ledig',
+
     notMountedVolume: 'Målet er ikke på en montert stasjon. Enheten kan ha blitt koblet fra.',
+
     chooseFolder: 'Velg…',
+
     filenameTemplate: 'Filnavnmal',
+
     targetDevice: 'Målenhet',
+
     templateHint: 'Variabler: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
+
     cleanupButton: 'Fjern filer som ikke er i utvalget',
+
     cleanupNothingToDelete: 'Ingenting å fjerne — enheten er allerede synkronisert.',
+
     confirmCleanup: 'Slette {{count}} fil(er) fra enheten som ikke er i det gjeldende utvalget. Fortsette?',
+
     cleanupComplete: '{{count}} fil(er) fjernet fra enheten.',
+
     selectedSources: 'Valgte kilder',
+
     noSourcesSelected: 'Ingen kilder valgt. Klikk på elementer i nettleseren for å legge dem til.',
+
     clearAll: 'Fjern alle',
+
     tabPlaylists: 'Spillelister',
+
     tabAlbums: 'Album',
+
     tabArtists: 'Artister',
+
     searchPlaceholder: 'Søk…',
+
     syncButton: 'Synkroniser til enhet',
+
     actionTransfer: 'Overfør til enhet',
+
     actionDelete: 'Slett fra enhet',
+
     actionApplyAll: 'Bruk alle endringer',
+
     templatePreview: 'Forhåndsvisning',
-    templatePresetStandard: 'Standard',
-    templatePresetMultiDisc: 'Multi-Disc',
-    templatePresetAltFolder: 'Alt. mappe',
-    tokenSlashHint: '/ = mappeskiller',
+
     cancel: 'Avbryt',
+
     noTargetDir: 'Velg en målmappe først.',
+
     noSources: 'Velg minst én kilde.',
+
     noTracks: 'Ingen spor funnet i de valgte kildene.',
+
     fetchError: 'Kunne ikke hente spor fra serveren.',
+
     syncComplete: 'Synkronisering fullført.',
+
     dismiss: 'Lukk',
-    cancelSync: 'Avbryt',
-    syncCancelled: 'Synkronisering avbrutt ({{done}} / {{total}} overført).',
+
     colName: 'Navn',
+
     colType: 'Type',
+
     colStatus: 'Status',
+
     onDevice: 'Enhetsbehandling',
+
     addSources: 'Legg til…',
+
     syncResult: '{{done}} overført, {{skipped}} allerede oppdatert ({{total}} totalt)',
+
     deleteFromDevice: 'Merk for sletting ({{count}})',
+
     confirmDelete: 'Slette {{count}} element(er) fra enheten: {{names}}?',
+
     deleteComplete: '{{count}} element(er) fjernet fra enheten.',
-    manifestImported: '{{count}} kilde(r) importert fra enhetsmanifest.',
+
     statusSynced: 'Synkronisert',
+
     statusPending: 'Venter',
+
     statusDeletion: 'Sletting',
+
     markForDeletion: 'Merk for sletting',
+
     removeSource: 'Fjern',
+
     undoDeletion: 'Angre sletting',
+
     syncInBackground: 'Synkronisering startet i bakgrunnen — du kan navigere bort.',
+
     syncInProgress: '{{done}} / {{total}} spor…',
+
     syncSummary: 'Synkroniseringssammendrag',
+
     calculating: 'Beregner nødvendig nyttelast…',
+
     filesToAdd: 'Filer som skal legges til:',
+
     filesToDelete: 'Filer som skal slettes:',
+
     netChange: 'Nettoendring:',
+
     availableSpace: 'Tilgjengelig diskplass:',
+
     spaceWarning: 'Advarsel: Målenheten har ikke nok rapportert plass.',
+
     proceed: 'Fortsett med synkronisering',
+
     notEnoughSpace: 'Ikke nok fysisk diskplass oppdaget!',
+
     liveSearch: 'Live',
+
     randomAlbumsLabel: 'Tilfeldige album',
+
   },
+
 };
+

--- a/src/locales/nb.ts
+++ b/src/locales/nb.ts
@@ -537,7 +537,7 @@ export const nbTranslation = {
     discordAppleCovers: 'Hent covere fra Apple Music til Discord',
     discordAppleCoversDesc: 'Sender artist- og albumnavn til Apples søke-API for å finne cover til Discord-profilen din. Deaktivert som standard av personvernhensyn.',
     discordTemplates: 'Egendefinerte tekstmaler',
-    discordTemplatesDesc: 'Tilpass hvilken informasjon som vises på Discord-profilen din. Variabler: {title}, {artist}, {album}, {paused}',
+    discordTemplatesDesc: 'Tilpass hvilken informasjon som vises på Discord-profilen din. Variabler: {title}, {artist}, {album}',
     discordTemplateDetails: 'Primær linje (details)',
     discordTemplateState: 'Sekundær linje (state)',
     discordTemplateLargeText: 'Album-verktøytips (largeText)',

--- a/src/locales/nb.ts
+++ b/src/locales/nb.ts
@@ -1,2264 +1,1168 @@
 export const nbTranslation = {
-
   sidebar: {
-
     library: 'Bibliotek',
-
     mainstage: 'Hovedscene',
-
     newReleases: 'Nye utgivelser',
-
     allAlbums: 'Alle album',
-
     randomAlbums: 'Tilfeldige album',
-
     randomPicker: 'Lag en miks',
-
     artists: 'Artister',
-
     randomMix: 'Tilfeldig miks',
-
     favorites: 'Favoritter',
-
     nowPlaying: 'Spilles nå',
-
     system: 'System',
-
     statistics: 'Statistikk',
-
     settings: 'Innstillinger',
-
     help: 'Hjelp',
-
     expand: 'Utvid sidefelt',
-
     collapse: 'Skjul sidefelt',
-
     downloadingTracks: 'Bufre {{n}} spor…',
-
     syncingTracks: 'Synkroniserer {{done}}/{{total}}…',
-
     cancelDownload: 'Avbryt nedlasting',
-
     offlineLibrary: 'Frakoblet bibliotek',
-
     genres: 'Sjangere',
-
     playlists: 'Spillelister',
-
     mostPlayed: 'Mest spilt',
-
     radio: 'Internettradio',
-
     folderBrowser: 'Mappeleser',
-
     deviceSync: 'Enhetssynk',
-
     libraryScope: 'Biblioteksomfang',
-
     allLibraries: 'Alle biblioteker',
-
     expandPlaylists: 'Utvid spillelister',
-
     collapsePlaylists: 'Skjul spillelister',
-
   },
-
   home: {
-
     hero: 'Utvalgt',
-
     starred: 'Personlige favoritter',
-
     recent: 'Nylig lagt til',
-
     mostPlayed: 'Mest spilt',
-
     recentlyPlayed: 'Nylig spilt',
-
     discover: 'Oppdag',
-
     loadMore: 'Last inn flere',
-
     discoverMore: 'Oppdag flere',
-
     discoverArtists: 'Oppdag artister',
-
     discoverArtistsMore: 'Alle artister'
-
   },
-
   hero: {
-
     eyebrow: 'Utvalgt album',
-
     playAlbum: 'Spill av album',
-
     enqueue: 'Legg til i kø',
-
     enqueueTooltip: 'Legg til hele albumet i køen',
-
   },
-
   search: {
-
     placeholder: 'Søk etter artist, album eller sang…',
-
     noResults: 'Ingen resultater funnet for "{{query}}"',
-
     artists: 'Artister',
-
     albums: 'Album',
-
     songs: 'Sanger',
-
     clearLabel: 'Fjern søk',
-
     title: 'Søk',
-
     resultsFor: 'Resultater for "{{query}}"',
-
     album: 'Album',
-
     advanced: 'Avansert søk',
-
     advancedSearchTerm: 'Søkeord',
-
     advancedSearchPlaceholder: 'Tittel, album, artist…',
-
     advancedGenre: 'Sjanger',
-
     advancedAllGenres: 'Alle sjangre',
-
     advancedYear: 'År',
-
     advancedYearFrom: 'fra',
-
     advancedYearTo: 'til',
-
     advancedAll: 'Alle',
-
     advancedSearch: 'Søk',
-
     advancedEmpty: 'Skriv inn et søkeord eller velg ett filter for å begynne.',
-
     advancedNoResults: 'Ingen resultater funnet.',
-
     advancedGenreNote: 'Sanger er tilfeldig valgt fra denne sjangeren.',
-
     recentSearches: 'Siste søk',
-
     browse: 'Utforsk',
-
     emptyHint: 'Hva vil du høre?',
-
     genres: 'Sjangre',
-
   },
-
   nowPlaying: {
-
     tooltip: 'Hvem lytter?',
-
     title: 'Hvem lytter?',
-
     loading: 'Laster…',
-
     nobody: 'Ingen lyttere for øyeblikket.',
-
     minutesAgo: '{{n}}m siden',
-
     nothingPlaying: 'Ingenting spiller akkurat å. Start et spor!',
-
     aboutArtist: 'Om artisten',
-
     fromAlbum: 'Fra dette albumet',
-
     viewAlbum: 'Se album',
-
     goToArtist: 'Gå til artist',
-
     readMore: 'Les mer',
-
     showLess: 'Vis mindre',
-
     genreInfo: 'Sjanger',
-
     trackInfo: 'Sporinfo',
-
   },
-
   contextMenu: {
-
     playNow: 'Spill nå',
-
     playNext: 'Spill neste',
-
     addToQueue: 'Legg til i kø',
-
     enqueueAlbum: 'Legg albumet i kø',
-
     startRadio: 'Start radio',
-
     instantMix: 'Instant Mix',
-
     instantMixFailed: 'Kunne ikke lage Instant Mix — server- eller pluginfeil.',
-
     cliMixNeedsTrack: 'Ingenting spilles — start avspilling først, og kjør mix-kommandoen på nytt.',
-
     lfmLove: 'Lik på Last.fm',
-
     lfmUnlove: 'Fjern fra likte på Last.fm',
-
     favorite: 'Favoritt',
-
     favoriteArtist: 'Favorittartist',
-
     favoriteAlbum: 'Favorittalbum',
-
     unfavorite: 'Fjern fra favoritter',
-
     unfavoriteArtist: 'Fjern artist fra favoritter',
-
     unfavoriteAlbum: 'Fjern album fra favoritter',
-
     removeFromQueue: 'Fjern fra kø',
-
     removeFromPlaylist: 'Fjern fra spilleliste',
-
     openAlbum: 'Åpne album',
-
     goToArtist: 'Gå til artist',
-
     download: 'Last ned (ZIP)',
-
     addToPlaylist: 'Legg til i spilleliste',
-
     selectedPlaylists: '{{count}} spillelister valgt',
-
     selectedAlbums: '{{count}} album valgt',
-
     selectedArtists: '{{count}} artister valgt',
-
     songInfo: 'Sanginfo',
-
   },
-
   albumDetail: {
-
     back: 'Tilbake',
-
     playAll: 'Spill alt',
-
     enqueue: 'Legg i kø',
-
     enqueueTooltip: 'Legg hele albumet i kø',
-
     artistBio: 'Artistbiografi',
-
     download: 'Last ned (ZIP)',
-
     downloading: 'Laster…',
-
     cacheOffline: 'Gjør tilgjengelig som frakoblet',
-
     offlineCached: 'Tilgjengelig frakoblet',
-
     offlineDownloading: 'Bufrer… ({{n}}/{{total}})',
-
     removeOffline: 'Fjern frakoblet hurtigbuffer',
-
     offlineStorageFull: 'Frakoblet lagring er full (lagringsgrense: {{mb}} MB). Frigjør plass, ved å slette et album fra ditt frakoblede bibliotek, eller øk lagringsgrensen i Innstillinger.',
-
     offlineStorageGoToLibrary: 'Frakoblet bibliotek',
-
     offlineStorageGoToSettings: 'Innstillinger',
-
     favoriteAdd: 'Legg til i favoritter',
-
     favoriteRemove: 'Fjern fra favoritter',
-
     favorite: 'Favoritt',
-
     noBio: 'Ingen biografi er tilgjengelig.',
-
     moreByArtist: 'Mer av {{artist}}',
-
     tracksCount: '{{n}} spor',
-
     goToArtist: 'Gå til {{artist}}',
-
     moreLabelAlbums: 'Flere album på {{label}}',
-
     trackTitle: 'Tittel',
-
     trackAlbum: 'Album',
-
     trackArtist: 'Artist',
-
     trackGenre: 'Sjanger',
-
     trackFormat: 'Format',
-
     trackFavorite: 'Favoritt',
-
     trackRating: 'Vurdering',
-
     trackDuration: 'Varighet',
-
     trackTotal: 'Totalt',
-
     columns: 'Kolonner',
-
+    resetColumns: 'Tilbakestill',
     notFound: 'Album ble ikke funnet.',
-
     bioModal: 'Artistbiografi',
-
     bioClose: 'Lukk',
-
     ratingLabel: 'Vurdering',
-
     enlargeCover: 'Forstørr',
-
     filterSongs: 'Filtrer sanger…',
-
     sortNatural: 'Naturlig',
-
     sortByTitle: 'A–Å (Tittel)',
-
     sortByArtist: 'A–Å (Artist)',
-
     sortByAlbum: 'A–Å (Album)',
-
   },
-
   entityRating: {
-
     albumShort: 'Albumvurdering',
-
     artistShort: 'Artistvurdering',
-
     albumAriaLabel: 'Albumvurdering',
-
     artistAriaLabel: 'Artistvurdering',
-
     saveFailed: 'Kunne ikke lagre vurderingen.',
-
   },
-
   artistDetail: {
-
     back: 'Tilbake',
-
     albums: 'Album',
-
     album: 'Album',
-
     playAll: 'Spill alt',
-
     shuffle: 'Tilfeldig rekkefølge',
-
     radio: 'Radio',
-
     loading: 'Laster…',
-
     noRadio: 'Ingen lignende spor funnet for denne artisten.',
-
     notFound: 'Artisten ble ikke funnet.',
-
     albumsBy: 'Album fra {{name}}',
-
     topTracks: 'Toppspor',
-
     noAlbums: 'Ingen album funnet.',
-
     trackTitle: 'Tittel',
-
     trackAlbum: 'Album',
-
     trackDuration: 'Varighet',
-
     favoriteAdd: 'Legg til i favoritter',
-
     favoriteRemove: 'Fjern fra favoritter',
-
     favorite: 'Favoritt',
-
     albumCount_one: '{{count}} album',
-
     albumCount_other: '{{count}} album',
-
     openedInBrowser: 'Åpnet i nettleser',
-
     featuredOn: 'Også en del av',
-
     similarArtists: 'Lignende artister',
-
     cacheOffline: 'Lagre diskografi som frakoblet',
-
     offlineCached: 'Diskografi bufret',
-
     offlineDownloading: 'Bufrer… ({{done}}/{{total}} album)',
-
     uploadImage: 'Last opp artistbilde',
-
     uploadImageError: 'Kunne ikke laste opp bildet',
-
   },
-
   favorites: {
-
     title: 'Favoritter',
-
     empty: "Du har ikke lagret noen favoritter ennå.",
-
     artists: 'Artister',
-
     albums: 'Album',
-
     songs: 'Sanger',
-
     enqueueAll: 'Legg alle i kø',
-
     playAll: 'Spill alle',
-
     removeSong: 'Fjern fra favoritter',
-
     stations: 'Radiostasjoner',
-
     showingFiltered: 'Viser {{filtered}} av {{total}} ({{artist}})',
-
     showingCount: 'Viser {{filtered}} av {{total}}',
-
     clearArtistFilter: 'Tøm artistfilter',
-
     noFilterResults: 'Ingen resultater med valgte filtre.',
-
     allArtists: 'Alle artister',
-
   },
-
   randomLanding: {
-
     title: 'Lag en miks',
-
     mixByTracks: 'Miks etter spor',
-
     mixByTracksDesc: 'Tilfeldig utvalg av spor fra hele biblioteket ditt',
-
     mixByAlbums: 'Miks etter album',
-
     mixByAlbumsDesc: 'Tilfeldige album for nye oppdagelser',
-
   },
-
   randomAlbums: {
-
     title: 'Tilfeldige album',
-
     refresh: 'Oppdater',
-
   },
-
   genres: {
-
     title: 'Sjangre',
-
     genreCount: 'Sjangre',
-
     albumCount_one: '{{count}} album',
-
     albumCount_other: '{{count}} album',
-
     loading: 'Laster sjangre…',
-
     empty: 'Ingen sjangre funnet.',
-
     albumsLoading: 'Laster album…',
-
     albumsEmpty: 'Ingen album funnet for denne sjangeren.',
-
     loadMore: 'Last mer',
-
     back: 'Tilbake',
-
   },
-
   randomMix: {
-
     title: 'Tilfeldig miks',
-
     remix: 'Remiks',
-
     remixTooltip: 'Last inn nye tilfeldige sanger',
-
     remixGenre: 'Remiks {{genre}}',
-
     remixTooltipGenre: 'Last inn nye {{genre}}-sanger',
-
     playAll: 'Spill alt',
-
     trackTitle: 'Tittel',
-
     trackArtist: 'Artist',
-
     trackAlbum: 'Album',
-
     trackFavorite: 'Favoritt',
-
     trackDuration: 'Varighet',
-
     favoriteAdd: 'Legg til i favoritter',
-
     favoriteRemove: 'Fjern fra favoritter',
-
     play: 'Spill',
-
     trackGenre: 'Sjanger',
-
     excludeAudiobooks: 'Ekskluder lydbøker og hørespill',
-
     excludeAudiobooksDesc: 'Samsvarer nøkkelord mot sjanger, tittel, album og artist - f.eks. Hørespill, Lydbok, Spoken Word, …',
-
     genreBlocked: 'Nøkkelord blokkert',
-
     genreAddedToBlacklist: 'Lagt til i filterliste',
-
     genreAlreadyBlocked: 'Allerede blokkert',
-
     artistBlocked: 'Artisten er blokkert',
-
     artistAddedToBlacklist: 'Artist er lagt til i filterliste',
-
     artistClickHint: 'Klikk for å blokkere denne artisten',
-
     blacklistToggle: 'Nøkkelordfilter',
-
     genreMixTitle: 'Sjangermiks',
-
     genreMixDesc: 'Topp 20 sjangre etter antall sanger - klikk for å laste en tilfeldig miks',
-
     genreMixAll: 'Alle sanger',
-
     genreMixLoadMore: 'Last 10 til',
-
     genreMixNoGenres: 'Ingen sjangre funnet på tjeneren.',
-
     shuffleGenres: 'Vis andre sjangre',
-
     filterPanelTitle: 'Filtre',
-
     filterPanelDesc: 'Klikk på en sjanger-tag eller på artistnavnet i sporlisten nedenfor, for å blokkere den fra fremtidige mikser.',
-
     genreClickHint: 'Klikk på en sjanger-tag for å legge den til\nsom et filternøkkelord.\nSamsvarer med sjanger, tittel, album og artist.',
-
   },
-
   albums: {
-
     title: 'Alle album',
-
     sortByName: 'A–Å (Album)',
-
     sortByArtist: 'A–Å (Artist)',
-
     sortNewest: 'Vis nyeste først',
-
     sortRandom: 'Tilfeldig',
-
 	yearFrom: 'Fra',
-
     yearTo: 'Til',
-
     yearFilterClear: 'Tøm år filteret',
-
     yearFilterLabel: 'År',
-
     select: 'Multivalg',
-
     startSelect: 'Aktiver multivalg',
-
     cancelSelect: 'Avbryt',
-
     selectionCount: '{{count}} valgt',
-
     downloadZips: 'Last ned ZIPs',
-
     addOffline: 'Legg til offline',
-
     downloadingZip: 'Laster ned {{current}}/{{total}}: {{name}}',
-
     downloadZipDone: '{{count}} ZIP(s) lastet ned',
-
     downloadZipFailed: 'Kunne ikke laste ned {{name}}',
-
     offlineQueuing: 'Legger {{count}} album i kø for offline…',
-
     offlineFailed: 'Kunne ikke legge til {{name}} offline',
-
   },
-
   artists: {
-
     title: 'Artister',
-
     search: 'Søk…',
-
     all: 'Alle',
-
     gridView: 'Rutenettvisning',
-
     listView: 'Listevisning',
-
     imagesOn: 'Artistbilder på - kan øke belastningen på nettverket og applikasjonen',
-
     imagesOff: 'Artistbilder av - viser kun initialer',
-
     loadMore: 'Last flere',
-
     notFound: 'Ingen artister funnet.',
-
     albumCount_one: '{{count}} album',
-
     albumCount_other: '{{count}} album',
-
     selectionCount: '{{count}} valgt',
-
     select: 'Multivalg',
-
     startSelect: 'Aktiver multivalg',
-
     cancelSelect: 'Avbryt',
-
     addToPlaylist: 'Legg til i spilleliste',
-
   },
-
   login: {
-
     subtitle: 'Din Navidrome-mediaspiller',
-
     serverName: 'Tjenernavn (valgfritt)',
-
     serverNamePlaceholder: 'Mitt mediabibliotek',
-
     serverUrl: 'Tjener-URL',
-
     serverUrlPlaceholder: '192.168.1.100:4533 eller https://musikk.eksempel.com',
-
     username: 'Brukernavn',
-
     usernamePlaceholder: 'admin',
-
     password: 'Passord',
-
     showPassword: 'Vis passord',
-
     hidePassword: 'Skjul passord',
-
     connect: 'Koble til',
-
     connecting: 'Kobler til…',
-
     connected: 'Tilkoblet!',
-
     error: 'Tilkoblingen mislyktes – vennligst sjekk instillingene.',
-
     urlRequired: 'Vennligst skriv inn en tjeneer-URL.',
-
     savedServers: 'Lagrede servere',
-
     addNew: 'Eller legg til en ny tjener',
-
   },
-
   connection: {
-
     connected: 'Tilkoblet',
-
     connectedTo: 'Tilkoblet til {{server}}',
-
     disconnected: 'Frakoblet',
-
     disconnectedFrom: 'Kan ikke nå {{server}} - klikk for å sjekke innstillinger',
-
     checking: 'Kobler til…',
-
     extern: 'Ekstern',
-
     offlineTitle: 'Ingen tjenertilkobling',
-
     offlineSubtitle: 'Kan ikke nå {{server}}. Sjekk nettverket eller tjeneren din.',
-
     offlineModeBanner: 'Frakoblet modus - spiller fra lokal hurtigbuffer',
-
     offlineNoCacheBanner: 'Ingen servertilkobling — kan ikke nå {{server}}',
-
     offlineLibraryTitle: 'Frakoblet bibliotek',
-
     offlineLibraryEmpty: 'Ingen album bufret ennå. Kobl deg til nettverket, åpne et album og klikk "Gjør tilgjengelig frakoblet".',
-
     offlineAlbumCount: '{{n}} album',
-
     offlineAlbumCount_plural: '{{n}} album',
-
     offlineFilterAll: 'Alle',
-
     offlineFilterAlbums: 'Album',
-
     offlineFilterPlaylists: 'Spillelister',
-
     offlineFilterArtists: 'Diskografier',
-
     retry: 'Prøv igjen',
-
     serverSettings: 'Serverinnstillinger',
-
     switchServerTitle: 'Bytt server',
-
     switchServerHint: 'Klikk for å velge en annen lagret server.',
-
     manageServers: 'Administrer servere…',
-
     switchFailed: 'Klarte ikke å bytte — serveren er utilgjengelig.',
-
     lastfmConnected: 'Last.fm tilkoblet som bruker @{{user}}',
-
     lastfmSessionInvalid: 'Sesjonen er ugyldig - klikk her for å koble til på nytt',
-
   },
-
   common: {
-
     albums: 'Album',
-
     album: 'Album',
-
     loading: 'Laster…',
-
     loadingMore: 'Laster…',
-
     loadingPlaylists: 'Laster spillelister…',
-
     noAlbums: 'Ingen album funnet.',
-
     downloading: 'Laster ned…',
-
     downloadZip: 'Last ned (ZIP)',
-
     back: 'Tilbake',
-
     cancel: 'Avbryt',
-
     save: 'Lagre',
-
     delete: 'Slett',
-
     use: 'Bruk',
-
     add: 'Legg til',
-
     active: 'Aktiv',
-
     download: 'Last ned',
-
     chooseDownloadFolder: 'Velg nedlastingsmappe',
-
     noFolderSelected: 'Ingen mappe valgt',
-
     rememberDownloadFolder: 'Husk denne mappen',
-
     filterGenre: 'Sjangerfilter',
-
     filterSearchGenres: 'Søk i sjangre…',
-
     filterNoGenres: 'Ingen sjangre samsvarer',
-
     filterClear: 'Tøm',
-
     play: 'Spill',
-
     bulkSelected: '{{count}} valgt',
-
     clearSelection: 'Fjern utvalg',
-
     bulkAddToPlaylist: 'Legg til i spilleliste',
-
     bulkRemoveFromPlaylist: 'Fjern fra spilleliste',
-
     bulkClear: 'Tøm utvalg',
-
     updaterAvailable: 'Ny versjon er tilgjengelig',
-
     updaterVersion: 'v{{version}} er tilgjengelig',
-
     updaterWebsite: 'Nettsted',
-
     updaterModalTitle: 'Ny versjon tilgjengelig',
-
     updaterChangelog: 'Hva er nytt',
-
     updaterDownloadBtn: 'Last ned nå',
-
     updaterSkipBtn: 'Hopp over denne versjonen',
-
     updaterRemindBtn: 'Påminn meg senere',
-
     updaterDone: 'Nedlasting fullført',
-
     updaterShowFolder: 'Vis i mappe',
-
     updaterInstallHint: 'Lukk Psysonic og kjør installasjonsprogrammet manuelt.',
-
     updaterAurHint: 'Installer oppdateringen via AUR:',
-
     updaterErrorMsg: 'Nedlasting mislyktes',
-
     updaterRetryBtn: 'Prøv igjen',
-
     durationHoursMinutes: '{{hours}} t {{minutes}} min',
-
     durationMinutesOnly: '{{minutes}} min',
-
     updaterOpenGitHub: 'Åpne på GitHub',
-
     filters: 'Filter',
-
     more: 'mer',
-
     yearRange: 'Årsspenn',
-
     clearAll: 'Tøm alt',
-
   },
-
   settings: {
-
     title: 'Innstillinger',
-
     language: 'Språk',
-
     languageEn: 'Engelsk',
-
     languageDe: 'Tysk',
-
     languageFr: 'Fransk',
-
     languageNl: 'Nederlandsk',
-
     languageZh: 'Kinesisk',
-
     languageNb: 'Norsk',
-
     languageRu: 'Russisk',
-
     font: 'Skrifttype',
-
     theme: 'Tema',
-
     appearance: 'Utseende',
-
     servers: 'Tjenere',
-
     serverName: 'Tjenernavn',
-
     serverUrl: 'Tjener-URL',
-
     serverUrlPlaceholder: '192.168.1.100:4533 eller https://musikk.eksempel.com',
-
     serverUsername: 'Brukernavn',
-
     serverPassword: 'Passord',
-
     addServer: 'Legg til tjener',
-
     addServerTitle: 'Legg til ny tjener',
-
     useServer: 'Bruk',
-
     deleteServer: 'Slett',
-
     noServers: 'Ingen tjenere lagret.',
-
     serverActive: 'Aktiv',
-
     confirmDeleteServer: 'Slett tjener "{{name}}"?',
-
     serverConnecting: 'Kobler til…',
-
     serverConnected: 'Tilkoblet!',
-
     serverFailed: 'Tilkobling mislyktes.',
-
     testBtn: 'Test tilkobling',
-
     testingBtn: 'Tester…',
-
     serverCompatible: 'Kompatibel med: Navidrome · Gonic · Airsonic · Subsonic',
-
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
-
     audiomuseDesc:
-
       'Slå på hvis denne serveren bruker <pluginLink>AudioMuse-AI Navidrome-plugin</pluginLink>. Aktiverer Instant Mix fra spor og henter lignende artister fra serveren i stedet for Last.fm på artistsider.',
-
     audiomuseIssueHint:
-
       'Instant Mix feilet nylig — sjekk Navidrome-plugin og AudioMuse API. Lignende artister hentes fra Last.fm hvis serveren ikke returnerer noe.',
-
     connected: 'Tilkoblet',
-
     failed: 'Mislyktes',
-
     eqTitle: 'Jevnstiller',
-
     eqEnabled: 'Aktiver jevnstiller',
-
     eqPreset: 'Forhåndsinnstilling',
-
     eqPresetCustom: 'Egendefinert',
-
     eqPresetBuiltin: 'Innebygde forhåndsinnstillinger',
-
     eqPresetCustomGroup: 'Mine forhåndsinnstillinger',
-
     eqSavePreset: 'Lagre som forhåndsinnstilling',
-
     eqPresetName: 'Navn på forhåndsinnstilling…',
-
     eqDeletePreset: 'Slett forhåndsinnstilling',
-
     eqResetBands: 'Tilbakestill til standard',
-
     eqPreGain: 'Forforsterkning',
-
     eqResetPreGain: 'Tilbakestill forforsterkning',
-
     eqAutoEqTitle: 'AutoEQ hodetelefonoppslag',
-
     eqAutoEqPlaceholder: 'Søk etter hodetelefon- / IEM-modell…',
-
     eqAutoEqSearching: 'Søker…',
-
     eqAutoEqNoResults: 'Ingen resultater funnet',
-
     eqAutoEqError: 'Søk mislyktes',
-
     eqAutoEqRateLimit: 'GitHub-hastighetsgrense nådd - prøv igjen om ett minutt',
-
     eqAutoEqFetchError: 'Kunne ikke hente EQ-profil',
-
     lfmTitle: 'Last.fm',
-
     lfmConnect: 'Koble til med Last.fm',
-
     lfmConnecting: 'Venter på autorisasjon…',
-
     lfmConfirm: 'Jeg har autorisert appen',
-
     lfmConnected: 'Tilkoblet som',
-
     lfmDisconnect: 'Koble fra',
-
     lfmConnectDesc: 'Koble til din Last.fm-konto for å aktivere scrobbling og få "Nå spiller"-oppdateringer direkte fra Psysonic - ingen Navidrome-konfigurasjon kreves.',
-
     lfmOpenBrowser: 'Et nettleservindu vil åpne seg. Autoriser Psysonic via Last.fm, og klikk deretter på knappen nedenfor.',
-
     lfmScrobbles: '{{n}} scrobbles',
-
     lfmMemberSince: 'Medlem siden {{year}}',
-
     scrobbleEnabled: 'Scrobbling er aktivert',
-
     scrobbleDesc: 'Send sanger til Last.fm etter 50 % avspilling',
-
     behavior: 'App-oppførsel',
-
     cacheTitle: 'Maks. lagringsstørrelse',
-
     cacheDesc: 'Plateomslag og artistbilder. Når den er full, fjernes de eldste oppføringene automatisk. Frakoblede album fjernes ikke automatisk, men slettes når hurtigbufferen tømmes manuelt.',
-
     cacheUsed: 'Brukt: {{images}} bilder · {{offline}} frakoblede spor',
-
 	cacheUsedImages: 'Bilder:',
-
     cacheUsedOffline: 'Frakoblede spor:',
-
     cacheUsedHot: 'Plass brukt:',
-
     hotCacheTrackCount: 'Spor i buffer:',
-
     cacheMaxLabel: 'Maks størrelse',															   
-
     cacheClearBtn: 'Tøm hurtigbuffer',
-
     cacheClearWarning: 'Dette vil også fjerne alle frakoblede album fra biblioteket.',
-
     cacheClearConfirm: 'Tøm alt',
-
     cacheClearCancel: 'Avbryt',
-
 	offlineDirTitle: 'Frakoblet bibliotek (In-App)',
-
 	offlineDirDesc: 'Lagringsplassering for spor som du gjør tilgjengelige som frakoblet i Psysonic.',
-
 	offlineDirDefault: 'Standard (App-data)',
-
 	offlineDirChange: 'Endre katalog',
-
 	offlineDirClear: 'Tilbakestill til standard',
-
 	offlineDirHint: 'Nye nedlastinger vil bruke denne plasseringen. Eksisterende nedlastinger forblir på sin opprinnelige lokasjon.',	
-
     hotCacheTitle: 'Varm avspillingsbuffer',
-
     hotCacheAlphaBadge: 'Alfa',
-
     hotCacheDisclaimer: 'Forhåndshenter neste spor i køen og beholder tidligere. Når aktivert: diskplass og nettverk.',
-
     hotCacheDirDefault: 'Standard (App-data)',
-
     hotCacheDirChange: 'Endre mappe',
-
     hotCacheDirClear: 'Tilbakestill til standard',
-
     hotCacheDirHint: 'Bytte mappe nullstiller indeksen i appen; gamle filer blir liggende til du sletter dem.',
-
     hotCacheEnabled: 'Aktiver varm avspillingsbuffer',
-
     hotCacheMaxMb: 'Maks bufferstørrelse',
-
     hotCacheDebounce: 'Utsettelse ved køendring',
-
     hotCacheDebounceImmediate: 'Umiddelbart',
-
     hotCacheDebounceSeconds: '{{n}} sek',
-
     hotCacheClearBtn: 'Tøm varm buffer',
-
     audioOutputDevice: 'Lydutgangsenhet',
-
     audioOutputDeviceDesc: 'Velg hvilken lydenhet Psysonic spiller gjennom. Endringer trer i kraft umiddelbart og starter gjeldende spor på nytt.',
-
     audioOutputDeviceDefault: 'Systemstandard',
-
     audioOutputDeviceRefresh: 'Oppdater enhetsliste',
-
     audioOutputDeviceOsDefaultNow: 'gjeldende systemutgang',
-
     audioOutputDeviceListError: 'Kunne ikke laste listen over lydenheter.',
-
     audioOutputDeviceNotInCurrentList: 'ikke i gjeldende liste',
-
     hiResTitle: 'Innebygd hi-res-avspilling',
-
     hiResEnabled: 'Aktiver innebygd hi-res-avspilling',
-
     hiResDesc: "Begrenser utdata til 44,1 kHz som standard for maksimal stabilitet. Aktiver kun hvis maskinvare og nettverk støtter høye samplingsrater (88,2 kHz+) pålitelig.",
-
     showArtistImages: 'Vis artistbilder',
-
     showArtistImagesDesc: 'Last inn og vis artistbilder i artistoversikten. Denne er deaktivert som standard, for å redusere disk-I/O og nettverksbelastningen på store biblioteker.',
-
     minimizeToTray: 'Minimer til oppgavelinjen',
-
     minimizeToTrayDesc: 'Når vinduet lukkes, vil Psysonic bli kjørende i oppgavelinjen fremfor å bli avsluttet.',
-
     discordRichPresence: 'Discord Rich Presence',
-
     discordRichPresenceDesc: 'Vis sporet som spilles i din Discord-profil. Krever at Discord kjører.',
-
     discordAppleCovers: 'Hent covere fra Apple Music til Discord',
-
     discordAppleCoversDesc: 'Sender artist- og albumnavn til Apples søke-API for å finne cover til Discord-profilen din. Deaktivert som standard av personvernhensyn.',
-
     discordTemplates: 'Egendefinerte tekstmaler',
-
     discordTemplatesDesc: 'Tilpass hvilken informasjon som vises på Discord-profilen din. Variabler: {title}, {artist}, {album}, {paused}',
-
-    discordTemplateDetails: 'Primærlinje (details)',
-
-    discordTemplateState: 'Sekundærlinje (state)',
-
-    discordTemplateLargeText: 'Album-tooltip (largeText)',
-
+    discordTemplateDetails: 'Primær linje (details)',
+    discordTemplateState: 'Sekundær linje (state)',
+    discordTemplateLargeText: 'Album-verktøytips (largeText)',
     nowPlayingEnabled: 'Vis i "Nå spiller"',
-
     nowPlayingEnabledDesc: 'Send sporet som spilles av til tjenerens live-lyttervisning. Deaktiver for å stoppe sending av avspillingsdata.',
-
     lyricsServerFirst: 'Foretrekk server-sangtekst',
-
     lyricsServerFirstDesc: 'Sjekk tjenerlevererte sangtekster (innebygde tagger, sidecar-filer) før LRCLIB. Deaktiver for å bruke LRCLIB først.',
-
     enableNeteaselyrics: 'Netease Cloud Music sangtekster',
-
     enableNeteaselyricsDesc: 'Bruk Netease Cloud Music som siste utvei når server og LRCLIB ikke finner noe. Best dekning for asiatisk og internasjonal musikk.',
-
     lyricsSourcesTitle: 'Sangtekstkilder',
-
     lyricsSourcesDesc: 'Velg hvilke kilder som skal brukes og i hvilken rekkefølge. Dra for å sortere. Deaktiverte kilder hoppes over.',
-
     lyricsSourceServer: 'Tjener',
-
     lyricsSourceLrclib: 'LRCLIB',
-
     lyricsSourceNetease: 'Netease Cloud Music',
-
     downloadsTitle: 'ZIP Eksport & Arkivering',
-
 	downloadsFolderDesc: 'Målmappe for album du laster ned som en ZIP-fil til datamaskinen din.',												  
-
     downloadsDefault: 'Standard nedlastingsmappe',
-
     pickFolder: 'Velg',
-
     pickFolderTitle: 'Velg nedlastingsmappe',
-
     clearFolder: 'Tøm nedlastingsmappe',
-
     logout: 'Logg ut',
-
     aboutTitle: 'Om Psysonic',
-
     aboutDesc: 'En moderne musikkspiller for Subsonic-kompatible tjenere (Navidrome, Gonic og andre). Bygget på Tauri v2 med en innebygd Rust-lydmotor - lett og rask, men fullpakket med funksjoner: bølgeform-søkelinje, synkroniserte sangtekster, Last.fm-integrasjon, 10-bånds jevnstiller, crossfade, gapless-avspilling, Replay Gain, sjangerlesing og et stort bibliotek med temaer.',
-
     aboutLicense: 'Lisens',
-
     aboutLicenseText: 'GNU GPL v3 - gratis å bruke, endre og distribuere under samme lisens.',
-
     aboutRepo: 'Kildekode på GitHub',
-
     aboutVersion: 'Versjon',
-
     aboutBuiltWith: 'Bygget med Tauri · React · TypeScript · Rust/rodio',
-
     aboutAiCredit: 'Utviklet med støtte fra Claude Code laget av Anthropic',
-
     aboutContributorsLabel: 'Bidragsytere',
-
     aboutSpecialThanksLabel: 'Spesiell takk',
-
     changelog: 'Endringslogg',
-
     showChangelogOnUpdate: "Vis 'Hva er nytt' ved oppdatering til ny versjon",
-
     showChangelogOnUpdateDesc: "Vis automatisk hva som er nytt når en ny versjon lanseres for første gang.",
-
     randomMixTitle: 'Tilfeldig miks',
-
     randomMixBlacklistTitle: 'Egendefinerte filternøkkelord',
-
     randomMixBlacklistDesc: 'Sanger ekskluderes når et nøkkelord samsvarer med sjanger, tittel, album eller artist (aktiv når avkrysningsboksen ovenfor er på).',
-
     randomMixBlacklistPlaceholder: 'Legg til nøkkelord…',
-
     randomMixBlacklistAdd: 'Legg til',
-
     randomMixBlacklistEmpty: 'Ingen egendefinerte nøkkelord lagt til ennå.',
-
     randomMixHardcodedTitle: 'Innebygde nøkkelord (aktiv når avkrysningsboksen er på)',
-
     tabPlayback: 'Avspilling',
-
     tabLibrary: 'Bibliotek',
-
     tabAppearance: 'Utseende',
-
     homeCustomizerTitle: 'Hjemmeside',
-
     sidebarTitle: 'Sidefelt',
-
     sidebarReset: 'Tilbakestill til standard',
-
     sidebarDrag: 'Dra for å endre rekkefølge',
-
     sidebarFixed: 'Alltid synlig',
-
+    randomNavSplitTitle: 'Del Mix-navigasjon',
+    randomNavSplitDesc: 'Vis "Tilfeldig miks" og "Tilfeldige album" som separate sidefeltsoppføringer i stedet for "Lag en miks"-huben.',
     tabShortcuts: 'Snarveier',
-
     tabServer: 'Tjener',
-
     tabSystem: 'System',
-
     tabGeneral: 'Generelt',
-
     ratingsSectionTitle: 'Vurderinger',
-
     ratingsSkipStarTitle: 'Hopp for 1 stjerne',
-
     ratingsSkipStarDesc:
-
       'Etter flere hopp på rad: sett sporet til 1 stjerne. Bare for spor som ikke var vurdert før.',
-
     ratingsSkipStarThresholdLabel: 'Hopp',
-
     ratingsMixFilterTitle: 'Filtrering etter vurdering',
-
     ratingsMixFilterDesc:
-
       'Filtrer innhold med lav vurdering i {{mix}} og {{albums}}. Klikk på den valgte stjerna igjen for å slå av terskelen.',
-
     ratingsMixMinSong: 'Spor',
-
     ratingsMixMinAlbum: 'Album',
-
     ratingsMixMinArtist: 'Artister',
-
     ratingsMixMinThresholdAria: 'Minimum stjerner: {{label}}',
-
     backupTitle: 'Sikkerhetskopiering og gjenoppretting',
-
     backupExport: 'Eksporter innstillinger',
-
     backupExportDesc: 'Lagrer alle innstillinger, tjenerprofiler, Last.fm-konfigurasjon, tema, jevnstiller og tastebindinger til en .psybkp-fil. Passordet lagres i klartekst – hold filen sikker.',
-
     backupImport: 'Importer innstillinger',
-
     backupImportDesc: 'Gjenoppretter innstillinger fra en .psybkp-fil. Applikasjonen starter på nytt etter import.',
-
     backupImportConfirm: 'Dette vil overskrive alle gjeldende innstillinger. Vil du fortsette?',
-
     backupSuccess: 'Sikkerhetskopiering lagret',
-
     backupImportSuccess: 'Innstillinger gjenopprettet – laster inn data på nytt…',
-
     backupImportError: 'Ugyldig eller ødelagt fil for sikkerhetskopi.',
-
     shortcutsReset: 'Tilbakestill til standardinnstillinger',
-
     shortcutListening: 'Trykk på en tast…',
-
     shortcutUnbound: '-',
-
     globalShortcutsTitle: 'Globale snarveier',
-
     globalShortcutsNote: 'Arbeid systemomfattende selv når Psysonic er i bakgrunnen. Krever Ctrl, Alt eller Super som modifikator.',
-
     shortcutClear: 'Fjern',
-
     shortcutPlayPause: 'Spill av / Pause',
-
     shortcutNext: 'Neste spor',
-
     shortcutPrev: 'Forrige spor',
-
     shortcutVolumeUp: 'Volum opp',
-
     shortcutVolumeDown: 'Volum ned',
-
     shortcutSeekForward: 'Søk fremover 10 sekunder',
-
     shortcutSeekBackward: 'Søk bakover 10 sekunder',
-
     shortcutToggleQueue: 'Veksle kø',
-
     shortcutOpenFolderBrowser: 'Åpne {{folderBrowser}}',
-
     shortcutFullscreenPlayer: 'Fullskjermsspiller',
-
     shortcutNativeFullscreen: 'Naturlig fullskjerm',
-
     playbackTitle: 'Avspilling',
-
     replayGain: 'Replay Gain',
-
     replayGainDesc: 'Normaliser sporvolumet ved hjelp av ReplayGain-metadata',
-
     replayGainMode: 'Modus',
-
     replayGainTrack: 'Spor',
-
     replayGainAlbum: 'Album',
-
     replayGainPreGain: 'Pre-Gain (taggede filer)',
-
     replayGainFallback: 'Reserveverdi (uten tagger / radio)',
-
     crossfade: 'Crossfade',
-
     crossfadeDesc: 'Tone mellom spor',
-
     crossfadeSecs: '{{n}}s',
-
     notWithGapless: 'Ikke tilgjengelig mens Gapless er aktiv',
-
     notWithCrossfade: 'Ikke tilgjengelig mens Crossfade er aktiv',
-
     gapless: 'Gapless avspilling',
-
     gaplessDesc: 'Forhåndsbuffer neste spor for å eliminere mellomrom mellom sanger',
-
     infiniteQueue: 'Uendelig kø',
-
     infiniteQueueDesc: 'Legg automatisk til tilfeldige spor når køen går tom',
-
     experimental: 'Eksperimentell',
-
     preloadMode: 'Forhåndslast neste spor',
-
     preloadModeDesc: 'Når buffering av neste spor i køen skal starte',
-
     nextTrackBufferingTitle: 'Neste spor – bufring',
-
     preloadHotCacheMutualExclusive: 'Forhåndslasting og Hot Cache tjener samme formål – bare én kan være aktiv om gangen. Å aktivere den ene deaktiverer automatisk den andre.',
-
     preloadOff: 'Av',
-
     preloadBalanced: 'Balansert (30 s før slutt)',
-
     preloadEarly: 'Tidlig (etter 5 s avspilling)',
-
     preloadCustom: 'Egendefinert',
-
     preloadCustomSeconds: 'Sekunder før slutt: {{n}}',
-
     fsPlayerSection: 'Fullskjermspiller',
-
     fsShowArtistPortrait: 'Vis artistbilde',
-
     fsShowArtistPortraitDesc: 'Vis artistbilde (eller albumomslag) på høyre side av fullskjermspilleren.',
-
     fsPortraitDim: 'Mørklegging av bilde',
-
     seekbarStyle: 'Søkefelt-stil',
-
     seekbarStyleDesc: 'Velg utseendet på avspillingssøkefeltet',
-
     seekbarWaveform: 'Bølgeform',
-
     seekbarLinedot: 'Linje & punkt',
-
     seekbarBar: 'Linje',
-
     seekbarThick: 'Tykk linje',
-
     seekbarSegmented: 'Segmentert',
-
     seekbarNeon: 'Neon',
-
     seekbarPulsewave: 'Pulsbølge',
-
     seekbarParticletrail: 'Partikkelspor',
-
     seekbarLiquidfill: 'Væskerør',
-
     seekbarRetrotape: 'Retrotape',
-
     themeSchedulerTitle: 'Tidsplanlagt tema',
-
     themeSchedulerEnable: 'Aktiver temaplanlegger',
-
     themeSchedulerEnableSub: 'Bytter automatisk mellom to temaer basert på tidspunkt',
-
     themeSchedulerDayTheme: 'Dagtema',
-
     themeSchedulerDayStart: 'Dag starter kl.',
-
     themeSchedulerNightTheme: 'Natttema',
-
     themeSchedulerNightStart: 'Natt starter kl.',
-
     themeSchedulerActiveHint: 'Temaplanlegger er aktiv - temaer byttes automatisk.',
-
     visualOptionsTitle: 'Visuelle Alternativer',
-
     coverArtBackground: 'Cover-bakgrunn',
-
     coverArtBackgroundSub: 'Vis uskarpt cover som bakgrunn i album/playlist-overskrifter',
-
     playlistCoverPhoto: 'Playlist-coverfoto',
-
     playlistCoverPhotoSub: 'Vis coverfoto-rutenett i playlist-detailedvisning',
-
     showBitrate: 'Vis Bitrate',
-
     showBitrateSub: 'Vis audio-bitrate i sporlister',
-
     uiScaleTitle: 'Grensesnittskala',
-
     uiScaleLabel: 'Zoom',
-
   },
-
   changelog: {
-
     modalTitle: "Nyheter",
-
     dontShowAgain: "Ikke vis igjen",
-
     close: 'Forstått',
-
   },
-
   help: {
-
     title: 'Hjelp',
-
     s1: 'Komme i gang',
-
     q1: 'Hvilke servere er kompatible?',
-
     a1: 'Psysonic fungerer med alle Subsonic-kompatible servere: Navidrome, Gonic, Subsonic, Airsonic og andre. Navidrome er det anbefalte valget.',
-
     q2: 'Hvordan kobler jeg til serveren min?',
-
     a2: 'Åpne Innstillinger og klikk på "Legg til server". Skriv inn server-URL-en (f.eks. 192.168.1.100:4533), brukernavn og passord. Psysonic tester tilkoblingen før den lagrer – ingenting lagres hvis tilkoblingen mislykkes.',
-
     q3: 'Kan jeg bruke flere servere?',
-
     a3: 'Ja. Du kan legge til så mange servere du vil i Innstillinger og bytte mellom dem når som helst. Bare én server er aktiv om gangen.',
-
     s2: 'Avspilling',
-
     q4: 'Hvordan spiller jeg musikk?',
-
     a4: 'Dobbeltklikk på et spor for å spille det av. På album- og artistsider bruker du "Spill av alle" for å starte hele albumet. Du kan også dra spor inn i køpanelet.',
-
     q5: 'Hvilke hurtigtaster er tilgjengelige?',
-
     a5: 'Mellomrom = Spill av / Pause · Escape = Lukk fullskjermsspiller. Medietaster (Spill av / Pause, Neste, Forrige) fungerer på alle plattformer. På Linux bruker du knappene i spillerlinjen for medietaster. Snarveier i appen og systemomfattende globale snarveier kan tilpasses i Innstillinger → Tastatursnarveier / Globale snarveier.',
-
     q6: 'Hva er køen?',
-
     a6: 'Køen viser alle kommende spor. Åpne den med panelikonet øverst til høyre (ved siden av Spilles nå-indikatoren). Du kan endre rekkefølgen på sporene ved å dra, spille av i tilfeldig rekkefølge med tilfeldig-knappen og lagre køen som en spilleliste.',
-
     q7: 'Hvordan åpner jeg fullskjermsspilleren?',
-
     a7: 'Klikk på miniatyrbildet av albumcoveret i spillerlinjen nederst, eller på utvid-ikonet ved siden av. Trykk på Escape for å lukke det igjen.',
-
     q8: 'Hvordan fungerer gjentakelse?',
-
     a8: 'Klikk på gjentakelsesknappen i spillerlinjen for å bla gjennom: Av → Gjenta alle → Gjenta én.',
-
     s3: 'Bibliotek',
-
     q9: 'Hvordan laster jeg ned et album?',
-
     a9: 'Åpne detaljsiden for et album og klikk på "Last ned (ZIP)". Serveren komprimerer albumet til en ZIP-fil først – for store album eller filer uten tap (FLAC/WAV) kan dette ta et øyeblikk før nedlastingen faktisk starter. Dette er normalt: fremdriftslinjen vises når serveren er ferdig med å zippe og overføringen starter.',
-
     q10: 'Hvordan stjernemerker/favoritterer jeg spor og album?',
-
     a10: 'Klikk på stjerneikonet på en hvilken som helst sporrad eller i albumoverskriften. Stjernemerkede elementer vises i Favoritter-delen i sidefeltet.',
-
     q11: 'Hva er hovedkarusellen på hjemmesiden?',
-
     a11: 'Banneret øverst på hjemmesiden velger tilfeldig album fra biblioteket ditt og roterer gjennom dem hvert 10. sekund. Klikk på prikkene for å hoppe til et bestemt album, eller klikk på banneret for å åpne albumet.',
-
     s4: 'Innstillinger',
-
     q12: 'Hvordan endrer jeg temaet?',
-
     a12: 'Innstillinger → Tema. Velg fra et stort utvalg av temaer på tvers av 8 grupper: Psysonic-temaer, mediaspiller, operativsystemer, spill, filmer, serier, sosiale medier og åpen kildekode-klassikere (Catppuccin, Nord, Gruvbox).',
-
     q13: 'Hvordan endrer jeg språket?',
-
     a13: 'Innstillinger → Språk. Engelsk, tysk, fransk, nederlandsk og kinesisk støttes.',
-
     q15: 'Hvordan angir jeg en nedlastingsmappe?',
-
     a15: 'Innstillinger → App-oppførsel → Nedlastingsmappe. Velg en hvilken som helst mappe – nedlastede album lagres der som ZIP-filer. Uten en tilpasset mappe brukes nettleserens standard nedlastingsplassering.',
-
     s5: 'Scrobbling',
-
     q16: 'Hvordan fungerer scrobbling?',
-
     a16: 'Psysonic scrobbler direkte til Last.fm - ingen Navidrome-konfigurasjon nødvendig. Koble til Last.fm-kontoen din i Innstillinger → Last.fm og aktiver scrobbling der.',
-
     q17: 'Når sendes en scrobble?',
-
     a17: 'En scrobble sendes etter at du har lyttet til 50 % av et spor.',
-
     q22: 'Hva er bølgeformen i avspillerlinjen?',
-
     a22: 'Bølgeformsøkelinjen erstatter den klassiske fremdriftsglidebryteren. Klikk hvor som helst på den for å hoppe til den posisjonen, eller dra for å skrubbe. Den avspilte delen lyser med en blå-til-lilla gradient, det bufrede området vises litt lysere, og den uavspilte delen er falmet.',
-
     q24: 'Kan jeg blande køen?',
-
     a24: 'Ja. Åpne køpanelet og klikk på blandeikonet i køoverskriften. Sporet som spilles av for øyeblikket forblir på posisjon 1 – alle gjenværende spor blir tilfeldig omorganisert.',
-
     q25: 'Åpnes Last.fm- og Wikipedia-lenker på artistsider i en nettleser?',
-
     a25: 'Ja – de åpnes i standardnettleseren din. Knappen viser kort en bekreftelsesetikett når du klikker på den.',
-
     s7: 'Tilfeldig miks',
-
     q26: 'Hva er tilfeldig miks?',
-
     a26: 'Tilfeldig miks bygger en spilleliste med tilfeldige spor fra hele biblioteket ditt. Åpne den via "Tilfeldig miks" i sidefeltet og klikk på "Ny miks". Du kan justere antall spor før generering.',
-
     q27: 'Hva er nøkkelordfilteret?',
-
     a27: 'Nøkkelordfilteret ekskluderer spor der sjanger, tittel eller albumnavn inneholder spesifikke ord. Lydbøker filtreres automatisk. Legg til egendefinerte nøkkelord i Innstillinger → Tilfeldig miks, eller klikk på en hvilken som helst sjangertagg i sporlisten for å legge den til umiddelbart.',
-
     q28: 'Hva er Super Genre Mix?',
-
     a28: 'Super Genre Mix grupperer biblioteket ditt i brede kategorier (rock, metal, elektronisk, jazz, klassisk osv.) og bygger en fokusert miks fra den stilen. Velg en kategoribrikke under sporlisten. Resultatene vises gradvis etter hvert som hver undersjanger hentes.',
-
     s6: 'Feilsøking',
-
     q18: 'Omslagsbilder og artistbilder lastes sakte.',
-
     a18: 'Bilder hentes fra serverens disk ved første innlasting og bufres deretter lokalt i 30 dager. Hvis serverens lagring er treg, kan det ta et øyeblikk før det første besøket på en side. Senere besøk vil være umiddelbare.',
-
     q19: 'Tilkoblingstesten mislykkes.',
-
     a19: 'Sjekk URL-en inkludert porten (f.eks. http://192.168.1.100:4533). Sørg for at ingen brannmur blokkerer tilkoblingen. Prøv http:// i stedet for https:// på et lokalt nettverk. Bekreft også at brukernavnet og passordet ditt er riktig.',
-
     q20: 'Ingen lyd på Linux.',
-
     a20: 'Psysonic er tilgjengelig som .deb (Ubuntu/Debian), .rpm (Fedora/RHEL), og via AUR på Arch/CachyOS (yay -S psysonic). Det finnes ingen AppImage. Hvis lyd mangler, sørg for at PipeWire eller PulseAudio kjører.',
-
     q21: 'Appen viser en svart skjerm på Linux.',
-
     a21: 'Dette er vanligvis et GPU/EGL-driverproblem i WebKitGTK. Start med GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. AUR-pakken og offisielle .deb/.rpm-installasjonsprogrammer setter disse automatisk.',
-
     q29: 'Hva er Crossfade og Gapless Playback?',
-
     a29: 'Begge er eksperimentelle lydfunksjoner i Innstillinger → Lyd. Gapless forhåndsbuffer neste spor for å eliminere stillhet mellom sanger. Crossfade fader ut gjeldende spor mens det fader inn det neste – juster varigheten (1–10 s) etter smak.',
-
     q30: 'Viser Psysonic sangtekst?',
-
     a30: 'Ja. Klikk på mikrofonikonet i spillerlinjen, for å åpne Sangtekst-fanen i køpanelet. Psysonic henter tekst automatisk fra LRCLIB. Hvis synkroniserte tekster er tilgjengelige, utheves den aktive linjen og ruller i sanntid mens sangen spilles av. Hvis bare ren tekst er tilgjengelig, vises fullteksten statisk.',
-
     q31: 'Kan jeg tilpasse hurtigtaster?',
-
     a31: 'Ja. Innstillinger → Tastatursnarveier lar deg tilordne handlinger i appen (Spill av/pause, Neste, Forrige, Volum opp/ned, Fullskjerm og mer) til en hvilken som helst tast. Innstillinger → Globale snarveier lar deg tilordne systemomfattende snarveier som utløses selv når Psysonic er i bakgrunnen.',
-
     q32: 'Kan jeg endre skrifttypen?',
-
     a32: 'Ja. Innstillinger → Skrifttype lar deg velge mellom 10 skrifttyper, inkludert IBM Plex Mono, Fira Code, JetBrains Mono, Courier Prime og andre. Den valgte skrifttypen gjelder for hele brukergrensesnittet.',
-
     s8: 'Frakoblet modus',
-
     q34: 'Hva er frakoblet modus?',
-
     a34: 'Frakoblet modus (beta) lar deg mellomlagre album til enheten din, slik at du kan lytte uten en aktiv servertilkobling. Bufrede spor lagres lokalt og spilles av direkte fra harddisken – ingen nettverksforespørsel gjøres under avspilling.',
-
     q35: 'Hvordan bufrer jeg et album for å bruke det offline?',
-
     a35: 'Åpne et hvilket som helst album og klikk på nedlastingsikonet i albumoverskriften. Psysonic laster ned alle spor i bakgrunnen. Fremdrift vises på knappen. Når bufren er lagret, blir ikonet grønt. Du kan vise og fjerne bufrede album på siden Offline bibliotek (sidefelt).',                                               
-
     q36: 'Hvor mye lagringsplass kan frakoblet mellomlagring bruke?',
-
     a36: 'Du kan angi en maksimal mellomlagringsstørrelse i Innstillinger → Bibliotek. Når grensen er nådd, vises et advarselsbanner på albumsiden. Du kan slette individuelle album fra frakoblet bibliotek for å frigjøre plass.',
-
     q37: 'Hvordan vurderer jeg sanger, album og artister?',
-
     a37: 'Psysonic støtter 1–5 stjernevurderinger via OpenSubsonic API (krever Navidrome ≥ 0.53). Vurder sanger i sporlistene, via høyreklikk-menyen eller i spillerlinjen. Album vurderes på detaljsiden, artister på artistsiden.',
-
     q38: 'Kan jeg fjerne eller endre en vurdering?',
-
     a38: 'Ja. Klikk på den aktive stjernen igjen for å slette vurderingen — et andre klikk på samme stjerne fjerner den. Klikk på en annen stjerne for å endre vurderingen.',
-
     q39: 'Hva er Skip-to-1★ og vurderingsfilter?',
-
     a39: 'Skip-to-1★ tildeler automatisk en 1-stjernevurdering etter et visst antall påfølgende manuelle hopp. Aktiver det i Innstillinger → Vurderinger. Der kan du også angi minimum stjerner for tilfeldige mikser.',
-
     q40: 'Hva er mappebrowseren?',
-
     a40: 'Mappebrowseren (sidepanel) lar deg navigere i serverens musikkmappe med Miller-kolonner. Klikk på en mappe for å utforske innholdet; bruk avspillingsikonen for å spille eller legge til i køen.',
-
     q41: 'Hva er temaplanleggeren?',
-
     a41: 'Innstillinger → Utseende → Bytt tema automatisk: angi et dagstema og et nattstema med starttider. Psysonic bytter automatisk på de angitte tidspunktene.',
-
     q42: 'Kan jeg skalere grensesnittet?',
-
     a42: 'Ja. Innstillinger → Utseende → Grensesnittskala lar deg skalere hele grensesnittet mellom 80 % og 125 %.',
-
     q43: 'Kan jeg endre søkelinjesstilen?',
-
     a43: 'Ja. Innstillinger → Utseende → Søkelinjestil tilbyr 10 stiler: Bølgeform, Linje & Punkt, Stolpe, Tykk stolpe, Segmentert, Neon Glow, Pulsbølge, Partikkelspor, Væskefylling og Retro Tape.',
-
     q44: 'Hva er AutoEQ?',
-
     a44: '10-bånds equalizer i Innstillinger → Lyd inkluderer AutoEQ-oppslag. Skriv inn hodetelefon-modellen for å laste inn en korreksjonsprofil automatisk.',
-
     q45: 'Hva er Replay Gain?',
-
     a45: 'Replay Gain normaliserer volumet slik at høye og stille album spilles av på et konsistent nivå. Aktiver det i Innstillinger → Lyd → Replay Gain; velg modus Spor eller Album.',
-
     q46: 'Hva er hurtigbufferen?',
-
     a46: 'Hurtigbuffer (Alpha, Innstillinger → Bibliotek) forhåndslaster de neste sporene i køen til disk for umiddelbar avspilling. Psysonic beholder gjeldende spor og de neste 5 og fjerner eldre innslag når grensen nås.',
-
     q47: 'Kan jeg mellomlagre en spilleliste frakoblet?',
-
     a47: 'Ja. Åpne spillelistedetaljene og klikk på nedlastingsikonen. Når alle spor er mellomlagret, endres ikonet til en rød søppelbøtte; klikk på den for å fjerne spillelisten fra frakoblet hurtigbuffer.',
-
+    q48: 'Hva er Infinite Queue?',
+    a48: 'Når køen tømmes og gjentakelse er deaktivert, legger Psysonic automatisk til tilfeldige spor så avspillingen aldri stopper. Automatisk tillagte spor vises under skillelinjen "— Lagt til automatisk —".',
+    q49: 'Kan jeg styre Psysonic fra kommandolinjen?',
+    a49: 'Ja. Eksempler: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one. Også: bytt server, lydenhet, filtrer bibliotek og søk. Full hjelp: psysonic --player --help.',
+    q50: 'Hvordan administrerer jeg spillelister?',
+    a50: 'Via "Spillelister" i sidefeltet. Opprett en med "Ny spilleliste". I detaljvisningen kan du dra spor for å sortere, fjerne dem med ×, legge til sanger via søk og bruke "Forslag" for smarte anbefalinger.',
+    q51: 'Kan jeg sikkerhetskopiere og gjenopprette innstillingene mine?',
+    a51: 'Ja. Innstillinger → Sikkerhetskopi og gjenoppretting eksporterer alle innstillinger, serverprofiler, temaer og snarveier til en JSON-fil.',
+    q52: 'Hvordan endrer jeg lydutgangsenheten?',
+    a52: 'Innstillinger → Lyd → Utgangsenhet. Psysonic viser alle tilgjengelige utganger. Valget trer i kraft umiddelbart.',
+    q53: 'Hva er Device Sync?',
+    a53: 'Device Sync kopierer album, spillelister eller artister til en USB-pinne eller SD-kort. Åpne via "Device Sync" i sidefeltet, velg en målmappe, velg kilder og klikk "Overfør til enhet".',
+    q54: 'Hva er filnavnmalen i Device Sync?',
+    a54: 'Malen styrer hvordan spor navngis og organiseres. Bruk forhåndsinnstillinger eller bygg din egen med klikkbare tokens: {artist}, {album}, {title}, {track_number}, {disc_number}, {year} og / som mappeskiller.',
+    q55: 'Fungerer Device Sync på tvers av plattformer?',
+    a55: 'Ja. Manifestet på enheten inneholder malen som ble brukt. På et annet OS gjenkjenner Psysonic eksisterende filer korrekt.',
+    s9: 'Device Sync',
+    q56: 'Hva er internettradio?',
+    a56: 'Internettradiosiden lar deg spille av direkte strømmer i Psysonic. Stasjoner hentes fra Navidrome-serveren din. Avspilling bruker HTML5-lyd.',
+    q57: 'Hvilke strømformater støtter internettradio?',
+    a57: 'MP3, AAC, OGG Vorbis og de fleste HLS-strømmer. MP3 og AAC fungerer på alle plattformer.',
+    s10: 'Internettradio',
+    q58: 'Hvor henter Psysonic sangtekster fra?',
+    a58: 'Tre konfigurerbare kilder i Innstillinger → Sangtekster: Navidrome-serveren din, LRCLIB og NetEase Cloud Music. Hver kilde kan aktiveres/deaktiveres og prioriteres ved dra-og-slipp.',
+    q59: 'Finnes det en visning av hva andre brukere hører på?',
+    a59: 'Ja. Klikk på kringkastingsikonet øverst til høyre for å se hva andre brukere på Navidrome-serveren din hører på, oppdatert hvert 10. sekund.',
   },
-
   queue: {
-
     title: 'Kø',
-
     savePlaylist: 'Lagre spilleliste',
-
     updatePlaylist: 'Oppdater spilleliste',
-
     filterPlaylists: 'Filtrer spillelister…',
-
     playlistName: 'Spillelistenavn',
-
     cancel: 'Avbryt',
-
     save: 'Lagre',
-
     loadPlaylist: 'Last inn spilleliste',
-
     loading: 'Laster…',
-
     noPlaylists: 'Ingen spillelister funnet.',
-
     load: 'Erstatt kø og spill av',
-
     appendToQueue: 'Legg til i kø',
-
     delete: 'Slett',
-
     deleteConfirm: 'Slett spillelisten "{{name}}"?',
-
     clear: 'Fjern',
-
     shuffle: 'Bland kø',
-
     gapless: 'Uten mellomrom',
-
     crossfade: 'Crossfade',
-
     infiniteQueue: 'Uendelig kø',
-
     autoAdded: '- Lagt til automatisk -',
-
     radioAdded: '- Radio -',
-
     hide: 'Skjul',
-
     close: 'Lukk',
-
     nextTracks: 'Neste spor',
-
     emptyQueue: 'Køen er tom.',
-
     trackSingular: 'spor',
-
     trackPlural: 'spor',
-
     showRemaining: 'Vis gjenværende tid',
-
     showTotal: 'Vis total tid',
-
   },
-
   statistics: {
-
     title: 'Statistikk',
-
     recentlyPlayed: 'Nylig spilt',
-
     mostPlayed: 'Mest spilte album',
-
     highestRated: 'Høyest rangerte album',
-
     genreDistribution: 'Sjangerfordeling (Topp 20)',
-
     loadMore: 'Last inn mer',
-
     statArtists: 'Artister',
-
     statArtistsTooltip: 'Kun albumartister — artister som bare opptrer som sporartist (featuring, gjest, osv.) uten eget album telles ikke med.',
-
     statAlbums: 'Album',
-
     statSongs: 'Sanger',
-
     statGenres: 'Sjangere',
-
     statPlaytime: 'Total spilletid',
-
     genreInsights: 'Sjangerinnsikt',
-
     formatDistribution: 'Formatdistribusjon',
-
     formatSample: 'Utvalg av {{n}} spor',
-
     computing: 'Utregner…',								   
-
     genreSongs: '{{count}} Sanger',
-
     genreAlbums: '{{count}} Album',
-
     recentlyAdded: 'Nylig lagt til',
-
     decadeDistribution: 'Album etter tiår',
-
     decadeAlbums_one: '{{count}} Album',
-
     decadeAlbums_other: '{{count}} Album',
-
     decadeUnknown: 'Ukjent',
-
     lfmTitle: 'Last.fm Statistikk',
-
     lfmTopArtists: 'Toppartister',
-
     lfmTopAlbums: 'Toppalbum',
-
     lfmTopTracks: 'Toppspor',
-
     lfmPlays: '{{count}} avspillinger',
-
     lfmPeriodOverall: 'Alltid',
-
     lfmPeriod7day: '7 dager',
-
     lfmPeriod1month: '1 måned',
-
     lfmPeriod3month: '3 måneder',
-
     lfmPeriod6month: '6 måneder',
-
     lfmPeriod12month: '12 måneder',
-
     lfmNotConnected: 'Koble til Last.fm i Innstillinger for å se statistikken din.',
-
     lfmRecentTracks: 'Siste Scrobble-innslag',
-
     lfmNowPlaying: 'Spilles nå',
-
     lfmJustNow: 'akkurat nå',
-
     lfmMinutesAgo: 'For {{n}}m siden',
-
     lfmHoursAgo: 'For {{n}}t siden',
-
     lfmDaysAgo: 'For {{n}}d siden',
-
     topRatedSongs: 'Høyest vurderte spor',
-
     topRatedArtists: 'Høyest vurderte artister',
-
     noRatedSongs: 'Ingen vurderte spor ennå. Vurder spor i album- eller spillelistevisning.',
-
     noRatedArtists: 'Ingen vurderte artister ennå.',
-
   },
-
   player: {
-
     regionLabel: 'Musikkspiller',
-
     openFullscreen: 'Åpne fullskjermsspiller',
-
     fullscreen: 'Fullskjermsspiller',
-
     closeFullscreen: 'Lukk fullskjerm',
-
     closeTooltip: 'Lukk (Esc)',
-
     noTitle: 'Ingen tittel',
-
     stop: 'Stopp',
-
     prev: 'Forrige spor',
-
     play: 'Spill av',
-
     pause: 'Pause',
-
     next: 'Neste spor',
-
     repeat: 'Gjenta',
-
     repeatOff: 'Av',
-
     repeatAll: 'Alle',
-
     repeatOne: 'Én',
-
     progress: 'Sangfremdrift',
-
     volume: 'Volum',
-
     toggleQueue: 'Veksle kø',
-
     lyrics: 'Sangtekst',
-
     fsLyricsToggle: 'Sangtekst i fullskjerm',
-
     lyricsLoading: 'Laster sangtekst…',
-
     lyricsNotFound: 'Ingen sangtekst funnet for dette sporet',
-
     lyricsSourceServer: 'Kilde: Server',
-
     lyricsSourceLrclib: 'Kilde: LRCLIB',
-
     lyricsSourceNetease: 'Kilde: Netease',
-
   },
-
   songInfo: {
-
     title: 'Sanginfo',
-
     songTitle: 'Tittel',
-
     artist: 'Artist',
-
     album: 'Album',
-
     albumArtist: 'Albumartist',
-
     year: 'År',
-
     genre: 'Sjanger',
-
     duration: 'Varighet',
-
     track: 'Spor',
-
     format: 'Format',
-
     bitrate: 'Bitrate',
-
     sampleRate: 'Samplingfrekvens',
-
     bitDepth: 'Bitdybde',
-
     channels: 'Kanaler',
-
     fileSize: 'Filstørrelse',
-
     path: 'Sti',
-
     replayGainTrack: 'RG-sporforsterkning',
-
     replayGainAlbum: 'RG-albumforsterkning',
-
     replayGainPeak: 'RG-sportopp',
-
     mono: 'Mono',
-
     stereo: 'Stereo',
-
   },
-
   playlists: {
-
     title: 'Spillelister',
-
     newPlaylist: 'Ny spilleliste',
-
     unnamed: 'Navnløs spilleliste',
-
     createName: 'Spillelistenavn…',
-
     create: 'Opprett',
-
     cancel: 'Avbryt',
-
     empty: 'Ingen spillelister ennå.',
-
     emptyPlaylist: 'Denne spillelisten er tom.',
-
     addFirstSong: 'Legg til din første sang',
-
     notFound: 'Spillelisten ble ikke funnet.',
-
     songs: '{{n}} sanger',
-
     playAll: 'Spill alle',
-
     shuffle: 'Bland',
-
     addToQueue: 'Legg til i kø',
-
     back: 'Tilbake til spillelister',
-
     deletePlaylist: 'Slett',
-
     confirmDelete: 'Klikk igjen for å bekrefte',
-
     removeSong: 'Fjern fra spilleliste',
-
     addSongs: 'Legg til sanger',
-
     searchPlaceholder: 'Søk i biblioteket ditt…',
-
     noResults: 'Ingen resultater.',
-
     suggestions: 'Foreslåtte sanger',
-
     noSuggestions: 'Ingen forslag tilgjengelig.',
-
     titleBadge: 'Spilleliste',
-
     refreshSuggestions: 'Nye forslag',
-
     addSong: 'Legg til i spilleliste',
-
     addSelected: 'Legg til valgte',
-
     cacheOffline: 'Bufre spilleliste offline',
-
     offlineCached: 'Spilleliste bufret',
-
     removeOffline: 'Fjern fra offline-buffer',
-
     offlineDownloading: 'Bufre… ({{done}}/{{total}} album)',
-
     publicLabel: 'Offentlig',
-
     privateLabel: 'Privat',
-
     editMeta: 'Rediger spilleliste',
-
     editNamePlaceholder: 'Spillelistenavn…',
-
     editCommentPlaceholder: 'Legg til en beskrivelse…',
-
     editPublic: 'Offentlig spilleliste',
-
     editSave: 'Lagre',
-
     editCancel: 'Avbryt',
-
     changeCover: 'Endre omslagsbilde',
-
     changeCoverLabel: 'Endre bilde',
-
     removeCover: 'Fjern bilde',
-
     coverUpdated: 'Omslag oppdatert',
-
     metaSaved: 'Spillelisten er oppdatert',
-
     downloadZip: 'Last ned (ZIP)',
-
     // Toast notifications for multi-select
-
     addSuccess: '{{count}} sanger lagt til i {{playlist}}',
-
     addPartial: '{{added}} lagt til, {{skipped}} hoppet over (duplikater)',
-
     addAllSkipped: 'Alle hoppet over ({{count}} duplikater)',
-
     addError: 'Feil ved å legge til sanger',
-
     createAndAddSuccess: 'Spilleliste "{{playlist}}" opprettet med {{count}} sanger',
-
     createError: 'Feil ved oppretting av spilleliste',
-
     deleteSuccess: '{{count}} spillelister slettet',
-
     deleteFailed: 'Feil ved sletting av {{name}}',
-
     deleteSelected: 'Slett valgte',
-
     mergeSuccess: '{{count}} sanger slått sammen i {{playlist}}',
-
     mergeNoNewSongs: 'Ingen nye sanger å legge til',
-
     mergeError: 'Feil ved sammenslåing av spillelister',
-
     mergeInto: 'Slå sammen i',
-
     selectionCount: '{{count}} valgt',
-
     select: 'Velg',
-
     startSelect: 'Aktiver valg',
-
     cancelSelect: 'Avbryt',
-
     loadingAlbums: 'Løser {{count}} album…',
-
     loadingArtists: 'Løser {{count}} artister…',
-
     myPlaylists: 'Mine spillelister',
-
     noOtherPlaylists: 'Ingen andre spillelister tilgjengelig',
-
     addToPlaylistSuccess: '{{count}} sanger lagt til i {{playlist}}',
-
     addToPlaylistNoNew: 'Ingen nye sanger for {{playlist}}',
-
     addToPlaylistError: 'Feil ved å legge til i spilleliste',
-
     removeSuccess: 'Sang fjernet fra spilleliste',
-
     removeError: 'Feil ved fjerning fra spilleliste',
-
     importCSV: 'Importer CSV',
-
     importCSVTooltip: 'Importer fra Spotify CSV',
-
     csvImportReport: 'CSV-importrapport',
-
     csvImportTotal: 'Totalt',
-
     csvImportAdded: 'Lagt til',
-
     csvImportDuplicates: 'Duplikater',
-
     csvImportNotFound: 'Ikke funnet',
-
     csvImportNetworkErrors: 'Nettverksfeil',
-
     csvImportDuplicatesTitle: 'Duplikater (allerede i spillelisten):',
-
     csvImportNotFoundTitle: 'Ikke funnet spor:',
-
     csvImportNetworkErrorsTitle: 'Nettverksfeil (kan prøve import på nytt):',
-
     csvImportDownloadReport: 'Last ned rapport',
-
     csvImportClose: 'Lukk',
-
     csvImportNoValidTracks: 'Ingen gyldige spor funnet i CSV-filen',
-
     csvImportFailed: 'Kunne ikke importere CSV-fil',
-
     csvImportToast: '{{added}} lagt til, {{notFound}} ikke funnet, {{duplicates}} duplikater',
-
   },
-
   mostPlayed: {
-
     title: 'Mest spilt',
-
     topArtists: 'Toppkunstnere',
-
     topAlbums: 'Toppalbum',
-
     plays: '{{n}} avspillinger',
-
     sortMost: 'Mest spilt først',
-
     sortLeast: 'Minst spilt først',
-
     loadMore: 'Last inn flere album',
-
     noData: 'Ingen avspillingsdata ennå. Begynn å høre!',
-
     noArtists: 'Alle artister filtrert bort.',
-
     filterCompilations: 'Skjul kompilasjonsartister (Various Artists, Soundtracks, etc.)',
-
     filterCompilationsShort: 'Skjul kompilasjoner',
-
   },
-
   radio: {
-
     title: 'Internettradio',
-
     empty: 'Ingen radiostasjoner konfigurert.',
-
     addStation: 'Legg til radio stasjon',
-
     editStation: 'Rediger',
-
     deleteStation: 'Slett stasjon',
-
     confirmDelete: 'Klikk igjen for å bekrefte',
-
     stationName: 'Stasjonsnavn…',
-
     streamUrl: 'Strøm-URL…',
-
     homepageUrl: 'Hjemmeside-URL (valgfritt)',
-
     save: 'Lagre',
-
     cancel: 'Avbryt',
-
     live: 'LIVE',
-
     liveStream: 'Internettradio',
-
     openHomepage: 'Åpne hjemmesiden',
-
     changeCoverLabel: 'Endre omslag',
-
     removeCover: 'Fjern omslag',
-
     browseDirectory: 'Søk i katalogen',
-
     directoryPlaceholder: 'Søk i stasjoner…',
-
     noResults: 'Ingen stasjoner funnet.',
-
     stationAdded: 'Stasjon lagt til',
-
     filterAll: 'Alle',
-
     filterFavorites: 'Favoritter',
-
     sortManual: 'Manuell',
-
     sortAZ: 'A → Å',
-
     sortZA: 'Å → A',
-
     sortNewest: 'Nyeste',
-
     favorite: 'Legg til i favoritter',
-
     unfavorite: 'Fjern fra favoritter',
-
     noFavorites: 'Ingen favorittstasjoner.',
-
     listenerCount_one: '{{count}} lytter',
-
     listenerCount_other: '{{count}} lyttere',
-
     recentlyPlayed: 'Nylig spilt',
-
     upNext: 'Neste ut',
-
   },
-
   folderBrowser: {
-
     empty: 'Tom mappe',
-
     error: 'Kunne ikke laste',
-
   },
-
   deviceSync: {
-
     title: 'Enhetssynk',
-
     targetFolder: 'Målmappe',
-
     noFolderChosen: 'Ingen mappe valgt',
-
     selectDrive: 'Velg en stasjon…',
-
     refreshDrives: 'Oppdater stasjoner',
-
     noDrivesDetected: 'Ingen flyttbare stasjoner oppdaget',
-
     browseManual: 'Bla manuelt…',
-
     free: 'ledig',
-
     notMountedVolume: 'Målet er ikke på en montert stasjon. Enheten kan ha blitt koblet fra.',
-
     chooseFolder: 'Velg…',
-
     filenameTemplate: 'Filnavnmal',
-
     targetDevice: 'Målenhet',
-
     templateHint: 'Variabler: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
-
     cleanupButton: 'Fjern filer som ikke er i utvalget',
-
     cleanupNothingToDelete: 'Ingenting å fjerne — enheten er allerede synkronisert.',
-
     confirmCleanup: 'Slette {{count}} fil(er) fra enheten som ikke er i det gjeldende utvalget. Fortsette?',
-
     cleanupComplete: '{{count}} fil(er) fjernet fra enheten.',
-
     selectedSources: 'Valgte kilder',
-
     noSourcesSelected: 'Ingen kilder valgt. Klikk på elementer i nettleseren for å legge dem til.',
-
     clearAll: 'Fjern alle',
-
     tabPlaylists: 'Spillelister',
-
     tabAlbums: 'Album',
-
     tabArtists: 'Artister',
-
     searchPlaceholder: 'Søk…',
-
     syncButton: 'Synkroniser til enhet',
-
     actionTransfer: 'Overfør til enhet',
-
     actionDelete: 'Slett fra enhet',
-
     actionApplyAll: 'Bruk alle endringer',
-
     templatePreview: 'Forhåndsvisning',
-
+    templatePresetStandard: 'Standard',
+    templatePresetMultiDisc: 'Multi-Disc',
+    templatePresetAltFolder: 'Alt. mappe',
+    tokenSlashHint: '/ = mappeskiller',
     cancel: 'Avbryt',
-
     noTargetDir: 'Velg en målmappe først.',
-
     noSources: 'Velg minst én kilde.',
-
     noTracks: 'Ingen spor funnet i de valgte kildene.',
-
     fetchError: 'Kunne ikke hente spor fra serveren.',
-
     syncComplete: 'Synkronisering fullført.',
-
     dismiss: 'Lukk',
-
+    cancelSync: 'Avbryt',
+    syncCancelled: 'Synkronisering avbrutt ({{done}} / {{total}} overført).',
     colName: 'Navn',
-
     colType: 'Type',
-
     colStatus: 'Status',
-
     onDevice: 'Enhetsbehandling',
-
     addSources: 'Legg til…',
-
     syncResult: '{{done}} overført, {{skipped}} allerede oppdatert ({{total}} totalt)',
-
     deleteFromDevice: 'Merk for sletting ({{count}})',
-
     confirmDelete: 'Slette {{count}} element(er) fra enheten: {{names}}?',
-
     deleteComplete: '{{count}} element(er) fjernet fra enheten.',
-
+    manifestImported: '{{count}} kilde(r) importert fra enhetsmanifest.',
     statusSynced: 'Synkronisert',
-
     statusPending: 'Venter',
-
     statusDeletion: 'Sletting',
-
     markForDeletion: 'Merk for sletting',
-
     removeSource: 'Fjern',
-
     undoDeletion: 'Angre sletting',
-
     syncInBackground: 'Synkronisering startet i bakgrunnen — du kan navigere bort.',
-
     syncInProgress: '{{done}} / {{total}} spor…',
-
     syncSummary: 'Synkroniseringssammendrag',
-
     calculating: 'Beregner nødvendig nyttelast…',
-
     filesToAdd: 'Filer som skal legges til:',
-
     filesToDelete: 'Filer som skal slettes:',
-
     netChange: 'Nettoendring:',
-
     availableSpace: 'Tilgjengelig diskplass:',
-
     spaceWarning: 'Advarsel: Målenheten har ikke nok rapportert plass.',
-
     proceed: 'Fortsett med synkronisering',
-
     notEnoughSpace: 'Ikke nok fysisk diskplass oppdaget!',
-
     liveSearch: 'Live',
-
     randomAlbumsLabel: 'Tilfeldige album',
-
   },
-
 };
-

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -1,1163 +1,2264 @@
 export const nlTranslation = {
+
   sidebar: {
+
     library: 'Bibliotheek',
+
     mainstage: 'Hoofdpodium',
+
     newReleases: 'Nieuw',
+
     allAlbums: 'Alle albums',
+
     randomAlbums: 'Willekeurige albums',
+
     randomPicker: 'Mix samenstellen',
+
     artists: 'Artiesten',
+
     randomMix: 'Willekeurige mix',
+
     favorites: 'Favorieten',
+
     nowPlaying: 'Nu bezig',
+
     system: 'Systeem',
+
     statistics: 'Statistieken',
+
     settings: 'Instellingen',
+
     help: 'Help',
+
     expand: 'Zijbalk uitklappen',
+
     collapse: 'Zijbalk inklappen',
+
     downloadingTracks: '{{n}} nummers worden gecached…',
+
     syncingTracks: 'Synchroniseren {{done}}/{{total}}…',
+
     cancelDownload: 'Download annuleren',
+
     offlineLibrary: 'Offline bibliotheek',
+
     genres: 'Genres',
+
     playlists: 'Playlists',
+
     mostPlayed: 'Meest gespeeld',
+
     radio: 'Internetradio',
+
     folderBrowser: 'Mappenverkenner',
+
     deviceSync: 'Apparaatsync',
+
     libraryScope: 'Bibliotheekbereik',
+
     allLibraries: 'Alle bibliotheken',
+
     expandPlaylists: 'Afspeellijsten uitklappen',
+
     collapsePlaylists: 'Afspeellijsten inklappen',
+
   },
+
   home: {
+
     hero: 'Uitgelicht',
+
     starred: 'Persoonlijke favorieten',
+
     recent: 'Recent toegevoegd',
+
     mostPlayed: 'Meest gespeeld',
+
     recentlyPlayed: 'Recent afgespeeld',
+
     discover: 'Ontdekken',
+
     loadMore: 'Meer laden',
+
     discoverMore: 'Meer ontdekken',
+
     discoverArtists: 'Artiesten ontdekken',
+
     discoverArtistsMore: 'Alle artiesten'
+
   },
+
   hero: {
+
     eyebrow: 'Uitgelicht album',
+
     playAlbum: 'Album afspelen',
+
     enqueue: 'In wachtrij',
+
     enqueueTooltip: 'Volledig album aan wachtrij toevoegen',
+
   },
+
   search: {
+
     placeholder: 'Zoek naar artiest, album of nummer…',
+
     noResults: 'Geen resultaten voor "{{query}}"',
+
     artists: 'Artiesten',
+
     albums: 'Albums',
+
     songs: 'Nummers',
+
     clearLabel: 'Zoekopdracht wissen',
+
     title: 'Zoeken',
+
     resultsFor: 'Resultaten voor "{{query}}"',
+
     album: 'Album',
+
     advanced: 'Geavanceerd zoeken',
+
     advancedSearchTerm: 'Zoekterm',
+
     advancedSearchPlaceholder: 'Titel, album, artiest…',
+
     advancedGenre: 'Genre',
+
     advancedAllGenres: 'Alle genres',
+
     advancedYear: 'Jaar',
+
     advancedYearFrom: 'van',
+
     advancedYearTo: 'tot',
+
     advancedAll: 'Alle',
+
     advancedSearch: 'Zoeken',
+
     advancedEmpty: 'Voer een zoekterm in of selecteer een filter.',
+
     advancedNoResults: 'Geen resultaten gevonden.',
+
     advancedGenreNote: 'Nummers worden willekeurig uit dit genre geselecteerd.',
+
     recentSearches: 'Recente zoekopdrachten',
+
     browse: 'Bladeren',
+
     emptyHint: 'Wat wil je horen?',
+
     genres: 'Genres',
+
   },
+
   nowPlaying: {
+
     tooltip: 'Wie luistert er?',
+
     title: 'Wie luistert er?',
+
     loading: 'Laden…',
+
     nobody: 'Er luistert momenteel niemand.',
+
     minutesAgo: '{{n}} min geleden',
+
     nothingPlaying: 'Nog niets bezig. Start een nummer!',
+
     aboutArtist: 'Over de artiest',
+
     fromAlbum: 'Van dit album',
+
     viewAlbum: 'Album openen',
+
     goToArtist: 'Naar artiest',
+
     readMore: 'Meer lezen',
+
     showLess: 'Minder tonen',
+
     genreInfo: 'Genre',
+
     trackInfo: 'Trackinfo',
+
   },
+
   contextMenu: {
+
     playNow: 'Nu afspelen',
+
     playNext: 'Volgende afspelen',
+
     addToQueue: 'Aan wachtrij toevoegen',
+
     enqueueAlbum: 'Album in wachtrij',
+
     startRadio: 'Radio starten',
+
     instantMix: 'Instant Mix',
+
     instantMixFailed: 'Instant Mix mislukt — server- of pluginfout.',
+
     cliMixNeedsTrack: 'Er speelt niets — start eerst afspelen en voer het mix-commando opnieuw uit.',
+
     lfmLove: 'Liken op Last.fm',
+
     lfmUnlove: 'Niet meer liken op Last.fm',
+
     favorite: 'Favoriet',
+
     favoriteArtist: 'Favoriete artiest',
+
     favoriteAlbum: 'Favoriet album',
+
     unfavorite: 'Verwijderen uit favorieten',
+
     unfavoriteArtist: 'Artiest uit favorieten verwijderen',
+
     unfavoriteAlbum: 'Album uit favorieten verwijderen',
+
     removeFromQueue: 'Uit wachtrij verwijderen',
+
     openAlbum: 'Album openen',
+
     goToArtist: 'Naar artiest',
+
     download: 'Downloaden (ZIP)',
+
     addToPlaylist: 'Toevoegen aan playlist',
+
     selectedPlaylists: '{{count}} playlists geselecteerd',
+
     selectedAlbums: '{{count}} albums geselecteerd',
+
     selectedArtists: '{{count}} artiesten geselecteerd',
+
     songInfo: 'Nummerinfo',
+
   },
+
   albumDetail: {
+
     back: 'Terug',
+
     playAll: 'Alles afspelen',
+
     enqueue: 'In wachtrij',
+
     enqueueTooltip: 'Volledig album aan wachtrij toevoegen',
+
     artistBio: 'Artiest biografie',
+
     download: 'Downloaden (ZIP)',
+
     downloading: 'Laden…',
+
     cacheOffline: 'Offline beschikbaar maken',
+
     offlineCached: 'Offline beschikbaar',
+
     offlineDownloading: 'Wordt gecached… ({{n}}/{{total}})',
+
     removeOffline: 'Offline cache verwijderen',
+
     offlineStorageFull: 'Offline opslag vol (limiet: {{mb}} MB). Verwijder een album uit je offline bibliotheek of verhoog de limiet in de instellingen.',
+
     offlineStorageGoToSettings: 'Instellingen',
+
     offlineStorageGoToLibrary: 'Offline bibliotheek',
+
     favoriteAdd: 'Aan favorieten toevoegen',
+
     favoriteRemove: 'Uit favorieten verwijderen',
+
     favorite: 'Favoriet',
+
     noBio: 'Geen biografie beschikbaar.',
+
     moreByArtist: 'Meer van {{artist}}',
+
     tracksCount: '{{n}} nummers',
+
     goToArtist: 'Naar {{artist}}',
+
     moreLabelAlbums: 'Meer albums op {{label}}',
+
     trackTitle: 'Titel',
+
     trackAlbum: 'Album',
+
     trackArtist: 'Artiest',
+
     trackGenre: 'Genre',
+
     trackFormat: 'Formaat',
+
     trackFavorite: 'Favoriet',
+
     trackRating: 'Beoordeling',
+
     trackDuration: 'Duur',
+
     trackTotal: 'Totaal',
+
     columns: 'Kolommen',
-    resetColumns: 'Standaard herstellen',
+
     notFound: 'Album niet gevonden.',
+
     bioModal: 'Artiest biografie',
+
     bioClose: 'Sluiten',
+
     ratingLabel: 'Beoordeling',
+
     enlargeCover: 'Vergroten',
+
     filterSongs: 'Filteren…',
+
     sortNatural: 'Natuurlijk',
+
     sortByTitle: 'A–Z (Titel)',
+
     sortByArtist: 'A–Z (Artiest)',
+
     sortByAlbum: 'A–Z (Album)',
+
   },
+
   entityRating: {
+
     albumShort: 'Albumbeoordeling',
+
     artistShort: 'Artiestbeoordeling',
+
     albumAriaLabel: 'Albumbeoordeling',
+
     artistAriaLabel: 'Artiestbeoordeling',
+
     saveFailed: 'Beoordeling opslaan mislukt.',
+
   },
+
   artistDetail: {
+
     back: 'Terug',
+
     albums: 'Albums',
+
     album: 'Album',
+
     playAll: 'Alles afspelen',
+
     shuffle: 'Willekeurig',
+
     radio: 'Radio',
+
     loading: 'Laden…',
+
     noRadio: 'Geen vergelijkbare nummers gevonden voor deze artiest.',
+
     notFound: 'Artiest niet gevonden.',
+
     albumsBy: 'Albums van {{name}}',
+
     topTracks: 'Populaire nummers',
+
     noAlbums: 'Geen albums gevonden.',
+
     trackTitle: 'Titel',
+
     trackAlbum: 'Album',
+
     trackDuration: 'Duur',
+
     favoriteAdd: 'Aan favorieten toevoegen',
+
     favoriteRemove: 'Uit favorieten verwijderen',
+
     favorite: 'Favoriet',
+
     albumCount_one: '{{count}} album',
+
     albumCount_other: '{{count}} albums',
+
     openedInBrowser: 'Geopend in browser',
+
     featuredOn: 'Ook te vinden op',
+
     similarArtists: 'Vergelijkbare artiesten',
+
     cacheOffline: 'Discografie offline opslaan',
+
     offlineCached: 'Discografie gecached',
+
     offlineDownloading: 'Cachen… ({{done}}/{{total}} albums)',
+
     uploadImage: 'Artiestafbeelding uploaden',
+
     uploadImageError: 'Uploaden van afbeelding mislukt',
+
   },
+
   favorites: {
+
     title: 'Favorieten',
+
     empty: 'Je hebt nog geen favorieten opgeslagen.',
+
     artists: 'Artiesten',
+
     albums: 'Albums',
+
     songs: 'Nummers',
+
     enqueueAll: 'Alles aan wachtrij toevoegen',
+
     playAll: 'Alles afspelen',
+
     removeSong: 'Verwijderen uit favorieten',
+
     stations: 'Radiostations',
+
     showingFiltered: 'Toont {{filtered}} van {{total}} ({{artist}})',
+
     showingCount: 'Toont {{filtered}} van {{total}}',
+
     clearArtistFilter: 'Artiestfilter wissen',
+
     noFilterResults: 'Geen resultaten met de geselecteerde filters.',
+
     allArtists: 'Alle artiesten',
+
   },
+
   randomLanding: {
+
     title: 'Mix samenstellen',
+
     mixByTracks: 'Mix op nummers',
+
     mixByTracksDesc: 'Willekeurige selectie uit je volledige mediatheek',
+
     mixByAlbums: 'Mix op albums',
+
     mixByAlbumsDesc: 'Willekeurige albums voor nieuwe ontdekkingen',
+
   },
+
   randomAlbums: {
+
     title: 'Willekeurige albums',
+
     refresh: 'Vernieuwen',
+
   },
+
   genres: {
+
     title: 'Genres',
+
     genreCount: 'genres',
+
     albumCount_one: '{{count}} album',
+
     albumCount_other: '{{count}} albums',
+
     loading: 'Genres laden…',
+
     empty: 'Geen genres gevonden.',
+
     albumsLoading: 'Albums laden…',
+
     albumsEmpty: 'Geen albums gevonden voor dit genre.',
+
     loadMore: 'Meer laden',
+
     back: 'Terug',
+
   },
+
   randomMix: {
+
     title: 'Willekeurige mix',
+
     remix: 'Opnieuw mixen',
+
     remixTooltip: 'Nieuwe willekeurige nummers laden',
+
     remixGenre: '{{genre}} mixen',
+
     remixTooltipGenre: 'Nieuwe {{genre}}-nummers laden',
+
     playAll: 'Alles afspelen',
+
     trackTitle: 'Titel',
+
     trackArtist: 'Artiest',
+
     trackAlbum: 'Album',
+
     trackFavorite: 'Favoriet',
+
     trackDuration: 'Duur',
+
     favoriteAdd: 'Aan favorieten toevoegen',
+
     favoriteRemove: 'Uit favorieten verwijderen',
+
     play: 'Afspelen',
+
     trackGenre: 'Genre',
+
     excludeAudiobooks: 'Luisterboeken en hoorspelen uitsluiten',
+
     excludeAudiobooksDesc: 'Vergelijkt trefwoorden met genre, titel, album en artiest — bijv. Hörbuch, Audiobook, Spoken Word, …',
+
     genreBlocked: 'Trefwoord geblokkeerd',
+
     genreAddedToBlacklist: 'Aan filterlijst toegevoegd',
+
     genreAlreadyBlocked: 'Al geblokkeerd',
+
     artistBlocked: 'Artiest geblokkeerd',
+
     artistAddedToBlacklist: 'Artiest aan filterlijst toegevoegd',
+
     artistClickHint: 'Klik om deze artiest te blokkeren',
+
     blacklistToggle: 'Trefwoordfilter',
+
     genreMixTitle: 'Genremix',
+
     genreMixDesc: 'Top 20 genres op aantal nummers — klik voor een willekeurige mix',
+
     genreMixAll: 'Alle nummers',
+
     genreMixLoadMore: '10 meer laden',
+
     genreMixNoGenres: 'Geen genres gevonden op server.',
+
     shuffleGenres: 'Andere genres tonen',
+
     filterPanelTitle: 'Filters',
+
     filterPanelDesc: 'Klik op een genre-tag of artiestennaam in de lijst om deze uit toekomstige mixes te weren.',
+
     genreClickHint: 'Klik op een genre-tag om het\ntoe te voegen als filtertrefwoord.\nVergelijkt genre, titel, album & artiest.',
+
   },
+
   albums: {
+
     title: 'Alle albums',
+
     sortByName: 'A–Z (Album)',
+
     sortByArtist: 'A–Z (Artiest)',
+
     sortNewest: 'Nieuwste eerst',
+
     sortRandom: 'Willekeurig',
+
     yearFrom: 'Van',
+
     yearTo: 'Tot',
+
     yearFilterClear: 'Jaarfilter wissen',
+
     yearFilterLabel: 'Jaar',
+
     select: 'Meervoudige selectie',
+
     startSelect: 'Meervoudige selectie inschakelen',
+
     cancelSelect: 'Annuleren',
+
     selectionCount: '{{count}} geselecteerd',
+
     downloadZips: 'ZIPs downloaden',
+
     addOffline: 'Offline toevoegen',
+
     downloadingZip: 'Downloaden {{current}}/{{total}}: {{name}}',
+
     downloadZipDone: '{{count}} ZIP(s) gedownload',
+
     downloadZipFailed: 'Downloaden van {{name}} mislukt',
+
     offlineQueuing: '{{count}} album(s) in wachtrij voor offline…',
+
     offlineFailed: 'Toevoegen van {{name}} offline mislukt',
+
   },
+
   artists: {
+
     title: 'Artiesten',
+
     search: 'Zoeken…',
+
     all: 'Alle',
+
     gridView: 'Rasterweergave',
+
     listView: 'Lijstweergave',
+
     imagesOn: 'Artiestafbeeldingen aan — kan netwerk- en systeembelasting verhogen',
+
     imagesOff: 'Artiestafbeeldingen uit — toont alleen initialen',
+
     loadMore: 'Meer laden',
+
     notFound: 'Geen artiesten gevonden.',
+
     albumCount_one: '{{count}} album',
+
     albumCount_other: '{{count}} albums',
+
     selectionCount: '{{count}} geselecteerd',
+
     select: 'Meervoudige selectie',
+
     startSelect: 'Meervoudige selectie inschakelen',
+
     cancelSelect: 'Annuleren',
+
     addToPlaylist: 'Toevoegen aan playlist',
+
   },
+
   login: {
+
     subtitle: 'Jouw Navidrome-desktopspeler',
+
     serverName: 'Servernaam (optioneel)',
+
     serverNamePlaceholder: 'Mijn Navidrome',
+
     serverUrl: 'Server-URL',
+
     serverUrlPlaceholder: '192.168.1.100:4533 of https://music.voorbeeld.nl',
+
     username: 'Gebruikersnaam',
+
     usernamePlaceholder: 'admin',
+
     password: 'Wachtwoord',
+
     showPassword: 'Wachtwoord tonen',
+
     hidePassword: 'Wachtwoord verbergen',
+
     connect: 'Verbinden',
+
     connecting: 'Verbinden…',
+
     connected: 'Verbonden!',
+
     error: 'Verbinding mislukt — controleer je gegevens.',
+
     urlRequired: 'Voer een server-URL in.',
+
     savedServers: 'Opgeslagen servers',
+
     addNew: 'Of een nieuwe server toevoegen',
+
   },
+
   connection: {
+
     connected: 'Verbonden',
+
     connectedTo: 'Verbonden met {{server}}',
+
     disconnected: 'Verbroken',
+
     disconnectedFrom: 'Kan {{server}} niet bereiken — klik om instellingen te controleren',
+
     checking: 'Verbinden…',
+
     extern: 'Extern',
+
     offlineTitle: 'Geen serververbinding',
+
     offlineSubtitle: 'Kan {{server}} niet bereiken. Controleer je netwerk of server.',
+
     offlineModeBanner: 'Offline modus — afspelen vanuit lokale cache',
+
     offlineNoCacheBanner: 'Geen serververbinding — {{server}} niet bereikbaar',
+
     offlineLibraryTitle: 'Offline bibliotheek',
+
     offlineLibraryEmpty: 'Nog geen albums gecached. Ga online, open een album en klik op "Offline beschikbaar maken".',
+
     offlineAlbumCount: '{{n}} album',
+
     offlineAlbumCount_plural: '{{n}} albums',
+
     offlineFilterAll: 'Alles',
+
     offlineFilterAlbums: 'Albums',
+
     offlineFilterPlaylists: 'Afspeellijsten',
+
     offlineFilterArtists: 'Discografieën',
+
     retry: 'Opnieuw proberen',
+
     serverSettings: 'Serverinstellingen',
+
     switchServerTitle: 'Server wisselen',
+
     switchServerHint: 'Klik om een andere opgeslagen server te kiezen.',
+
     manageServers: 'Servers beheren…',
+
     switchFailed: 'Wisselen mislukt — server niet bereikbaar.',
+
     lastfmConnected: 'Last.fm verbonden als @{{user}}',
+
     lastfmSessionInvalid: 'Sessie ongeldig — klik om opnieuw te verbinden',
+
   },
+
   common: {
+
     albums: 'Albums',
+
     album: 'Album',
+
     loading: 'Laden…',
+
     loadingMore: 'Laden…',
+
     loadingPlaylists: 'Afspeellijsten laden…',
+
     noAlbums: 'Geen albums gevonden.',
+
     downloading: 'Downloaden…',
+
     downloadZip: 'Downloaden (ZIP)',
+
     back: 'Terug',
+
     cancel: 'Annuleren',
+
     save: 'Opslaan',
+
     delete: 'Verwijderen',
+
     use: 'Gebruiken',
+
     add: 'Toevoegen',
+
     active: 'Actief',
+
     download: 'Downloaden',
+
     chooseDownloadFolder: 'Downloadmap kiezen',
+
     noFolderSelected: 'Geen map geselecteerd',
+
     rememberDownloadFolder: 'Deze map onthouden',
+
     filterGenre: 'Genre-filter',
+
     filterSearchGenres: 'Genres zoeken…',
+
     filterNoGenres: 'Geen genres gevonden',
+
     filterClear: 'Wissen',
+
     play: 'Afspelen',
+
     bulkSelected: '{{count}} geselecteerd',
+
     clearSelection: 'Selectie wissen',
+
     bulkAddToPlaylist: 'Toevoegen aan afspeellijst',
+
     bulkRemoveFromPlaylist: 'Verwijderen uit afspeellijst',
+
     bulkClear: 'Selectie wissen',
+
     updaterAvailable: 'Update beschikbaar',
+
     updaterVersion: 'v{{version}} beschikbaar',
+
     updaterWebsite: 'Website',
+
     updaterModalTitle: 'Nieuwe versie beschikbaar',
+
     updaterChangelog: 'Wat is er nieuw',
+
     updaterDownloadBtn: 'Nu downloaden',
+
     updaterSkipBtn: 'Deze versie overslaan',
+
     updaterRemindBtn: 'Later herinneren',
+
     updaterDone: 'Download voltooid',
+
     updaterShowFolder: 'Tonen in map',
+
     updaterInstallHint: 'Sluit Psysonic en voer het installatieprogramma handmatig uit.',
+
     updaterAurHint: 'Update installeren via AUR:',
+
     updaterErrorMsg: 'Downloaden mislukt',
+
     updaterRetryBtn: 'Opnieuw proberen',
+
     durationHoursMinutes: '{{hours}} u {{minutes}} min',
+
     durationMinutesOnly: '{{minutes}} min',
+
     updaterOpenGitHub: 'Openen op GitHub',
+
     filters: 'Filters',
+
     more: 'meer',
+
     yearRange: 'Jaarbereik',
+
     clearAll: 'Alles wissen',
+
   },
+
   settings: {
+
     title: 'Instellingen',
+
     language: 'Taal',
+
     languageEn: 'Engels',
+
     languageDe: 'Duits',
+
     languageFr: 'Frans',
+
     languageNl: 'Nederlands',
+
     languageZh: 'Chinees',
+
     languageNb: 'Noors',
+
     languageRu: 'Russisch',
+
     font: 'Lettertype',
+
     theme: 'Thema',
+
     appearance: 'Weergave',
+
     servers: 'Servers',
+
     serverName: 'Servernaam',
+
     serverUrl: 'Server-URL',
+
     serverUrlPlaceholder: '192.168.1.100:4533 of https://music.voorbeeld.nl',
+
     serverUsername: 'Gebruikersnaam',
+
     serverPassword: 'Wachtwoord',
+
     addServer: 'Server toevoegen',
+
     addServerTitle: 'Nieuwe server toevoegen',
+
     useServer: 'Gebruiken',
+
     deleteServer: 'Verwijderen',
+
     noServers: 'Geen servers opgeslagen.',
+
     serverActive: 'Actief',
+
     confirmDeleteServer: 'Server "{{name}}" verwijderen?',
+
     serverConnecting: 'Verbinden…',
+
     serverConnected: 'Verbonden!',
+
     serverFailed: 'Verbinding mislukt.',
+
     testBtn: 'Verbinding testen',
+
     testingBtn: 'Testen…',
+
     serverCompatible: 'Compatibel met: Navidrome · Gonic · Airsonic · Subsonic',
+
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+
     audiomuseDesc:
+
       'Zet aan als deze server de <pluginLink>AudioMuse-AI Navidrome-plugin</pluginLink> gebruikt. Schakelt Instant Mix per nummer in en toont vergelijkbare artiesten van de server i.p.v. Last.fm op artiestpagina’s.',
+
     audiomuseIssueHint:
+
       'Instant Mix is onlangs mislukt — controleer de Navidrome-plugin en AudioMuse API. Zonder serverresultaten worden vergelijkbare artiesten via Last.fm geladen.',
+
     connected: 'Verbonden',
+
     failed: 'Mislukt',
+
     eqTitle: 'Equalizer',
+
     eqEnabled: 'Equalizer inschakelen',
+
     eqPreset: 'Voorinstelling',
+
     eqPresetCustom: 'Aangepast',
+
     eqPresetBuiltin: 'Ingebouwde voorinstellingen',
+
     eqPresetCustomGroup: 'Mijn voorinstellingen',
+
     eqSavePreset: 'Opslaan als voorinstelling',
+
     eqPresetName: 'Naam voorinstelling…',
+
     eqDeletePreset: 'Voorinstelling verwijderen',
+
     eqResetBands: 'Terugzetten naar vlak',
+
     eqPreGain: 'Voorversterking',
+
     eqResetPreGain: 'Voorversterking resetten',
+
     eqAutoEqTitle: 'AutoEQ Hoofdtelefoon Zoeken',
+
     eqAutoEqPlaceholder: 'Zoek hoofdtelefoon / IEM model…',
+
     eqAutoEqSearching: 'Zoeken…',
+
     eqAutoEqNoResults: 'Geen resultaten gevonden',
+
     eqAutoEqError: 'Zoeken mislukt',
+
     eqAutoEqRateLimit: 'GitHub limiet bereikt — probeer over een minuut opnieuw',
+
     eqAutoEqFetchError: 'EQ-profiel kon niet worden geladen',
+
     lfmTitle: 'Last.fm',
+
     lfmConnect: 'Verbinden met Last.fm',
+
     lfmConnecting: 'Wachten op autorisatie…',
+
     lfmConfirm: 'Ik heb de app geautoriseerd',
+
     lfmConnected: 'Verbonden als',
+
     lfmDisconnect: 'Verbinding verbreken',
+
     lfmConnectDesc: 'Verbind je Last.fm-account om scrobbling en Nu bezig-updates rechtstreeks vanuit Psysonic in te schakelen — geen Navidrome-configuratie vereist.',
+
     lfmOpenBrowser: 'Er opent een browservenster. Autoriseer Psysonic op Last.fm en klik daarna op de knop hieronder.',
+
     lfmScrobbles: '{{n}} scrobbles',
+
     lfmMemberSince: 'Lid sinds {{year}}',
+
     scrobbleEnabled: 'Scrobbling ingeschakeld',
+
     scrobbleDesc: 'Nummers naar Last.fm sturen na 50% afspeeltijd',
+
     behavior: 'App-gedrag',
+
     cacheTitle: 'Max. opslaggrootte',
+
     cacheDesc: 'Albumhoezen en artiestafbeeldingen. Als de cache vol is, worden de oudste items automatisch verwijderd. Offline albums worden niet automatisch verwijderd, maar wel bij handmatig leegmaken.',
+
     cacheUsedImages: 'Afbeeldingen:',
+
     cacheUsedOffline: 'Offline nummers:',
+
     cacheUsedHot: 'Schijfgebruik:',
+
     hotCacheTrackCount: 'Nummers in cache:',
+
     cacheMaxLabel: 'Max. grootte',
+
     cacheClearBtn: 'Cache wissen',
+
     cacheClearWarning: 'Dit verwijdert ook alle offline albums uit de bibliotheek.',
+
     cacheClearConfirm: 'Alles wissen',
+
     cacheClearCancel: 'Annuleren',
+
     offlineDirTitle: 'Offline-bibliotheek (In-app)',
+
     offlineDirDesc: 'Opslaglocatie voor nummers die je offline beschikbaar maakt in Psysonic.',
+
     offlineDirDefault: 'Standaard (app-gegevens)',
+
     offlineDirChange: 'Map wijzigen',
+
     offlineDirClear: 'Terugzetten naar standaard',
+
     offlineDirHint: 'Nieuwe downloads worden op deze locatie opgeslagen. Bestaande downloads blijven op hun oorspronkelijke locatie.',
+
     hotCacheTitle: 'Warme afspeelcache',
+
     hotCacheAlphaBadge: 'Alpha',
+
     hotCacheDisclaimer: 'Laadt aankomende wachtrijtracks voor en bewaart eerdere. Indien ingeschakeld: schijfruimte en netwerk.',
+
     hotCacheDirDefault: 'Standaard (app-gegevens)',
+
     hotCacheDirChange: 'Map wijzigen',
+
     hotCacheDirClear: 'Terugzetten naar standaard',
+
     hotCacheDirHint: 'Een andere map kiest: de index in de app wordt gereset; oude bestanden blijven staan tot je ze verwijdert.',
+
     hotCacheEnabled: 'Warme afspeelcache inschakelen',
+
     hotCacheMaxMb: 'Maximale cachegrootte',
+
     hotCacheDebounce: 'Uitstel bij wachtrijwijziging',
+
     hotCacheDebounceImmediate: 'Direct',
+
     hotCacheDebounceSeconds: '{{n}} s',
+
     hotCacheClearBtn: 'Warme cache wissen',
+
     audioOutputDevice: 'Audio-uitvoerapparaat',
+
     audioOutputDeviceDesc: 'Kies via welk audioapparaat Psysonic afspeelt. Wijzigingen worden direct toegepast en starten het huidige nummer opnieuw.',
+
     audioOutputDeviceDefault: 'Systeemstandaard',
+
     audioOutputDeviceRefresh: 'Apparatenlijst vernieuwen',
+
     audioOutputDeviceOsDefaultNow: 'huidige systeemuitvoer',
+
     audioOutputDeviceListError: 'De lijst met audio-apparaten kon niet worden geladen.',
+
     audioOutputDeviceNotInCurrentList: 'staat niet in de huidige lijst',
+
     hiResTitle: 'Natieve hi-res-weergave',
+
     hiResEnabled: 'Natieve hi-res-weergave inschakelen',
+
     hiResDesc: "Beperkt de uitvoer standaard tot 44,1 kHz voor maximale stabiliteit. Alleen inschakelen als hardware en netwerk hoge samplerates (88,2 kHz+) ondersteunen.",
+
     showArtistImages: 'Artiestafbeeldingen weergeven',
+
     showArtistImagesDesc: 'Laadt en toont artiestafbeeldingen in het artiestenoverzicht. Standaard uitgeschakeld om server-I/O en netwerkbelasting bij grote bibliotheken te beperken.',
+
     showTrayIcon: 'Tray-pictogram weergeven',
+
     showTrayIconDesc: 'Toont het Psysonic-pictogram in het systeemvak / de menubalk.',
+
     minimizeToTray: 'Minimaliseren naar systeemvak',
+
     minimizeToTrayDesc: 'Bij het sluiten van het venster blijft Psysonic actief in het systeemvak in plaats van af te sluiten.',
+
     discordRichPresence: 'Discord Rich Presence',
+
     discordRichPresenceDesc: 'Toont het huidige nummer op je Discord-profiel. Discord moet daarvoor geopend zijn.',
+
     discordAppleCovers: 'Hoezen ophalen via Apple Music voor Discord',
+
     discordAppleCoversDesc: 'Stuurt artiest- en albumnaam naar de Apple-zoek-API om een hoes te vinden voor je Discord-profiel. Standaard uitgeschakeld vanwege privacy.',
+
+    discordTemplates: 'Aangepaste tekstsjablonen',
+
+    discordTemplatesDesc: 'Pas aan welke informatie wordt weergegeven op je Discord-profiel. Variabelen: {title}, {artist}, {album}, {paused}',
+
+    discordTemplateDetails: 'Primaire regel (details)',
+
+    discordTemplateState: 'Secundaire regel (state)',
+
+    discordTemplateLargeText: 'Album-tooltip (largeText)',
+
     nowPlayingEnabled: 'Weergeven in live-venster',
+
     nowPlayingEnabledDesc: 'Stuurt het huidige nummer naar de live-luisteraarsweergave van de server. Uitschakelen om geen afspeelgegevens te verzenden.',
+
     lyricsServerFirst: 'Server-songtekst voorrang geven',
+
     lyricsServerFirstDesc: 'Controleer eerst door de server geleverde songteksten (ingebedde tags, sidecar-bestanden) vóór LRCLIB. Uitschakelen om LRCLIB eerst te gebruiken.',
+
     enableNeteaselyrics: 'Netease Cloud Music songteksten',
+
     enableNeteaselyricsDesc: 'Gebruik Netease Cloud Music als laatste bron wanneer server en LRCLIB niets opleveren. Beste dekking voor Aziatische en internationale muziek.',
+
     lyricsSourcesTitle: 'Songtekstbronnen',
+
     lyricsSourcesDesc: 'Kies welke bronnen worden geraadpleegd en in welke volgorde. Sleep om te sorteren. Uitgeschakelde bronnen worden overgeslagen.',
+
     lyricsSourceServer: 'Server',
+
     lyricsSourceLrclib: 'LRCLIB',
+
     lyricsSourceNetease: 'Netease Cloud Music',
+
     downloadsTitle: 'ZIP-export & Archivering',
+
     downloadsFolderDesc: 'Doelmap voor albums die je als ZIP-bestand naar je computer downloadt.',
+
     downloadsDefault: 'Standaard downloadmap',
+
     pickFolder: 'Selecteren',
+
     pickFolderTitle: 'Downloadmap selecteren',
+
     clearFolder: 'Map wissen',
+
     logout: 'Uitloggen',
+
     aboutTitle: 'Over Psysonic',
+
     aboutDesc: 'Een moderne desktopmuziekspeeler voor Subsonic-compatibele servers (Navidrome, Gonic en anderen). Gebouwd op Tauri v2 met een native Rust audio-engine — licht en snel, maar boordevol functies: golfvorm-zoekbalk, gesynchroniseerde songteksten, Last.fm-integratie, 10-bands equalizer, crossfade, naadloos afspelen, Replay Gain, genres en een uitgebreide themabibliotheek.',
+
     aboutLicense: 'Licentie',
+
     aboutLicenseText: 'GNU GPL v3 — vrij te gebruiken, wijzigen en verspreiden onder dezelfde licentie.',
+
     aboutRepo: 'Broncode op GitHub',
+
     aboutVersion: 'Versie',
+
     aboutBuiltWith: 'Gebouwd met Tauri · React · TypeScript · Rust/rodio',
+
     aboutAiCredit: 'Ontwikkeld met ondersteuning van Claude Code door Anthropic',
+
     aboutContributorsLabel: 'Bijdragers',
+
     aboutSpecialThanksLabel: 'Speciale dank',
+
     changelog: 'Wijzigingslog',
+
     showChangelogOnUpdate: "'Wat is nieuw' tonen bij update",
+
     showChangelogOnUpdateDesc: 'Toont automatisch de nieuwigheden bij de eerste start van een nieuwe versie.',
+
     randomMixTitle: 'Willekeurige mix',
+
     randomMixBlacklistTitle: 'Aangepaste filtertrefwoorden',
+
     randomMixBlacklistDesc: 'Nummers worden uitgesloten als een trefwoord overeenkomt met hun genre, titel, album of artiest (actief wanneer het selectievakje hierboven is aangevinkt).',
+
     randomMixBlacklistPlaceholder: 'Trefwoord toevoegen…',
+
     randomMixBlacklistAdd: 'Toevoegen',
+
     randomMixBlacklistEmpty: 'Nog geen aangepaste trefwoorden toegevoegd.',
+
     randomMixHardcodedTitle: 'Ingebouwde trefwoorden (actief wanneer selectievakje is aangevinkt)',
+
     tabAudio: 'Audio',
+
     tabStorage: 'Opslag & Downloads',
+
     tabAppearance: 'Weergave',
+
     homeCustomizerTitle: 'Startpagina',
+
     sidebarTitle: 'Zijbalk',
+
     sidebarReset: 'Standaard herstellen',
+
     sidebarDrag: 'Slepen om te herordenen',
+
     sidebarFixed: 'Altijd zichtbaar',
-    randomNavSplitTitle: 'Mix-navigatie splitsen',
-    randomNavSplitDesc: 'Toon "Willekeurige mix" en "Willekeurige albums" als afzonderlijke zijbalkitems in plaats van de "Mix samenstellen"-hub.',
+
     tabInput: 'Invoer',
+
     tabServer: 'Server',
+
     shortcutsReset: 'Standaard herstellen',
+
     shortcutListening: 'Druk op een toets…',
+
     shortcutUnbound: '—',
+
     shortcutClear: 'Wissen',
+
     globalShortcutsTitle: 'Globale sneltoetsen',
+
     globalShortcutsNote: 'Werken systeembreed, ook als Psysonic op de achtergrond draait. Vereist Ctrl, Alt of Super als modifier.',
+
     shortcutPlayPause: 'Afspelen / Pauzeren',
+
     shortcutNext: 'Volgend nummer',
+
     shortcutPrev: 'Vorig nummer',
+
     shortcutVolumeUp: 'Volume omhoog',
+
     shortcutVolumeDown: 'Volume omlaag',
+
     shortcutSeekForward: '10s vooruitspoelen',
+
     shortcutSeekBackward: '10s terugspoelen',
+
     shortcutToggleQueue: 'Wachtrij tonen/verbergen',
+
     shortcutOpenFolderBrowser: '{{folderBrowser}} openen',
+
     shortcutFullscreenPlayer: 'Volledigschermspeler',
+
     shortcutNativeFullscreen: 'Systeemvolledig scherm',
+
     tabSystem: 'Systeem',
+
     tabGeneral: 'Algemeen',
+
     ratingsSectionTitle: 'Beoordelingen',
+
     ratingsSkipStarTitle: 'Overslaan voor 1 ster',
+
     ratingsSkipStarDesc:
+
       'Na meerdere overslagen op rij: nummer op 1 ster zetten. Alleen voor nummers die nog niet beoordeeld waren.',
+
     ratingsSkipStarThresholdLabel: 'Overslagen',
+
     ratingsMixFilterTitle: 'Filter op beoordeling',
+
     ratingsMixFilterDesc:
+
       'Content met lage beoordeling filteren in {{mix}} en {{albums}}. Klik opnieuw op de gekozen ster om de drempel uit te zetten.',
+
     ratingsMixMinSong: 'Nummers',
+
     ratingsMixMinAlbum: 'Albums',
+
     ratingsMixMinArtist: 'Artiesten',
+
     ratingsMixMinThresholdAria: 'Minimum sterren: {{label}}',
+
     backupTitle: 'Back-up & Herstel',
+
     backupExport: 'Instellingen exporteren',
+
     backupExportDesc: 'Slaat alle instellingen, serverprofielen, Last.fm-configuratie, thema, EQ en sneltoetsen op in een .psybkp-bestand. Wachtwoorden worden opgeslagen als leesbare tekst — bewaar het bestand veilig.',
+
     backupImport: 'Instellingen importeren',
+
     backupImportDesc: 'Herstelt instellingen vanuit een .psybkp-bestand. De app wordt herladen na het importeren.',
+
     backupImportConfirm: 'Alle huidige instellingen worden overschreven. Doorgaan?',
+
     backupSuccess: 'Back-up opgeslagen',
+
     backupImportSuccess: 'Instellingen hersteld — herladen…',
+
     backupImportError: 'Ongeldig of beschadigd back-upbestand.',
+
     playbackTitle: 'Afspelen',
+
     replayGain: 'Replay Gain',
+
     replayGainDesc: 'Nummervolume normaliseren met ReplayGain-metadata',
+
     replayGainMode: 'Modus',
+
     replayGainTrack: 'Nummer',
+
     replayGainAlbum: 'Album',
+
     replayGainPreGain: 'Pre-Gain (getagde bestanden)',
+
     replayGainFallback: 'Terugval (zonder tags / radio)',
+
     crossfade: 'Overgang',
+
     crossfadeDesc: 'Fade tussen nummers',
+
     crossfadeSecs: '{{n}} s',
+
     notWithGapless: 'Niet beschikbaar als naadloos afspelen actief is',
+
     notWithCrossfade: 'Niet beschikbaar als overgang actief is',
+
     gapless: 'Naadloos afspelen',
+
     gaplessDesc: 'Volgend nummer vooraf bufferen om stiltes tussen nummers te elimineren',
+
     preloadMode: 'Volgend nummer vooraf laden',
+
     preloadModeDesc: 'Wanneer met het bufferen van het volgende nummer wordt begonnen',
+
     nextTrackBufferingTitle: 'Volgend nummer – buffering',
+
     preloadHotCacheMutualExclusive: 'Preload en Hot Cache dienen hetzelfde doel — slechts één kan tegelijk actief zijn. Het inschakelen van de ene schakelt de andere automatisch uit.',
+
     preloadOff: 'Uit',
+
     preloadBalanced: 'Gebalanceerd (30 s voor einde)',
+
     preloadEarly: 'Vroeg (na 5 s afspelen)',
+
     preloadCustom: 'Aangepast',
+
     preloadCustomSeconds: 'Seconden voor einde: {{n}}',
+
     infiniteQueue: 'Oneindige wachtrij',
+
     infiniteQueueDesc: 'Automatisch willekeurige nummers toevoegen als de wachtrij leeg raakt',
+
     experimental: 'Experimenteel',
+
     fsPlayerSection: 'Volledig scherm speler',
+
     fsShowArtistPortrait: 'Artiestfoto tonen',
+
     fsShowArtistPortraitDesc: 'Artiestfoto (of albumhoes) weergeven aan de rechterkant van de volledigschermspeler.',
+
     fsPortraitDim: 'Verduistering foto',
+
     seekbarStyle: 'Zoekbalkstijl',
+
     seekbarStyleDesc: 'Kies het uiterlijk van de afspeelbalk',
+
     seekbarWaveform: 'Golfvorm',
+
     seekbarLinedot: 'Lijn & punt',
+
     seekbarBar: 'Balk',
+
     seekbarThick: 'Dikke balk',
+
     seekbarSegmented: 'Gesegmenteerd',
+
     seekbarNeon: 'Neon',
+
     seekbarPulsewave: 'Pulsgolf',
+
     seekbarParticletrail: 'Deeltjesspoor',
+
     seekbarLiquidfill: 'Vloeistofbuis',
+
     seekbarRetrotape: 'Retrotape',
+
     themeSchedulerTitle: 'Thema-planner',
+
     themeSchedulerEnable: 'Thema-planner inschakelen',
+
     themeSchedulerEnableSub: 'Schakelt automatisch tussen twee thema\'s op basis van de tijd',
+
     themeSchedulerDayTheme: 'Dagthema',
+
     themeSchedulerDayStart: 'Dag begint om',
+
     themeSchedulerNightTheme: 'Nachtthema',
+
     themeSchedulerNightStart: 'Nacht begint om',
+
     themeSchedulerActiveHint: "Thema-planner is actief - thema's worden automatisch gewisseld.",
+
     visualOptionsTitle: 'Visuele Opties',
+
     coverArtBackground: 'Cover Achtergrond',
+
     coverArtBackgroundSub: 'Toon vervaagde cover als achtergrond in album/playlist headers',
+
     playlistCoverPhoto: 'Playlist Coverfoto',
+
     playlistCoverPhotoSub: 'Toon coverfoto raster in playlist detailweergave',
+
     showBitrate: 'Toon Bitrate',
+
     showBitrateSub: 'Toon audio bitrate in tracklijsten',
+
     uiScaleTitle: 'Interface schaal',
+
     uiScaleLabel: 'Zoom',
+
   },
+
   changelog: {
+
     modalTitle: 'Wat is nieuw',
+
     dontShowAgain: 'Niet meer weergeven',
+
     close: 'Begrepen',
+
   },
+
   help: {
+
     title: 'Help',
+
     s1: 'Aan de slag',
+
     q1: 'Welke servers zijn compatibel?',
+
     a1: 'Psysonic werkt met elke Subsonic-compatibele server: Navidrome, Gonic, Subsonic, Airsonic en anderen. Navidrome is de aanbevolen keuze.',
+
     q2: 'Hoe verbind ik me met mijn server?',
+
     a2: 'Open Instellingen en klik op "Server toevoegen". Voer de server-URL in (bijv. 192.168.1.100:4533), je gebruikersnaam en wachtwoord. Psysonic test de verbinding voor het opslaan.',
+
     q3: 'Kan ik meerdere servers gebruiken?',
+
     a3: 'Ja. Je kunt zoveel servers toevoegen als je wilt in Instellingen en er op elk moment tussen wisselen. Slechts één server is tegelijk actief.',
+
     s2: 'Afspelen',
+
     q4: 'Hoe speel ik muziek af?',
+
     a4: 'Dubbelklik op een nummer om het af te spelen. Gebruik op album- en artiestpagina\'s "Alles afspelen" om het hele album te starten. Je kunt ook nummers naar de wachtrij slepen.',
+
     q5: 'Welke sneltoetsen zijn beschikbaar?',
+
     a5: 'Spatie = Afspelen / Pauzeren · Escape = Volledig scherm sluiten. Mediatoetsen werken op alle platforms. Gebruik op Linux de knoppen van de spelerbalk. In-app sneltoetsen en systeembrede globale sneltoetsen zijn aan te passen via Instellingen → Sneltoetsen / Globale sneltoetsen.',
+
     q6: 'Wat is de wachtrij?',
+
     a6: 'De wachtrij toont alle komende nummers. Open deze met het paneelpictogram rechtsboven. Je kunt nummers herordenen door te slepen, shufflen en de wachtrij opslaan als afspeellijst.',
+
     q7: 'Hoe open ik de volledig-schermspeler?',
+
     a7: 'Klik op de albumhoes in de spelerbalk onderaan, of het uitvouwpictogram ernaast. Druk op Escape om te sluiten.',
+
     q8: 'Hoe werkt herhalen?',
+
     a8: 'Klik op de herhalknop om te wisselen: Uit → Alles herhalen → Één herhalen.',
+
     s3: 'Bibliotheek',
+
     q9: 'Hoe download ik een album?',
+
     a9: 'Open de detailpagina van een album en klik op "Downloaden (ZIP)". De server comprimeert het album eerst naar een ZIP-bestand — voor grote albums of verliesvrije bestanden (FLAC / WAV) kan het even duren voordat de download daadwerkelijk start. De voortgangsbalk verschijnt pas als de server klaar is met inpakken.',
+
     q10: 'Hoe markeer ik nummers en albums als favoriet?',
+
     a10: 'Klik op het sterpictogram op een nummervak of de albumkoptekst. Gemarkeerde items verschijnen in de sectie Favorieten in de zijbalk.',
+
     q11: 'Wat is de hero-carrousel op de startpagina?',
+
     a11: 'De banner bovenaan de startpagina kiest willekeurig albums uit je bibliotheek en wisselt deze elke 10 seconden af. Klik op de puntjes om naar een specifiek album te springen.',
+
     s4: 'Instellingen',
+
     q12: 'Hoe verander ik het thema?',
+
     a12: 'Instellingen → Thema. Een ruime keuze aan thema\'s in 8 groepen: Psysonic Themes, Mediaplayer, Besturingssystemen, Games, Films, Series, Social Media en Open Source Classics (Catppuccin, Nord, Gruvbox, Nightfox).',
+
     q13: 'Hoe verander ik de taal?',
+
     a13: 'Instellingen → Taal. Engels, Duits, Frans, Nederlands en Chinees worden momenteel ondersteund.',
+
     q15: 'Hoe stel ik een downloadmap in?',
+
     a15: 'Instellingen → App-gedrag → Downloadmap. Gedownloade albums worden daar opgeslagen als ZIP-bestanden.',
+
     s5: 'Scrobbling',
+
     q16: 'Hoe werkt scrobbling?',
+
     a16: 'Psysonic scrobbelt rechtstreeks naar Last.fm — geen Navidrome-configuratie nodig. Verbind je Last.fm-account in Instellingen → Last.fm en schakel scrobbling in.',
+
     q17: 'Wanneer wordt een scrobble verstuurd?',
+
     a17: 'Een scrobble wordt verstuurd nadat je 50% van een nummer hebt geluisterd.',
+
     q22: 'Wat is de golfvorm in de spelerbalk?',
+
     a22: 'De golfvormzoekbalk vervangt de klassieke voortgangsschuifregelaar. Klik ergens om naar die positie te springen, of sleep om door het nummer te navigeren.',
+
     q24: 'Kan ik de wachtrij shufflen?',
+
     a24: 'Ja. Open het wachtrijpaneel en klik op het shufflepictogram. Het huidige nummer blijft op positie 1 — alle overige nummers worden willekeurig geherordend.',
+
     q25: 'Openen Last.fm- en Wikipedia-links in een browser?',
+
     a25: 'Ja — ze openen in je standaard systeembrowser. De knop toont kort een bevestiging bij klikken.',
+
     s7: 'Willekeurige mix',
+
     q26: 'Wat is de Willekeurige mix?',
+
     a26: 'De Willekeurige mix bouwt een afspeellijst van willekeurige nummers uit je hele bibliotheek. Open het via "Willekeurige mix" in de zijbalk en klik op "Nieuwe mix".',
+
     q27: 'Wat is het Trefwoordfilter?',
+
     a27: 'Het Trefwoordfilter sluit nummers uit waarvan het genre, de titel of de albumnaam bepaalde woorden bevat. Luisterboeken worden automatisch gefilterd. Voeg aangepaste trefwoorden toe in Instellingen → Willekeurige mix.',
+
     q28: 'Wat is de Super-genremix?',
+
     a28: 'De Super-genremix groepeert je bibliotheek in brede categorieën (Rock, Metal, Elektronisch, Jazz, Klassiek, enz.) en bouwt een gerichte mix van die stijl. Selecteer een categoriechip onder de lijst.',
+
     s6: 'Probleemoplossing',
+
     q18: 'Albumhoezen en artiestenafbeeldingen laden langzaam.',
+
     a18: 'Afbeeldingen worden bij het eerste laden van de schijf van je server opgehaald en vervolgens 30 dagen lokaal gecachet. Volgende bezoeken zijn direct.',
+
     q19: 'De verbindingstest mislukt.',
+
     a19: 'Controleer de URL inclusief de poort (bijv. http://192.168.1.100:4533). Zorg dat geen firewall de verbinding blokkeert. Probeer http:// in plaats van https:// op een lokaal netwerk.',
+
     q20: 'Geen audio op Linux.',
+
     a20: 'Psysonic is beschikbaar als .deb (Ubuntu/Debian), .rpm (Fedora/RHEL) en via AUR voor Arch/CachyOS (yay -S psysonic). Er is geen AppImage. Controleer of PipeWire of PulseAudio actief is als er geen audio is.',
+
     q21: 'De app toont een zwart scherm op Linux.',
+
     a21: 'Dit is meestal een GPU/EGL-driverprobleem in WebKitGTK. Start met GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. Het AUR-pakket en officiële .deb/.rpm-installatieprogramma\'s doen dit automatisch.',
+
     q29: 'Wat zijn overgang (crossfade) en naadloos afspelen?',
+
     a29: 'Dit zijn experimentele audiofuncties in Instellingen → Audio. Naadloos afspelen buffert het volgende nummer voor om stiltes te elimineren. Overgang fadeert het huidige nummer uit terwijl het volgende infadeert — duur (1–10 s) instelbaar.',
+
     q30: 'Toont Psysonic songteksten?',
+
     a30: 'Ja. Klik op het microfoonpictogram in de spelerbalk om het tabblad Songteksten te openen. Psysonic haalt teksten automatisch op van LRCLIB. Als gesynchroniseerde teksten beschikbaar zijn, wordt de actieve regel gemarkeerd en scrolt mee in realtime. Anders wordt de volledige tekst statisch getoond.',
+
     q31: 'Kan ik sneltoetsen aanpassen?',
+
     a31: 'Ja. Instellingen → Sneltoetsen laat je in-app acties (Afspelen/Pauzeren, Volgende, Vorige, Volume, Volledig scherm, enz.) hertoewijzen. Instellingen → Globale sneltoetsen laat je systeembrede sneltoetsen instellen die werken ook als de app op de achtergrond staat.',
+
     q32: 'Kan ik het lettertype wijzigen?',
+
     a32: 'Ja. Instellingen → Lettertype biedt 10 lettertypen waaronder IBM Plex Mono, Fira Code, JetBrains Mono en Courier Prime. Het gekozen lettertype geldt voor de gehele interface.',
+
     s8: 'Offlinemodus',
+
     q34: 'Wat is de Offlinemodus?',
+
     a34: 'De Offlinemodus (Beta) laat je albums op het apparaat opslaan zodat je zonder actieve serververbinding kunt luisteren. Gecachte nummers worden lokaal opgeslagen en direct van schijf afgespeeld — zonder netwerkverzoek.',
+
     q35: 'Hoe sla ik een album op voor offline gebruik?',
+
     a35: 'Open een album en klik op het downloadpictogram in de albumkoptekst. Psysonic downloadt alle nummers op de achtergrond. De voortgang wordt op de knop weergegeven. Na het cachen wordt het pictogram groen. Gecachte albums zijn te bekijken en verwijderen via de Offline bibliotheek (zijbalk).',
+
     q36: 'Hoeveel opslagruimte mag de offlinecache gebruiken?',
+
     a36: 'Je kunt een maximale cachegrootte instellen via Instellingen → Bibliotheek. Als de limiet is bereikt, verschijnt er een waarschuwingsbanner op de albumpagina. Je kunt afzonderlijke albums verwijderen in de Offline bibliotheek om ruimte vrij te maken.',
+
     q37: 'Hoe beoordeel ik nummers, albums en artiesten?',
+
     a37: 'Psysonic ondersteunt 1–5 sterrenwaarderingen via de OpenSubsonic API (vereist Navidrome ≥ 0.53). Beoordeel nummers in de tracklist van een album of afspeellijst, via het rechtsklikmenu of in de spelersbalk. Albums worden beoordeeld op hun detailpagina, artiesten op hun artiestenpagina.',
+
     q38: 'Kan ik een beoordeling verwijderen of wijzigen?',
+
     a38: 'Ja. Klik opnieuw op de actieve ster om de beoordeling volledig te verwijderen — een tweede klik op dezelfde ster wist hem. Klik op een andere ster om de beoordeling te wijzigen.',
+
     q39: 'Wat is Skip-to-1★ en het beoordelingsfilter?',
+
     a39: 'Skip-to-1★ kent automatisch een 1-sterrenbeoordeling toe na een bepaald aantal opeenvolgende skips. Activeer het in Instellingen → Beoordelingen. Stel daar ook een minimale sterrenbeoordeling in voor willekeurige mixen.',
+
     q40: 'Wat is de Mappenverkenner?',
+
     a40: 'De Mappenverkenner (zijbalk) laat je de muziekmap van de server navigeren via Miller-kolommen. Klik op een map om de inhoud te bekijken; gebruik het afspeelpictogram om de inhoud direct af te spelen of toe te voegen aan de wachtrij.',
+
     q41: 'Wat is de themasplanner?',
+
     a41: 'Instellingen → Uiterlijk → Thema automatisch wisselen: stel een dagthema en een nachtthema in met starttijden. Psysonic wisselt automatisch op de ingestelde tijden.',
+
     q42: 'Kan ik de interface schalen?',
+
     a42: 'Ja. Instellingen → Uiterlijk → Interfaceschaal laat je de volledige UI schalen tussen 80 % en 125 %.',
+
     q43: 'Kan ik de zoekbalkstijl wijzigen?',
+
     a43: 'Ja. Instellingen → Uiterlijk → Zoekbalkstijl biedt 10 stijlen: Golfvorm, Lijn & Punt, Balk, Dikke balk, Gesegmenteerd, Neon Glow, Pulsgolf, Partikelspoor, Vloeistofvulling en Retro Tape.',
+
     q44: 'Wat is AutoEQ?',
+
     a44: 'De 10-bands equalizer in Instellingen → Audio bevat een AutoEQ-zoekopdracht. Voer je hoofdtelefoonmodel in om automatisch een correctieprofiel te laden.',
+
     q45: 'Wat is Replay Gain?',
+
     a45: 'Replay Gain normaliseert het volume zodat harde en stille albums op een consistent niveau worden afgespeeld. Activeer het in Instellingen → Audio → Replay Gain; kies modus Track of Album.',
+
     q46: 'Wat is de Hot Cache?',
+
     a46: 'De Hot Cache (Alpha, Instellingen → Bibliotheek) laadt de volgende nummers in de wachtrij vooraf naar de schijf voor directe weergave. Psysonic bewaart het huidige nummer en de volgende 5 en verwijdert oudere items wanneer de limiet is bereikt.',
+
     q47: 'Kan ik een afspeellijst offline cachen?',
+
     a47: 'Ja. Open de afspeellijstdetails en klik op het downloadpictogram. Zodra alle tracks zijn gecached, verandert het pictogram in een rode prullenbak; klik erop om de afspeellijst uit de offlinecache te verwijderen.',
-    q48: 'Wat is de Infinite Queue?',
-    a48: 'Als de wachtrij leeg raakt en herhalen uitgeschakeld is, voegt Psysonic automatisch willekeurige nummers toe zodat het afspelen nooit stopt. Automatisch toegevoegde nummers verschijnen onder het scheidingsteken "— Automatisch toegevoegd —". Schakel in/uit via het oneindig-pictogram in de wachtrij-header.',
-    q49: 'Kan ik Psysonic via de opdrachtregel bedienen?',
-    a49: 'Ja. Voorbeelden: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one. Ook: van server wisselen, audioapparaat wijzigen, bibliotheek filteren en zoeken. Volledige hulp: psysonic --player --help.',
-    q50: 'Hoe beheer ik afspeellijsten?',
-    a50: 'Via "Afspeellijsten" in de zijbalk. Maak een afspeellijst aan met "Nieuwe afspeellijst". In de detailweergave kunt u nummers slepen om te herordenen, verwijderen met ×, nieuwe toevoegen via zoeken en "Suggesties" gebruiken voor slimme aanbevelingen.',
-    q51: 'Kan ik mijn instellingen back-uppen en herstellen?',
-    a51: 'Ja. Instellingen → Back-up & Herstel exporteert alle instellingen, serverprofielen, thema\'s en snelkoppelingen naar een JSON-bestand. Importeer het op een ander apparaat om alles in één keer te herstellen.',
-    q52: 'Hoe wijzig ik het audio-uitvoerapparaat?',
-    a52: 'Instellingen → Audio → Uitvoerapparaat. Psysonic toont alle beschikbare uitgangen. De selectie wordt direct van kracht. Gebruik de verversknop als een apparaat na het starten van de app is aangesloten.',
-    q53: 'Wat is Device Sync?',
-    a53: 'Device Sync kopieert albums, afspeellijsten of artiesten naar een USB-stick of SD-kaart. Open het via "Device Sync" in de zijbalk, kies een doelmap, selecteer bronnen en klik op "Naar apparaat overbrengen".',
-    q54: 'Wat is de bestandsnaamsjabloon in Device Sync?',
-    a54: 'Het sjabloon bepaalt hoe nummers worden benoemd en georganiseerd. Gebruik de voorinstellingen of bouw uw eigen sjabloon met de klikbare tokens: {artist}, {album}, {title}, {track_number}, {disc_number}, {year} en / als mapscheidingsteken.',
-    q55: 'Werkt Device Sync platformoverschrijdend?',
-    a55: 'Ja. Het manifest op het apparaat bevat het gebruikte sjabloon. Op een ander besturingssysteem herkent Psysonic bestaande bestanden correct, ook bij een ander sjabloon.',
-    s9: 'Device Sync',
-    q56: 'Wat is internetradio?',
-    a56: 'De internetradiopagina speelt live streams af in Psysonic. Stations komen van uw Navidrome-server — voeg ze toe via het beheerpaneel of importeer een .pls/.m3u-bestand. Afspelen gebruikt HTML5-audio.',
-    q57: 'Welke streamformaten ondersteunt internetradio?',
-    a57: 'MP3, AAC, OGG Vorbis en de meeste HLS-streams. MP3 en AAC werken op alle platforms.',
-    s10: 'Internetradio',
-    q58: 'Waar haalt Psysonic songteksten vandaan?',
-    a58: 'Drie configureerbare bronnen in Instellingen → Songteksten: uw Navidrome-server, LRCLIB en NetEase Cloud Music. Elke bron kan worden in-/uitgeschakeld en geprioriteerd door te slepen.',
-    q59: 'Is er een weergave van wat andere gebruikers luisteren?',
-    a59: 'Ja. Klik op het uitzendpictogram rechtsboven om te zien wat andere gebruikers op uw Navidrome-server beluisteren, elke 10 seconden bijgewerkt.',
+
   },
+
   queue: {
+
     title: 'Wachtrij',
+
     savePlaylist: 'Afspeellijst opslaan',
+
     updatePlaylist: 'Afspeellijst bijwerken',
+
     filterPlaylists: 'Afspeellijsten filteren…',
+
     playlistName: 'Naam afspeellijst',
+
     cancel: 'Annuleren',
+
     save: 'Opslaan',
+
     loadPlaylist: 'Afspeellijst laden',
+
     loading: 'Laden…',
+
     noPlaylists: 'Geen afspeellijsten gevonden.',
+
     load: 'Wachtrij vervangen & afspelen',
+
     appendToQueue: 'Toevoegen aan wachtrij',
+
     delete: 'Verwijderen',
+
     deleteConfirm: 'Afspeellijst "{{name}}" verwijderen?',
+
     clear: 'Leegmaken',
+
     shuffle: 'Wachtrij shufflen',
+
     gapless: 'Naadloos',
+
     crossfade: 'Overgang',
+
     infiniteQueue: 'Oneindige wachtrij',
+
     autoAdded: '— Automatisch toegevoegd —',
+
     radioAdded: '— Radio —',
+
     hide: 'Verbergen',
+
     close: 'Sluiten',
+
     nextTracks: 'Volgende nummers',
+
     emptyQueue: 'De wachtrij is leeg.',
+
     trackSingular: 'nummer',
+
     trackPlural: 'nummers',
+
     showRemaining: 'Resterende tijd tonen',
+
     showTotal: 'Totale tijd tonen',
+
   },
+
   statistics: {
+
     title: 'Statistieken',
+
     recentlyPlayed: 'Recent afgespeeld',
+
     mostPlayed: 'Meest gespeelde albums',
+
     highestRated: 'Best beoordeelde albums',
+
     genreDistribution: 'Genreverdeling (Top 20)',
+
     loadMore: 'Meer laden',
+
     statArtists: 'Artiesten',
+
     statArtistsTooltip: 'Alleen albumartiesten — artiesten die enkel als trackartiest voorkomen (featuring, gast, enz.) zonder eigen album worden niet meegeteld.',
+
     statAlbums: 'Albums',
+
     statSongs: 'Nummers',
+
     statGenres: 'Genres',
+
     statPlaytime: 'Totale speelduur',
+
     genreInsights: 'Genre-inzichten',
+
     formatDistribution: 'Formaatdistributie',
+
     formatSample: 'Steekproef van {{n}} nummers',
+
     computing: 'Berekenen…',
+
     genreSongs: '{{count}} nummers',
+
     genreAlbums: '{{count}} albums',
+
     recentlyAdded: 'Recent toegevoegd',
+
     decadeDistribution: 'Albums per decennium',
+
     decadeAlbums_one: '{{count}} album',
+
     decadeAlbums_other: '{{count}} albums',
+
     decadeUnknown: 'Onbekend',
+
     lfmTitle: 'Last.fm-statistieken',
+
     lfmTopArtists: 'Topartiesten',
+
     lfmTopAlbums: 'Topalbums',
+
     lfmTopTracks: 'Topnummers',
+
     lfmPlays: '{{count}} keer gespeeld',
+
     lfmPeriodOverall: 'Alle tijd',
+
     lfmPeriod7day: '7 dagen',
+
     lfmPeriod1month: '1 maand',
+
     lfmPeriod3month: '3 maanden',
+
     lfmPeriod6month: '6 maanden',
+
     lfmPeriod12month: '12 maanden',
+
     lfmNotConnected: 'Verbind Last.fm in Instellingen om je statistieken te zien.',
+
     lfmRecentTracks: 'Recente scrobbles',
+
     lfmNowPlaying: 'Nu bezig',
+
     lfmJustNow: 'zojuist',
+
     lfmMinutesAgo: '{{n}} min geleden',
+
     lfmHoursAgo: '{{n}} uur geleden',
+
     lfmDaysAgo: '{{n}} dagen geleden',
+
     topRatedSongs: 'Best beoordeelde nummers',
+
     topRatedArtists: 'Best beoordeelde artiesten',
+
     noRatedSongs: 'Nog geen beoordeelde nummers. Beoordeel nummers in album- of afspeellijstweergave.',
+
     noRatedArtists: 'Nog geen beoordeelde artiesten.',
+
   },
+
   player: {
+
     regionLabel: 'Muziekspeler',
+
     openFullscreen: 'Volledig-schermspeler openen',
+
     fullscreen: 'Volledig-schermspeler',
+
     closeFullscreen: 'Volledig scherm sluiten',
+
     closeTooltip: 'Sluiten (Escape)',
+
     noTitle: 'Geen titel',
+
     stop: 'Stoppen',
+
     prev: 'Vorig nummer',
+
     play: 'Afspelen',
+
     pause: 'Pauzeren',
+
     next: 'Volgend nummer',
+
     repeat: 'Herhalen',
+
     repeatOff: 'Uit',
+
     repeatAll: 'Alles',
+
     repeatOne: 'Één',
+
     progress: 'Nummervoortgang',
+
     volume: 'Volume',
+
     toggleQueue: 'Wachtrij in-/uitschakelen',
+
     lyrics: 'Songtekst',
+
     fsLyricsToggle: 'Songtekst in volledig scherm',
+
     lyricsLoading: 'Songtekst laden…',
+
     lyricsNotFound: 'Geen songtekst gevonden voor dit nummer',
+
     lyricsSourceServer: 'Bron: Server',
+
     lyricsSourceLrclib: 'Bron: LRCLIB',
+
     lyricsSourceNetease: 'Bron: Netease',
+
   },
+
   songInfo: {
+
     title: 'Nummerinfo',
+
     songTitle: 'Titel',
+
     artist: 'Artiest',
+
     album: 'Album',
+
     albumArtist: 'Albumartiest',
+
     year: 'Jaar',
+
     genre: 'Genre',
+
     duration: 'Duur',
+
     track: 'Track',
+
     format: 'Formaat',
+
     bitrate: 'Bitrate',
+
     sampleRate: 'Samplefrequentie',
+
     bitDepth: 'Bitdiepte',
+
     channels: 'Kanalen',
+
     fileSize: 'Bestandsgrootte',
+
     path: 'Locatie',
+
     replayGainTrack: 'RG Track Gain',
+
     replayGainAlbum: 'RG Album Gain',
+
     replayGainPeak: 'RG Track Peak',
+
     mono: 'Mono',
+
     stereo: 'Stereo',
+
   },
+
   playlists: {
+
     title: 'Playlists',
+
     newPlaylist: 'Nieuwe playlist',
+
     unnamed: 'Naamloze playlist',
+
     createName: 'Playlistnaam…',
+
     create: 'Aanmaken',
+
     cancel: 'Annuleren',
+
     empty: 'Nog geen playlists.',
+
     emptyPlaylist: 'Deze playlist is leeg.',
+
     addFirstSong: 'Voeg je eerste nummer toe',
+
     notFound: 'Playlist niet gevonden.',
+
     songs: '{{n}} nummers',
+
     playAll: 'Alles afspelen',
+
     shuffle: 'Willekeurig',
+
     addToQueue: 'Aan wachtrij toevoegen',
+
     back: 'Terug naar playlists',
+
     deletePlaylist: 'Verwijderen',
+
     confirmDelete: 'Nogmaals klikken om te bevestigen',
+
     removeSong: 'Uit playlist verwijderen',
+
     addSongs: 'Nummers toevoegen',
+
     searchPlaceholder: 'Doorzoek bibliotheek…',
+
     noResults: 'Geen resultaten.',
+
     suggestions: 'Aanbevolen nummers',
+
     noSuggestions: 'Geen suggesties beschikbaar.',
+
     titleBadge: 'Playlist',
+
     refreshSuggestions: 'Nieuwe suggesties',
+
     addSong: 'Toevoegen aan playlist',
+
     addSelected: 'Geselecteerde toevoegen',
+
     cacheOffline: 'Playlist offline opslaan',
+
     offlineCached: 'Playlist gecached',
+
     removeOffline: 'Verwijder uit offline cache',
+
     offlineDownloading: 'Cachen… ({{done}}/{{total}} albums)',
+
     publicLabel: 'Openbaar',
+
     privateLabel: 'Privé',
+
     editMeta: 'Playlist bewerken',
+
     editNamePlaceholder: 'Playlistnaam…',
+
     editCommentPlaceholder: 'Beschrijving toevoegen…',
+
     editPublic: 'Openbare playlist',
+
     editSave: 'Opslaan',
+
     editCancel: 'Annuleren',
+
     changeCover: 'Omslagafbeelding wijzigen',
+
     changeCoverLabel: 'Foto wijzigen',
+
     removeCover: 'Foto verwijderen',
+
     coverUpdated: 'Omslag bijgewerkt',
+
     metaSaved: 'Playlist bijgewerkt',
+
     downloadZip: 'Downloaden (ZIP)',
+
     // Toast notifications for multi-select
+
     addSuccess: '{{count}} nummers toegevoegd aan {{playlist}}',
+
     addPartial: '{{added}} toegevoegd, {{skipped}} overgeslagen (duplicaten)',
+
     addAllSkipped: 'Alles overgeslagen ({{count}} duplicaten)',
+
     addError: 'Fout bij toevoegen van nummers',
+
     createAndAddSuccess: 'Playlist "{{playlist}}" aangemaakt met {{count}} nummers',
+
     createError: 'Fout bij aanmaken van playlist',
+
     deleteSuccess: '{{count}} playlists verwijderd',
+
     deleteFailed: 'Fout bij verwijderen van {{name}}',
+
     deleteSelected: 'Geselecteerde verwijderen',
+
     mergeSuccess: '{{count}} nummers samengevoegd in {{playlist}}',
+
     mergeNoNewSongs: 'Geen nieuwe nummers om toe te voegen',
+
     mergeError: 'Fout bij samenvoegen van playlists',
+
     mergeInto: 'Samenvoegen in',
+
     selectionCount: '{{count}} geselecteerd',
+
     select: 'Selecteren',
+
     startSelect: 'Selectie inschakelen',
+
     cancelSelect: 'Annuleren',
+
     loadingAlbums: '{{count}} albums oplossen…',
+
     loadingArtists: '{{count}} artiesten oplossen…',
+
     myPlaylists: 'Mijn playlists',
+
     noOtherPlaylists: 'Geen andere playlists beschikbaar',
+
     addToPlaylistSuccess: '{{count}} nummers toegevoegd aan {{playlist}}',
+
     addToPlaylistNoNew: 'Geen nieuwe nummers voor {{playlist}}',
+
     addToPlaylistError: 'Fout bij toevoegen aan playlist',
+
     removeSuccess: 'Nummer verwijderd van playlist',
+
     removeError: 'Fout bij verwijderen uit playlist',
+
     importCSV: 'CSV Importeren',
+
     importCSVTooltip: 'Importeren vanuit Spotify CSV',
+
     csvImportReport: 'CSV-importrapport',
+
     csvImportTotal: 'Totaal',
+
     csvImportAdded: 'Toegevoegd',
+
     csvImportDuplicates: 'Duplicaten',
+
     csvImportNotFound: 'Niet Gevonden',
+
     csvImportNetworkErrors: 'Netwerkfouten',
+
     csvImportDuplicatesTitle: 'Dubbele nummers (al in playlist):',
+
     csvImportNotFoundTitle: 'Niet gevonden nummers:',
+
     csvImportNetworkErrorsTitle: 'Netwerkfouten (import kan opnieuw proberen):',
+
     csvImportDownloadReport: 'Rapport downloaden',
+
     csvImportClose: 'Sluiten',
+
     csvImportNoValidTracks: 'Geen geldige nummers gevonden in CSV-bestand',
+
     csvImportFailed: 'CSV-import mislukt',
+
     csvImportToast: '{{added}} toegevoegd, {{notFound}} niet gevonden, {{duplicates}} duplicaten',
+
   },
+
   mostPlayed: {
+
     title: 'Meest gespeeld',
+
     topArtists: 'Topkunstenaars',
+
     topAlbums: 'Topalbums',
+
     plays: '{{n}} keer gespeeld',
+
     sortMost: 'Meest gespeeld eerst',
+
     sortLeast: 'Minst gespeeld eerst',
+
     loadMore: 'Meer albums laden',
+
     noData: 'Nog geen afspeelgegevens. Begin met luisteren!',
+
     noArtists: 'Alle artiesten gefilterd.',
+
     filterCompilations: 'Compilatie-artiesten verbergen (Various Artists, Soundtracks, etc.)',
+
     filterCompilationsShort: 'Compilaties verbergen',
+
   },
+
   radio: {
+
     title: 'Internetradio',
+
     empty: 'Geen radiostations geconfigureerd.',
+
     addStation: 'Station toevoegen',
+
     editStation: 'Bewerken',
+
     deleteStation: 'Station verwijderen',
+
     confirmDelete: 'Klik opnieuw om te bevestigen',
+
     stationName: 'Stationsnaam…',
+
     streamUrl: 'Stream-URL…',
+
     homepageUrl: 'Homepage-URL (optioneel)',
+
     save: 'Opslaan',
+
     cancel: 'Annuleren',
+
     live: 'LIVE',
+
     liveStream: 'Internetradio',
+
     openHomepage: 'Homepage openen',
+
     changeCoverLabel: 'Cover wijzigen',
+
     removeCover: 'Cover verwijderen',
+
     browseDirectory: 'Gids doorzoeken',
+
     directoryPlaceholder: 'Stations zoeken…',
+
     noResults: 'Geen stations gevonden.',
+
     stationAdded: 'Station toegevoegd',
+
     filterAll: 'Alle',
+
     filterFavorites: 'Favorieten',
+
     sortManual: 'Handmatig',
+
     sortAZ: 'A → Z',
+
     sortZA: 'Z → A',
+
     sortNewest: 'Nieuwste',
+
     favorite: 'Toevoegen aan favorieten',
+
     unfavorite: 'Verwijderen uit favorieten',
+
     noFavorites: 'Geen favoriete stations.',
+
     listenerCount_one: '{{count}} luisteraar',
+
     listenerCount_other: '{{count}} luisteraars',
+
     recentlyPlayed: 'Recent gespeeld',
+
     upNext: 'Volgende',
+
   },
+
   folderBrowser: {
+
     empty: 'Lege map',
+
     error: 'Laden mislukt',
+
   },
+
   deviceSync: {
+
     title: 'Apparaatsync',
+
     targetFolder: 'Doelmap',
+
     noFolderChosen: 'Geen map gekozen',
+
     selectDrive: 'Selecteer een schijf…',
+
     refreshDrives: 'Schijven vernieuwen',
+
     noDrivesDetected: 'Geen verwijderbare schijven gedetecteerd',
+
     browseManual: 'Handmatig bladeren…',
+
     free: 'vrij',
+
     notMountedVolume: 'Het doel bevindt zich niet op een gekoppeld volume. De schijf is mogelijk losgekoppeld.',
+
     chooseFolder: 'Kiezen…',
+
     filenameTemplate: 'Bestandsnaamsjabloon',
+
     targetDevice: 'Doelapparaat',
+
     templateHint: 'Variabelen: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
+
     cleanupButton: 'Niet-geselecteerde bestanden verwijderen',
+
     cleanupNothingToDelete: 'Niets te verwijderen — apparaat is al gesynchroniseerd.',
+
     confirmCleanup: '{{count}} bestand(en) verwijderen van het apparaat die niet in de huidige selectie staan. Doorgaan?',
+
     cleanupComplete: '{{count}} bestand(en) van het apparaat verwijderd.',
+
     selectedSources: 'Geselecteerde bronnen',
+
     noSourcesSelected: 'Geen bronnen geselecteerd. Klik op items in de browser om ze toe te voegen.',
+
     clearAll: 'Alles wissen',
+
     tabPlaylists: 'Afspeellijsten',
+
     tabAlbums: 'Albums',
+
     tabArtists: 'Artiesten',
+
     searchPlaceholder: 'Zoeken…',
+
     syncButton: 'Synchroniseren naar apparaat',
+
     actionTransfer: 'Overdragen naar apparaat',
+
     actionDelete: 'Verwijderen van apparaat',
+
     actionApplyAll: 'Alle wijzigingen toepassen',
+
     templatePreview: 'Voorbeeld',
-    templatePresetStandard: 'Standaard',
-    templatePresetMultiDisc: 'Multi-Disc',
-    templatePresetAltFolder: 'Alt. map',
-    tokenSlashHint: '/ = mapscheidingsteken',
+
     cancel: 'Annuleren',
+
     noTargetDir: 'Kies eerst een doelmap.',
+
     noSources: 'Selecteer minimaal één bron.',
+
     noTracks: 'Geen nummers gevonden in de geselecteerde bronnen.',
+
     fetchError: 'Ophalen van nummers van de server mislukt.',
+
     syncComplete: 'Synchronisatie voltooid.',
+
     dismiss: 'Sluiten',
-    cancelSync: 'Annuleren',
-    syncCancelled: 'Synchronisatie geannuleerd ({{done}} / {{total}} overgebracht).',
+
     colName: 'Naam',
+
     colType: 'Type',
+
     colStatus: 'Status',
+
     onDevice: 'Apparaatbeheer',
+
     addSources: 'Toevoegen…',
+
     syncResult: '{{done}} overgedragen, {{skipped}} al up-to-date ({{total}} totaal)',
+
     deleteFromDevice: 'Markeren voor verwijdering ({{count}})',
+
     confirmDelete: '{{count}} item(s) van het apparaat verwijderen: {{names}}?',
+
     deleteComplete: '{{count}} item(s) van het apparaat verwijderd.',
-    manifestImported: '{{count}} bron(nen) geïmporteerd uit apparaatmanifest.',
+
     statusSynced: 'Gesynchroniseerd',
+
     statusPending: 'In behandeling',
+
     statusDeletion: 'Verwijdering',
+
     markForDeletion: 'Markeren voor verwijdering',
+
     removeSource: 'Verwijderen',
+
     undoDeletion: 'Verwijdering ongedaan maken',
+
     syncInBackground: 'Sync gestart op achtergrond — u kunt navigeren.',
+
     syncInProgress: '{{done}} / {{total}} nummers…',
+
     syncSummary: 'Synchronisatieoverzicht',
+
     calculating: 'Vereiste payload berekenen…',
+
     filesToAdd: 'Te toevoegen bestanden:',
+
     filesToDelete: 'Te verwijderen bestanden:',
+
     netChange: 'Nettoverandering:',
+
     availableSpace: 'Beschikbare schijfruimte:',
+
     spaceWarning: 'Waarschuwing: Het doelapparaat heeft niet genoeg gerapporteerde ruimte.',
+
     proceed: 'Doorgaan met synchronisatie',
+
     notEnoughSpace: 'Onvoldoende fysieke schijfruimte gedetecteerd!',
+
     liveSearch: 'Live',
+
     randomAlbumsLabel: 'Willekeurige albums',
+
   },
+
 };
+

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -537,7 +537,7 @@ export const nlTranslation = {
     discordAppleCovers: 'Hoezen ophalen via Apple Music voor Discord',
     discordAppleCoversDesc: 'Stuurt artiest- en albumnaam naar de Apple-zoek-API om een hoes te vinden voor je Discord-profiel. Standaard uitgeschakeld vanwege privacy.',
     discordTemplates: 'Aangepaste tekstsjablonen',
-    discordTemplatesDesc: 'Pas aan welke informatie wordt weergegeven op je Discord-profiel. Variabelen: {title}, {artist}, {album}, {paused}',
+    discordTemplatesDesc: 'Pas aan welke informatie wordt weergegeven op je Discord-profiel. Variabelen: {title}, {artist}, {album}',
     discordTemplateDetails: 'Primaire regel (details)',
     discordTemplateState: 'Secundaire regel (state)',
     discordTemplateLargeText: 'Album-tooltip (largeText)',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -1,2264 +1,1168 @@
 export const nlTranslation = {
-
   sidebar: {
-
     library: 'Bibliotheek',
-
     mainstage: 'Hoofdpodium',
-
     newReleases: 'Nieuw',
-
     allAlbums: 'Alle albums',
-
     randomAlbums: 'Willekeurige albums',
-
     randomPicker: 'Mix samenstellen',
-
     artists: 'Artiesten',
-
     randomMix: 'Willekeurige mix',
-
     favorites: 'Favorieten',
-
     nowPlaying: 'Nu bezig',
-
     system: 'Systeem',
-
     statistics: 'Statistieken',
-
     settings: 'Instellingen',
-
     help: 'Help',
-
     expand: 'Zijbalk uitklappen',
-
     collapse: 'Zijbalk inklappen',
-
     downloadingTracks: '{{n}} nummers worden gecached…',
-
     syncingTracks: 'Synchroniseren {{done}}/{{total}}…',
-
     cancelDownload: 'Download annuleren',
-
     offlineLibrary: 'Offline bibliotheek',
-
     genres: 'Genres',
-
     playlists: 'Playlists',
-
     mostPlayed: 'Meest gespeeld',
-
     radio: 'Internetradio',
-
     folderBrowser: 'Mappenverkenner',
-
     deviceSync: 'Apparaatsync',
-
     libraryScope: 'Bibliotheekbereik',
-
     allLibraries: 'Alle bibliotheken',
-
     expandPlaylists: 'Afspeellijsten uitklappen',
-
     collapsePlaylists: 'Afspeellijsten inklappen',
-
   },
-
   home: {
-
     hero: 'Uitgelicht',
-
     starred: 'Persoonlijke favorieten',
-
     recent: 'Recent toegevoegd',
-
     mostPlayed: 'Meest gespeeld',
-
     recentlyPlayed: 'Recent afgespeeld',
-
     discover: 'Ontdekken',
-
     loadMore: 'Meer laden',
-
     discoverMore: 'Meer ontdekken',
-
     discoverArtists: 'Artiesten ontdekken',
-
     discoverArtistsMore: 'Alle artiesten'
-
   },
-
   hero: {
-
     eyebrow: 'Uitgelicht album',
-
     playAlbum: 'Album afspelen',
-
     enqueue: 'In wachtrij',
-
     enqueueTooltip: 'Volledig album aan wachtrij toevoegen',
-
   },
-
   search: {
-
     placeholder: 'Zoek naar artiest, album of nummer…',
-
     noResults: 'Geen resultaten voor "{{query}}"',
-
     artists: 'Artiesten',
-
     albums: 'Albums',
-
     songs: 'Nummers',
-
     clearLabel: 'Zoekopdracht wissen',
-
     title: 'Zoeken',
-
     resultsFor: 'Resultaten voor "{{query}}"',
-
     album: 'Album',
-
     advanced: 'Geavanceerd zoeken',
-
     advancedSearchTerm: 'Zoekterm',
-
     advancedSearchPlaceholder: 'Titel, album, artiest…',
-
     advancedGenre: 'Genre',
-
     advancedAllGenres: 'Alle genres',
-
     advancedYear: 'Jaar',
-
     advancedYearFrom: 'van',
-
     advancedYearTo: 'tot',
-
     advancedAll: 'Alle',
-
     advancedSearch: 'Zoeken',
-
     advancedEmpty: 'Voer een zoekterm in of selecteer een filter.',
-
     advancedNoResults: 'Geen resultaten gevonden.',
-
     advancedGenreNote: 'Nummers worden willekeurig uit dit genre geselecteerd.',
-
     recentSearches: 'Recente zoekopdrachten',
-
     browse: 'Bladeren',
-
     emptyHint: 'Wat wil je horen?',
-
     genres: 'Genres',
-
   },
-
   nowPlaying: {
-
     tooltip: 'Wie luistert er?',
-
     title: 'Wie luistert er?',
-
     loading: 'Laden…',
-
     nobody: 'Er luistert momenteel niemand.',
-
     minutesAgo: '{{n}} min geleden',
-
     nothingPlaying: 'Nog niets bezig. Start een nummer!',
-
     aboutArtist: 'Over de artiest',
-
     fromAlbum: 'Van dit album',
-
     viewAlbum: 'Album openen',
-
     goToArtist: 'Naar artiest',
-
     readMore: 'Meer lezen',
-
     showLess: 'Minder tonen',
-
     genreInfo: 'Genre',
-
     trackInfo: 'Trackinfo',
-
   },
-
   contextMenu: {
-
     playNow: 'Nu afspelen',
-
     playNext: 'Volgende afspelen',
-
     addToQueue: 'Aan wachtrij toevoegen',
-
     enqueueAlbum: 'Album in wachtrij',
-
     startRadio: 'Radio starten',
-
     instantMix: 'Instant Mix',
-
     instantMixFailed: 'Instant Mix mislukt — server- of pluginfout.',
-
     cliMixNeedsTrack: 'Er speelt niets — start eerst afspelen en voer het mix-commando opnieuw uit.',
-
     lfmLove: 'Liken op Last.fm',
-
     lfmUnlove: 'Niet meer liken op Last.fm',
-
     favorite: 'Favoriet',
-
     favoriteArtist: 'Favoriete artiest',
-
     favoriteAlbum: 'Favoriet album',
-
     unfavorite: 'Verwijderen uit favorieten',
-
     unfavoriteArtist: 'Artiest uit favorieten verwijderen',
-
     unfavoriteAlbum: 'Album uit favorieten verwijderen',
-
     removeFromQueue: 'Uit wachtrij verwijderen',
-
     openAlbum: 'Album openen',
-
     goToArtist: 'Naar artiest',
-
     download: 'Downloaden (ZIP)',
-
     addToPlaylist: 'Toevoegen aan playlist',
-
     selectedPlaylists: '{{count}} playlists geselecteerd',
-
     selectedAlbums: '{{count}} albums geselecteerd',
-
     selectedArtists: '{{count}} artiesten geselecteerd',
-
     songInfo: 'Nummerinfo',
-
   },
-
   albumDetail: {
-
     back: 'Terug',
-
     playAll: 'Alles afspelen',
-
     enqueue: 'In wachtrij',
-
     enqueueTooltip: 'Volledig album aan wachtrij toevoegen',
-
     artistBio: 'Artiest biografie',
-
     download: 'Downloaden (ZIP)',
-
     downloading: 'Laden…',
-
     cacheOffline: 'Offline beschikbaar maken',
-
     offlineCached: 'Offline beschikbaar',
-
     offlineDownloading: 'Wordt gecached… ({{n}}/{{total}})',
-
     removeOffline: 'Offline cache verwijderen',
-
     offlineStorageFull: 'Offline opslag vol (limiet: {{mb}} MB). Verwijder een album uit je offline bibliotheek of verhoog de limiet in de instellingen.',
-
     offlineStorageGoToSettings: 'Instellingen',
-
     offlineStorageGoToLibrary: 'Offline bibliotheek',
-
     favoriteAdd: 'Aan favorieten toevoegen',
-
     favoriteRemove: 'Uit favorieten verwijderen',
-
     favorite: 'Favoriet',
-
     noBio: 'Geen biografie beschikbaar.',
-
     moreByArtist: 'Meer van {{artist}}',
-
     tracksCount: '{{n}} nummers',
-
     goToArtist: 'Naar {{artist}}',
-
     moreLabelAlbums: 'Meer albums op {{label}}',
-
     trackTitle: 'Titel',
-
     trackAlbum: 'Album',
-
     trackArtist: 'Artiest',
-
     trackGenre: 'Genre',
-
     trackFormat: 'Formaat',
-
     trackFavorite: 'Favoriet',
-
     trackRating: 'Beoordeling',
-
     trackDuration: 'Duur',
-
     trackTotal: 'Totaal',
-
     columns: 'Kolommen',
-
+    resetColumns: 'Standaard herstellen',
     notFound: 'Album niet gevonden.',
-
     bioModal: 'Artiest biografie',
-
     bioClose: 'Sluiten',
-
     ratingLabel: 'Beoordeling',
-
     enlargeCover: 'Vergroten',
-
     filterSongs: 'Filteren…',
-
     sortNatural: 'Natuurlijk',
-
     sortByTitle: 'A–Z (Titel)',
-
     sortByArtist: 'A–Z (Artiest)',
-
     sortByAlbum: 'A–Z (Album)',
-
   },
-
   entityRating: {
-
     albumShort: 'Albumbeoordeling',
-
     artistShort: 'Artiestbeoordeling',
-
     albumAriaLabel: 'Albumbeoordeling',
-
     artistAriaLabel: 'Artiestbeoordeling',
-
     saveFailed: 'Beoordeling opslaan mislukt.',
-
   },
-
   artistDetail: {
-
     back: 'Terug',
-
     albums: 'Albums',
-
     album: 'Album',
-
     playAll: 'Alles afspelen',
-
     shuffle: 'Willekeurig',
-
     radio: 'Radio',
-
     loading: 'Laden…',
-
     noRadio: 'Geen vergelijkbare nummers gevonden voor deze artiest.',
-
     notFound: 'Artiest niet gevonden.',
-
     albumsBy: 'Albums van {{name}}',
-
     topTracks: 'Populaire nummers',
-
     noAlbums: 'Geen albums gevonden.',
-
     trackTitle: 'Titel',
-
     trackAlbum: 'Album',
-
     trackDuration: 'Duur',
-
     favoriteAdd: 'Aan favorieten toevoegen',
-
     favoriteRemove: 'Uit favorieten verwijderen',
-
     favorite: 'Favoriet',
-
     albumCount_one: '{{count}} album',
-
     albumCount_other: '{{count}} albums',
-
     openedInBrowser: 'Geopend in browser',
-
     featuredOn: 'Ook te vinden op',
-
     similarArtists: 'Vergelijkbare artiesten',
-
     cacheOffline: 'Discografie offline opslaan',
-
     offlineCached: 'Discografie gecached',
-
     offlineDownloading: 'Cachen… ({{done}}/{{total}} albums)',
-
     uploadImage: 'Artiestafbeelding uploaden',
-
     uploadImageError: 'Uploaden van afbeelding mislukt',
-
   },
-
   favorites: {
-
     title: 'Favorieten',
-
     empty: 'Je hebt nog geen favorieten opgeslagen.',
-
     artists: 'Artiesten',
-
     albums: 'Albums',
-
     songs: 'Nummers',
-
     enqueueAll: 'Alles aan wachtrij toevoegen',
-
     playAll: 'Alles afspelen',
-
     removeSong: 'Verwijderen uit favorieten',
-
     stations: 'Radiostations',
-
     showingFiltered: 'Toont {{filtered}} van {{total}} ({{artist}})',
-
     showingCount: 'Toont {{filtered}} van {{total}}',
-
     clearArtistFilter: 'Artiestfilter wissen',
-
     noFilterResults: 'Geen resultaten met de geselecteerde filters.',
-
     allArtists: 'Alle artiesten',
-
   },
-
   randomLanding: {
-
     title: 'Mix samenstellen',
-
     mixByTracks: 'Mix op nummers',
-
     mixByTracksDesc: 'Willekeurige selectie uit je volledige mediatheek',
-
     mixByAlbums: 'Mix op albums',
-
     mixByAlbumsDesc: 'Willekeurige albums voor nieuwe ontdekkingen',
-
   },
-
   randomAlbums: {
-
     title: 'Willekeurige albums',
-
     refresh: 'Vernieuwen',
-
   },
-
   genres: {
-
     title: 'Genres',
-
     genreCount: 'genres',
-
     albumCount_one: '{{count}} album',
-
     albumCount_other: '{{count}} albums',
-
     loading: 'Genres laden…',
-
     empty: 'Geen genres gevonden.',
-
     albumsLoading: 'Albums laden…',
-
     albumsEmpty: 'Geen albums gevonden voor dit genre.',
-
     loadMore: 'Meer laden',
-
     back: 'Terug',
-
   },
-
   randomMix: {
-
     title: 'Willekeurige mix',
-
     remix: 'Opnieuw mixen',
-
     remixTooltip: 'Nieuwe willekeurige nummers laden',
-
     remixGenre: '{{genre}} mixen',
-
     remixTooltipGenre: 'Nieuwe {{genre}}-nummers laden',
-
     playAll: 'Alles afspelen',
-
     trackTitle: 'Titel',
-
     trackArtist: 'Artiest',
-
     trackAlbum: 'Album',
-
     trackFavorite: 'Favoriet',
-
     trackDuration: 'Duur',
-
     favoriteAdd: 'Aan favorieten toevoegen',
-
     favoriteRemove: 'Uit favorieten verwijderen',
-
     play: 'Afspelen',
-
     trackGenre: 'Genre',
-
     excludeAudiobooks: 'Luisterboeken en hoorspelen uitsluiten',
-
     excludeAudiobooksDesc: 'Vergelijkt trefwoorden met genre, titel, album en artiest — bijv. Hörbuch, Audiobook, Spoken Word, …',
-
     genreBlocked: 'Trefwoord geblokkeerd',
-
     genreAddedToBlacklist: 'Aan filterlijst toegevoegd',
-
     genreAlreadyBlocked: 'Al geblokkeerd',
-
     artistBlocked: 'Artiest geblokkeerd',
-
     artistAddedToBlacklist: 'Artiest aan filterlijst toegevoegd',
-
     artistClickHint: 'Klik om deze artiest te blokkeren',
-
     blacklistToggle: 'Trefwoordfilter',
-
     genreMixTitle: 'Genremix',
-
     genreMixDesc: 'Top 20 genres op aantal nummers — klik voor een willekeurige mix',
-
     genreMixAll: 'Alle nummers',
-
     genreMixLoadMore: '10 meer laden',
-
     genreMixNoGenres: 'Geen genres gevonden op server.',
-
     shuffleGenres: 'Andere genres tonen',
-
     filterPanelTitle: 'Filters',
-
     filterPanelDesc: 'Klik op een genre-tag of artiestennaam in de lijst om deze uit toekomstige mixes te weren.',
-
     genreClickHint: 'Klik op een genre-tag om het\ntoe te voegen als filtertrefwoord.\nVergelijkt genre, titel, album & artiest.',
-
   },
-
   albums: {
-
     title: 'Alle albums',
-
     sortByName: 'A–Z (Album)',
-
     sortByArtist: 'A–Z (Artiest)',
-
     sortNewest: 'Nieuwste eerst',
-
     sortRandom: 'Willekeurig',
-
     yearFrom: 'Van',
-
     yearTo: 'Tot',
-
     yearFilterClear: 'Jaarfilter wissen',
-
     yearFilterLabel: 'Jaar',
-
     select: 'Meervoudige selectie',
-
     startSelect: 'Meervoudige selectie inschakelen',
-
     cancelSelect: 'Annuleren',
-
     selectionCount: '{{count}} geselecteerd',
-
     downloadZips: 'ZIPs downloaden',
-
     addOffline: 'Offline toevoegen',
-
     downloadingZip: 'Downloaden {{current}}/{{total}}: {{name}}',
-
     downloadZipDone: '{{count}} ZIP(s) gedownload',
-
     downloadZipFailed: 'Downloaden van {{name}} mislukt',
-
     offlineQueuing: '{{count}} album(s) in wachtrij voor offline…',
-
     offlineFailed: 'Toevoegen van {{name}} offline mislukt',
-
   },
-
   artists: {
-
     title: 'Artiesten',
-
     search: 'Zoeken…',
-
     all: 'Alle',
-
     gridView: 'Rasterweergave',
-
     listView: 'Lijstweergave',
-
     imagesOn: 'Artiestafbeeldingen aan — kan netwerk- en systeembelasting verhogen',
-
     imagesOff: 'Artiestafbeeldingen uit — toont alleen initialen',
-
     loadMore: 'Meer laden',
-
     notFound: 'Geen artiesten gevonden.',
-
     albumCount_one: '{{count}} album',
-
     albumCount_other: '{{count}} albums',
-
     selectionCount: '{{count}} geselecteerd',
-
     select: 'Meervoudige selectie',
-
     startSelect: 'Meervoudige selectie inschakelen',
-
     cancelSelect: 'Annuleren',
-
     addToPlaylist: 'Toevoegen aan playlist',
-
   },
-
   login: {
-
     subtitle: 'Jouw Navidrome-desktopspeler',
-
     serverName: 'Servernaam (optioneel)',
-
     serverNamePlaceholder: 'Mijn Navidrome',
-
     serverUrl: 'Server-URL',
-
     serverUrlPlaceholder: '192.168.1.100:4533 of https://music.voorbeeld.nl',
-
     username: 'Gebruikersnaam',
-
     usernamePlaceholder: 'admin',
-
     password: 'Wachtwoord',
-
     showPassword: 'Wachtwoord tonen',
-
     hidePassword: 'Wachtwoord verbergen',
-
     connect: 'Verbinden',
-
     connecting: 'Verbinden…',
-
     connected: 'Verbonden!',
-
     error: 'Verbinding mislukt — controleer je gegevens.',
-
     urlRequired: 'Voer een server-URL in.',
-
     savedServers: 'Opgeslagen servers',
-
     addNew: 'Of een nieuwe server toevoegen',
-
   },
-
   connection: {
-
     connected: 'Verbonden',
-
     connectedTo: 'Verbonden met {{server}}',
-
     disconnected: 'Verbroken',
-
     disconnectedFrom: 'Kan {{server}} niet bereiken — klik om instellingen te controleren',
-
     checking: 'Verbinden…',
-
     extern: 'Extern',
-
     offlineTitle: 'Geen serververbinding',
-
     offlineSubtitle: 'Kan {{server}} niet bereiken. Controleer je netwerk of server.',
-
     offlineModeBanner: 'Offline modus — afspelen vanuit lokale cache',
-
     offlineNoCacheBanner: 'Geen serververbinding — {{server}} niet bereikbaar',
-
     offlineLibraryTitle: 'Offline bibliotheek',
-
     offlineLibraryEmpty: 'Nog geen albums gecached. Ga online, open een album en klik op "Offline beschikbaar maken".',
-
     offlineAlbumCount: '{{n}} album',
-
     offlineAlbumCount_plural: '{{n}} albums',
-
     offlineFilterAll: 'Alles',
-
     offlineFilterAlbums: 'Albums',
-
     offlineFilterPlaylists: 'Afspeellijsten',
-
     offlineFilterArtists: 'Discografieën',
-
     retry: 'Opnieuw proberen',
-
     serverSettings: 'Serverinstellingen',
-
     switchServerTitle: 'Server wisselen',
-
     switchServerHint: 'Klik om een andere opgeslagen server te kiezen.',
-
     manageServers: 'Servers beheren…',
-
     switchFailed: 'Wisselen mislukt — server niet bereikbaar.',
-
     lastfmConnected: 'Last.fm verbonden als @{{user}}',
-
     lastfmSessionInvalid: 'Sessie ongeldig — klik om opnieuw te verbinden',
-
   },
-
   common: {
-
     albums: 'Albums',
-
     album: 'Album',
-
     loading: 'Laden…',
-
     loadingMore: 'Laden…',
-
     loadingPlaylists: 'Afspeellijsten laden…',
-
     noAlbums: 'Geen albums gevonden.',
-
     downloading: 'Downloaden…',
-
     downloadZip: 'Downloaden (ZIP)',
-
     back: 'Terug',
-
     cancel: 'Annuleren',
-
     save: 'Opslaan',
-
     delete: 'Verwijderen',
-
     use: 'Gebruiken',
-
     add: 'Toevoegen',
-
     active: 'Actief',
-
     download: 'Downloaden',
-
     chooseDownloadFolder: 'Downloadmap kiezen',
-
     noFolderSelected: 'Geen map geselecteerd',
-
     rememberDownloadFolder: 'Deze map onthouden',
-
     filterGenre: 'Genre-filter',
-
     filterSearchGenres: 'Genres zoeken…',
-
     filterNoGenres: 'Geen genres gevonden',
-
     filterClear: 'Wissen',
-
     play: 'Afspelen',
-
     bulkSelected: '{{count}} geselecteerd',
-
     clearSelection: 'Selectie wissen',
-
     bulkAddToPlaylist: 'Toevoegen aan afspeellijst',
-
     bulkRemoveFromPlaylist: 'Verwijderen uit afspeellijst',
-
     bulkClear: 'Selectie wissen',
-
     updaterAvailable: 'Update beschikbaar',
-
     updaterVersion: 'v{{version}} beschikbaar',
-
     updaterWebsite: 'Website',
-
     updaterModalTitle: 'Nieuwe versie beschikbaar',
-
     updaterChangelog: 'Wat is er nieuw',
-
     updaterDownloadBtn: 'Nu downloaden',
-
     updaterSkipBtn: 'Deze versie overslaan',
-
     updaterRemindBtn: 'Later herinneren',
-
     updaterDone: 'Download voltooid',
-
     updaterShowFolder: 'Tonen in map',
-
     updaterInstallHint: 'Sluit Psysonic en voer het installatieprogramma handmatig uit.',
-
     updaterAurHint: 'Update installeren via AUR:',
-
     updaterErrorMsg: 'Downloaden mislukt',
-
     updaterRetryBtn: 'Opnieuw proberen',
-
     durationHoursMinutes: '{{hours}} u {{minutes}} min',
-
     durationMinutesOnly: '{{minutes}} min',
-
     updaterOpenGitHub: 'Openen op GitHub',
-
     filters: 'Filters',
-
     more: 'meer',
-
     yearRange: 'Jaarbereik',
-
     clearAll: 'Alles wissen',
-
   },
-
   settings: {
-
     title: 'Instellingen',
-
     language: 'Taal',
-
     languageEn: 'Engels',
-
     languageDe: 'Duits',
-
     languageFr: 'Frans',
-
     languageNl: 'Nederlands',
-
     languageZh: 'Chinees',
-
     languageNb: 'Noors',
-
     languageRu: 'Russisch',
-
     font: 'Lettertype',
-
     theme: 'Thema',
-
     appearance: 'Weergave',
-
     servers: 'Servers',
-
     serverName: 'Servernaam',
-
     serverUrl: 'Server-URL',
-
     serverUrlPlaceholder: '192.168.1.100:4533 of https://music.voorbeeld.nl',
-
     serverUsername: 'Gebruikersnaam',
-
     serverPassword: 'Wachtwoord',
-
     addServer: 'Server toevoegen',
-
     addServerTitle: 'Nieuwe server toevoegen',
-
     useServer: 'Gebruiken',
-
     deleteServer: 'Verwijderen',
-
     noServers: 'Geen servers opgeslagen.',
-
     serverActive: 'Actief',
-
     confirmDeleteServer: 'Server "{{name}}" verwijderen?',
-
     serverConnecting: 'Verbinden…',
-
     serverConnected: 'Verbonden!',
-
     serverFailed: 'Verbinding mislukt.',
-
     testBtn: 'Verbinding testen',
-
     testingBtn: 'Testen…',
-
     serverCompatible: 'Compatibel met: Navidrome · Gonic · Airsonic · Subsonic',
-
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
-
     audiomuseDesc:
-
       'Zet aan als deze server de <pluginLink>AudioMuse-AI Navidrome-plugin</pluginLink> gebruikt. Schakelt Instant Mix per nummer in en toont vergelijkbare artiesten van de server i.p.v. Last.fm op artiestpagina’s.',
-
     audiomuseIssueHint:
-
       'Instant Mix is onlangs mislukt — controleer de Navidrome-plugin en AudioMuse API. Zonder serverresultaten worden vergelijkbare artiesten via Last.fm geladen.',
-
     connected: 'Verbonden',
-
     failed: 'Mislukt',
-
     eqTitle: 'Equalizer',
-
     eqEnabled: 'Equalizer inschakelen',
-
     eqPreset: 'Voorinstelling',
-
     eqPresetCustom: 'Aangepast',
-
     eqPresetBuiltin: 'Ingebouwde voorinstellingen',
-
     eqPresetCustomGroup: 'Mijn voorinstellingen',
-
     eqSavePreset: 'Opslaan als voorinstelling',
-
     eqPresetName: 'Naam voorinstelling…',
-
     eqDeletePreset: 'Voorinstelling verwijderen',
-
     eqResetBands: 'Terugzetten naar vlak',
-
     eqPreGain: 'Voorversterking',
-
     eqResetPreGain: 'Voorversterking resetten',
-
     eqAutoEqTitle: 'AutoEQ Hoofdtelefoon Zoeken',
-
     eqAutoEqPlaceholder: 'Zoek hoofdtelefoon / IEM model…',
-
     eqAutoEqSearching: 'Zoeken…',
-
     eqAutoEqNoResults: 'Geen resultaten gevonden',
-
     eqAutoEqError: 'Zoeken mislukt',
-
     eqAutoEqRateLimit: 'GitHub limiet bereikt — probeer over een minuut opnieuw',
-
     eqAutoEqFetchError: 'EQ-profiel kon niet worden geladen',
-
     lfmTitle: 'Last.fm',
-
     lfmConnect: 'Verbinden met Last.fm',
-
     lfmConnecting: 'Wachten op autorisatie…',
-
     lfmConfirm: 'Ik heb de app geautoriseerd',
-
     lfmConnected: 'Verbonden als',
-
     lfmDisconnect: 'Verbinding verbreken',
-
     lfmConnectDesc: 'Verbind je Last.fm-account om scrobbling en Nu bezig-updates rechtstreeks vanuit Psysonic in te schakelen — geen Navidrome-configuratie vereist.',
-
     lfmOpenBrowser: 'Er opent een browservenster. Autoriseer Psysonic op Last.fm en klik daarna op de knop hieronder.',
-
     lfmScrobbles: '{{n}} scrobbles',
-
     lfmMemberSince: 'Lid sinds {{year}}',
-
     scrobbleEnabled: 'Scrobbling ingeschakeld',
-
     scrobbleDesc: 'Nummers naar Last.fm sturen na 50% afspeeltijd',
-
     behavior: 'App-gedrag',
-
     cacheTitle: 'Max. opslaggrootte',
-
     cacheDesc: 'Albumhoezen en artiestafbeeldingen. Als de cache vol is, worden de oudste items automatisch verwijderd. Offline albums worden niet automatisch verwijderd, maar wel bij handmatig leegmaken.',
-
     cacheUsedImages: 'Afbeeldingen:',
-
     cacheUsedOffline: 'Offline nummers:',
-
     cacheUsedHot: 'Schijfgebruik:',
-
     hotCacheTrackCount: 'Nummers in cache:',
-
     cacheMaxLabel: 'Max. grootte',
-
     cacheClearBtn: 'Cache wissen',
-
     cacheClearWarning: 'Dit verwijdert ook alle offline albums uit de bibliotheek.',
-
     cacheClearConfirm: 'Alles wissen',
-
     cacheClearCancel: 'Annuleren',
-
     offlineDirTitle: 'Offline-bibliotheek (In-app)',
-
     offlineDirDesc: 'Opslaglocatie voor nummers die je offline beschikbaar maakt in Psysonic.',
-
     offlineDirDefault: 'Standaard (app-gegevens)',
-
     offlineDirChange: 'Map wijzigen',
-
     offlineDirClear: 'Terugzetten naar standaard',
-
     offlineDirHint: 'Nieuwe downloads worden op deze locatie opgeslagen. Bestaande downloads blijven op hun oorspronkelijke locatie.',
-
     hotCacheTitle: 'Warme afspeelcache',
-
     hotCacheAlphaBadge: 'Alpha',
-
     hotCacheDisclaimer: 'Laadt aankomende wachtrijtracks voor en bewaart eerdere. Indien ingeschakeld: schijfruimte en netwerk.',
-
     hotCacheDirDefault: 'Standaard (app-gegevens)',
-
     hotCacheDirChange: 'Map wijzigen',
-
     hotCacheDirClear: 'Terugzetten naar standaard',
-
     hotCacheDirHint: 'Een andere map kiest: de index in de app wordt gereset; oude bestanden blijven staan tot je ze verwijdert.',
-
     hotCacheEnabled: 'Warme afspeelcache inschakelen',
-
     hotCacheMaxMb: 'Maximale cachegrootte',
-
     hotCacheDebounce: 'Uitstel bij wachtrijwijziging',
-
     hotCacheDebounceImmediate: 'Direct',
-
     hotCacheDebounceSeconds: '{{n}} s',
-
     hotCacheClearBtn: 'Warme cache wissen',
-
     audioOutputDevice: 'Audio-uitvoerapparaat',
-
     audioOutputDeviceDesc: 'Kies via welk audioapparaat Psysonic afspeelt. Wijzigingen worden direct toegepast en starten het huidige nummer opnieuw.',
-
     audioOutputDeviceDefault: 'Systeemstandaard',
-
     audioOutputDeviceRefresh: 'Apparatenlijst vernieuwen',
-
     audioOutputDeviceOsDefaultNow: 'huidige systeemuitvoer',
-
     audioOutputDeviceListError: 'De lijst met audio-apparaten kon niet worden geladen.',
-
     audioOutputDeviceNotInCurrentList: 'staat niet in de huidige lijst',
-
     hiResTitle: 'Natieve hi-res-weergave',
-
     hiResEnabled: 'Natieve hi-res-weergave inschakelen',
-
     hiResDesc: "Beperkt de uitvoer standaard tot 44,1 kHz voor maximale stabiliteit. Alleen inschakelen als hardware en netwerk hoge samplerates (88,2 kHz+) ondersteunen.",
-
     showArtistImages: 'Artiestafbeeldingen weergeven',
-
     showArtistImagesDesc: 'Laadt en toont artiestafbeeldingen in het artiestenoverzicht. Standaard uitgeschakeld om server-I/O en netwerkbelasting bij grote bibliotheken te beperken.',
-
     showTrayIcon: 'Tray-pictogram weergeven',
-
     showTrayIconDesc: 'Toont het Psysonic-pictogram in het systeemvak / de menubalk.',
-
     minimizeToTray: 'Minimaliseren naar systeemvak',
-
     minimizeToTrayDesc: 'Bij het sluiten van het venster blijft Psysonic actief in het systeemvak in plaats van af te sluiten.',
-
     discordRichPresence: 'Discord Rich Presence',
-
     discordRichPresenceDesc: 'Toont het huidige nummer op je Discord-profiel. Discord moet daarvoor geopend zijn.',
-
     discordAppleCovers: 'Hoezen ophalen via Apple Music voor Discord',
-
     discordAppleCoversDesc: 'Stuurt artiest- en albumnaam naar de Apple-zoek-API om een hoes te vinden voor je Discord-profiel. Standaard uitgeschakeld vanwege privacy.',
-
     discordTemplates: 'Aangepaste tekstsjablonen',
-
     discordTemplatesDesc: 'Pas aan welke informatie wordt weergegeven op je Discord-profiel. Variabelen: {title}, {artist}, {album}, {paused}',
-
     discordTemplateDetails: 'Primaire regel (details)',
-
     discordTemplateState: 'Secundaire regel (state)',
-
     discordTemplateLargeText: 'Album-tooltip (largeText)',
-
     nowPlayingEnabled: 'Weergeven in live-venster',
-
     nowPlayingEnabledDesc: 'Stuurt het huidige nummer naar de live-luisteraarsweergave van de server. Uitschakelen om geen afspeelgegevens te verzenden.',
-
     lyricsServerFirst: 'Server-songtekst voorrang geven',
-
     lyricsServerFirstDesc: 'Controleer eerst door de server geleverde songteksten (ingebedde tags, sidecar-bestanden) vóór LRCLIB. Uitschakelen om LRCLIB eerst te gebruiken.',
-
     enableNeteaselyrics: 'Netease Cloud Music songteksten',
-
     enableNeteaselyricsDesc: 'Gebruik Netease Cloud Music als laatste bron wanneer server en LRCLIB niets opleveren. Beste dekking voor Aziatische en internationale muziek.',
-
     lyricsSourcesTitle: 'Songtekstbronnen',
-
     lyricsSourcesDesc: 'Kies welke bronnen worden geraadpleegd en in welke volgorde. Sleep om te sorteren. Uitgeschakelde bronnen worden overgeslagen.',
-
     lyricsSourceServer: 'Server',
-
     lyricsSourceLrclib: 'LRCLIB',
-
     lyricsSourceNetease: 'Netease Cloud Music',
-
     downloadsTitle: 'ZIP-export & Archivering',
-
     downloadsFolderDesc: 'Doelmap voor albums die je als ZIP-bestand naar je computer downloadt.',
-
     downloadsDefault: 'Standaard downloadmap',
-
     pickFolder: 'Selecteren',
-
     pickFolderTitle: 'Downloadmap selecteren',
-
     clearFolder: 'Map wissen',
-
     logout: 'Uitloggen',
-
     aboutTitle: 'Over Psysonic',
-
     aboutDesc: 'Een moderne desktopmuziekspeeler voor Subsonic-compatibele servers (Navidrome, Gonic en anderen). Gebouwd op Tauri v2 met een native Rust audio-engine — licht en snel, maar boordevol functies: golfvorm-zoekbalk, gesynchroniseerde songteksten, Last.fm-integratie, 10-bands equalizer, crossfade, naadloos afspelen, Replay Gain, genres en een uitgebreide themabibliotheek.',
-
     aboutLicense: 'Licentie',
-
     aboutLicenseText: 'GNU GPL v3 — vrij te gebruiken, wijzigen en verspreiden onder dezelfde licentie.',
-
     aboutRepo: 'Broncode op GitHub',
-
     aboutVersion: 'Versie',
-
     aboutBuiltWith: 'Gebouwd met Tauri · React · TypeScript · Rust/rodio',
-
     aboutAiCredit: 'Ontwikkeld met ondersteuning van Claude Code door Anthropic',
-
     aboutContributorsLabel: 'Bijdragers',
-
     aboutSpecialThanksLabel: 'Speciale dank',
-
     changelog: 'Wijzigingslog',
-
     showChangelogOnUpdate: "'Wat is nieuw' tonen bij update",
-
     showChangelogOnUpdateDesc: 'Toont automatisch de nieuwigheden bij de eerste start van een nieuwe versie.',
-
     randomMixTitle: 'Willekeurige mix',
-
     randomMixBlacklistTitle: 'Aangepaste filtertrefwoorden',
-
     randomMixBlacklistDesc: 'Nummers worden uitgesloten als een trefwoord overeenkomt met hun genre, titel, album of artiest (actief wanneer het selectievakje hierboven is aangevinkt).',
-
     randomMixBlacklistPlaceholder: 'Trefwoord toevoegen…',
-
     randomMixBlacklistAdd: 'Toevoegen',
-
     randomMixBlacklistEmpty: 'Nog geen aangepaste trefwoorden toegevoegd.',
-
     randomMixHardcodedTitle: 'Ingebouwde trefwoorden (actief wanneer selectievakje is aangevinkt)',
-
     tabAudio: 'Audio',
-
     tabStorage: 'Opslag & Downloads',
-
     tabAppearance: 'Weergave',
-
     homeCustomizerTitle: 'Startpagina',
-
     sidebarTitle: 'Zijbalk',
-
     sidebarReset: 'Standaard herstellen',
-
     sidebarDrag: 'Slepen om te herordenen',
-
     sidebarFixed: 'Altijd zichtbaar',
-
+    randomNavSplitTitle: 'Mix-navigatie splitsen',
+    randomNavSplitDesc: 'Toon "Willekeurige mix" en "Willekeurige albums" als afzonderlijke zijbalkitems in plaats van de "Mix samenstellen"-hub.',
     tabInput: 'Invoer',
-
     tabServer: 'Server',
-
     shortcutsReset: 'Standaard herstellen',
-
     shortcutListening: 'Druk op een toets…',
-
     shortcutUnbound: '—',
-
     shortcutClear: 'Wissen',
-
     globalShortcutsTitle: 'Globale sneltoetsen',
-
     globalShortcutsNote: 'Werken systeembreed, ook als Psysonic op de achtergrond draait. Vereist Ctrl, Alt of Super als modifier.',
-
     shortcutPlayPause: 'Afspelen / Pauzeren',
-
     shortcutNext: 'Volgend nummer',
-
     shortcutPrev: 'Vorig nummer',
-
     shortcutVolumeUp: 'Volume omhoog',
-
     shortcutVolumeDown: 'Volume omlaag',
-
     shortcutSeekForward: '10s vooruitspoelen',
-
     shortcutSeekBackward: '10s terugspoelen',
-
     shortcutToggleQueue: 'Wachtrij tonen/verbergen',
-
     shortcutOpenFolderBrowser: '{{folderBrowser}} openen',
-
     shortcutFullscreenPlayer: 'Volledigschermspeler',
-
     shortcutNativeFullscreen: 'Systeemvolledig scherm',
-
     tabSystem: 'Systeem',
-
     tabGeneral: 'Algemeen',
-
     ratingsSectionTitle: 'Beoordelingen',
-
     ratingsSkipStarTitle: 'Overslaan voor 1 ster',
-
     ratingsSkipStarDesc:
-
       'Na meerdere overslagen op rij: nummer op 1 ster zetten. Alleen voor nummers die nog niet beoordeeld waren.',
-
     ratingsSkipStarThresholdLabel: 'Overslagen',
-
     ratingsMixFilterTitle: 'Filter op beoordeling',
-
     ratingsMixFilterDesc:
-
       'Content met lage beoordeling filteren in {{mix}} en {{albums}}. Klik opnieuw op de gekozen ster om de drempel uit te zetten.',
-
     ratingsMixMinSong: 'Nummers',
-
     ratingsMixMinAlbum: 'Albums',
-
     ratingsMixMinArtist: 'Artiesten',
-
     ratingsMixMinThresholdAria: 'Minimum sterren: {{label}}',
-
     backupTitle: 'Back-up & Herstel',
-
     backupExport: 'Instellingen exporteren',
-
     backupExportDesc: 'Slaat alle instellingen, serverprofielen, Last.fm-configuratie, thema, EQ en sneltoetsen op in een .psybkp-bestand. Wachtwoorden worden opgeslagen als leesbare tekst — bewaar het bestand veilig.',
-
     backupImport: 'Instellingen importeren',
-
     backupImportDesc: 'Herstelt instellingen vanuit een .psybkp-bestand. De app wordt herladen na het importeren.',
-
     backupImportConfirm: 'Alle huidige instellingen worden overschreven. Doorgaan?',
-
     backupSuccess: 'Back-up opgeslagen',
-
     backupImportSuccess: 'Instellingen hersteld — herladen…',
-
     backupImportError: 'Ongeldig of beschadigd back-upbestand.',
-
     playbackTitle: 'Afspelen',
-
     replayGain: 'Replay Gain',
-
     replayGainDesc: 'Nummervolume normaliseren met ReplayGain-metadata',
-
     replayGainMode: 'Modus',
-
     replayGainTrack: 'Nummer',
-
     replayGainAlbum: 'Album',
-
     replayGainPreGain: 'Pre-Gain (getagde bestanden)',
-
     replayGainFallback: 'Terugval (zonder tags / radio)',
-
     crossfade: 'Overgang',
-
     crossfadeDesc: 'Fade tussen nummers',
-
     crossfadeSecs: '{{n}} s',
-
     notWithGapless: 'Niet beschikbaar als naadloos afspelen actief is',
-
     notWithCrossfade: 'Niet beschikbaar als overgang actief is',
-
     gapless: 'Naadloos afspelen',
-
     gaplessDesc: 'Volgend nummer vooraf bufferen om stiltes tussen nummers te elimineren',
-
     preloadMode: 'Volgend nummer vooraf laden',
-
     preloadModeDesc: 'Wanneer met het bufferen van het volgende nummer wordt begonnen',
-
     nextTrackBufferingTitle: 'Volgend nummer – buffering',
-
     preloadHotCacheMutualExclusive: 'Preload en Hot Cache dienen hetzelfde doel — slechts één kan tegelijk actief zijn. Het inschakelen van de ene schakelt de andere automatisch uit.',
-
     preloadOff: 'Uit',
-
     preloadBalanced: 'Gebalanceerd (30 s voor einde)',
-
     preloadEarly: 'Vroeg (na 5 s afspelen)',
-
     preloadCustom: 'Aangepast',
-
     preloadCustomSeconds: 'Seconden voor einde: {{n}}',
-
     infiniteQueue: 'Oneindige wachtrij',
-
     infiniteQueueDesc: 'Automatisch willekeurige nummers toevoegen als de wachtrij leeg raakt',
-
     experimental: 'Experimenteel',
-
     fsPlayerSection: 'Volledig scherm speler',
-
     fsShowArtistPortrait: 'Artiestfoto tonen',
-
     fsShowArtistPortraitDesc: 'Artiestfoto (of albumhoes) weergeven aan de rechterkant van de volledigschermspeler.',
-
     fsPortraitDim: 'Verduistering foto',
-
     seekbarStyle: 'Zoekbalkstijl',
-
     seekbarStyleDesc: 'Kies het uiterlijk van de afspeelbalk',
-
     seekbarWaveform: 'Golfvorm',
-
     seekbarLinedot: 'Lijn & punt',
-
     seekbarBar: 'Balk',
-
     seekbarThick: 'Dikke balk',
-
     seekbarSegmented: 'Gesegmenteerd',
-
     seekbarNeon: 'Neon',
-
     seekbarPulsewave: 'Pulsgolf',
-
     seekbarParticletrail: 'Deeltjesspoor',
-
     seekbarLiquidfill: 'Vloeistofbuis',
-
     seekbarRetrotape: 'Retrotape',
-
     themeSchedulerTitle: 'Thema-planner',
-
     themeSchedulerEnable: 'Thema-planner inschakelen',
-
     themeSchedulerEnableSub: 'Schakelt automatisch tussen twee thema\'s op basis van de tijd',
-
     themeSchedulerDayTheme: 'Dagthema',
-
     themeSchedulerDayStart: 'Dag begint om',
-
     themeSchedulerNightTheme: 'Nachtthema',
-
     themeSchedulerNightStart: 'Nacht begint om',
-
     themeSchedulerActiveHint: "Thema-planner is actief - thema's worden automatisch gewisseld.",
-
     visualOptionsTitle: 'Visuele Opties',
-
     coverArtBackground: 'Cover Achtergrond',
-
     coverArtBackgroundSub: 'Toon vervaagde cover als achtergrond in album/playlist headers',
-
     playlistCoverPhoto: 'Playlist Coverfoto',
-
     playlistCoverPhotoSub: 'Toon coverfoto raster in playlist detailweergave',
-
     showBitrate: 'Toon Bitrate',
-
     showBitrateSub: 'Toon audio bitrate in tracklijsten',
-
     uiScaleTitle: 'Interface schaal',
-
     uiScaleLabel: 'Zoom',
-
   },
-
   changelog: {
-
     modalTitle: 'Wat is nieuw',
-
     dontShowAgain: 'Niet meer weergeven',
-
     close: 'Begrepen',
-
   },
-
   help: {
-
     title: 'Help',
-
     s1: 'Aan de slag',
-
     q1: 'Welke servers zijn compatibel?',
-
     a1: 'Psysonic werkt met elke Subsonic-compatibele server: Navidrome, Gonic, Subsonic, Airsonic en anderen. Navidrome is de aanbevolen keuze.',
-
     q2: 'Hoe verbind ik me met mijn server?',
-
     a2: 'Open Instellingen en klik op "Server toevoegen". Voer de server-URL in (bijv. 192.168.1.100:4533), je gebruikersnaam en wachtwoord. Psysonic test de verbinding voor het opslaan.',
-
     q3: 'Kan ik meerdere servers gebruiken?',
-
     a3: 'Ja. Je kunt zoveel servers toevoegen als je wilt in Instellingen en er op elk moment tussen wisselen. Slechts één server is tegelijk actief.',
-
     s2: 'Afspelen',
-
     q4: 'Hoe speel ik muziek af?',
-
     a4: 'Dubbelklik op een nummer om het af te spelen. Gebruik op album- en artiestpagina\'s "Alles afspelen" om het hele album te starten. Je kunt ook nummers naar de wachtrij slepen.',
-
     q5: 'Welke sneltoetsen zijn beschikbaar?',
-
     a5: 'Spatie = Afspelen / Pauzeren · Escape = Volledig scherm sluiten. Mediatoetsen werken op alle platforms. Gebruik op Linux de knoppen van de spelerbalk. In-app sneltoetsen en systeembrede globale sneltoetsen zijn aan te passen via Instellingen → Sneltoetsen / Globale sneltoetsen.',
-
     q6: 'Wat is de wachtrij?',
-
     a6: 'De wachtrij toont alle komende nummers. Open deze met het paneelpictogram rechtsboven. Je kunt nummers herordenen door te slepen, shufflen en de wachtrij opslaan als afspeellijst.',
-
     q7: 'Hoe open ik de volledig-schermspeler?',
-
     a7: 'Klik op de albumhoes in de spelerbalk onderaan, of het uitvouwpictogram ernaast. Druk op Escape om te sluiten.',
-
     q8: 'Hoe werkt herhalen?',
-
     a8: 'Klik op de herhalknop om te wisselen: Uit → Alles herhalen → Één herhalen.',
-
     s3: 'Bibliotheek',
-
     q9: 'Hoe download ik een album?',
-
     a9: 'Open de detailpagina van een album en klik op "Downloaden (ZIP)". De server comprimeert het album eerst naar een ZIP-bestand — voor grote albums of verliesvrije bestanden (FLAC / WAV) kan het even duren voordat de download daadwerkelijk start. De voortgangsbalk verschijnt pas als de server klaar is met inpakken.',
-
     q10: 'Hoe markeer ik nummers en albums als favoriet?',
-
     a10: 'Klik op het sterpictogram op een nummervak of de albumkoptekst. Gemarkeerde items verschijnen in de sectie Favorieten in de zijbalk.',
-
     q11: 'Wat is de hero-carrousel op de startpagina?',
-
     a11: 'De banner bovenaan de startpagina kiest willekeurig albums uit je bibliotheek en wisselt deze elke 10 seconden af. Klik op de puntjes om naar een specifiek album te springen.',
-
     s4: 'Instellingen',
-
     q12: 'Hoe verander ik het thema?',
-
     a12: 'Instellingen → Thema. Een ruime keuze aan thema\'s in 8 groepen: Psysonic Themes, Mediaplayer, Besturingssystemen, Games, Films, Series, Social Media en Open Source Classics (Catppuccin, Nord, Gruvbox, Nightfox).',
-
     q13: 'Hoe verander ik de taal?',
-
     a13: 'Instellingen → Taal. Engels, Duits, Frans, Nederlands en Chinees worden momenteel ondersteund.',
-
     q15: 'Hoe stel ik een downloadmap in?',
-
     a15: 'Instellingen → App-gedrag → Downloadmap. Gedownloade albums worden daar opgeslagen als ZIP-bestanden.',
-
     s5: 'Scrobbling',
-
     q16: 'Hoe werkt scrobbling?',
-
     a16: 'Psysonic scrobbelt rechtstreeks naar Last.fm — geen Navidrome-configuratie nodig. Verbind je Last.fm-account in Instellingen → Last.fm en schakel scrobbling in.',
-
     q17: 'Wanneer wordt een scrobble verstuurd?',
-
     a17: 'Een scrobble wordt verstuurd nadat je 50% van een nummer hebt geluisterd.',
-
     q22: 'Wat is de golfvorm in de spelerbalk?',
-
     a22: 'De golfvormzoekbalk vervangt de klassieke voortgangsschuifregelaar. Klik ergens om naar die positie te springen, of sleep om door het nummer te navigeren.',
-
     q24: 'Kan ik de wachtrij shufflen?',
-
     a24: 'Ja. Open het wachtrijpaneel en klik op het shufflepictogram. Het huidige nummer blijft op positie 1 — alle overige nummers worden willekeurig geherordend.',
-
     q25: 'Openen Last.fm- en Wikipedia-links in een browser?',
-
     a25: 'Ja — ze openen in je standaard systeembrowser. De knop toont kort een bevestiging bij klikken.',
-
     s7: 'Willekeurige mix',
-
     q26: 'Wat is de Willekeurige mix?',
-
     a26: 'De Willekeurige mix bouwt een afspeellijst van willekeurige nummers uit je hele bibliotheek. Open het via "Willekeurige mix" in de zijbalk en klik op "Nieuwe mix".',
-
     q27: 'Wat is het Trefwoordfilter?',
-
     a27: 'Het Trefwoordfilter sluit nummers uit waarvan het genre, de titel of de albumnaam bepaalde woorden bevat. Luisterboeken worden automatisch gefilterd. Voeg aangepaste trefwoorden toe in Instellingen → Willekeurige mix.',
-
     q28: 'Wat is de Super-genremix?',
-
     a28: 'De Super-genremix groepeert je bibliotheek in brede categorieën (Rock, Metal, Elektronisch, Jazz, Klassiek, enz.) en bouwt een gerichte mix van die stijl. Selecteer een categoriechip onder de lijst.',
-
     s6: 'Probleemoplossing',
-
     q18: 'Albumhoezen en artiestenafbeeldingen laden langzaam.',
-
     a18: 'Afbeeldingen worden bij het eerste laden van de schijf van je server opgehaald en vervolgens 30 dagen lokaal gecachet. Volgende bezoeken zijn direct.',
-
     q19: 'De verbindingstest mislukt.',
-
     a19: 'Controleer de URL inclusief de poort (bijv. http://192.168.1.100:4533). Zorg dat geen firewall de verbinding blokkeert. Probeer http:// in plaats van https:// op een lokaal netwerk.',
-
     q20: 'Geen audio op Linux.',
-
     a20: 'Psysonic is beschikbaar als .deb (Ubuntu/Debian), .rpm (Fedora/RHEL) en via AUR voor Arch/CachyOS (yay -S psysonic). Er is geen AppImage. Controleer of PipeWire of PulseAudio actief is als er geen audio is.',
-
     q21: 'De app toont een zwart scherm op Linux.',
-
     a21: 'Dit is meestal een GPU/EGL-driverprobleem in WebKitGTK. Start met GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. Het AUR-pakket en officiële .deb/.rpm-installatieprogramma\'s doen dit automatisch.',
-
     q29: 'Wat zijn overgang (crossfade) en naadloos afspelen?',
-
     a29: 'Dit zijn experimentele audiofuncties in Instellingen → Audio. Naadloos afspelen buffert het volgende nummer voor om stiltes te elimineren. Overgang fadeert het huidige nummer uit terwijl het volgende infadeert — duur (1–10 s) instelbaar.',
-
     q30: 'Toont Psysonic songteksten?',
-
     a30: 'Ja. Klik op het microfoonpictogram in de spelerbalk om het tabblad Songteksten te openen. Psysonic haalt teksten automatisch op van LRCLIB. Als gesynchroniseerde teksten beschikbaar zijn, wordt de actieve regel gemarkeerd en scrolt mee in realtime. Anders wordt de volledige tekst statisch getoond.',
-
     q31: 'Kan ik sneltoetsen aanpassen?',
-
     a31: 'Ja. Instellingen → Sneltoetsen laat je in-app acties (Afspelen/Pauzeren, Volgende, Vorige, Volume, Volledig scherm, enz.) hertoewijzen. Instellingen → Globale sneltoetsen laat je systeembrede sneltoetsen instellen die werken ook als de app op de achtergrond staat.',
-
     q32: 'Kan ik het lettertype wijzigen?',
-
     a32: 'Ja. Instellingen → Lettertype biedt 10 lettertypen waaronder IBM Plex Mono, Fira Code, JetBrains Mono en Courier Prime. Het gekozen lettertype geldt voor de gehele interface.',
-
     s8: 'Offlinemodus',
-
     q34: 'Wat is de Offlinemodus?',
-
     a34: 'De Offlinemodus (Beta) laat je albums op het apparaat opslaan zodat je zonder actieve serververbinding kunt luisteren. Gecachte nummers worden lokaal opgeslagen en direct van schijf afgespeeld — zonder netwerkverzoek.',
-
     q35: 'Hoe sla ik een album op voor offline gebruik?',
-
     a35: 'Open een album en klik op het downloadpictogram in de albumkoptekst. Psysonic downloadt alle nummers op de achtergrond. De voortgang wordt op de knop weergegeven. Na het cachen wordt het pictogram groen. Gecachte albums zijn te bekijken en verwijderen via de Offline bibliotheek (zijbalk).',
-
     q36: 'Hoeveel opslagruimte mag de offlinecache gebruiken?',
-
     a36: 'Je kunt een maximale cachegrootte instellen via Instellingen → Bibliotheek. Als de limiet is bereikt, verschijnt er een waarschuwingsbanner op de albumpagina. Je kunt afzonderlijke albums verwijderen in de Offline bibliotheek om ruimte vrij te maken.',
-
     q37: 'Hoe beoordeel ik nummers, albums en artiesten?',
-
     a37: 'Psysonic ondersteunt 1–5 sterrenwaarderingen via de OpenSubsonic API (vereist Navidrome ≥ 0.53). Beoordeel nummers in de tracklist van een album of afspeellijst, via het rechtsklikmenu of in de spelersbalk. Albums worden beoordeeld op hun detailpagina, artiesten op hun artiestenpagina.',
-
     q38: 'Kan ik een beoordeling verwijderen of wijzigen?',
-
     a38: 'Ja. Klik opnieuw op de actieve ster om de beoordeling volledig te verwijderen — een tweede klik op dezelfde ster wist hem. Klik op een andere ster om de beoordeling te wijzigen.',
-
     q39: 'Wat is Skip-to-1★ en het beoordelingsfilter?',
-
     a39: 'Skip-to-1★ kent automatisch een 1-sterrenbeoordeling toe na een bepaald aantal opeenvolgende skips. Activeer het in Instellingen → Beoordelingen. Stel daar ook een minimale sterrenbeoordeling in voor willekeurige mixen.',
-
     q40: 'Wat is de Mappenverkenner?',
-
     a40: 'De Mappenverkenner (zijbalk) laat je de muziekmap van de server navigeren via Miller-kolommen. Klik op een map om de inhoud te bekijken; gebruik het afspeelpictogram om de inhoud direct af te spelen of toe te voegen aan de wachtrij.',
-
     q41: 'Wat is de themasplanner?',
-
     a41: 'Instellingen → Uiterlijk → Thema automatisch wisselen: stel een dagthema en een nachtthema in met starttijden. Psysonic wisselt automatisch op de ingestelde tijden.',
-
     q42: 'Kan ik de interface schalen?',
-
     a42: 'Ja. Instellingen → Uiterlijk → Interfaceschaal laat je de volledige UI schalen tussen 80 % en 125 %.',
-
     q43: 'Kan ik de zoekbalkstijl wijzigen?',
-
     a43: 'Ja. Instellingen → Uiterlijk → Zoekbalkstijl biedt 10 stijlen: Golfvorm, Lijn & Punt, Balk, Dikke balk, Gesegmenteerd, Neon Glow, Pulsgolf, Partikelspoor, Vloeistofvulling en Retro Tape.',
-
     q44: 'Wat is AutoEQ?',
-
     a44: 'De 10-bands equalizer in Instellingen → Audio bevat een AutoEQ-zoekopdracht. Voer je hoofdtelefoonmodel in om automatisch een correctieprofiel te laden.',
-
     q45: 'Wat is Replay Gain?',
-
     a45: 'Replay Gain normaliseert het volume zodat harde en stille albums op een consistent niveau worden afgespeeld. Activeer het in Instellingen → Audio → Replay Gain; kies modus Track of Album.',
-
     q46: 'Wat is de Hot Cache?',
-
     a46: 'De Hot Cache (Alpha, Instellingen → Bibliotheek) laadt de volgende nummers in de wachtrij vooraf naar de schijf voor directe weergave. Psysonic bewaart het huidige nummer en de volgende 5 en verwijdert oudere items wanneer de limiet is bereikt.',
-
     q47: 'Kan ik een afspeellijst offline cachen?',
-
     a47: 'Ja. Open de afspeellijstdetails en klik op het downloadpictogram. Zodra alle tracks zijn gecached, verandert het pictogram in een rode prullenbak; klik erop om de afspeellijst uit de offlinecache te verwijderen.',
-
+    q48: 'Wat is de Infinite Queue?',
+    a48: 'Als de wachtrij leeg raakt en herhalen uitgeschakeld is, voegt Psysonic automatisch willekeurige nummers toe zodat het afspelen nooit stopt. Automatisch toegevoegde nummers verschijnen onder het scheidingsteken "— Automatisch toegevoegd —". Schakel in/uit via het oneindig-pictogram in de wachtrij-header.',
+    q49: 'Kan ik Psysonic via de opdrachtregel bedienen?',
+    a49: 'Ja. Voorbeelden: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one. Ook: van server wisselen, audioapparaat wijzigen, bibliotheek filteren en zoeken. Volledige hulp: psysonic --player --help.',
+    q50: 'Hoe beheer ik afspeellijsten?',
+    a50: 'Via "Afspeellijsten" in de zijbalk. Maak een afspeellijst aan met "Nieuwe afspeellijst". In de detailweergave kunt u nummers slepen om te herordenen, verwijderen met ×, nieuwe toevoegen via zoeken en "Suggesties" gebruiken voor slimme aanbevelingen.',
+    q51: 'Kan ik mijn instellingen back-uppen en herstellen?',
+    a51: 'Ja. Instellingen → Back-up & Herstel exporteert alle instellingen, serverprofielen, thema\'s en snelkoppelingen naar een JSON-bestand. Importeer het op een ander apparaat om alles in één keer te herstellen.',
+    q52: 'Hoe wijzig ik het audio-uitvoerapparaat?',
+    a52: 'Instellingen → Audio → Uitvoerapparaat. Psysonic toont alle beschikbare uitgangen. De selectie wordt direct van kracht. Gebruik de verversknop als een apparaat na het starten van de app is aangesloten.',
+    q53: 'Wat is Device Sync?',
+    a53: 'Device Sync kopieert albums, afspeellijsten of artiesten naar een USB-stick of SD-kaart. Open het via "Device Sync" in de zijbalk, kies een doelmap, selecteer bronnen en klik op "Naar apparaat overbrengen".',
+    q54: 'Wat is de bestandsnaamsjabloon in Device Sync?',
+    a54: 'Het sjabloon bepaalt hoe nummers worden benoemd en georganiseerd. Gebruik de voorinstellingen of bouw uw eigen sjabloon met de klikbare tokens: {artist}, {album}, {title}, {track_number}, {disc_number}, {year} en / als mapscheidingsteken.',
+    q55: 'Werkt Device Sync platformoverschrijdend?',
+    a55: 'Ja. Het manifest op het apparaat bevat het gebruikte sjabloon. Op een ander besturingssysteem herkent Psysonic bestaande bestanden correct, ook bij een ander sjabloon.',
+    s9: 'Device Sync',
+    q56: 'Wat is internetradio?',
+    a56: 'De internetradiopagina speelt live streams af in Psysonic. Stations komen van uw Navidrome-server — voeg ze toe via het beheerpaneel of importeer een .pls/.m3u-bestand. Afspelen gebruikt HTML5-audio.',
+    q57: 'Welke streamformaten ondersteunt internetradio?',
+    a57: 'MP3, AAC, OGG Vorbis en de meeste HLS-streams. MP3 en AAC werken op alle platforms.',
+    s10: 'Internetradio',
+    q58: 'Waar haalt Psysonic songteksten vandaan?',
+    a58: 'Drie configureerbare bronnen in Instellingen → Songteksten: uw Navidrome-server, LRCLIB en NetEase Cloud Music. Elke bron kan worden in-/uitgeschakeld en geprioriteerd door te slepen.',
+    q59: 'Is er een weergave van wat andere gebruikers luisteren?',
+    a59: 'Ja. Klik op het uitzendpictogram rechtsboven om te zien wat andere gebruikers op uw Navidrome-server beluisteren, elke 10 seconden bijgewerkt.',
   },
-
   queue: {
-
     title: 'Wachtrij',
-
     savePlaylist: 'Afspeellijst opslaan',
-
     updatePlaylist: 'Afspeellijst bijwerken',
-
     filterPlaylists: 'Afspeellijsten filteren…',
-
     playlistName: 'Naam afspeellijst',
-
     cancel: 'Annuleren',
-
     save: 'Opslaan',
-
     loadPlaylist: 'Afspeellijst laden',
-
     loading: 'Laden…',
-
     noPlaylists: 'Geen afspeellijsten gevonden.',
-
     load: 'Wachtrij vervangen & afspelen',
-
     appendToQueue: 'Toevoegen aan wachtrij',
-
     delete: 'Verwijderen',
-
     deleteConfirm: 'Afspeellijst "{{name}}" verwijderen?',
-
     clear: 'Leegmaken',
-
     shuffle: 'Wachtrij shufflen',
-
     gapless: 'Naadloos',
-
     crossfade: 'Overgang',
-
     infiniteQueue: 'Oneindige wachtrij',
-
     autoAdded: '— Automatisch toegevoegd —',
-
     radioAdded: '— Radio —',
-
     hide: 'Verbergen',
-
     close: 'Sluiten',
-
     nextTracks: 'Volgende nummers',
-
     emptyQueue: 'De wachtrij is leeg.',
-
     trackSingular: 'nummer',
-
     trackPlural: 'nummers',
-
     showRemaining: 'Resterende tijd tonen',
-
     showTotal: 'Totale tijd tonen',
-
   },
-
   statistics: {
-
     title: 'Statistieken',
-
     recentlyPlayed: 'Recent afgespeeld',
-
     mostPlayed: 'Meest gespeelde albums',
-
     highestRated: 'Best beoordeelde albums',
-
     genreDistribution: 'Genreverdeling (Top 20)',
-
     loadMore: 'Meer laden',
-
     statArtists: 'Artiesten',
-
     statArtistsTooltip: 'Alleen albumartiesten — artiesten die enkel als trackartiest voorkomen (featuring, gast, enz.) zonder eigen album worden niet meegeteld.',
-
     statAlbums: 'Albums',
-
     statSongs: 'Nummers',
-
     statGenres: 'Genres',
-
     statPlaytime: 'Totale speelduur',
-
     genreInsights: 'Genre-inzichten',
-
     formatDistribution: 'Formaatdistributie',
-
     formatSample: 'Steekproef van {{n}} nummers',
-
     computing: 'Berekenen…',
-
     genreSongs: '{{count}} nummers',
-
     genreAlbums: '{{count}} albums',
-
     recentlyAdded: 'Recent toegevoegd',
-
     decadeDistribution: 'Albums per decennium',
-
     decadeAlbums_one: '{{count}} album',
-
     decadeAlbums_other: '{{count}} albums',
-
     decadeUnknown: 'Onbekend',
-
     lfmTitle: 'Last.fm-statistieken',
-
     lfmTopArtists: 'Topartiesten',
-
     lfmTopAlbums: 'Topalbums',
-
     lfmTopTracks: 'Topnummers',
-
     lfmPlays: '{{count}} keer gespeeld',
-
     lfmPeriodOverall: 'Alle tijd',
-
     lfmPeriod7day: '7 dagen',
-
     lfmPeriod1month: '1 maand',
-
     lfmPeriod3month: '3 maanden',
-
     lfmPeriod6month: '6 maanden',
-
     lfmPeriod12month: '12 maanden',
-
     lfmNotConnected: 'Verbind Last.fm in Instellingen om je statistieken te zien.',
-
     lfmRecentTracks: 'Recente scrobbles',
-
     lfmNowPlaying: 'Nu bezig',
-
     lfmJustNow: 'zojuist',
-
     lfmMinutesAgo: '{{n}} min geleden',
-
     lfmHoursAgo: '{{n}} uur geleden',
-
     lfmDaysAgo: '{{n}} dagen geleden',
-
     topRatedSongs: 'Best beoordeelde nummers',
-
     topRatedArtists: 'Best beoordeelde artiesten',
-
     noRatedSongs: 'Nog geen beoordeelde nummers. Beoordeel nummers in album- of afspeellijstweergave.',
-
     noRatedArtists: 'Nog geen beoordeelde artiesten.',
-
   },
-
   player: {
-
     regionLabel: 'Muziekspeler',
-
     openFullscreen: 'Volledig-schermspeler openen',
-
     fullscreen: 'Volledig-schermspeler',
-
     closeFullscreen: 'Volledig scherm sluiten',
-
     closeTooltip: 'Sluiten (Escape)',
-
     noTitle: 'Geen titel',
-
     stop: 'Stoppen',
-
     prev: 'Vorig nummer',
-
     play: 'Afspelen',
-
     pause: 'Pauzeren',
-
     next: 'Volgend nummer',
-
     repeat: 'Herhalen',
-
     repeatOff: 'Uit',
-
     repeatAll: 'Alles',
-
     repeatOne: 'Één',
-
     progress: 'Nummervoortgang',
-
     volume: 'Volume',
-
     toggleQueue: 'Wachtrij in-/uitschakelen',
-
     lyrics: 'Songtekst',
-
     fsLyricsToggle: 'Songtekst in volledig scherm',
-
     lyricsLoading: 'Songtekst laden…',
-
     lyricsNotFound: 'Geen songtekst gevonden voor dit nummer',
-
     lyricsSourceServer: 'Bron: Server',
-
     lyricsSourceLrclib: 'Bron: LRCLIB',
-
     lyricsSourceNetease: 'Bron: Netease',
-
   },
-
   songInfo: {
-
     title: 'Nummerinfo',
-
     songTitle: 'Titel',
-
     artist: 'Artiest',
-
     album: 'Album',
-
     albumArtist: 'Albumartiest',
-
     year: 'Jaar',
-
     genre: 'Genre',
-
     duration: 'Duur',
-
     track: 'Track',
-
     format: 'Formaat',
-
     bitrate: 'Bitrate',
-
     sampleRate: 'Samplefrequentie',
-
     bitDepth: 'Bitdiepte',
-
     channels: 'Kanalen',
-
     fileSize: 'Bestandsgrootte',
-
     path: 'Locatie',
-
     replayGainTrack: 'RG Track Gain',
-
     replayGainAlbum: 'RG Album Gain',
-
     replayGainPeak: 'RG Track Peak',
-
     mono: 'Mono',
-
     stereo: 'Stereo',
-
   },
-
   playlists: {
-
     title: 'Playlists',
-
     newPlaylist: 'Nieuwe playlist',
-
     unnamed: 'Naamloze playlist',
-
     createName: 'Playlistnaam…',
-
     create: 'Aanmaken',
-
     cancel: 'Annuleren',
-
     empty: 'Nog geen playlists.',
-
     emptyPlaylist: 'Deze playlist is leeg.',
-
     addFirstSong: 'Voeg je eerste nummer toe',
-
     notFound: 'Playlist niet gevonden.',
-
     songs: '{{n}} nummers',
-
     playAll: 'Alles afspelen',
-
     shuffle: 'Willekeurig',
-
     addToQueue: 'Aan wachtrij toevoegen',
-
     back: 'Terug naar playlists',
-
     deletePlaylist: 'Verwijderen',
-
     confirmDelete: 'Nogmaals klikken om te bevestigen',
-
     removeSong: 'Uit playlist verwijderen',
-
     addSongs: 'Nummers toevoegen',
-
     searchPlaceholder: 'Doorzoek bibliotheek…',
-
     noResults: 'Geen resultaten.',
-
     suggestions: 'Aanbevolen nummers',
-
     noSuggestions: 'Geen suggesties beschikbaar.',
-
     titleBadge: 'Playlist',
-
     refreshSuggestions: 'Nieuwe suggesties',
-
     addSong: 'Toevoegen aan playlist',
-
     addSelected: 'Geselecteerde toevoegen',
-
     cacheOffline: 'Playlist offline opslaan',
-
     offlineCached: 'Playlist gecached',
-
     removeOffline: 'Verwijder uit offline cache',
-
     offlineDownloading: 'Cachen… ({{done}}/{{total}} albums)',
-
     publicLabel: 'Openbaar',
-
     privateLabel: 'Privé',
-
     editMeta: 'Playlist bewerken',
-
     editNamePlaceholder: 'Playlistnaam…',
-
     editCommentPlaceholder: 'Beschrijving toevoegen…',
-
     editPublic: 'Openbare playlist',
-
     editSave: 'Opslaan',
-
     editCancel: 'Annuleren',
-
     changeCover: 'Omslagafbeelding wijzigen',
-
     changeCoverLabel: 'Foto wijzigen',
-
     removeCover: 'Foto verwijderen',
-
     coverUpdated: 'Omslag bijgewerkt',
-
     metaSaved: 'Playlist bijgewerkt',
-
     downloadZip: 'Downloaden (ZIP)',
-
     // Toast notifications for multi-select
-
     addSuccess: '{{count}} nummers toegevoegd aan {{playlist}}',
-
     addPartial: '{{added}} toegevoegd, {{skipped}} overgeslagen (duplicaten)',
-
     addAllSkipped: 'Alles overgeslagen ({{count}} duplicaten)',
-
     addError: 'Fout bij toevoegen van nummers',
-
     createAndAddSuccess: 'Playlist "{{playlist}}" aangemaakt met {{count}} nummers',
-
     createError: 'Fout bij aanmaken van playlist',
-
     deleteSuccess: '{{count}} playlists verwijderd',
-
     deleteFailed: 'Fout bij verwijderen van {{name}}',
-
     deleteSelected: 'Geselecteerde verwijderen',
-
     mergeSuccess: '{{count}} nummers samengevoegd in {{playlist}}',
-
     mergeNoNewSongs: 'Geen nieuwe nummers om toe te voegen',
-
     mergeError: 'Fout bij samenvoegen van playlists',
-
     mergeInto: 'Samenvoegen in',
-
     selectionCount: '{{count}} geselecteerd',
-
     select: 'Selecteren',
-
     startSelect: 'Selectie inschakelen',
-
     cancelSelect: 'Annuleren',
-
     loadingAlbums: '{{count}} albums oplossen…',
-
     loadingArtists: '{{count}} artiesten oplossen…',
-
     myPlaylists: 'Mijn playlists',
-
     noOtherPlaylists: 'Geen andere playlists beschikbaar',
-
     addToPlaylistSuccess: '{{count}} nummers toegevoegd aan {{playlist}}',
-
     addToPlaylistNoNew: 'Geen nieuwe nummers voor {{playlist}}',
-
     addToPlaylistError: 'Fout bij toevoegen aan playlist',
-
     removeSuccess: 'Nummer verwijderd van playlist',
-
     removeError: 'Fout bij verwijderen uit playlist',
-
     importCSV: 'CSV Importeren',
-
     importCSVTooltip: 'Importeren vanuit Spotify CSV',
-
     csvImportReport: 'CSV-importrapport',
-
     csvImportTotal: 'Totaal',
-
     csvImportAdded: 'Toegevoegd',
-
     csvImportDuplicates: 'Duplicaten',
-
     csvImportNotFound: 'Niet Gevonden',
-
     csvImportNetworkErrors: 'Netwerkfouten',
-
     csvImportDuplicatesTitle: 'Dubbele nummers (al in playlist):',
-
     csvImportNotFoundTitle: 'Niet gevonden nummers:',
-
     csvImportNetworkErrorsTitle: 'Netwerkfouten (import kan opnieuw proberen):',
-
     csvImportDownloadReport: 'Rapport downloaden',
-
     csvImportClose: 'Sluiten',
-
     csvImportNoValidTracks: 'Geen geldige nummers gevonden in CSV-bestand',
-
     csvImportFailed: 'CSV-import mislukt',
-
     csvImportToast: '{{added}} toegevoegd, {{notFound}} niet gevonden, {{duplicates}} duplicaten',
-
   },
-
   mostPlayed: {
-
     title: 'Meest gespeeld',
-
     topArtists: 'Topkunstenaars',
-
     topAlbums: 'Topalbums',
-
     plays: '{{n}} keer gespeeld',
-
     sortMost: 'Meest gespeeld eerst',
-
     sortLeast: 'Minst gespeeld eerst',
-
     loadMore: 'Meer albums laden',
-
     noData: 'Nog geen afspeelgegevens. Begin met luisteren!',
-
     noArtists: 'Alle artiesten gefilterd.',
-
     filterCompilations: 'Compilatie-artiesten verbergen (Various Artists, Soundtracks, etc.)',
-
     filterCompilationsShort: 'Compilaties verbergen',
-
   },
-
   radio: {
-
     title: 'Internetradio',
-
     empty: 'Geen radiostations geconfigureerd.',
-
     addStation: 'Station toevoegen',
-
     editStation: 'Bewerken',
-
     deleteStation: 'Station verwijderen',
-
     confirmDelete: 'Klik opnieuw om te bevestigen',
-
     stationName: 'Stationsnaam…',
-
     streamUrl: 'Stream-URL…',
-
     homepageUrl: 'Homepage-URL (optioneel)',
-
     save: 'Opslaan',
-
     cancel: 'Annuleren',
-
     live: 'LIVE',
-
     liveStream: 'Internetradio',
-
     openHomepage: 'Homepage openen',
-
     changeCoverLabel: 'Cover wijzigen',
-
     removeCover: 'Cover verwijderen',
-
     browseDirectory: 'Gids doorzoeken',
-
     directoryPlaceholder: 'Stations zoeken…',
-
     noResults: 'Geen stations gevonden.',
-
     stationAdded: 'Station toegevoegd',
-
     filterAll: 'Alle',
-
     filterFavorites: 'Favorieten',
-
     sortManual: 'Handmatig',
-
     sortAZ: 'A → Z',
-
     sortZA: 'Z → A',
-
     sortNewest: 'Nieuwste',
-
     favorite: 'Toevoegen aan favorieten',
-
     unfavorite: 'Verwijderen uit favorieten',
-
     noFavorites: 'Geen favoriete stations.',
-
     listenerCount_one: '{{count}} luisteraar',
-
     listenerCount_other: '{{count}} luisteraars',
-
     recentlyPlayed: 'Recent gespeeld',
-
     upNext: 'Volgende',
-
   },
-
   folderBrowser: {
-
     empty: 'Lege map',
-
     error: 'Laden mislukt',
-
   },
-
   deviceSync: {
-
     title: 'Apparaatsync',
-
     targetFolder: 'Doelmap',
-
     noFolderChosen: 'Geen map gekozen',
-
     selectDrive: 'Selecteer een schijf…',
-
     refreshDrives: 'Schijven vernieuwen',
-
     noDrivesDetected: 'Geen verwijderbare schijven gedetecteerd',
-
     browseManual: 'Handmatig bladeren…',
-
     free: 'vrij',
-
     notMountedVolume: 'Het doel bevindt zich niet op een gekoppeld volume. De schijf is mogelijk losgekoppeld.',
-
     chooseFolder: 'Kiezen…',
-
     filenameTemplate: 'Bestandsnaamsjabloon',
-
     targetDevice: 'Doelapparaat',
-
     templateHint: 'Variabelen: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
-
     cleanupButton: 'Niet-geselecteerde bestanden verwijderen',
-
     cleanupNothingToDelete: 'Niets te verwijderen — apparaat is al gesynchroniseerd.',
-
     confirmCleanup: '{{count}} bestand(en) verwijderen van het apparaat die niet in de huidige selectie staan. Doorgaan?',
-
     cleanupComplete: '{{count}} bestand(en) van het apparaat verwijderd.',
-
     selectedSources: 'Geselecteerde bronnen',
-
     noSourcesSelected: 'Geen bronnen geselecteerd. Klik op items in de browser om ze toe te voegen.',
-
     clearAll: 'Alles wissen',
-
     tabPlaylists: 'Afspeellijsten',
-
     tabAlbums: 'Albums',
-
     tabArtists: 'Artiesten',
-
     searchPlaceholder: 'Zoeken…',
-
     syncButton: 'Synchroniseren naar apparaat',
-
     actionTransfer: 'Overdragen naar apparaat',
-
     actionDelete: 'Verwijderen van apparaat',
-
     actionApplyAll: 'Alle wijzigingen toepassen',
-
     templatePreview: 'Voorbeeld',
-
+    templatePresetStandard: 'Standaard',
+    templatePresetMultiDisc: 'Multi-Disc',
+    templatePresetAltFolder: 'Alt. map',
+    tokenSlashHint: '/ = mapscheidingsteken',
     cancel: 'Annuleren',
-
     noTargetDir: 'Kies eerst een doelmap.',
-
     noSources: 'Selecteer minimaal één bron.',
-
     noTracks: 'Geen nummers gevonden in de geselecteerde bronnen.',
-
     fetchError: 'Ophalen van nummers van de server mislukt.',
-
     syncComplete: 'Synchronisatie voltooid.',
-
     dismiss: 'Sluiten',
-
+    cancelSync: 'Annuleren',
+    syncCancelled: 'Synchronisatie geannuleerd ({{done}} / {{total}} overgebracht).',
     colName: 'Naam',
-
     colType: 'Type',
-
     colStatus: 'Status',
-
     onDevice: 'Apparaatbeheer',
-
     addSources: 'Toevoegen…',
-
     syncResult: '{{done}} overgedragen, {{skipped}} al up-to-date ({{total}} totaal)',
-
     deleteFromDevice: 'Markeren voor verwijdering ({{count}})',
-
     confirmDelete: '{{count}} item(s) van het apparaat verwijderen: {{names}}?',
-
     deleteComplete: '{{count}} item(s) van het apparaat verwijderd.',
-
+    manifestImported: '{{count}} bron(nen) geïmporteerd uit apparaatmanifest.',
     statusSynced: 'Gesynchroniseerd',
-
     statusPending: 'In behandeling',
-
     statusDeletion: 'Verwijdering',
-
     markForDeletion: 'Markeren voor verwijdering',
-
     removeSource: 'Verwijderen',
-
     undoDeletion: 'Verwijdering ongedaan maken',
-
     syncInBackground: 'Sync gestart op achtergrond — u kunt navigeren.',
-
     syncInProgress: '{{done}} / {{total}} nummers…',
-
     syncSummary: 'Synchronisatieoverzicht',
-
     calculating: 'Vereiste payload berekenen…',
-
     filesToAdd: 'Te toevoegen bestanden:',
-
     filesToDelete: 'Te verwijderen bestanden:',
-
     netChange: 'Nettoverandering:',
-
     availableSpace: 'Beschikbare schijfruimte:',
-
     spaceWarning: 'Waarschuwing: Het doelapparaat heeft niet genoeg gerapporteerde ruimte.',
-
     proceed: 'Doorgaan met synchronisatie',
-
     notEnoughSpace: 'Onvoldoende fysieke schijfruimte gedetecteerd!',
-
     liveSearch: 'Live',
-
     randomAlbumsLabel: 'Willekeurige albums',
-
   },
-
 };
-

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -1,1222 +1,2382 @@
 /** Russian UI strings — natural phrasing for a music desktop app */
+
 export const ruTranslation = {
+
   sidebar: {
+
     library: 'Медиатека',
+
     mainstage: 'Для вас',
+
     newReleases: 'Новинки',
+
     allAlbums: 'Все альбомы',
+
     randomAlbums: 'Случайные альбомы',
+
     randomPicker: 'Собрать микс',
+
     artists: 'Исполнители',
+
     randomMix: 'Случайный микс',
+
     favorites: 'Избранное',
+
     nowPlaying: 'Сейчас играет',
+
     system: 'Система',
+
     statistics: 'Статистика',
+
     settings: 'Настройки',
+
     help: 'Справка',
+
     expand: 'Развернуть боковую панель',
+
     collapse: 'Свернуть боковую панель',
+
     downloadingTracks: 'Кэширование {{n}} треков…',
+
     syncingTracks: 'Синхронизация {{done}}/{{total}}…',
+
     cancelDownload: 'Отменить загрузку',
+
     offlineLibrary: 'Офлайн-библиотека',
+
     genres: 'Жанры',
+
     playlists: 'Плейлисты',
+
     mostPlayed: 'Популярное',
+
     radio: 'Онлайн-радио',
+
     folderBrowser: 'Браузер папок',
+
     deviceSync: 'Синхронизация устройства',
+
     libraryScope: 'Область медиатеки',
+
     allLibraries: 'Все библиотеки',
+
     expandPlaylists: 'Развернуть плейлисты',
+
     collapsePlaylists: 'Свернуть плейлисты',
+
   },
+
   home: {
+
     hero: 'Подборка',
+
     starred: 'Личное избранное',
+
     recent: 'Недавно добавлено',
+
     mostPlayed: 'Популярное',
+
     recentlyPlayed: 'Недавно проиграно',
+
     discover: 'Обзор',
+
     loadMore: 'Ещё',
+
     discoverMore: 'Смотреть ещё',
+
     discoverArtists: 'Исполнители',
+
     discoverArtistsMore: 'Все исполнители',
+
   },
+
   hero: {
+
     eyebrow: 'Альбом дня',
+
     playAlbum: 'Воспроизвести альбом',
+
     enqueue: 'В очередь',
+
     enqueueTooltip: 'Добавить весь альбом в очередь',
+
   },
+
   search: {
+
     placeholder: 'Исполнитель, альбом или трек…',
+
     noResults: 'Ничего не найдено по запросу «{{query}}»',
+
     artists: 'Исполнители',
+
     albums: 'Альбомы',
+
     songs: 'Треки',
+
     clearLabel: 'Очистить поиск',
+
     title: 'Поиск',
+
     resultsFor: 'Результаты по «{{query}}»',
+
     album: 'Альбом',
+
     advanced: 'Расширенный поиск',
+
     advancedSearchTerm: 'Поисковый запрос',
+
     advancedSearchPlaceholder: 'Название, альбом, исполнитель…',
+
     advancedGenre: 'Жанр',
+
     advancedAllGenres: 'Все жанры',
+
     advancedYear: 'Год',
+
     advancedYearFrom: 'от',
+
     advancedYearTo: 'до',
+
     advancedAll: 'Все',
+
     advancedSearch: 'Найти',
+
     advancedEmpty: 'Введите запрос или выберите фильтр.',
+
     advancedNoResults: 'Ничего не найдено.',
+
     advancedGenreNote: 'Треки выбираются случайно в рамках жанра.',
+
     recentSearches: 'Недавние запросы',
+
     browse: 'Обзор',
+
     emptyHint: 'Что хочешь послушать?',
+
     genres: 'Жанры',
+
   },
+
   nowPlaying: {
+
     tooltip: 'Кто сейчас слушает?',
+
     title: 'Кто сейчас слушает?',
+
     loading: 'Загрузка…',
+
     nobody: 'Сейчас никто не слушает.',
+
     minutesAgo: '{{n}} мин назад',
+
     nothingPlaying: 'Пока ничего не играет — включите трек.',
+
     aboutArtist: 'Об исполнителе',
+
     fromAlbum: 'Из этого альбома',
+
     viewAlbum: 'Просмотр альбома',
+
     goToArtist: 'Перейти к исполнителю',
+
     readMore: 'Читать далее',
+
     showLess: 'Свернуть',
+
     genreInfo: 'Жанр',
+
     trackInfo: 'О треке',
+
   },
+
   contextMenu: {
+
     playNow: 'Играть сейчас',
+
     playNext: 'Играть следующим',
+
     addToQueue: 'В конец очереди',
+
     enqueueAlbum: 'Альбом в очередь',
+
     startRadio: 'Радио по похожим',
+
     instantMix: 'Instant Mix',
+
     instantMixFailed: 'Не удалось собрать Instant Mix — ошибка сервера или плагина.',
+
     cliMixNeedsTrack: 'Ничего не играет — сначала начните воспроизведение, затем снова выполните команду микса.',
+
     lfmLove: 'Любимое на Last.fm',
+
     lfmUnlove: 'Убрать с Last.fm',
+
     favorite: 'В избранное',
+
     favoriteArtist: 'Исполнитель в избранное',
+
     favoriteAlbum: 'Альбом в избранное',
+
     unfavorite: 'Убрать из избранного',
+
     unfavoriteArtist: 'Убрать исполнителя из избранного',
+
     unfavoriteAlbum: 'Убрать альбом из избранного',
+
     removeFromQueue: 'Убрать из очереди',
+
     removeFromPlaylist: 'Убрать из плейлиста',
+
     openAlbum: 'Открыть альбом',
+
     goToArtist: 'К исполнителю',
+
     download: 'Скачать (ZIP)',
+
     addToPlaylist: 'В плейлист',
+
     selectedPlaylists: '{{count}} плейлистов выбрано',
+
     selectedAlbums: '{{count}} альбомов выбрано',
+
     selectedArtists: '{{count}} исполнителей выбрано',
+
     songInfo: 'Сведения о треке',
+
   },
+
   albumDetail: {
+
     back: 'Назад',
+
     playAll: 'Воспроизвести всё',
+
     enqueue: 'В очередь',
+
     enqueueTooltip: 'Добавить весь альбом в очередь',
+
     artistBio: 'Биография',
+
     download: 'Скачать (ZIP)',
+
     downloading: 'Загрузка…',
+
     cacheOffline: 'Сохранить офлайн',
+
     offlineCached: 'Доступно офлайн',
+
     offlineDownloading: 'Кэширование… ({{n}} из {{total}})',
+
     removeOffline: 'Удалить офлайн-копию',
+
     offlineStorageFull:
+
       'Место для офлайн закончилось (лимит {{mb}} МБ). Освободите место в офлайн-библиотеке или увеличьте лимит в настройках.',
+
     offlineStorageGoToLibrary: 'Офлайн-библиотека',
+
     offlineStorageGoToSettings: 'Настройки',
+
     favoriteAdd: 'В избранное',
+
     favoriteRemove: 'Убрать из избранного',
+
     favorite: 'Избранное',
+
     noBio: 'Биография недоступна.',
+
     moreByArtist: 'Ещё от {{artist}}',
+
     tracksCount: 'Композиций: {{n}}',
+
     goToArtist: 'Перейти к {{artist}}',
+
     moreLabelAlbums: 'Другие альбомы на {{label}}',
+
     trackTitle: 'Название',
+
     trackAlbum: 'Альбом',
+
     trackArtist: 'Исполнитель',
+
     trackGenre: 'Жанр',
+
     trackFormat: 'Формат',
+
     trackFavorite: 'Избранное',
+
     trackRating: 'Оценка',
+
     trackDuration: 'Длительность',
+
     trackTotal: 'Итого',
+
     columns: 'Колонки',
-    resetColumns: 'Сбросить',
+
     notFound: 'Альбом не найден.',
+
     bioModal: 'Биография исполнителя',
+
     bioClose: 'Закрыть',
+
     ratingLabel: 'Оценка',
+
     enlargeCover: 'Увеличить обложку',
+
     filterSongs: 'Фильтр треков…',
+
     sortNatural: 'По умолчанию',
+
     sortByTitle: 'А–Я (название)',
+
     sortByArtist: 'А–Я (исполнитель)',
+
     sortByAlbum: 'А–Я (альбом)',
+
   },
+
   entityRating: {
+
     albumShort: 'Оценка альбома',
+
     artistShort: 'Оценка исполнителя',
+
     albumAriaLabel: 'Оценка альбома',
+
     artistAriaLabel: 'Оценка исполнителя',
+
     saveFailed: 'Не удалось сохранить оценку.',
+
   },
+
   artistDetail: {
+
     back: 'Назад',
+
     albums: 'Альбомы',
+
     album: 'Альбом',
+
     playAll: 'Воспроизвести всё',
+
     shuffle: 'Перемешать',
+
     radio: 'Радио',
+
     loading: 'Загрузка…',
+
     noRadio: 'Похожие треки для этого исполнителя не найдены.',
+
     notFound: 'Исполнитель не найден.',
+
     albumsBy: 'Альбомы — {{name}}',
+
     topTracks: 'Популярные треки',
+
     noAlbums: 'Альбомов нет.',
+
     trackTitle: 'Название',
+
     trackAlbum: 'Альбом',
+
     trackDuration: 'Длительность',
+
     favoriteAdd: 'В избранное',
+
     favoriteRemove: 'Убрать из избранного',
+
     favorite: 'Избранное',
+
     albumCount_one: '{{count}} альбом',
+
     albumCount_few: '{{count}} альбома',
+
     albumCount_many: '{{count}} альбомов',
+
     albumCount_other: '{{count}} альбомов',
+
     openedInBrowser: 'Открыто в браузере',
+
     featuredOn: 'Также участвует в',
+
     similarArtists: 'Похожие исполнители',
+
     cacheOffline: 'Сохранить дискографию офлайн',
+
     offlineCached: 'Дискография сохранена',
+
     offlineDownloading: 'Кэширование… ({{done}} из {{total}} альбомов)',
+
     uploadImage: 'Загрузить фото исполнителя',
+
     uploadImageError: 'Не удалось загрузить изображение',
+
   },
+
   favorites: {
+
     title: 'Избранное',
+
     empty: 'Пока ничего не отмечено звёздочкой.',
+
     artists: 'Исполнители',
+
     albums: 'Альбомы',
+
     songs: 'Треки',
+
     enqueueAll: 'Всё в очередь',
+
     playAll: 'Воспроизвести всё',
+
     removeSong: 'Убрать из избранного',
+
     stations: 'Радиостанции',
+
     showingFiltered: 'Показано {{filtered}} из {{total}} ({{artist}})',
+
     showingCount: 'Показано {{filtered}} из {{total}}',
+
     clearArtistFilter: 'Сбросить фильтр исполнителя',
+
     noFilterResults: 'Нет результатов с выбранными фильтрами.',
+
     allArtists: 'Все исполнители',
+
   },
+
   randomLanding: {
+
     title: 'Собрать микс',
+
     mixByTracks: 'Микс по трекам',
+
     mixByTracksDesc: 'Случайная подборка треков со всей медиатеки',
+
     mixByAlbums: 'Микс по альбомам',
+
     mixByAlbumsDesc: 'Случайная подборка альбомов для открытий',
+
   },
+
   randomAlbums: {
+
     title: 'Случайные альбомы',
+
     refresh: 'Обновить',
+
   },
+
   genres: {
+
     title: 'Жанры',
+
     genreCount: 'Жанры',
+
     albumCount_one: '{{count}} альбом',
+
     albumCount_few: '{{count}} альбома',
+
     albumCount_many: '{{count}} альбомов',
+
     albumCount_other: '{{count}} альбомов',
+
     loading: 'Загрузка жанров…',
+
     empty: 'Жанры не найдены.',
+
     albumsLoading: 'Загрузка альбомов…',
+
     albumsEmpty: 'В этом жанре альбомов нет.',
+
     loadMore: 'Ещё',
+
     back: 'Назад',
+
   },
+
   randomMix: {
+
     title: 'Случайный микс',
+
     remix: 'Новый микс',
+
     remixTooltip: 'Подобрать другие случайные треки',
+
     remixGenre: 'Новый микс: {{genre}}',
+
     remixTooltipGenre: 'Подобрать другие треки жанра {{genre}}',
+
     playAll: 'Воспроизвести всё',
+
     trackTitle: 'Название',
+
     trackArtist: 'Исполнитель',
+
     trackAlbum: 'Альбом',
+
     trackFavorite: 'Избранное',
+
     trackDuration: 'Длительность',
+
     favoriteAdd: 'В избранное',
+
     favoriteRemove: 'Убрать из избранного',
+
     play: 'Играть',
+
     trackGenre: 'Жанр',
+
     excludeAudiobooks: 'Исключать аудиокниги и радиоспектакли',
+
     excludeAudiobooksDesc:
+
       'По ключевым словам в жанре, названии, альбоме и исполнителе — например Hörbuch, Audiobook, Spoken Word и т. п.',
+
     genreBlocked: 'Слово отфильтровано',
+
     genreAddedToBlacklist: 'Добавлено в список фильтра',
+
     genreAlreadyBlocked: 'Уже в списке',
+
     artistBlocked: 'Исполнитель отфильтрован',
+
     artistAddedToBlacklist: 'Исполнитель добавлен в фильтр',
+
     artistClickHint: 'Нажмите, чтобы скрыть этого исполнителя',
+
     blacklistToggle: 'Фильтр по словам',
+
     genreMixTitle: 'Микс по жанру',
+
     genreMixDesc: 'Топ-20 жанров по числу треков — нажмите, чтобы собрать микс',
+
     genreMixAll: 'Все треки',
+
     genreMixLoadMore: 'Ещё 10 жанров',
+
     genreMixNoGenres: 'На сервере нет данных о жанрах.',
+
     shuffleGenres: 'Другие жанры',
+
     filterPanelTitle: 'Фильтры',
+
     filterPanelDesc:
+
       'Нажмите на тег жанра или имя исполнителя в списке ниже, чтобы исключить их из будущих миксов.',
+
     genreClickHint:
+
       'Нажмите на тег жанра — слово попадёт в фильтр.\nУчитываются жанр, название, альбом и исполнитель.',
+
   },
+
   albums: {
+
     title: 'Все альбомы',
+
     sortByName: 'А–Я (альбом)',
+
     sortByArtist: 'А–Я (исполнитель)',
+
     sortNewest: 'Сначала новые',
+
     sortRandom: 'Случайно',
+
     yearFrom: 'С',
+
     yearTo: 'По',
+
     yearFilterClear: 'Сбросить год',
+
     yearFilterLabel: 'Год',
+
     select: 'Множественный выбор',
+
     startSelect: 'Включить множественный выбор',
+
     cancelSelect: 'Отмена',
+
     selectionCount: '{{count}} выбрано',
+
     downloadZips: 'Скачать ZIP-архивы',
+
     addOffline: 'Добавить офлайн',
+
     downloadingZip: 'Загрузка {{current}}/{{total}}: {{name}}',
+
     downloadZipDone: '{{count}} ZIP-архив(ов) загружено',
+
     downloadZipFailed: 'Не удалось скачать {{name}}',
+
     offlineQueuing: 'Добавление {{count}} альбом(ов) в офлайн…',
+
     offlineFailed: 'Не удалось добавить {{name}} офлайн',
+
   },
+
   artists: {
+
     title: 'Исполнители',
+
     search: 'Поиск…',
+
     all: 'Все',
+
     gridView: 'Сетка',
+
     listView: 'Список',
+
     imagesOn: 'Фото исполнителей — больше трафика и нагрузка на систему',
+
     imagesOff: 'Только инициалы — экономнее по трафику',
+
     loadMore: 'Ещё',
+
     notFound: 'Исполнители не найдены.',
+
     albumCount_one: '{{count}} альбом',
+
     albumCount_few: '{{count}} альбома',
+
     albumCount_many: '{{count}} альбомов',
+
     albumCount_other: '{{count}} альбомов',
+
     selectionCount: '{{count}} выбрано',
+
     select: 'Множественный выбор',
+
     startSelect: 'Включить множественный выбор',
+
     cancelSelect: 'Отмена',
+
     addToPlaylist: 'В плейлист',
+
   },
+
   login: {
+
     subtitle: 'Десктопный клиент для Navidrome',
+
     serverName: 'Название сервера (необязательно)',
+
     serverNamePlaceholder: 'Мой Navidrome',
+
     serverUrl: 'Адрес сервера',
+
     serverUrlPlaceholder: '192.168.1.100:4533 или https://music.example.com',
+
     username: 'Логин',
+
     usernamePlaceholder: 'admin',
+
     password: 'Пароль',
+
     showPassword: 'Показать пароль',
+
     hidePassword: 'Скрыть пароль',
+
     connect: 'Подключиться',
+
     connecting: 'Подключение…',
+
     connected: 'Готово!',
+
     error: 'Не удалось подключиться — проверьте данные.',
+
     urlRequired: 'Укажите адрес сервера.',
+
     savedServers: 'Сохранённые серверы',
+
     addNew: 'Или добавить новый сервер',
+
   },
+
   connection: {
+
     connected: 'Подключено',
+
     connectedTo: 'Сервер: {{server}}',
+
     disconnected: 'Нет связи',
+
     disconnectedFrom: 'Сервер {{server}} недоступен — нажмите для настроек',
+
     checking: 'Подключение…',
+
     extern: 'Внешний',
+
     offlineTitle: 'Нет связи с сервером',
+
     offlineSubtitle: 'Сервер {{server}} недоступен. Проверьте сеть и адрес.',
+
     offlineModeBanner: 'Офлайн — воспроизведение из локального кэша',
+
     offlineNoCacheBanner: 'Нет соединения с сервером — {{server}} недоступен',
+
     offlineLibraryTitle: 'Офлайн-библиотека',
+
     offlineLibraryEmpty:
+
       'Пока ничего не сохранено. Подключитесь к сети, откройте альбом и нажмите «Сохранить офлайн».',
+
     offlineAlbumCount_one: '{{n}} альбом',
+
     offlineAlbumCount_few: '{{n}} альбома',
+
     offlineAlbumCount_many: '{{n}} альбомов',
+
     offlineAlbumCount_other: '{{n}} альбомов',
+
     offlineFilterAll: 'Всё',
+
     offlineFilterAlbums: 'Альбомы',
+
     offlineFilterPlaylists: 'Плейлисты',
+
     offlineFilterArtists: 'Дискографии',
+
     retry: 'Повторить',
+
     serverSettings: 'Настройки сервера',
+
     switchServerTitle: 'Сменить сервер',
+
     switchServerHint: 'Нажмите, чтобы выбрать другой сохранённый сервер.',
+
     manageServers: 'Управление серверами…',
+
     switchFailed: 'Не удалось переключиться — сервер недоступен.',
+
     lastfmConnected: 'Last.fm: @{{user}}',
+
     lastfmSessionInvalid: 'Сессия недействительна — подключите снова',
+
   },
+
   common: {
+
     albums: 'Альбомы',
+
     album: 'Альбом',
+
     loading: 'Загрузка…',
+
     loadingMore: 'Загрузка…',
+
     loadingPlaylists: 'Загрузка плейлистов…',
+
     noAlbums: 'Альбомов нет.',
+
     downloading: 'Скачивание…',
+
     downloadZip: 'Скачать (ZIP)',
+
     back: 'Назад',
+
     cancel: 'Отмена',
+
     save: 'Сохранить',
+
     delete: 'Удалить',
+
     use: 'Использовать',
+
     add: 'Добавить',
+
     active: 'Активен',
+
     download: 'Скачать',
+
     chooseDownloadFolder: 'Выбрать папку',
+
     noFolderSelected: 'Папка не выбрана',
+
     rememberDownloadFolder: 'Запомнить папку',
+
     filterGenre: 'Фильтр по жанру',
+
     filterSearchGenres: 'Поиск жанров…',
+
     filterNoGenres: 'Нет совпадений',
+
     filterClear: 'Сбросить',
+
     play: 'Воспроизвести',
+
     bulkSelected: 'Выбрано: {{count}}',
+
     clearSelection: 'Сбросить выбор',
+
     bulkAddToPlaylist: 'В плейлист',
+
     bulkRemoveFromPlaylist: 'Убрать из плейлиста',
+
     bulkClear: 'Снять выделение',
+
     updaterAvailable: 'Доступно обновление',
+
     updaterVersion: 'Версия {{version}} доступна',
+
     updaterWebsite: 'Сайт',
+
     updaterModalTitle: 'Доступна новая версия',
+
     updaterChangelog: 'Что нового',
+
     updaterDownloadBtn: 'Скачать сейчас',
+
     updaterSkipBtn: 'Пропустить эту версию',
+
     updaterRemindBtn: 'Напомнить позже',
+
     updaterDone: 'Загрузка завершена',
+
     updaterShowFolder: 'Показать в папке',
+
     updaterInstallHint: 'Закройте Psysonic и запустите установщик вручную.',
+
     updaterAurHint: 'Установить обновление через AUR:',
+
     updaterErrorMsg: 'Ошибка загрузки',
+
     updaterRetryBtn: 'Повторить',
+
     durationHoursMinutes: '{{hours}}ч {{minutes}}мин',
+
     durationMinutesOnly: '{{minutes}}мин',
+
     updaterOpenGitHub: 'Открыть на GitHub',
+
     filters: 'Фильтры',
+
     more: 'еще',
+
     yearRange: 'Диапазон лет',
+
     clearAll: 'Очистить всё',
+
   },
+
   settings: {
+
     title: 'Настройки',
+
     language: 'Язык',
+
     languageEn: 'Английский',
+
     languageDe: 'Немецкий',
+
     languageFr: 'Французский',
+
     languageNl: 'Нидерландский',
+
     languageZh: 'Китайский',
+
     languageNb: 'Норвежский',
+
     languageRu: 'Русский',
+
     languageRu2: 'Русский 2',
+
     font: 'Шрифт',
+
     theme: 'Тема',
+
     appearance: 'Оформление',
+
     servers: 'Серверы',
+
     serverName: 'Название',
+
     serverUrl: 'Адрес',
+
     serverUrlPlaceholder: '192.168.1.100:4533 или https://music.example.com',
+
     serverUsername: 'Логин',
+
     serverPassword: 'Пароль',
+
     addServer: 'Добавить сервер',
+
     addServerTitle: 'Новый сервер',
+
     useServer: 'Выбрать',
+
     deleteServer: 'Удалить',
+
     noServers: 'Нет сохранённых серверов.',
+
     serverActive: 'Активен',
+
     confirmDeleteServer: 'Удалить сервер «{{name}}»?',
+
     serverConnecting: 'Подключение…',
+
     serverConnected: 'Подключено!',
+
     serverFailed: 'Ошибка подключения.',
+
     testBtn: 'Проверить',
+
     testingBtn: 'Проверка…',
+
     serverCompatible: 'Совместимость: Navidrome · Gonic · Airsonic · Subsonic',
+
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+
     audiomuseDesc:
+
       'Включите, если на этом сервере настроен <pluginLink>плагин AudioMuse-AI для Navidrome</pluginLink>. Появится Instant Mix для треков, а на странице исполнителя похожие будут браться с сервера вместо Last.fm.',
+
     audiomuseIssueHint:
+
       'Недавно не удалось собрать Instant Mix — проверьте плагин Navidrome и API AudioMuse. Похожие исполнители подтянутся с Last.fm, если сервер ничего не вернёт.',
+
     connected: 'Подключено',
+
     failed: 'Ошибка',
+
     eqTitle: 'Эквалайзер',
+
     eqEnabled: 'Включить эквалайзер',
+
     eqPreset: 'Пресет',
+
     eqPresetCustom: 'Свой',
+
     eqPresetBuiltin: 'Встроенные',
+
     eqPresetCustomGroup: 'Мои пресеты',
+
     eqSavePreset: 'Сохранить как пресет',
+
     eqPresetName: 'Название пресета…',
+
     eqDeletePreset: 'Удалить пресет',
+
     eqResetBands: 'Сбросить полосы',
+
     eqPreGain: 'Предусиление',
+
     eqResetPreGain: 'Сбросить предусиление',
+
     eqAutoEqTitle: 'AutoEQ — поиск профиля наушников',
+
     eqAutoEqPlaceholder: 'Модель наушников или IEM…',
+
     eqAutoEqSearching: 'Поиск…',
+
     eqAutoEqNoResults: 'Ничего не найдено',
+
     eqAutoEqError: 'Ошибка поиска',
+
     eqAutoEqRateLimit: 'Лимит GitHub — попробуйте через минуту',
+
     eqAutoEqFetchError: 'Не удалось загрузить профиль EQ',
+
     lfmTitle: 'Last.fm',
+
     lfmConnect: 'Подключить Last.fm',
+
     lfmConnecting: 'Ожидание авторизации…',
+
     lfmConfirm: 'Я разрешил доступ',
+
     lfmConnected: 'Аккаунт',
+
     lfmDisconnect: 'Отключить',
+
     lfmConnectDesc:
+
       'Привяжите Last.fm для скробблинга и статуса «Сейчас слушаю» прямо из Psysonic — настраивать Navidrome не нужно.',
+
     lfmOpenBrowser: 'Откроется браузер. Разрешите доступ на Last.fm, затем нажмите кнопку ниже.',
+
     lfmScrobbles: 'Скробблов: {{n}}',
+
     lfmMemberSince: 'С {{year}} года',
+
     scrobbleEnabled: 'Скробблинг включён',
+
     scrobbleDesc: 'Отправлять прослушивания на Last.fm после 50% трека',
+
     behavior: 'Поведение',
+
     cacheTitle: 'Макс. размер кэша',
+
     cacheDesc:
+
       'Обложки и фото исполнителей. При переполнении старые записи удаляются. Офлайн-альбомы не трогаются автоматически, но сотрутся при полной очистке кэша.',
+
     cacheUsedImages: 'Изображения:',
+
     cacheUsedOffline: 'Офлайн-треки:',
+
     cacheUsedHot: 'На диске:',
+
     hotCacheTrackCount: 'Треков в кэше:',
+
     cacheMaxLabel: 'Лимит',
+
     cacheClearBtn: 'Очистить кэш',
+
     cacheClearWarning: 'Будут удалены и все офлайн-альбомы.',
+
     cacheClearConfirm: 'Очистить всё',
+
     cacheClearCancel: 'Отмена',
+
     offlineDirTitle: 'Офлайн-библиотека (в приложении)',
+
     offlineDirDesc: 'Папка для треков, сохранённых для офлайн-прослушивания.',
+
     offlineDirDefault: 'По умолчанию (данные приложения)',
+
     offlineDirChange: 'Сменить папку',
+
     offlineDirClear: 'Сбросить по умолчанию',
+
     offlineDirHint: 'Новые загрузки пойдут в выбранную папку. Старые останутся на прежнем месте.',
+
     hotCacheTitle: 'Горячий кэш воспроизведения',
+
     hotCacheAlphaBadge: 'Альфа',
+
     hotCacheDisclaimer: 'Заранее подгружает следующие треки из очереди и сохраняет предыдущие. При включении использует место на диске и сеть.',
+
     hotCacheDirDefault: 'По умолчанию (данные приложения)',
+
     hotCacheDirChange: 'Сменить папку',
+
     hotCacheDirClear: 'Сбросить по умолчанию',
+
     hotCacheDirHint: 'При смене папки сбрасывается список в приложении; уже скачанные файлы остаются на старом пути, пока вы их не удалите.',
+
     hotCacheEnabled: 'Включить горячий кэш воспроизведения',
+
     hotCacheMaxMb: 'Максимальный размер кэша',
+
     hotCacheDebounce: 'Задержка после изменения очереди',
+
     hotCacheDebounceImmediate: 'Сразу',
+
     hotCacheDebounceSeconds: '{{n}} с',
+
     hotCacheClearBtn: 'Очистить горячий кэш',
+
     audioOutputDevice: 'Устройство вывода звука',
+
     audioOutputDeviceDesc: 'Выберите аудиоустройство для воспроизведения. Изменения применяются немедленно и перезапускают текущий трек.',
+
     audioOutputDeviceDefault: 'Системное по умолчанию',
+
     audioOutputDeviceRefresh: 'Обновить список устройств',
+
     audioOutputDeviceOsDefaultNow: 'текущий системный вывод',
+
     audioOutputDeviceListError: 'Не удалось загрузить список аудиоустройств.',
+
     audioOutputDeviceNotInCurrentList: 'нет в текущем списке',
+
     hiResTitle: 'Нативное воспроизведение Hi-Res',
+
     hiResEnabled: 'Включить нативное Hi-Res воспроизведение',
+
     hiResDesc: "По умолчанию вывод ограничен до 44,1 кГц для максимальной стабильности. Включайте только если оборудование и сеть надёжно поддерживают высокие частоты (88,2 кГц+).",
+
     showArtistImages: 'Фото исполнителей',
+
     showArtistImagesDesc:
+
       'Показывать обложки в разделе «Исполнители». По умолчанию выключено — меньше нагрузки на диск и сеть.',
+
     showTrayIcon: 'Иконка в трее',
+
     showTrayIconDesc: 'Показывать Psysonic в области уведомлений / строке меню.',
+
     minimizeToTray: 'Сворачивать в трей',
+
     minimizeToTrayDesc: 'При закрытии окна не выходить из приложения, а оставаться в трее.',
+
     useCustomTitlebar: 'Своя строка заголовка',
+
     useCustomTitlebarDesc:
+
       'Заменить системную строку заголовка встроенной, в стиле темы приложения. Отключите, чтобы использовать родную строку GNOME/GTK и т.д.',
+
     discordRichPresence: 'Статус в Discord',
+
     discordRichPresenceDesc:
+
       'Показывать текущий трек в профиле и статусе Discord. Нужен запущенный клиент Discord.',
+
     discordAppleCovers: 'Загружать обложки через Apple Music для Discord',
+
     discordAppleCoversDesc: 'Отправляет имя исполнителя и альбома в Apple Music API для поиска обложки для профиля Discord. По умолчанию отключено из соображений конфиденциальности.',
+
+    discordTemplates: 'Пользовательские шаблоны текста',
+
+    discordTemplatesDesc: 'Настройте, какая информация отображается в вашем профиле Discord. Переменные: {title}, {artist}, {album}, {paused}',
+
+    discordTemplateDetails: 'Основная строка (details)',
+
+    discordTemplateState: 'Вторичная строка (state)',
+
+    discordTemplateLargeText: 'Подсказка альбома (largeText)',
+
     nowPlayingEnabled: 'Показывать в «Сейчас играет»',
+
     nowPlayingEnabledDesc:
+
       'Отправлять на сервер, что вы сейчас слушаете. Отключите, чтобы не делиться этим.',
+
     lyricsServerFirst: 'Предпочитать тексты с сервера',
+
     lyricsServerFirstDesc: 'Проверять тексты песен, предоставленные сервером (встроенные теги, sidecar-файлы) перед запросом LRCLIB. Отключите, чтобы сначала использовать LRCLIB.',
+
     enableNeteaselyrics: 'Тексты из Netease Cloud Music',
+
     enableNeteaselyricsDesc: 'Использовать Netease Cloud Music как последний источник текстов, когда остальные способы не находят ничего. Лучшее покрытие для азиатской и международной музыки.',
+
     lyricsSourcesTitle: 'Источники текстов',
+
     lyricsSourcesDesc: 'Выберите источники для поиска текстов и их порядок. Перетаскивайте для сортировки. Отключённые источники пропускаются.',
+
     lyricsSourceServer: 'Сервер',
+
     lyricsSourceLrclib: 'LRCLIB',
+
     lyricsSourceNetease: 'Netease Cloud Music',
+
     downloadsTitle: 'Экспорт ZIP и архивов',
+
     downloadsFolderDesc: 'Куда сохранять альбомы в ZIP архиве на диск.',
+
     downloadsDefault: 'Папка «Загрузки» по умолчанию',
+
     pickFolder: 'Выбрать',
+
     pickFolderTitle: 'Папка для загрузок',
+
     clearFolder: 'Сбросить папку',
+
     logout: 'Выйти',
+
     aboutTitle: 'О Psysonic',
+
     aboutDesc:
+
       'Современный десктопный плеер для серверов с протоколом Subsonic (Navidrome, Gonic и др.). На Tauri v2 и нативном аудиодвижке на Rust — лёгкий и быстрый: волновая шкала, синхронные тексты, Last.fm, 10-полосный EQ, кроссфейд, воспроизведение без пауз, Replay Gain, жанры и много тем оформления.',
+
     aboutLicense: 'Лицензия',
+
     aboutLicenseText: 'GNU GPL v3 — свободное использование и изменение на тех же условиях.',
+
     aboutRepo: 'Исходный код на GitHub',
+
     aboutVersion: 'Версия',
+
     aboutBuiltWith: 'Tauri · React · TypeScript · Rust/rodio',
+
     aboutAiCredit: 'При поддержке Claude Code (Anthropic)',
+
     aboutContributorsLabel: 'Участники',
+
     aboutSpecialThanksLabel: 'Особая благодарность',
+
     changelog: 'Список изменений',
+
     showChangelogOnUpdate: 'Показывать «Что нового» после обновления',
+
     showChangelogOnUpdateDesc: 'Автоматически при первом запуске новой версии.',
+
     randomMixTitle: 'Случайный микс',
+
     randomMixBlacklistTitle: 'Свои слова-фильтры',
+
     randomMixBlacklistDesc:
+
       'Треки скрываются, если слово встречается в жанре, названии, альбоме или исполнителе (когда включён фильтр выше).',
+
     randomMixBlacklistPlaceholder: 'Добавить слово…',
+
     randomMixBlacklistAdd: 'Добавить',
+
     randomMixBlacklistEmpty: 'Пока пусто.',
+
     randomMixHardcodedTitle: 'Встроенные слова (при включённом фильтре)',
+
     tabAudio: 'Звук',
+
     tabStorage: 'Хранилище и загрузки',
+
     tabAppearance: 'Внешний вид',
+
     homeCustomizerTitle: 'Главная',
+
     sidebarTitle: 'Боковая панель',
+
     sidebarReset: 'Сбросить порядок',
+
     sidebarDrag: 'Перетащите для порядка',
+
     sidebarFixed: 'Всегда показывать',
-    randomNavSplitTitle: 'Разделить навигацию микса',
-    randomNavSplitDesc: 'Показывать «Случайный микс» и «Случайные альбомы» как отдельные пункты боковой панели вместо хаба «Собрать микс».',
+
     tabInput: 'Ввод',
+
     tabServer: 'Сервер',
+
     tabSystem: 'Система',
+
     tabGeneral: 'Общие',
+
     ratingsSectionTitle: 'Рейтинги',
+
     ratingsSkipStarTitle: 'Скипнуть для 1 звезды',
+
     ratingsSkipStarDesc:
+
       'При N скипов подряд ставить 1★ треку. Только для не оцененных ранее.',
+
     ratingsSkipStarThresholdLabel: 'Скипов',
+
     ratingsMixFilterTitle: 'Фильтрация по рейтингу',
+
     ratingsMixFilterDesc:
+
       'Фильтровать с низким рейтингом в «{{mix}}» и «{{albums}}». Повторный клик по выбранной звезде отключает порог.',
+
     ratingsMixMinSong: 'Песни',
+
     ratingsMixMinAlbum: 'Альбомы',
+
     ratingsMixMinArtist: 'Исполнители',
+
     ratingsMixMinThresholdAria: 'Минимум звёзд: {{label}}',
+
     backupTitle: 'Резервная копия',
+
     backupExport: 'Экспорт настроек',
+
     backupExportDesc:
+
       'Сохраняет настройки, серверы, Last.fm, тему, EQ и горячие клавиши в файл .psybkp. Пароли в открытом виде — храните файл в безопасности.',
+
     backupImport: 'Импорт настроек',
+
     backupImportDesc: 'Восстановить из .psybkp. Приложение перезапустится.',
+
     backupImportConfirm: 'Текущие настройки будут заменены. Продолжить?',
+
     backupSuccess: 'Копия сохранена',
+
     backupImportSuccess: 'Настройки восстановлены — перезапуск…',
+
     backupImportError: 'Файл повреждён или не подходит.',
+
     shortcutsReset: 'Сбросить',
+
     shortcutListening: 'Нажмите клавишу…',
+
     shortcutUnbound: '—',
+
     globalShortcutsTitle: 'Глобальные сочетания',
+
     globalShortcutsNote:
+
       'Работают, когда окно не в фокусе. Нужен модификатор: Ctrl, Alt или Super.',
+
     shortcutClear: 'Сбросить',
+
     shortcutPlayPause: 'Пауза / воспроизведение',
+
     shortcutNext: 'Следующий трек',
+
     shortcutPrev: 'Предыдущий трек',
+
     shortcutVolumeUp: 'Громче',
+
     shortcutVolumeDown: 'Тише',
+
     shortcutSeekForward: 'Вперёд на 10 с',
+
     shortcutSeekBackward: 'Назад на 10 с',
+
     shortcutToggleQueue: 'Показать / скрыть очередь',
+
     shortcutOpenFolderBrowser: 'Открыть {{folderBrowser}}',
+
     shortcutFullscreenPlayer: 'Полноэкранный плеер',
+
     shortcutNativeFullscreen: 'Системный полный экран',
+
     playbackTitle: 'Воспроизведение',
+
     replayGain: 'Replay Gain',
+
     replayGainDesc: 'Выравнивание громкости по метаданным ReplayGain',
+
     replayGainMode: 'Режим',
+
     replayGainTrack: 'По треку',
+
     replayGainAlbum: 'По альбому',
+
     replayGainPreGain: 'Предусиление (файлы с тегами)',
+
     replayGainFallback: 'Резерв (без тегов / радио)',
+
     crossfade: 'Кроссфейд',
+
     crossfadeDesc: 'Плавный переход между треками',
+
     crossfadeSecs: '{{n}} с',
+
     notWithGapless: 'Недоступно при включённом режиме без пауз',
+
     notWithCrossfade: 'Недоступно при включённом кроссфейде',
+
     gapless: 'Без пауз между треками',
+
     gaplessDesc: 'Заранее подгружать следующий трек, чтобы не было тишины',
+
     preloadMode: 'Предзагрузка следующего трека',
+
     preloadModeDesc: 'Когда начинать буферизацию следующего в очереди',
+
     nextTrackBufferingTitle: 'Буферизация следующего трека',
+
     preloadHotCacheMutualExclusive: 'Предзагрузка и Hot Cache выполняют одну функцию — одновременно может быть активна только одна. Включение одной автоматически отключает другую.',
+
     preloadOff: 'Выкл.',
+
     preloadBalanced: 'Умеренно (за 30 с до конца)',
+
     preloadEarly: 'Рано (через 5 с после старта)',
+
     preloadCustom: 'Свой интервал',
+
     preloadCustomSeconds: 'Секунд до конца: {{n}}',
+
     infiniteQueue: 'Бесконечная очередь',
+
     infiniteQueueDesc: 'Подмешивать случайные треки, когда очередь закончится',
+
     experimental: 'Экспериментально',
+
     fsPlayerSection: 'Полноэкранный плеер',
+
     fsShowArtistPortrait: 'Отображать фото артиста',
+
     fsShowArtistPortraitDesc: 'Показывать фото артиста (или обложку альбома) в правой части полноэкранного плеера.',
+
     fsPortraitDim: 'Затемнение фото',
+
     seekbarStyle: 'Стиль прогресс-бара',
+
     seekbarStyleDesc: 'Выбор внешнего вида полосы воспроизведения',
+
     seekbarWaveform: 'Форма волны',
+
     seekbarLinedot: 'Линия и точка',
+
     seekbarBar: 'Полоса',
+
     seekbarThick: 'Толстая полоса',
+
     seekbarSegmented: 'Сегменты',
+
     seekbarNeon: 'Неон',
+
     seekbarPulsewave: 'Пульс-волна',
+
     seekbarParticletrail: 'Частицы',
+
     seekbarLiquidfill: 'Жидкость',
+
     seekbarRetrotape: 'Ретро-лента',
+
     themeSchedulerTitle: 'Расписание тем',
+
     themeSchedulerEnable: 'Включить расписание тем',
+
     themeSchedulerEnableSub: 'Автоматически переключается между двумя темами в зависимости от времени суток',
+
     themeSchedulerDayTheme: 'Дневная тема',
+
     themeSchedulerDayStart: 'День начинается в',
+
     themeSchedulerNightTheme: 'Ночная тема',
+
     themeSchedulerNightStart: 'Ночь начинается в',
+
     themeSchedulerActiveHint: 'Расписание тем активно - темы переключаются автоматически.',
+
     visualOptionsTitle: 'Визуальные Настройки',
+
     coverArtBackground: 'Фон Обложки',
+
     coverArtBackgroundSub: 'Показывать размытую обложку как фон в заголовках альбомов и плейлистов',
+
     playlistCoverPhoto: 'Обложка Плейлиста',
+
     playlistCoverPhotoSub: 'Показывать сетку обложек в детальном виде плейлиста',
+
     showBitrate: 'Показывать Битрейт',
+
     showBitrateSub: 'Отображать битрейт аудио в списках треков',
+
     uiScaleTitle: 'Масштаб интерфейса',
+
     uiScaleLabel: 'Масштаб',
+
   },
+
   changelog: {
+
     modalTitle: 'Что нового',
+
     dontShowAgain: 'Больше не показывать',
+
     close: 'Понятно',
+
   },
+
   help: {
+
     title: 'Справка',
+
     s1: 'С чего начать',
+
     q1: 'Какие серверы подходят?',
+
     a1:
+
       'Любой с API Subsonic: Navidrome, Gonic, Subsonic, Airsonic и др. Для новых проектов чаще всего рекомендуют Navidrome.',
+
     q2: 'Как подключиться?',
+
     a2:
+
       'Настройки → «Добавить сервер»: адрес (например 192.168.1.100:4533), логин и пароль. Соединение проверяется до сохранения — при ошибке профиль не записывается.',
+
     q3: 'Можно несколько серверов?',
+
     a3: 'Да. Добавляйте сколько нужно и переключайтесь. Активен всегда один.',
+
     s2: 'Воспроизведение',
+
     q4: 'Как включить музыку?',
+
     a4:
+
       'Двойной щелчок по треку. На странице альбома или исполнителя — «Воспроизвести всё». Треки можно перетащить в панель очереди.',
+
     q5: 'Какие есть горячие клавиши?',
+
     a5:
+
       'Пробел — пауза/воспроизведение, Esc — закрыть полноэкранный плеер. Медиаклавиши работают на всех платформах; на Linux иногда удобнее кнопки в панели плеера. Свои сочетания — в Настройках.',
+
     q6: 'Что такое очередь?',
+
     a6:
+
       'Список следующих треков. Открывается иконкой справа вверху. Можно перетаскивать порядок, перемешивать и сохранять как плейлист.',
+
     q7: 'Как открыть полноэкранный плеер?',
+
     a7: 'Миниатюра обложки внизу или кнопка разворота рядом. Esc — выход.',
+
     q8: 'Как работает повтор?',
+
     a8: 'Кнопка повтора в панели: выкл. → все → один трек.',
+
     s3: 'Медиатека',
+
     q9: 'Как скачать альбом?',
+
     a9:
+
       'Страница альбома → «Скачать (ZIP)». Сервер сначала собирает архив — для больших альбомов или FLAC это может занять время; прогресс появится, когда начнётся передача файла.',
+
     q10: 'Как добавить в избранное?',
+
     a10: 'Звёздочка у трека или в шапке альбома. Всё избранное — в разделе слева.',
+
     q11: 'Что за карусель на главной?',
+
     a11:
+
       'Случайные альбомы из библиотеки, смена примерно каждые 10 с. Точки — перейти к слайду, клик по баннеру — открыть альбом.',
+
     s4: 'Настройки',
+
     q12: 'Как сменить тему?',
+
     a12: 'Настройки → Тема. Много готовых наборов в нескольких категориях.',
+
     q13: 'Как сменить язык?',
+
     a13:
+
       'Настройки → Язык: английский, немецкий, французский, нидерландский, китайский, норвежский, русский и русский (альтернативный, Русский 2).',
+
     q15: 'Куда сохраняются ZIP?',
+
     a15:
+
       'Настройки → Поведение → папка загрузок. Без выбора используется стандартная папка загрузок браузера/системы.',
+
     s5: 'Скробблинг',
+
     q16: 'Как устроен скробблинг?',
+
     a16:
+
       'Psysonic шлёт прослушивания напрямую на Last.fm — в Navidrome ничего настраивать не нужно. Подключите аккаунт в настройках.',
+
     q17: 'Когда уходит скроббл?',
+
     a17: 'После прослушивания примерно половины трека.',
+
     q22: 'Что за волна внизу?',
+
     a22:
+
       'Волновая шкала вместо ползунка: клик — переход, перетаскивание — перемотка. Пройденный фрагмент подсвечен, дальше — буфер и остаток.',
+
     q24: 'Можно перемешать очередь?',
+
     a24: 'Да. В панели очереди — кнопка перемешивания. Текущий трек остаётся первым.',
+
     q25: 'Ссылки Last.fm и Wikipedia открываются в браузере?',
+
     a25: 'Да, в системном браузере по умолчанию. Кратко показывается подтверждение.',
+
     s7: 'Случайный микс',
+
     q26: 'Что такое случайный микс?',
+
     a26:
+
       'Случайный набор треков из всей библиотеки. Раздел в боковой панели → «Новый микс». Число треков можно задать заранее.',
+
     q27: 'Что за фильтр по словам?',
+
     a27:
+
       'Исключает треки, где в жанре, названии или альбоме есть заданные слова. Аудиокниги отсекаются автоматически. Свои слова — в настройках микса или кликом по тегу жанра в списке.',
+
     q28: 'Что за «супер-микс» по жанру?',
+
     a28:
+
       'Грубая группировка стилей (рок, метал, электроника и т. д.) и микс внутри выбранной группы. Результаты подгружаются по мере запросов.',
+
     s6: 'Если что-то не так',
+
     q18: 'Медленно грузятся обложки.',
+
     a18:
+
       'Первый раз картинки тянутся с сервера и кэшируются на ~30 дней. Медленный диск на сервере даёт задержку только при первом заходе.',
+
     q19: 'Тест соединения не проходит.',
+
     a19:
+
       'Проверьте адрес с портом (http://192.168.1.100:4533), файрвол, для локалки иногда нужен http вместо https. Логин и пароль должны совпадать с сервером.',
+
     q20: 'Нет звука в Linux.',
+
     a20:
+
       'Есть пакеты .deb, .rpm и AUR. Убедитесь, что запущены PipeWire или PulseAudio.',
+
     q21: 'Чёрный экран в Linux.',
+
     a21:
+
       'Часто драйвер GPU / WebKitGTK. Запуск с GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. В официальных пакетах это часто уже задано.',
+
     q29: 'Кроссфейд и воспроизведение без пауз?',
+
     a29:
+
       'Экспериментальные опции в Настройках → Звук. Режим без пауз заранее подгружает следующий трек. Кроссфейд плавно накладывает треки, длина 1–10 с.',
+
     q30: 'Есть тексты песен?',
+
     a30:
+
       'Да. Иконка микрофона в панели плеера — вкладка текстов в очереди. Источник LRCLIB; синхронные строки подсвечиваются по ходу трека.',
+
     q31: 'Можно переназначить клавиши?',
+
     a31: 'Да: Настройки → сочетания в приложении и глобальные (работают в фоне).',
+
     q32: 'Можно сменить шрифт?',
+
     a32: 'Да, в настройках шрифта — набор гарнитур на весь интерфейс.',
+
     s8: 'Офлайн',
+
     q34: 'Что такое офлайн-режим?',
+
     a34:
+
       'Кэш альбомов на устройстве для прослушивания без сервера. Воспроизведение идёт с диска.',
+
     q35: 'Как сохранить альбом офлайн?',
+
     a35:
+
       'Страница альбома → иконка загрузки в шапке. Прогресс на кнопке, после загрузки — индикатор готовности. Список — в офлайн-библиотеке.',
+
     q36: 'Сколько места занимает офлайн?',
+
     a36:
+
       'Лимит задаётся в настройках. При переполнении на странице альбома появится предупреждение; удалить можно из офлайн-библиотеки.',
+
     q37: 'Как ставить оценки трекам, альбомам и исполнителям?',
+
     a37: 'Psysonic поддерживает оценки от 1 до 5 звёзд через OpenSubsonic API (требует Navidrome ≥ 0.53). Треки оцениваются в списке треков альбома или плейлиста, в контекстном меню или прямо в панели плеера. Альбомы — на странице альбома, исполнители — на странице исполнителя.',
+
     q38: 'Можно ли удалить или изменить оценку?',
+
     a38: 'Да. Повторный клик по активной звезде полностью удаляет оценку — второй клик по той же звезде её стирает. Для изменения оценки просто нажмите другую звезду.',
+
     q39: 'Что такое Skip-to-1★ и фильтр по рейтингу?',
+
     a39: 'Skip-to-1★ автоматически присваивает оценку 1 звезда после заданного числа последовательных пропусков. Включается в Настройки → Рейтинги. Там же задаётся минимальный рейтинг для случайных миксов.',
+
     q40: 'Что такое браузер папок?',
+
     a40: 'Браузер папок (боковая панель) позволяет навигировать по музыкальному каталогу сервера в колонках Миллера. Клик по папке открывает содержимое; иконка воспроизведения запускает или добавляет в очередь.',
+
     q41: 'Что такое планировщик тем?',
+
     a41: 'Настройки → Внешний вид → Авто-смена темы: задайте дневную и ночную тему со временем начала. Psysonic переключается автоматически в указанное время.',
+
     q42: 'Можно ли масштабировать интерфейс?',
+
     a42: 'Да. Настройки → Внешний вид → Масштаб интерфейса позволяет масштабировать весь UI от 80 % до 125 %.',
+
     q43: 'Можно ли изменить стиль seekbar?',
+
     a43: 'Да. Настройки → Внешний вид → Стиль seekbar предлагает 10 стилей: Осциллограмма, Линия и точка, Полоса, Толстая полоса, Сегментированная, Неоновое свечение, Пульсовая волна, Частицы, Жидкое заполнение и Ретро кассета.',
+
     q44: 'Что такое AutoEQ?',
+
     a44: '10-полосный эквалайзер в Настройки → Аудио включает поиск AutoEQ. Введите модель наушников — Psysonic автоматически загрузит и применит профиль коррекции.',
+
     q45: 'Что такое Replay Gain?',
+
     a45: 'Replay Gain нормализует громкость, чтобы громкие и тихие альбомы воспроизводились на одинаковом уровне. Включается в Настройки → Аудио → Replay Gain; режим трека или альбома.',
+
     q46: 'Что такое горячий кэш?',
+
     a46: 'Горячий кэш (Alpha, Настройки → Библиотека) предзагружает следующие треки очереди на диск для мгновенного воспроизведения. Psysonic хранит текущий трек и следующие 5, вытесняя старые записи при достижении лимита.',
+
     q47: 'Можно ли кэшировать плейлист для офлайн?',
+
     a47: 'Да. Откройте детали плейлиста и нажмите иконку загрузки. После полного кэширования иконка сменяется на красную корзину; нажмите её, чтобы удалить плейлист из офлайн-кэша.',
-    q48: 'Что такое бесконечная очередь?',
-    a48: 'Когда очередь заканчивается и повтор отключён, Psysonic автоматически добавляет случайные треки, чтобы воспроизведение не прерывалось. Автодобавленные треки отображаются под разделителем «— Добавлено автоматически —».',
-    q49: 'Можно ли управлять Psysonic через командную строку?',
-    a49: 'Да. Примеры: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one. Также: переключение сервера, аудиоустройства, фильтрация библиотеки и поиск. Полная справка: psysonic --player --help.',
-    q50: 'Как управлять плейлистами?',
-    a50: 'Через «Плейлисты» на боковой панели. Создайте новый плейлист кнопкой «Новый плейлист». В детальном представлении перетаскивайте треки для сортировки, удаляйте кнопкой ×, добавляйте через поиск и используйте «Предложения» для умных рекомендаций.',
-    q51: 'Можно ли создать резервную копию настроек?',
-    a51: 'Да. Настройки → Резервная копия и восстановление экспортирует все настройки, профили серверов, темы и горячие клавиши в JSON-файл.',
-    q52: 'Как изменить устройство вывода звука?',
-    a52: 'Настройки → Аудио → Устройство вывода. Psysonic показывает все доступные выходы. Выбор вступает в силу немедленно.',
-    q53: 'Что такое синхронизация с устройством?',
-    a53: 'Device Sync копирует альбомы, плейлисты или исполнителей на USB-накопитель или SD-карту. Откройте через «Device Sync» на боковой панели, выберите папку назначения, источники и нажмите «Передать на устройство».',
-    q54: 'Что такое шаблон имени файла в Device Sync?',
-    a54: 'Шаблон определяет, как треки будут называться и организованы. Используйте предустановки или создайте свой шаблон из токенов: {artist}, {album}, {title}, {track_number}, {disc_number}, {year} и / как разделитель папок.',
-    q55: 'Работает ли Device Sync между разными платформами?',
-    a55: 'Да. Манифест на устройстве содержит использованный шаблон. На другой ОС Psysonic корректно распознаёт уже существующие файлы.',
-    s9: 'Device Sync',
-    q56: 'Что такое интернет-радио?',
-    a56: 'Страница интернет-радио позволяет воспроизводить прямые трансляции в Psysonic. Станции берутся с сервера Navidrome. Воспроизведение использует HTML5-аудио.',
-    q57: 'Какие форматы потоков поддерживает интернет-радио?',
-    a57: 'MP3, AAC, OGG Vorbis и большинство HLS-потоков. MP3 и AAC работают на всех платформах.',
-    s10: 'Интернет-радио',
-    q58: 'Откуда Psysonic берёт тексты песен?',
-    a58: 'Три настраиваемых источника в Настройках → Тексты: сервер Navidrome, LRCLIB и NetEase Cloud Music. Каждый источник можно включить/отключить и приоритизировать перетаскиванием.',
-    q59: 'Есть ли просмотр того, что слушают другие пользователи?',
-    a59: 'Да. Нажмите на иконку трансляции в правом верхнем углу, чтобы увидеть, что слушают другие пользователи на вашем сервере Navidrome, с обновлением каждые 10 секунд.',
+
   },
+
   queue: {
+
     title: 'Очередь',
+
     savePlaylist: 'Сохранить как плейлист',
+
     updatePlaylist: 'Обновить плейлист',
+
     filterPlaylists: 'Фильтр плейлистов…',
+
     playlistName: 'Название плейлиста',
+
     cancel: 'Отмена',
+
     save: 'Сохранить',
+
     loadPlaylist: 'Загрузить плейлист',
+
     loading: 'Загрузка…',
+
     noPlaylists: 'Плейлистов нет.',
+
     load: 'Заменить очередь и играть',
+
     appendToQueue: 'Добавить в очередь',
+
     delete: 'Удалить',
+
     deleteConfirm: 'Удалить плейлист «{{name}}»?',
+
     clear: 'Очистить',
+
     shuffle: 'Перемешать',
+
     gapless: 'Без пауз',
+
     crossfade: 'Кроссфейд',
+
     infiniteQueue: 'Бесконечная очередь',
+
     autoAdded: '— Добавлено автоматически —',
+
     radioAdded: '— Радио —',
+
     hide: 'Скрыть',
+
     close: 'Закрыть',
+
     nextTracks: 'Дальше',
+
     emptyQueue: 'Очередь пуста.',
+
     trackSingular: 'трек',
+
     trackPlural: 'треков',
+
     showRemaining: 'Осталось',
+
     showTotal: 'Всего',
+
   },
+
   statistics: {
+
     title: 'Статистика',
+
     recentlyPlayed: 'Недавно проиграно',
+
     mostPlayed: 'Самые проигранные альбомы',
+
     highestRated: 'С высоким рейтингом',
+
     genreDistribution: 'Жанры (топ-20)',
+
     loadMore: 'Ещё',
+
     statArtists: 'Исполнители',
+
     statArtistsTooltip: 'Только исполнители альбомов — артисты, присутствующие лишь в треках (фичеринг, гость и т. д.) без собственного альбома, не учитываются.',
+
     statAlbums: 'Альбомы',
+
     statSongs: 'Треки',
+
     statGenres: 'Жанры',
+
     statPlaytime: 'Время звучания',
+
     genreInsights: 'По жанрам',
+
     formatDistribution: 'Форматы',
+
     formatSample: 'Выборка {{n}} треков',
+
     computing: 'Считаем…',
+
     genreSongs_one: '{{count}} композиция',
+
     genreSongs_few: '{{count}} композиции',
+
     genreSongs_many: '{{count}} композиций',
+
     genreSongs_other: '{{count}} композиций',
+
     genreAlbums_one: '{{count}} альбом',
+
     genreAlbums_few: '{{count}} альбома',
+
     genreAlbums_many: '{{count}} альбомов',
+
     genreAlbums_other: '{{count}} альбомов',
+
     recentlyAdded: 'Недавно добавлено',
+
     decadeDistribution: 'Альбомы по десятилетиям',
+
     decadeAlbums_one: '{{count}} альбом',
+
     decadeAlbums_few: '{{count}} альбома',
+
     decadeAlbums_many: '{{count}} альбомов',
+
     decadeAlbums_other: '{{count}} альбомов',
+
     decadeUnknown: 'Неизвестно',
+
     lfmTitle: 'Статистика Last.fm',
+
     lfmTopArtists: 'Топ исполнителей',
+
     lfmTopAlbums: 'Топ альбомов',
+
     lfmTopTracks: 'Топ треков',
+
     lfmPlays_one: '{{count}} прослушивание',
+
     lfmPlays_few: '{{count}} прослушивания',
+
     lfmPlays_many: '{{count}} прослушиваний',
+
     lfmPlays_other: '{{count}} прослушиваний',
+
     lfmPeriodOverall: 'За всё время',
+
     lfmPeriod7day: '7 дней',
+
     lfmPeriod1month: 'Месяц',
+
     lfmPeriod3month: '3 месяца',
+
     lfmPeriod6month: '6 месяцев',
+
     lfmPeriod12month: 'Год',
+
     lfmNotConnected: 'Подключите Last.fm в настройках.',
+
     lfmRecentTracks: 'Последние скробблы',
+
     lfmNowPlaying: 'Сейчас играет',
+
     lfmJustNow: 'только что',
+
     lfmMinutesAgo: '{{n}} мин назад',
+
     lfmHoursAgo: '{{n}} ч назад',
+
     lfmDaysAgo: '{{n}} дн. назад',
+
     topRatedSongs: 'Лучшие по рейтингу треки',
+
     topRatedArtists: 'Лучшие по рейтингу исполнители',
+
     noRatedSongs: 'Нет оценённых треков. Ставьте оценки в альбомах или плейлистах.',
+
     noRatedArtists: 'Нет оценённых исполнителей.',
+
   },
+
   player: {
+
     regionLabel: 'Плеер',
+
     openFullscreen: 'Полноэкранный плеер',
+
     fullscreen: 'Полноэкранный режим',
+
     closeFullscreen: 'Выйти из полноэкранного',
+
     closeTooltip: 'Закрыть (Esc)',
+
     noTitle: 'Без названия',
+
     stop: 'Стоп',
+
     prev: 'Предыдущий трек',
+
     play: 'Играть',
+
     pause: 'Пауза',
+
     next: 'Следующий трек',
+
     repeat: 'Повтор',
+
     repeatOff: 'Выкл.',
+
     repeatAll: 'Все',
+
     repeatOne: 'Один',
+
     progress: 'Прогресс',
+
     volume: 'Громкость',
+
     toggleQueue: 'Очередь',
+
     lyrics: 'Текст',
+
     lyricsLoading: 'Загрузка текста…',
+
     lyricsNotFound: 'Текст не найден',
+
     lyricsSourceNetease: 'Источник: Netease',
+
   },
+
   songInfo: {
+
     title: 'О треке',
+
     songTitle: 'Название',
+
     artist: 'Исполнитель',
+
     album: 'Альбом',
+
     albumArtist: 'Альбомный исполнитель',
+
     year: 'Год',
+
     genre: 'Жанр',
+
     duration: 'Длительность',
+
     track: 'Номер',
+
     format: 'Формат',
+
     bitrate: 'Битрейт',
+
     sampleRate: 'Частота',
+
     bitDepth: 'Разрядность',
+
     channels: 'Каналы',
+
     fileSize: 'Размер файла',
+
     path: 'Путь',
+
     replayGainTrack: 'RG по треку',
+
     replayGainAlbum: 'RG по альбому',
+
     replayGainPeak: 'Пик RG',
+
     mono: 'Моно',
+
     stereo: 'Стерео',
+
   },
+
   playlists: {
+
     title: 'Плейлисты',
+
     newPlaylist: 'Новый плейлист',
+
     unnamed: 'Без названия',
+
     createName: 'Название…',
+
     create: 'Создать',
+
     cancel: 'Отмена',
+
     empty: 'Плейлистов пока нет.',
+
     emptyPlaylist: 'Плейлист пуст.',
+
     addFirstSong: 'Добавьте первый трек',
+
     notFound: 'Плейлист не найден.',
+
     songs: 'Треков: {{n}}',
+
     playAll: 'Воспроизвести всё',
+
     shuffle: 'Перемешать',
+
     addToQueue: 'В очередь',
+
     back: 'К списку плейлистов',
+
     deletePlaylist: 'Удалить',
+
     confirmDelete: 'Нажмите ещё раз для подтверждения',
+
     removeSong: 'Убрать из плейлиста',
+
     addSongs: 'Добавить треки',
+
     searchPlaceholder: 'Поиск по библиотеке…',
+
     noResults: 'Ничего не найдено.',
+
     suggestions: 'Рекомендации',
+
     noSuggestions: 'Пока нет рекомендаций.',
+
     titleBadge: 'Плейлист',
+
     refreshSuggestions: 'Обновить подборку',
+
     addSong: 'В плейлист',
+
     addSelected: 'Добавить выбранные',
+
     cacheOffline: 'Сохранить плейлист офлайн',
+
     offlineCached: 'Плейлист сохранён',
+
     removeOffline: 'Удалить из офлайн-кэша',
+
     offlineDownloading: 'Кэширование… ({{done}} из {{total}} альбомов)',
+
     publicLabel: 'Публичный',
+
     privateLabel: 'Личный',
+
     editMeta: 'Изменить плейлист',
+
     editNamePlaceholder: 'Название…',
+
     editCommentPlaceholder: 'Описание…',
+
     editPublic: 'Публичный плейлист',
+
     editSave: 'Сохранить',
+
     editCancel: 'Отмена',
+
     changeCover: 'Сменить обложку',
+
     changeCoverLabel: 'Сменить фото',
+
     removeCover: 'Убрать фото',
+
     coverUpdated: 'Обложка обновлена',
+
     metaSaved: 'Плейлист сохранён',
+
     downloadZip: 'Скачать (ZIP)',
+
     // Toast notifications for multi-select
+
     addSuccess: '{{count}} треков добавлено в {{playlist}}',
+
     addPartial: '{{added}} добавлено, {{skipped}} пропущено (дубликаты)',
+
     addAllSkipped: 'Все пропущены ({{count}} дубликатов)',
+
     addError: 'Ошибка при добавлении треков',
+
     createAndAddSuccess: 'Плейлист "{{playlist}}" создан с {{count}} треками',
+
     createError: 'Ошибка при создании плейлиста',
+
     deleteSuccess: '{{count}} плейлистов удалено',
+
     deleteFailed: 'Ошибка при удалении {{name}}',
+
     deleteSelected: 'Удалить выбранные',
+
     mergeSuccess: '{{count}} треков объединено в {{playlist}}',
+
     mergeNoNewSongs: 'Нет новых треков для добавления',
+
     mergeError: 'Ошибка при объединении плейлистов',
+
     mergeInto: 'Объединить в',
+
     selectionCount: '{{count}} выбрано',
+
     select: 'Выбрать',
+
     startSelect: 'Включить выбор',
+
     cancelSelect: 'Отмена',
+
     loadingAlbums: 'Загрузка {{count}} альбомов…',
+
     loadingArtists: 'Загрузка {{count}} исполнителей…',
+
     myPlaylists: 'Мои плейлисты',
+
     noOtherPlaylists: 'Нет других доступных плейлистов',
+
     addToPlaylistSuccess: '{{count}} треков добавлено в {{playlist}}',
+
     addToPlaylistNoNew: 'Нет новых треков для {{playlist}}',
+
     addToPlaylistError: 'Ошибка при добавлении в плейлист',
+
     removeSuccess: 'Трек убран из плейлиста',
+
     removeError: 'Ошибка при удалении из плейлиста',
+
     importCSV: 'Импорт CSV',
+
     importCSVTooltip: 'Импорт из CSV Spotify',
+
     csvImportReport: 'Отчёт об импорте CSV',
+
     csvImportTotal: 'Всего',
+
     csvImportAdded: 'Добавлено',
+
     csvImportDuplicates: 'Дубликаты',
+
     csvImportNotFound: 'Не найдено',
+
     csvImportNetworkErrors: 'Ошибки сети',
+
     csvImportDuplicatesTitle: 'Дубликаты (уже в плейлисте):',
+
     csvImportNotFoundTitle: 'Не найденные треки:',
+
     csvImportNetworkErrorsTitle: 'Ошибки сети (можно повторить импорт):',
+
     csvImportDownloadReport: 'Скачать отчёт',
+
     csvImportClose: 'Закрыть',
+
     csvImportNoValidTracks: 'В CSV-файле не найдено действительных треков',
+
     csvImportFailed: 'Не удалось импортировать CSV-файл',
+
     csvImportToast: '{{added}} добавлено, {{notFound}} не найдено, {{duplicates}} дубликатов',
+
   },
+
   mostPlayed: {
+
     title: 'Популярное',
+
     topArtists: 'Топ исполнителей',
+
     topAlbums: 'Топ альбомов',
+
     plays: '{{n}} прослушиваний',
+
     sortMost: 'Сначала популярные',
+
     sortLeast: 'Сначала малоизвестные',
+
     loadMore: 'Загрузить больше альбомов',
+
     noData: 'Пока нет данных о прослушивании. Начните слушать!',
+
     noArtists: 'Все исполнители отфильтрованы.',
+
     filterCompilations: 'Скрыть исполнителей сборников (Various Artists, Soundtracks и др.)',
+
     filterCompilationsShort: 'Скрыть сборники',
+
   },
+
   radio: {
+
     title: 'Онлайн-радио',
+
     empty: 'Радиостанции не настроены.',
+
     addStation: 'Добавить станцию',
+
     editStation: 'Изменить',
+
     deleteStation: 'Удалить станцию',
+
     confirmDelete: 'Нажмите ещё раз для подтверждения',
+
     stationName: 'Название станции…',
+
     streamUrl: 'URL потока…',
+
     homepageUrl: 'Сайт станции (необязательно)',
+
     save: 'Сохранить',
+
     cancel: 'Отмена',
+
     live: 'ЭФИР',
+
     liveStream: 'Онлайн-радио',
+
     openHomepage: 'Открыть сайт',
+
     changeCoverLabel: 'Сменить обложку',
+
     removeCover: 'Убрать обложку',
+
     browseDirectory: 'Каталог станций',
+
     directoryPlaceholder: 'Поиск станций…',
+
     noResults: 'Станции не найдены.',
+
     stationAdded: 'Станция добавлена',
+
     filterAll: 'Все',
+
     filterFavorites: 'Избранное',
+
     sortManual: 'Вручную',
+
     sortAZ: 'А → Я',
+
     sortZA: 'Я → А',
+
     sortNewest: 'Сначала новые',
+
     favorite: 'В избранное',
+
     unfavorite: 'Убрать из избранного',
+
     noFavorites: 'Избранных станций нет.',
+
     listenerCount_one: '{{count}} слушатель',
+
     listenerCount_other: '{{count}} слушателей',
+
     recentlyPlayed: 'Недавно сыгранное',
+
     upNext: 'Следующий',
+
   },
+
   folderBrowser: {
+
     empty: 'Папка пуста',
+
     error: 'Ошибка загрузки',
+
   },
+
   deviceSync: {
+
     title: 'Синхронизация устройства',
+
     targetFolder: 'Папка назначения',
+
     noFolderChosen: 'Папка не выбрана',
+
     selectDrive: 'Выберите диск…',
+
     refreshDrives: 'Обновить диски',
+
     noDrivesDetected: 'Съёмные диски не обнаружены',
+
     browseManual: 'Обзор вручную…',
+
     free: 'свободно',
+
     notMountedVolume: 'Цель не находится на смонтированном томе. Диск мог быть отключён.',
+
     chooseFolder: 'Выбрать…',
+
     filenameTemplate: 'Шаблон имени файла',
+
     targetDevice: 'Целевое устройство',
+
     templateHint: 'Переменные: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
+
     cleanupButton: 'Удалить файлы вне выборки',
+
     cleanupNothingToDelete: 'Нечего удалять — устройство уже синхронизировано.',
+
     confirmCleanup: 'Удалить {{count}} файл(ов) с устройства, не входящих в текущую выборку. Продолжить?',
+
     cleanupComplete: '{{count}} файл(ов) удалено с устройства.',
+
     selectedSources: 'Выбранные источники',
+
     noSourcesSelected: 'Источники не выбраны. Нажмите на элементы в браузере, чтобы добавить их.',
+
     clearAll: 'Очистить всё',
+
     tabPlaylists: 'Плейлисты',
+
     tabAlbums: 'Альбомы',
+
     tabArtists: 'Исполнители',
+
     searchPlaceholder: 'Поиск…',
+
     syncButton: 'Синхронизировать на устройство',
+
     actionTransfer: 'Перенести на устройство',
+
     actionDelete: 'Удалить с устройства',
+
     actionApplyAll: 'Применить все изменения',
+
     templatePreview: 'Предпросмотр',
-    templatePresetStandard: 'Стандарт',
-    templatePresetMultiDisc: 'Мульти-диск',
-    templatePresetAltFolder: 'Альт. папка',
-    tokenSlashHint: '/ = разделитель папок',
+
     cancel: 'Отмена',
+
     noTargetDir: 'Сначала выберите папку назначения.',
+
     noSources: 'Выберите хотя бы один источник.',
+
     noTracks: 'В выбранных источниках не найдено треков.',
+
     fetchError: 'Ошибка загрузки треков с сервера.',
+
     syncComplete: 'Синхронизация завершена.',
+
     dismiss: 'Закрыть',
-    cancelSync: 'Отмена',
-    syncCancelled: 'Синхронизация отменена ({{done}} / {{total}} перенесено).',
+
     colName: 'Название',
+
     colType: 'Тип',
+
     colStatus: 'Статус',
+
     onDevice: 'Управление устройством',
+
     addSources: 'Добавить…',
+
     syncResult: '{{done}} перенесено, {{skipped}} уже актуально ({{total}} всего)',
+
     deleteFromDevice: 'Пометить для удаления ({{count}})',
+
     confirmDelete: 'Удалить {{count}} запись(ей) с устройства: {{names}}?',
+
     deleteComplete: '{{count}} запись(ей) удалено с устройства.',
-    manifestImported: 'Импортировано {{count}} источник(ов) из манифеста устройства.',
+
     statusSynced: 'Синхронизировано',
+
     statusPending: 'Ожидает',
+
     statusDeletion: 'Удаление',
+
     markForDeletion: 'Пометить для удаления',
+
     removeSource: 'Удалить',
+
     undoDeletion: 'Отменить удаление',
+
     syncInBackground: 'Синхронизация запущена в фоне — можно перейти в другой раздел.',
+
     syncInProgress: '{{done}} / {{total}} треков…',
+
     syncSummary: 'Сводка синхронизации',
+
     calculating: 'Вычисление необходимых данных…',
+
     filesToAdd: 'Файлы для добавления:',
+
     filesToDelete: 'Файлы для удаления:',
+
     netChange: 'Чистое изменение:',
+
     availableSpace: 'Доступное место на диске:',
+
     spaceWarning: 'Предупреждение: на целевом устройстве недостаточно сообщаемого места.',
+
     proceed: 'Продолжить синхронизацию',
+
     notEnoughSpace: 'Обнаружено недостаточно физического места на диске!',
+
     liveSearch: 'Live',
+
     randomAlbumsLabel: 'Случайные альбомы',
+
   },
+
 };
+

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -560,7 +560,7 @@ export const ruTranslation = {
     discordAppleCovers: 'Загружать обложки через Apple Music для Discord',
     discordAppleCoversDesc: 'Отправляет имя исполнителя и альбома в Apple Music API для поиска обложки для профиля Discord. По умолчанию отключено из соображений конфиденциальности.',
     discordTemplates: 'Пользовательские шаблоны текста',
-    discordTemplatesDesc: 'Настройте, какая информация отображается в профиле Discord. Переменные: {title}, {artist}, {album}, {paused}',
+    discordTemplatesDesc: 'Настройте, какая информация отображается в профиле Discord. Переменные: {title}, {artist}, {album}',
     discordTemplateDetails: 'Основная строка (details)',
     discordTemplateState: 'Вторичная строка (state)',
     discordTemplateLargeText: 'Подсказка альбома (largeText)',

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -1,2382 +1,1227 @@
 /** Russian UI strings — natural phrasing for a music desktop app */
-
 export const ruTranslation = {
-
   sidebar: {
-
     library: 'Медиатека',
-
     mainstage: 'Для вас',
-
     newReleases: 'Новинки',
-
     allAlbums: 'Все альбомы',
-
     randomAlbums: 'Случайные альбомы',
-
     randomPicker: 'Собрать микс',
-
     artists: 'Исполнители',
-
     randomMix: 'Случайный микс',
-
     favorites: 'Избранное',
-
     nowPlaying: 'Сейчас играет',
-
     system: 'Система',
-
     statistics: 'Статистика',
-
     settings: 'Настройки',
-
     help: 'Справка',
-
     expand: 'Развернуть боковую панель',
-
     collapse: 'Свернуть боковую панель',
-
     downloadingTracks: 'Кэширование {{n}} треков…',
-
     syncingTracks: 'Синхронизация {{done}}/{{total}}…',
-
     cancelDownload: 'Отменить загрузку',
-
     offlineLibrary: 'Офлайн-библиотека',
-
     genres: 'Жанры',
-
     playlists: 'Плейлисты',
-
     mostPlayed: 'Популярное',
-
     radio: 'Онлайн-радио',
-
     folderBrowser: 'Браузер папок',
-
     deviceSync: 'Синхронизация устройства',
-
     libraryScope: 'Область медиатеки',
-
     allLibraries: 'Все библиотеки',
-
     expandPlaylists: 'Развернуть плейлисты',
-
     collapsePlaylists: 'Свернуть плейлисты',
-
   },
-
   home: {
-
     hero: 'Подборка',
-
     starred: 'Личное избранное',
-
     recent: 'Недавно добавлено',
-
     mostPlayed: 'Популярное',
-
     recentlyPlayed: 'Недавно проиграно',
-
     discover: 'Обзор',
-
     loadMore: 'Ещё',
-
     discoverMore: 'Смотреть ещё',
-
     discoverArtists: 'Исполнители',
-
     discoverArtistsMore: 'Все исполнители',
-
   },
-
   hero: {
-
     eyebrow: 'Альбом дня',
-
     playAlbum: 'Воспроизвести альбом',
-
     enqueue: 'В очередь',
-
     enqueueTooltip: 'Добавить весь альбом в очередь',
-
   },
-
   search: {
-
     placeholder: 'Исполнитель, альбом или трек…',
-
     noResults: 'Ничего не найдено по запросу «{{query}}»',
-
     artists: 'Исполнители',
-
     albums: 'Альбомы',
-
     songs: 'Треки',
-
     clearLabel: 'Очистить поиск',
-
     title: 'Поиск',
-
     resultsFor: 'Результаты по «{{query}}»',
-
     album: 'Альбом',
-
     advanced: 'Расширенный поиск',
-
     advancedSearchTerm: 'Поисковый запрос',
-
     advancedSearchPlaceholder: 'Название, альбом, исполнитель…',
-
     advancedGenre: 'Жанр',
-
     advancedAllGenres: 'Все жанры',
-
     advancedYear: 'Год',
-
     advancedYearFrom: 'от',
-
     advancedYearTo: 'до',
-
     advancedAll: 'Все',
-
     advancedSearch: 'Найти',
-
     advancedEmpty: 'Введите запрос или выберите фильтр.',
-
     advancedNoResults: 'Ничего не найдено.',
-
     advancedGenreNote: 'Треки выбираются случайно в рамках жанра.',
-
     recentSearches: 'Недавние запросы',
-
     browse: 'Обзор',
-
     emptyHint: 'Что хочешь послушать?',
-
     genres: 'Жанры',
-
   },
-
   nowPlaying: {
-
     tooltip: 'Кто сейчас слушает?',
-
     title: 'Кто сейчас слушает?',
-
     loading: 'Загрузка…',
-
     nobody: 'Сейчас никто не слушает.',
-
     minutesAgo: '{{n}} мин назад',
-
     nothingPlaying: 'Пока ничего не играет — включите трек.',
-
     aboutArtist: 'Об исполнителе',
-
     fromAlbum: 'Из этого альбома',
-
     viewAlbum: 'Просмотр альбома',
-
     goToArtist: 'Перейти к исполнителю',
-
     readMore: 'Читать далее',
-
     showLess: 'Свернуть',
-
     genreInfo: 'Жанр',
-
     trackInfo: 'О треке',
-
   },
-
   contextMenu: {
-
     playNow: 'Играть сейчас',
-
     playNext: 'Играть следующим',
-
     addToQueue: 'В конец очереди',
-
     enqueueAlbum: 'Альбом в очередь',
-
     startRadio: 'Радио по похожим',
-
     instantMix: 'Instant Mix',
-
     instantMixFailed: 'Не удалось собрать Instant Mix — ошибка сервера или плагина.',
-
     cliMixNeedsTrack: 'Ничего не играет — сначала начните воспроизведение, затем снова выполните команду микса.',
-
     lfmLove: 'Любимое на Last.fm',
-
     lfmUnlove: 'Убрать с Last.fm',
-
     favorite: 'В избранное',
-
     favoriteArtist: 'Исполнитель в избранное',
-
     favoriteAlbum: 'Альбом в избранное',
-
     unfavorite: 'Убрать из избранного',
-
     unfavoriteArtist: 'Убрать исполнителя из избранного',
-
     unfavoriteAlbum: 'Убрать альбом из избранного',
-
     removeFromQueue: 'Убрать из очереди',
-
     removeFromPlaylist: 'Убрать из плейлиста',
-
     openAlbum: 'Открыть альбом',
-
     goToArtist: 'К исполнителю',
-
     download: 'Скачать (ZIP)',
-
     addToPlaylist: 'В плейлист',
-
     selectedPlaylists: '{{count}} плейлистов выбрано',
-
     selectedAlbums: '{{count}} альбомов выбрано',
-
     selectedArtists: '{{count}} исполнителей выбрано',
-
     songInfo: 'Сведения о треке',
-
   },
-
   albumDetail: {
-
     back: 'Назад',
-
     playAll: 'Воспроизвести всё',
-
     enqueue: 'В очередь',
-
     enqueueTooltip: 'Добавить весь альбом в очередь',
-
     artistBio: 'Биография',
-
     download: 'Скачать (ZIP)',
-
     downloading: 'Загрузка…',
-
     cacheOffline: 'Сохранить офлайн',
-
     offlineCached: 'Доступно офлайн',
-
     offlineDownloading: 'Кэширование… ({{n}} из {{total}})',
-
     removeOffline: 'Удалить офлайн-копию',
-
     offlineStorageFull:
-
       'Место для офлайн закончилось (лимит {{mb}} МБ). Освободите место в офлайн-библиотеке или увеличьте лимит в настройках.',
-
     offlineStorageGoToLibrary: 'Офлайн-библиотека',
-
     offlineStorageGoToSettings: 'Настройки',
-
     favoriteAdd: 'В избранное',
-
     favoriteRemove: 'Убрать из избранного',
-
     favorite: 'Избранное',
-
     noBio: 'Биография недоступна.',
-
     moreByArtist: 'Ещё от {{artist}}',
-
     tracksCount: 'Композиций: {{n}}',
-
     goToArtist: 'Перейти к {{artist}}',
-
     moreLabelAlbums: 'Другие альбомы на {{label}}',
-
     trackTitle: 'Название',
-
     trackAlbum: 'Альбом',
-
     trackArtist: 'Исполнитель',
-
     trackGenre: 'Жанр',
-
     trackFormat: 'Формат',
-
     trackFavorite: 'Избранное',
-
     trackRating: 'Оценка',
-
     trackDuration: 'Длительность',
-
     trackTotal: 'Итого',
-
     columns: 'Колонки',
-
+    resetColumns: 'Сбросить',
     notFound: 'Альбом не найден.',
-
     bioModal: 'Биография исполнителя',
-
     bioClose: 'Закрыть',
-
     ratingLabel: 'Оценка',
-
     enlargeCover: 'Увеличить обложку',
-
     filterSongs: 'Фильтр треков…',
-
     sortNatural: 'По умолчанию',
-
     sortByTitle: 'А–Я (название)',
-
     sortByArtist: 'А–Я (исполнитель)',
-
     sortByAlbum: 'А–Я (альбом)',
-
   },
-
   entityRating: {
-
     albumShort: 'Оценка альбома',
-
     artistShort: 'Оценка исполнителя',
-
     albumAriaLabel: 'Оценка альбома',
-
     artistAriaLabel: 'Оценка исполнителя',
-
     saveFailed: 'Не удалось сохранить оценку.',
-
   },
-
   artistDetail: {
-
     back: 'Назад',
-
     albums: 'Альбомы',
-
     album: 'Альбом',
-
     playAll: 'Воспроизвести всё',
-
     shuffle: 'Перемешать',
-
     radio: 'Радио',
-
     loading: 'Загрузка…',
-
     noRadio: 'Похожие треки для этого исполнителя не найдены.',
-
     notFound: 'Исполнитель не найден.',
-
     albumsBy: 'Альбомы — {{name}}',
-
     topTracks: 'Популярные треки',
-
     noAlbums: 'Альбомов нет.',
-
     trackTitle: 'Название',
-
     trackAlbum: 'Альбом',
-
     trackDuration: 'Длительность',
-
     favoriteAdd: 'В избранное',
-
     favoriteRemove: 'Убрать из избранного',
-
     favorite: 'Избранное',
-
     albumCount_one: '{{count}} альбом',
-
     albumCount_few: '{{count}} альбома',
-
     albumCount_many: '{{count}} альбомов',
-
     albumCount_other: '{{count}} альбомов',
-
     openedInBrowser: 'Открыто в браузере',
-
     featuredOn: 'Также участвует в',
-
     similarArtists: 'Похожие исполнители',
-
     cacheOffline: 'Сохранить дискографию офлайн',
-
     offlineCached: 'Дискография сохранена',
-
     offlineDownloading: 'Кэширование… ({{done}} из {{total}} альбомов)',
-
     uploadImage: 'Загрузить фото исполнителя',
-
     uploadImageError: 'Не удалось загрузить изображение',
-
   },
-
   favorites: {
-
     title: 'Избранное',
-
     empty: 'Пока ничего не отмечено звёздочкой.',
-
     artists: 'Исполнители',
-
     albums: 'Альбомы',
-
     songs: 'Треки',
-
     enqueueAll: 'Всё в очередь',
-
     playAll: 'Воспроизвести всё',
-
     removeSong: 'Убрать из избранного',
-
     stations: 'Радиостанции',
-
     showingFiltered: 'Показано {{filtered}} из {{total}} ({{artist}})',
-
     showingCount: 'Показано {{filtered}} из {{total}}',
-
     clearArtistFilter: 'Сбросить фильтр исполнителя',
-
     noFilterResults: 'Нет результатов с выбранными фильтрами.',
-
     allArtists: 'Все исполнители',
-
   },
-
   randomLanding: {
-
     title: 'Собрать микс',
-
     mixByTracks: 'Микс по трекам',
-
     mixByTracksDesc: 'Случайная подборка треков со всей медиатеки',
-
     mixByAlbums: 'Микс по альбомам',
-
     mixByAlbumsDesc: 'Случайная подборка альбомов для открытий',
-
   },
-
   randomAlbums: {
-
     title: 'Случайные альбомы',
-
     refresh: 'Обновить',
-
   },
-
   genres: {
-
     title: 'Жанры',
-
     genreCount: 'Жанры',
-
     albumCount_one: '{{count}} альбом',
-
     albumCount_few: '{{count}} альбома',
-
     albumCount_many: '{{count}} альбомов',
-
     albumCount_other: '{{count}} альбомов',
-
     loading: 'Загрузка жанров…',
-
     empty: 'Жанры не найдены.',
-
     albumsLoading: 'Загрузка альбомов…',
-
     albumsEmpty: 'В этом жанре альбомов нет.',
-
     loadMore: 'Ещё',
-
     back: 'Назад',
-
   },
-
   randomMix: {
-
     title: 'Случайный микс',
-
     remix: 'Новый микс',
-
     remixTooltip: 'Подобрать другие случайные треки',
-
     remixGenre: 'Новый микс: {{genre}}',
-
     remixTooltipGenre: 'Подобрать другие треки жанра {{genre}}',
-
     playAll: 'Воспроизвести всё',
-
     trackTitle: 'Название',
-
     trackArtist: 'Исполнитель',
-
     trackAlbum: 'Альбом',
-
     trackFavorite: 'Избранное',
-
     trackDuration: 'Длительность',
-
     favoriteAdd: 'В избранное',
-
     favoriteRemove: 'Убрать из избранного',
-
     play: 'Играть',
-
     trackGenre: 'Жанр',
-
     excludeAudiobooks: 'Исключать аудиокниги и радиоспектакли',
-
     excludeAudiobooksDesc:
-
       'По ключевым словам в жанре, названии, альбоме и исполнителе — например Hörbuch, Audiobook, Spoken Word и т. п.',
-
     genreBlocked: 'Слово отфильтровано',
-
     genreAddedToBlacklist: 'Добавлено в список фильтра',
-
     genreAlreadyBlocked: 'Уже в списке',
-
     artistBlocked: 'Исполнитель отфильтрован',
-
     artistAddedToBlacklist: 'Исполнитель добавлен в фильтр',
-
     artistClickHint: 'Нажмите, чтобы скрыть этого исполнителя',
-
     blacklistToggle: 'Фильтр по словам',
-
     genreMixTitle: 'Микс по жанру',
-
     genreMixDesc: 'Топ-20 жанров по числу треков — нажмите, чтобы собрать микс',
-
     genreMixAll: 'Все треки',
-
     genreMixLoadMore: 'Ещё 10 жанров',
-
     genreMixNoGenres: 'На сервере нет данных о жанрах.',
-
     shuffleGenres: 'Другие жанры',
-
     filterPanelTitle: 'Фильтры',
-
     filterPanelDesc:
-
       'Нажмите на тег жанра или имя исполнителя в списке ниже, чтобы исключить их из будущих миксов.',
-
     genreClickHint:
-
       'Нажмите на тег жанра — слово попадёт в фильтр.\nУчитываются жанр, название, альбом и исполнитель.',
-
   },
-
   albums: {
-
     title: 'Все альбомы',
-
     sortByName: 'А–Я (альбом)',
-
     sortByArtist: 'А–Я (исполнитель)',
-
     sortNewest: 'Сначала новые',
-
     sortRandom: 'Случайно',
-
     yearFrom: 'С',
-
     yearTo: 'По',
-
     yearFilterClear: 'Сбросить год',
-
     yearFilterLabel: 'Год',
-
     select: 'Множественный выбор',
-
     startSelect: 'Включить множественный выбор',
-
     cancelSelect: 'Отмена',
-
     selectionCount: '{{count}} выбрано',
-
     downloadZips: 'Скачать ZIP-архивы',
-
     addOffline: 'Добавить офлайн',
-
     downloadingZip: 'Загрузка {{current}}/{{total}}: {{name}}',
-
     downloadZipDone: '{{count}} ZIP-архив(ов) загружено',
-
     downloadZipFailed: 'Не удалось скачать {{name}}',
-
     offlineQueuing: 'Добавление {{count}} альбом(ов) в офлайн…',
-
     offlineFailed: 'Не удалось добавить {{name}} офлайн',
-
   },
-
   artists: {
-
     title: 'Исполнители',
-
     search: 'Поиск…',
-
     all: 'Все',
-
     gridView: 'Сетка',
-
     listView: 'Список',
-
     imagesOn: 'Фото исполнителей — больше трафика и нагрузка на систему',
-
     imagesOff: 'Только инициалы — экономнее по трафику',
-
     loadMore: 'Ещё',
-
     notFound: 'Исполнители не найдены.',
-
     albumCount_one: '{{count}} альбом',
-
     albumCount_few: '{{count}} альбома',
-
     albumCount_many: '{{count}} альбомов',
-
     albumCount_other: '{{count}} альбомов',
-
     selectionCount: '{{count}} выбрано',
-
     select: 'Множественный выбор',
-
     startSelect: 'Включить множественный выбор',
-
     cancelSelect: 'Отмена',
-
     addToPlaylist: 'В плейлист',
-
   },
-
   login: {
-
     subtitle: 'Десктопный клиент для Navidrome',
-
     serverName: 'Название сервера (необязательно)',
-
     serverNamePlaceholder: 'Мой Navidrome',
-
     serverUrl: 'Адрес сервера',
-
     serverUrlPlaceholder: '192.168.1.100:4533 или https://music.example.com',
-
     username: 'Логин',
-
     usernamePlaceholder: 'admin',
-
     password: 'Пароль',
-
     showPassword: 'Показать пароль',
-
     hidePassword: 'Скрыть пароль',
-
     connect: 'Подключиться',
-
     connecting: 'Подключение…',
-
     connected: 'Готово!',
-
     error: 'Не удалось подключиться — проверьте данные.',
-
     urlRequired: 'Укажите адрес сервера.',
-
     savedServers: 'Сохранённые серверы',
-
     addNew: 'Или добавить новый сервер',
-
   },
-
   connection: {
-
     connected: 'Подключено',
-
     connectedTo: 'Сервер: {{server}}',
-
     disconnected: 'Нет связи',
-
     disconnectedFrom: 'Сервер {{server}} недоступен — нажмите для настроек',
-
     checking: 'Подключение…',
-
     extern: 'Внешний',
-
     offlineTitle: 'Нет связи с сервером',
-
     offlineSubtitle: 'Сервер {{server}} недоступен. Проверьте сеть и адрес.',
-
     offlineModeBanner: 'Офлайн — воспроизведение из локального кэша',
-
     offlineNoCacheBanner: 'Нет соединения с сервером — {{server}} недоступен',
-
     offlineLibraryTitle: 'Офлайн-библиотека',
-
     offlineLibraryEmpty:
-
       'Пока ничего не сохранено. Подключитесь к сети, откройте альбом и нажмите «Сохранить офлайн».',
-
     offlineAlbumCount_one: '{{n}} альбом',
-
     offlineAlbumCount_few: '{{n}} альбома',
-
     offlineAlbumCount_many: '{{n}} альбомов',
-
     offlineAlbumCount_other: '{{n}} альбомов',
-
     offlineFilterAll: 'Всё',
-
     offlineFilterAlbums: 'Альбомы',
-
     offlineFilterPlaylists: 'Плейлисты',
-
     offlineFilterArtists: 'Дискографии',
-
     retry: 'Повторить',
-
     serverSettings: 'Настройки сервера',
-
     switchServerTitle: 'Сменить сервер',
-
     switchServerHint: 'Нажмите, чтобы выбрать другой сохранённый сервер.',
-
     manageServers: 'Управление серверами…',
-
     switchFailed: 'Не удалось переключиться — сервер недоступен.',
-
     lastfmConnected: 'Last.fm: @{{user}}',
-
     lastfmSessionInvalid: 'Сессия недействительна — подключите снова',
-
   },
-
   common: {
-
     albums: 'Альбомы',
-
     album: 'Альбом',
-
     loading: 'Загрузка…',
-
     loadingMore: 'Загрузка…',
-
     loadingPlaylists: 'Загрузка плейлистов…',
-
     noAlbums: 'Альбомов нет.',
-
     downloading: 'Скачивание…',
-
     downloadZip: 'Скачать (ZIP)',
-
     back: 'Назад',
-
     cancel: 'Отмена',
-
     save: 'Сохранить',
-
     delete: 'Удалить',
-
     use: 'Использовать',
-
     add: 'Добавить',
-
     active: 'Активен',
-
     download: 'Скачать',
-
     chooseDownloadFolder: 'Выбрать папку',
-
     noFolderSelected: 'Папка не выбрана',
-
     rememberDownloadFolder: 'Запомнить папку',
-
     filterGenre: 'Фильтр по жанру',
-
     filterSearchGenres: 'Поиск жанров…',
-
     filterNoGenres: 'Нет совпадений',
-
     filterClear: 'Сбросить',
-
     play: 'Воспроизвести',
-
     bulkSelected: 'Выбрано: {{count}}',
-
     clearSelection: 'Сбросить выбор',
-
     bulkAddToPlaylist: 'В плейлист',
-
     bulkRemoveFromPlaylist: 'Убрать из плейлиста',
-
     bulkClear: 'Снять выделение',
-
     updaterAvailable: 'Доступно обновление',
-
     updaterVersion: 'Версия {{version}} доступна',
-
     updaterWebsite: 'Сайт',
-
     updaterModalTitle: 'Доступна новая версия',
-
     updaterChangelog: 'Что нового',
-
     updaterDownloadBtn: 'Скачать сейчас',
-
     updaterSkipBtn: 'Пропустить эту версию',
-
     updaterRemindBtn: 'Напомнить позже',
-
     updaterDone: 'Загрузка завершена',
-
     updaterShowFolder: 'Показать в папке',
-
     updaterInstallHint: 'Закройте Psysonic и запустите установщик вручную.',
-
     updaterAurHint: 'Установить обновление через AUR:',
-
     updaterErrorMsg: 'Ошибка загрузки',
-
     updaterRetryBtn: 'Повторить',
-
     durationHoursMinutes: '{{hours}}ч {{minutes}}мин',
-
     durationMinutesOnly: '{{minutes}}мин',
-
     updaterOpenGitHub: 'Открыть на GitHub',
-
     filters: 'Фильтры',
-
     more: 'еще',
-
     yearRange: 'Диапазон лет',
-
     clearAll: 'Очистить всё',
-
   },
-
   settings: {
-
     title: 'Настройки',
-
     language: 'Язык',
-
     languageEn: 'Английский',
-
     languageDe: 'Немецкий',
-
     languageFr: 'Французский',
-
     languageNl: 'Нидерландский',
-
     languageZh: 'Китайский',
-
     languageNb: 'Норвежский',
-
     languageRu: 'Русский',
-
     languageRu2: 'Русский 2',
-
     font: 'Шрифт',
-
     theme: 'Тема',
-
     appearance: 'Оформление',
-
     servers: 'Серверы',
-
     serverName: 'Название',
-
     serverUrl: 'Адрес',
-
     serverUrlPlaceholder: '192.168.1.100:4533 или https://music.example.com',
-
     serverUsername: 'Логин',
-
     serverPassword: 'Пароль',
-
     addServer: 'Добавить сервер',
-
     addServerTitle: 'Новый сервер',
-
     useServer: 'Выбрать',
-
     deleteServer: 'Удалить',
-
     noServers: 'Нет сохранённых серверов.',
-
     serverActive: 'Активен',
-
     confirmDeleteServer: 'Удалить сервер «{{name}}»?',
-
     serverConnecting: 'Подключение…',
-
     serverConnected: 'Подключено!',
-
     serverFailed: 'Ошибка подключения.',
-
     testBtn: 'Проверить',
-
     testingBtn: 'Проверка…',
-
     serverCompatible: 'Совместимость: Navidrome · Gonic · Airsonic · Subsonic',
-
     audiomuseTitle: 'AudioMuse-AI (Navidrome)',
-
     audiomuseDesc:
-
       'Включите, если на этом сервере настроен <pluginLink>плагин AudioMuse-AI для Navidrome</pluginLink>. Появится Instant Mix для треков, а на странице исполнителя похожие будут браться с сервера вместо Last.fm.',
-
     audiomuseIssueHint:
-
       'Недавно не удалось собрать Instant Mix — проверьте плагин Navidrome и API AudioMuse. Похожие исполнители подтянутся с Last.fm, если сервер ничего не вернёт.',
-
     connected: 'Подключено',
-
     failed: 'Ошибка',
-
     eqTitle: 'Эквалайзер',
-
     eqEnabled: 'Включить эквалайзер',
-
     eqPreset: 'Пресет',
-
     eqPresetCustom: 'Свой',
-
     eqPresetBuiltin: 'Встроенные',
-
     eqPresetCustomGroup: 'Мои пресеты',
-
     eqSavePreset: 'Сохранить как пресет',
-
     eqPresetName: 'Название пресета…',
-
     eqDeletePreset: 'Удалить пресет',
-
     eqResetBands: 'Сбросить полосы',
-
     eqPreGain: 'Предусиление',
-
     eqResetPreGain: 'Сбросить предусиление',
-
     eqAutoEqTitle: 'AutoEQ — поиск профиля наушников',
-
     eqAutoEqPlaceholder: 'Модель наушников или IEM…',
-
     eqAutoEqSearching: 'Поиск…',
-
     eqAutoEqNoResults: 'Ничего не найдено',
-
     eqAutoEqError: 'Ошибка поиска',
-
     eqAutoEqRateLimit: 'Лимит GitHub — попробуйте через минуту',
-
     eqAutoEqFetchError: 'Не удалось загрузить профиль EQ',
-
     lfmTitle: 'Last.fm',
-
     lfmConnect: 'Подключить Last.fm',
-
     lfmConnecting: 'Ожидание авторизации…',
-
     lfmConfirm: 'Я разрешил доступ',
-
     lfmConnected: 'Аккаунт',
-
     lfmDisconnect: 'Отключить',
-
     lfmConnectDesc:
-
       'Привяжите Last.fm для скробблинга и статуса «Сейчас слушаю» прямо из Psysonic — настраивать Navidrome не нужно.',
-
     lfmOpenBrowser: 'Откроется браузер. Разрешите доступ на Last.fm, затем нажмите кнопку ниже.',
-
     lfmScrobbles: 'Скробблов: {{n}}',
-
     lfmMemberSince: 'С {{year}} года',
-
     scrobbleEnabled: 'Скробблинг включён',
-
     scrobbleDesc: 'Отправлять прослушивания на Last.fm после 50% трека',
-
     behavior: 'Поведение',
-
     cacheTitle: 'Макс. размер кэша',
-
     cacheDesc:
-
       'Обложки и фото исполнителей. При переполнении старые записи удаляются. Офлайн-альбомы не трогаются автоматически, но сотрутся при полной очистке кэша.',
-
     cacheUsedImages: 'Изображения:',
-
     cacheUsedOffline: 'Офлайн-треки:',
-
     cacheUsedHot: 'На диске:',
-
     hotCacheTrackCount: 'Треков в кэше:',
-
     cacheMaxLabel: 'Лимит',
-
     cacheClearBtn: 'Очистить кэш',
-
     cacheClearWarning: 'Будут удалены и все офлайн-альбомы.',
-
     cacheClearConfirm: 'Очистить всё',
-
     cacheClearCancel: 'Отмена',
-
     offlineDirTitle: 'Офлайн-библиотека (в приложении)',
-
     offlineDirDesc: 'Папка для треков, сохранённых для офлайн-прослушивания.',
-
     offlineDirDefault: 'По умолчанию (данные приложения)',
-
     offlineDirChange: 'Сменить папку',
-
     offlineDirClear: 'Сбросить по умолчанию',
-
     offlineDirHint: 'Новые загрузки пойдут в выбранную папку. Старые останутся на прежнем месте.',
-
     hotCacheTitle: 'Горячий кэш воспроизведения',
-
     hotCacheAlphaBadge: 'Альфа',
-
     hotCacheDisclaimer: 'Заранее подгружает следующие треки из очереди и сохраняет предыдущие. При включении использует место на диске и сеть.',
-
     hotCacheDirDefault: 'По умолчанию (данные приложения)',
-
     hotCacheDirChange: 'Сменить папку',
-
     hotCacheDirClear: 'Сбросить по умолчанию',
-
     hotCacheDirHint: 'При смене папки сбрасывается список в приложении; уже скачанные файлы остаются на старом пути, пока вы их не удалите.',
-
     hotCacheEnabled: 'Включить горячий кэш воспроизведения',
-
     hotCacheMaxMb: 'Максимальный размер кэша',
-
     hotCacheDebounce: 'Задержка после изменения очереди',
-
     hotCacheDebounceImmediate: 'Сразу',
-
     hotCacheDebounceSeconds: '{{n}} с',
-
     hotCacheClearBtn: 'Очистить горячий кэш',
-
     audioOutputDevice: 'Устройство вывода звука',
-
     audioOutputDeviceDesc: 'Выберите аудиоустройство для воспроизведения. Изменения применяются немедленно и перезапускают текущий трек.',
-
     audioOutputDeviceDefault: 'Системное по умолчанию',
-
     audioOutputDeviceRefresh: 'Обновить список устройств',
-
     audioOutputDeviceOsDefaultNow: 'текущий системный вывод',
-
     audioOutputDeviceListError: 'Не удалось загрузить список аудиоустройств.',
-
     audioOutputDeviceNotInCurrentList: 'нет в текущем списке',
-
     hiResTitle: 'Нативное воспроизведение Hi-Res',
-
     hiResEnabled: 'Включить нативное Hi-Res воспроизведение',
-
     hiResDesc: "По умолчанию вывод ограничен до 44,1 кГц для максимальной стабильности. Включайте только если оборудование и сеть надёжно поддерживают высокие частоты (88,2 кГц+).",
-
     showArtistImages: 'Фото исполнителей',
-
     showArtistImagesDesc:
-
       'Показывать обложки в разделе «Исполнители». По умолчанию выключено — меньше нагрузки на диск и сеть.',
-
     showTrayIcon: 'Иконка в трее',
-
     showTrayIconDesc: 'Показывать Psysonic в области уведомлений / строке меню.',
-
     minimizeToTray: 'Сворачивать в трей',
-
     minimizeToTrayDesc: 'При закрытии окна не выходить из приложения, а оставаться в трее.',
-
     useCustomTitlebar: 'Своя строка заголовка',
-
     useCustomTitlebarDesc:
-
       'Заменить системную строку заголовка встроенной, в стиле темы приложения. Отключите, чтобы использовать родную строку GNOME/GTK и т.д.',
-
     discordRichPresence: 'Статус в Discord',
-
     discordRichPresenceDesc:
-
       'Показывать текущий трек в профиле и статусе Discord. Нужен запущенный клиент Discord.',
-
     discordAppleCovers: 'Загружать обложки через Apple Music для Discord',
-
     discordAppleCoversDesc: 'Отправляет имя исполнителя и альбома в Apple Music API для поиска обложки для профиля Discord. По умолчанию отключено из соображений конфиденциальности.',
-
     discordTemplates: 'Пользовательские шаблоны текста',
-
-    discordTemplatesDesc: 'Настройте, какая информация отображается в вашем профиле Discord. Переменные: {title}, {artist}, {album}, {paused}',
-
+    discordTemplatesDesc: 'Настройте, какая информация отображается в профиле Discord. Переменные: {title}, {artist}, {album}, {paused}',
     discordTemplateDetails: 'Основная строка (details)',
-
     discordTemplateState: 'Вторичная строка (state)',
-
     discordTemplateLargeText: 'Подсказка альбома (largeText)',
-
     nowPlayingEnabled: 'Показывать в «Сейчас играет»',
-
     nowPlayingEnabledDesc:
-
       'Отправлять на сервер, что вы сейчас слушаете. Отключите, чтобы не делиться этим.',
-
     lyricsServerFirst: 'Предпочитать тексты с сервера',
-
     lyricsServerFirstDesc: 'Проверять тексты песен, предоставленные сервером (встроенные теги, sidecar-файлы) перед запросом LRCLIB. Отключите, чтобы сначала использовать LRCLIB.',
-
     enableNeteaselyrics: 'Тексты из Netease Cloud Music',
-
     enableNeteaselyricsDesc: 'Использовать Netease Cloud Music как последний источник текстов, когда остальные способы не находят ничего. Лучшее покрытие для азиатской и международной музыки.',
-
     lyricsSourcesTitle: 'Источники текстов',
-
     lyricsSourcesDesc: 'Выберите источники для поиска текстов и их порядок. Перетаскивайте для сортировки. Отключённые источники пропускаются.',
-
     lyricsSourceServer: 'Сервер',
-
     lyricsSourceLrclib: 'LRCLIB',
-
     lyricsSourceNetease: 'Netease Cloud Music',
-
     downloadsTitle: 'Экспорт ZIP и архивов',
-
     downloadsFolderDesc: 'Куда сохранять альбомы в ZIP архиве на диск.',
-
     downloadsDefault: 'Папка «Загрузки» по умолчанию',
-
     pickFolder: 'Выбрать',
-
     pickFolderTitle: 'Папка для загрузок',
-
     clearFolder: 'Сбросить папку',
-
     logout: 'Выйти',
-
     aboutTitle: 'О Psysonic',
-
     aboutDesc:
-
       'Современный десктопный плеер для серверов с протоколом Subsonic (Navidrome, Gonic и др.). На Tauri v2 и нативном аудиодвижке на Rust — лёгкий и быстрый: волновая шкала, синхронные тексты, Last.fm, 10-полосный EQ, кроссфейд, воспроизведение без пауз, Replay Gain, жанры и много тем оформления.',
-
     aboutLicense: 'Лицензия',
-
     aboutLicenseText: 'GNU GPL v3 — свободное использование и изменение на тех же условиях.',
-
     aboutRepo: 'Исходный код на GitHub',
-
     aboutVersion: 'Версия',
-
     aboutBuiltWith: 'Tauri · React · TypeScript · Rust/rodio',
-
     aboutAiCredit: 'При поддержке Claude Code (Anthropic)',
-
     aboutContributorsLabel: 'Участники',
-
     aboutSpecialThanksLabel: 'Особая благодарность',
-
     changelog: 'Список изменений',
-
     showChangelogOnUpdate: 'Показывать «Что нового» после обновления',
-
     showChangelogOnUpdateDesc: 'Автоматически при первом запуске новой версии.',
-
     randomMixTitle: 'Случайный микс',
-
     randomMixBlacklistTitle: 'Свои слова-фильтры',
-
     randomMixBlacklistDesc:
-
       'Треки скрываются, если слово встречается в жанре, названии, альбоме или исполнителе (когда включён фильтр выше).',
-
     randomMixBlacklistPlaceholder: 'Добавить слово…',
-
     randomMixBlacklistAdd: 'Добавить',
-
     randomMixBlacklistEmpty: 'Пока пусто.',
-
     randomMixHardcodedTitle: 'Встроенные слова (при включённом фильтре)',
-
     tabAudio: 'Звук',
-
     tabStorage: 'Хранилище и загрузки',
-
     tabAppearance: 'Внешний вид',
-
     homeCustomizerTitle: 'Главная',
-
     sidebarTitle: 'Боковая панель',
-
     sidebarReset: 'Сбросить порядок',
-
     sidebarDrag: 'Перетащите для порядка',
-
     sidebarFixed: 'Всегда показывать',
-
+    randomNavSplitTitle: 'Разделить навигацию микса',
+    randomNavSplitDesc: 'Показывать «Случайный микс» и «Случайные альбомы» как отдельные пункты боковой панели вместо хаба «Собрать микс».',
     tabInput: 'Ввод',
-
     tabServer: 'Сервер',
-
     tabSystem: 'Система',
-
     tabGeneral: 'Общие',
-
     ratingsSectionTitle: 'Рейтинги',
-
     ratingsSkipStarTitle: 'Скипнуть для 1 звезды',
-
     ratingsSkipStarDesc:
-
       'При N скипов подряд ставить 1★ треку. Только для не оцененных ранее.',
-
     ratingsSkipStarThresholdLabel: 'Скипов',
-
     ratingsMixFilterTitle: 'Фильтрация по рейтингу',
-
     ratingsMixFilterDesc:
-
       'Фильтровать с низким рейтингом в «{{mix}}» и «{{albums}}». Повторный клик по выбранной звезде отключает порог.',
-
     ratingsMixMinSong: 'Песни',
-
     ratingsMixMinAlbum: 'Альбомы',
-
     ratingsMixMinArtist: 'Исполнители',
-
     ratingsMixMinThresholdAria: 'Минимум звёзд: {{label}}',
-
     backupTitle: 'Резервная копия',
-
     backupExport: 'Экспорт настроек',
-
     backupExportDesc:
-
       'Сохраняет настройки, серверы, Last.fm, тему, EQ и горячие клавиши в файл .psybkp. Пароли в открытом виде — храните файл в безопасности.',
-
     backupImport: 'Импорт настроек',
-
     backupImportDesc: 'Восстановить из .psybkp. Приложение перезапустится.',
-
     backupImportConfirm: 'Текущие настройки будут заменены. Продолжить?',
-
     backupSuccess: 'Копия сохранена',
-
     backupImportSuccess: 'Настройки восстановлены — перезапуск…',
-
     backupImportError: 'Файл повреждён или не подходит.',
-
     shortcutsReset: 'Сбросить',
-
     shortcutListening: 'Нажмите клавишу…',
-
     shortcutUnbound: '—',
-
     globalShortcutsTitle: 'Глобальные сочетания',
-
     globalShortcutsNote:
-
       'Работают, когда окно не в фокусе. Нужен модификатор: Ctrl, Alt или Super.',
-
     shortcutClear: 'Сбросить',
-
     shortcutPlayPause: 'Пауза / воспроизведение',
-
     shortcutNext: 'Следующий трек',
-
     shortcutPrev: 'Предыдущий трек',
-
     shortcutVolumeUp: 'Громче',
-
     shortcutVolumeDown: 'Тише',
-
     shortcutSeekForward: 'Вперёд на 10 с',
-
     shortcutSeekBackward: 'Назад на 10 с',
-
     shortcutToggleQueue: 'Показать / скрыть очередь',
-
     shortcutOpenFolderBrowser: 'Открыть {{folderBrowser}}',
-
     shortcutFullscreenPlayer: 'Полноэкранный плеер',
-
     shortcutNativeFullscreen: 'Системный полный экран',
-
     playbackTitle: 'Воспроизведение',
-
     replayGain: 'Replay Gain',
-
     replayGainDesc: 'Выравнивание громкости по метаданным ReplayGain',
-
     replayGainMode: 'Режим',
-
     replayGainTrack: 'По треку',
-
     replayGainAlbum: 'По альбому',
-
     replayGainPreGain: 'Предусиление (файлы с тегами)',
-
     replayGainFallback: 'Резерв (без тегов / радио)',
-
     crossfade: 'Кроссфейд',
-
     crossfadeDesc: 'Плавный переход между треками',
-
     crossfadeSecs: '{{n}} с',
-
     notWithGapless: 'Недоступно при включённом режиме без пауз',
-
     notWithCrossfade: 'Недоступно при включённом кроссфейде',
-
     gapless: 'Без пауз между треками',
-
     gaplessDesc: 'Заранее подгружать следующий трек, чтобы не было тишины',
-
     preloadMode: 'Предзагрузка следующего трека',
-
     preloadModeDesc: 'Когда начинать буферизацию следующего в очереди',
-
     nextTrackBufferingTitle: 'Буферизация следующего трека',
-
     preloadHotCacheMutualExclusive: 'Предзагрузка и Hot Cache выполняют одну функцию — одновременно может быть активна только одна. Включение одной автоматически отключает другую.',
-
     preloadOff: 'Выкл.',
-
     preloadBalanced: 'Умеренно (за 30 с до конца)',
-
     preloadEarly: 'Рано (через 5 с после старта)',
-
     preloadCustom: 'Свой интервал',
-
     preloadCustomSeconds: 'Секунд до конца: {{n}}',
-
     infiniteQueue: 'Бесконечная очередь',
-
     infiniteQueueDesc: 'Подмешивать случайные треки, когда очередь закончится',
-
     experimental: 'Экспериментально',
-
     fsPlayerSection: 'Полноэкранный плеер',
-
     fsShowArtistPortrait: 'Отображать фото артиста',
-
     fsShowArtistPortraitDesc: 'Показывать фото артиста (или обложку альбома) в правой части полноэкранного плеера.',
-
     fsPortraitDim: 'Затемнение фото',
-
     seekbarStyle: 'Стиль прогресс-бара',
-
     seekbarStyleDesc: 'Выбор внешнего вида полосы воспроизведения',
-
     seekbarWaveform: 'Форма волны',
-
     seekbarLinedot: 'Линия и точка',
-
     seekbarBar: 'Полоса',
-
     seekbarThick: 'Толстая полоса',
-
     seekbarSegmented: 'Сегменты',
-
     seekbarNeon: 'Неон',
-
     seekbarPulsewave: 'Пульс-волна',
-
     seekbarParticletrail: 'Частицы',
-
     seekbarLiquidfill: 'Жидкость',
-
     seekbarRetrotape: 'Ретро-лента',
-
     themeSchedulerTitle: 'Расписание тем',
-
     themeSchedulerEnable: 'Включить расписание тем',
-
     themeSchedulerEnableSub: 'Автоматически переключается между двумя темами в зависимости от времени суток',
-
     themeSchedulerDayTheme: 'Дневная тема',
-
     themeSchedulerDayStart: 'День начинается в',
-
     themeSchedulerNightTheme: 'Ночная тема',
-
     themeSchedulerNightStart: 'Ночь начинается в',
-
     themeSchedulerActiveHint: 'Расписание тем активно - темы переключаются автоматически.',
-
     visualOptionsTitle: 'Визуальные Настройки',
-
     coverArtBackground: 'Фон Обложки',
-
     coverArtBackgroundSub: 'Показывать размытую обложку как фон в заголовках альбомов и плейлистов',
-
     playlistCoverPhoto: 'Обложка Плейлиста',
-
     playlistCoverPhotoSub: 'Показывать сетку обложек в детальном виде плейлиста',
-
     showBitrate: 'Показывать Битрейт',
-
     showBitrateSub: 'Отображать битрейт аудио в списках треков',
-
     uiScaleTitle: 'Масштаб интерфейса',
-
     uiScaleLabel: 'Масштаб',
-
   },
-
   changelog: {
-
     modalTitle: 'Что нового',
-
     dontShowAgain: 'Больше не показывать',
-
     close: 'Понятно',
-
   },
-
   help: {
-
     title: 'Справка',
-
     s1: 'С чего начать',
-
     q1: 'Какие серверы подходят?',
-
     a1:
-
       'Любой с API Subsonic: Navidrome, Gonic, Subsonic, Airsonic и др. Для новых проектов чаще всего рекомендуют Navidrome.',
-
     q2: 'Как подключиться?',
-
     a2:
-
       'Настройки → «Добавить сервер»: адрес (например 192.168.1.100:4533), логин и пароль. Соединение проверяется до сохранения — при ошибке профиль не записывается.',
-
     q3: 'Можно несколько серверов?',
-
     a3: 'Да. Добавляйте сколько нужно и переключайтесь. Активен всегда один.',
-
     s2: 'Воспроизведение',
-
     q4: 'Как включить музыку?',
-
     a4:
-
       'Двойной щелчок по треку. На странице альбома или исполнителя — «Воспроизвести всё». Треки можно перетащить в панель очереди.',
-
     q5: 'Какие есть горячие клавиши?',
-
     a5:
-
       'Пробел — пауза/воспроизведение, Esc — закрыть полноэкранный плеер. Медиаклавиши работают на всех платформах; на Linux иногда удобнее кнопки в панели плеера. Свои сочетания — в Настройках.',
-
     q6: 'Что такое очередь?',
-
     a6:
-
       'Список следующих треков. Открывается иконкой справа вверху. Можно перетаскивать порядок, перемешивать и сохранять как плейлист.',
-
     q7: 'Как открыть полноэкранный плеер?',
-
     a7: 'Миниатюра обложки внизу или кнопка разворота рядом. Esc — выход.',
-
     q8: 'Как работает повтор?',
-
     a8: 'Кнопка повтора в панели: выкл. → все → один трек.',
-
     s3: 'Медиатека',
-
     q9: 'Как скачать альбом?',
-
     a9:
-
       'Страница альбома → «Скачать (ZIP)». Сервер сначала собирает архив — для больших альбомов или FLAC это может занять время; прогресс появится, когда начнётся передача файла.',
-
     q10: 'Как добавить в избранное?',
-
     a10: 'Звёздочка у трека или в шапке альбома. Всё избранное — в разделе слева.',
-
     q11: 'Что за карусель на главной?',
-
     a11:
-
       'Случайные альбомы из библиотеки, смена примерно каждые 10 с. Точки — перейти к слайду, клик по баннеру — открыть альбом.',
-
     s4: 'Настройки',
-
     q12: 'Как сменить тему?',
-
     a12: 'Настройки → Тема. Много готовых наборов в нескольких категориях.',
-
     q13: 'Как сменить язык?',
-
     a13:
-
       'Настройки → Язык: английский, немецкий, французский, нидерландский, китайский, норвежский, русский и русский (альтернативный, Русский 2).',
-
     q15: 'Куда сохраняются ZIP?',
-
     a15:
-
       'Настройки → Поведение → папка загрузок. Без выбора используется стандартная папка загрузок браузера/системы.',
-
     s5: 'Скробблинг',
-
     q16: 'Как устроен скробблинг?',
-
     a16:
-
       'Psysonic шлёт прослушивания напрямую на Last.fm — в Navidrome ничего настраивать не нужно. Подключите аккаунт в настройках.',
-
     q17: 'Когда уходит скроббл?',
-
     a17: 'После прослушивания примерно половины трека.',
-
     q22: 'Что за волна внизу?',
-
     a22:
-
       'Волновая шкала вместо ползунка: клик — переход, перетаскивание — перемотка. Пройденный фрагмент подсвечен, дальше — буфер и остаток.',
-
     q24: 'Можно перемешать очередь?',
-
     a24: 'Да. В панели очереди — кнопка перемешивания. Текущий трек остаётся первым.',
-
     q25: 'Ссылки Last.fm и Wikipedia открываются в браузере?',
-
     a25: 'Да, в системном браузере по умолчанию. Кратко показывается подтверждение.',
-
     s7: 'Случайный микс',
-
     q26: 'Что такое случайный микс?',
-
     a26:
-
       'Случайный набор треков из всей библиотеки. Раздел в боковой панели → «Новый микс». Число треков можно задать заранее.',
-
     q27: 'Что за фильтр по словам?',
-
     a27:
-
       'Исключает треки, где в жанре, названии или альбоме есть заданные слова. Аудиокниги отсекаются автоматически. Свои слова — в настройках микса или кликом по тегу жанра в списке.',
-
     q28: 'Что за «супер-микс» по жанру?',
-
     a28:
-
       'Грубая группировка стилей (рок, метал, электроника и т. д.) и микс внутри выбранной группы. Результаты подгружаются по мере запросов.',
-
     s6: 'Если что-то не так',
-
     q18: 'Медленно грузятся обложки.',
-
     a18:
-
       'Первый раз картинки тянутся с сервера и кэшируются на ~30 дней. Медленный диск на сервере даёт задержку только при первом заходе.',
-
     q19: 'Тест соединения не проходит.',
-
     a19:
-
       'Проверьте адрес с портом (http://192.168.1.100:4533), файрвол, для локалки иногда нужен http вместо https. Логин и пароль должны совпадать с сервером.',
-
     q20: 'Нет звука в Linux.',
-
     a20:
-
       'Есть пакеты .deb, .rpm и AUR. Убедитесь, что запущены PipeWire или PulseAudio.',
-
     q21: 'Чёрный экран в Linux.',
-
     a21:
-
       'Часто драйвер GPU / WebKitGTK. Запуск с GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1. В официальных пакетах это часто уже задано.',
-
     q29: 'Кроссфейд и воспроизведение без пауз?',
-
     a29:
-
       'Экспериментальные опции в Настройках → Звук. Режим без пауз заранее подгружает следующий трек. Кроссфейд плавно накладывает треки, длина 1–10 с.',
-
     q30: 'Есть тексты песен?',
-
     a30:
-
       'Да. Иконка микрофона в панели плеера — вкладка текстов в очереди. Источник LRCLIB; синхронные строки подсвечиваются по ходу трека.',
-
     q31: 'Можно переназначить клавиши?',
-
     a31: 'Да: Настройки → сочетания в приложении и глобальные (работают в фоне).',
-
     q32: 'Можно сменить шрифт?',
-
     a32: 'Да, в настройках шрифта — набор гарнитур на весь интерфейс.',
-
     s8: 'Офлайн',
-
     q34: 'Что такое офлайн-режим?',
-
     a34:
-
       'Кэш альбомов на устройстве для прослушивания без сервера. Воспроизведение идёт с диска.',
-
     q35: 'Как сохранить альбом офлайн?',
-
     a35:
-
       'Страница альбома → иконка загрузки в шапке. Прогресс на кнопке, после загрузки — индикатор готовности. Список — в офлайн-библиотеке.',
-
     q36: 'Сколько места занимает офлайн?',
-
     a36:
-
       'Лимит задаётся в настройках. При переполнении на странице альбома появится предупреждение; удалить можно из офлайн-библиотеки.',
-
     q37: 'Как ставить оценки трекам, альбомам и исполнителям?',
-
     a37: 'Psysonic поддерживает оценки от 1 до 5 звёзд через OpenSubsonic API (требует Navidrome ≥ 0.53). Треки оцениваются в списке треков альбома или плейлиста, в контекстном меню или прямо в панели плеера. Альбомы — на странице альбома, исполнители — на странице исполнителя.',
-
     q38: 'Можно ли удалить или изменить оценку?',
-
     a38: 'Да. Повторный клик по активной звезде полностью удаляет оценку — второй клик по той же звезде её стирает. Для изменения оценки просто нажмите другую звезду.',
-
     q39: 'Что такое Skip-to-1★ и фильтр по рейтингу?',
-
     a39: 'Skip-to-1★ автоматически присваивает оценку 1 звезда после заданного числа последовательных пропусков. Включается в Настройки → Рейтинги. Там же задаётся минимальный рейтинг для случайных миксов.',
-
     q40: 'Что такое браузер папок?',
-
     a40: 'Браузер папок (боковая панель) позволяет навигировать по музыкальному каталогу сервера в колонках Миллера. Клик по папке открывает содержимое; иконка воспроизведения запускает или добавляет в очередь.',
-
     q41: 'Что такое планировщик тем?',
-
     a41: 'Настройки → Внешний вид → Авто-смена темы: задайте дневную и ночную тему со временем начала. Psysonic переключается автоматически в указанное время.',
-
     q42: 'Можно ли масштабировать интерфейс?',
-
     a42: 'Да. Настройки → Внешний вид → Масштаб интерфейса позволяет масштабировать весь UI от 80 % до 125 %.',
-
     q43: 'Можно ли изменить стиль seekbar?',
-
     a43: 'Да. Настройки → Внешний вид → Стиль seekbar предлагает 10 стилей: Осциллограмма, Линия и точка, Полоса, Толстая полоса, Сегментированная, Неоновое свечение, Пульсовая волна, Частицы, Жидкое заполнение и Ретро кассета.',
-
     q44: 'Что такое AutoEQ?',
-
     a44: '10-полосный эквалайзер в Настройки → Аудио включает поиск AutoEQ. Введите модель наушников — Psysonic автоматически загрузит и применит профиль коррекции.',
-
     q45: 'Что такое Replay Gain?',
-
     a45: 'Replay Gain нормализует громкость, чтобы громкие и тихие альбомы воспроизводились на одинаковом уровне. Включается в Настройки → Аудио → Replay Gain; режим трека или альбома.',
-
     q46: 'Что такое горячий кэш?',
-
     a46: 'Горячий кэш (Alpha, Настройки → Библиотека) предзагружает следующие треки очереди на диск для мгновенного воспроизведения. Psysonic хранит текущий трек и следующие 5, вытесняя старые записи при достижении лимита.',
-
     q47: 'Можно ли кэшировать плейлист для офлайн?',
-
     a47: 'Да. Откройте детали плейлиста и нажмите иконку загрузки. После полного кэширования иконка сменяется на красную корзину; нажмите её, чтобы удалить плейлист из офлайн-кэша.',
-
+    q48: 'Что такое бесконечная очередь?',
+    a48: 'Когда очередь заканчивается и повтор отключён, Psysonic автоматически добавляет случайные треки, чтобы воспроизведение не прерывалось. Автодобавленные треки отображаются под разделителем «— Добавлено автоматически —».',
+    q49: 'Можно ли управлять Psysonic через командную строку?',
+    a49: 'Да. Примеры: psysonic --player play / pause / next / prev, --player volume 75, --player seek 15, --player mute, --player shuffle, --player repeat off|all|one. Также: переключение сервера, аудиоустройства, фильтрация библиотеки и поиск. Полная справка: psysonic --player --help.',
+    q50: 'Как управлять плейлистами?',
+    a50: 'Через «Плейлисты» на боковой панели. Создайте новый плейлист кнопкой «Новый плейлист». В детальном представлении перетаскивайте треки для сортировки, удаляйте кнопкой ×, добавляйте через поиск и используйте «Предложения» для умных рекомендаций.',
+    q51: 'Можно ли создать резервную копию настроек?',
+    a51: 'Да. Настройки → Резервная копия и восстановление экспортирует все настройки, профили серверов, темы и горячие клавиши в JSON-файл.',
+    q52: 'Как изменить устройство вывода звука?',
+    a52: 'Настройки → Аудио → Устройство вывода. Psysonic показывает все доступные выходы. Выбор вступает в силу немедленно.',
+    q53: 'Что такое синхронизация с устройством?',
+    a53: 'Device Sync копирует альбомы, плейлисты или исполнителей на USB-накопитель или SD-карту. Откройте через «Device Sync» на боковой панели, выберите папку назначения, источники и нажмите «Передать на устройство».',
+    q54: 'Что такое шаблон имени файла в Device Sync?',
+    a54: 'Шаблон определяет, как треки будут называться и организованы. Используйте предустановки или создайте свой шаблон из токенов: {artist}, {album}, {title}, {track_number}, {disc_number}, {year} и / как разделитель папок.',
+    q55: 'Работает ли Device Sync между разными платформами?',
+    a55: 'Да. Манифест на устройстве содержит использованный шаблон. На другой ОС Psysonic корректно распознаёт уже существующие файлы.',
+    s9: 'Device Sync',
+    q56: 'Что такое интернет-радио?',
+    a56: 'Страница интернет-радио позволяет воспроизводить прямые трансляции в Psysonic. Станции берутся с сервера Navidrome. Воспроизведение использует HTML5-аудио.',
+    q57: 'Какие форматы потоков поддерживает интернет-радио?',
+    a57: 'MP3, AAC, OGG Vorbis и большинство HLS-потоков. MP3 и AAC работают на всех платформах.',
+    s10: 'Интернет-радио',
+    q58: 'Откуда Psysonic берёт тексты песен?',
+    a58: 'Три настраиваемых источника в Настройках → Тексты: сервер Navidrome, LRCLIB и NetEase Cloud Music. Каждый источник можно включить/отключить и приоритизировать перетаскиванием.',
+    q59: 'Есть ли просмотр того, что слушают другие пользователи?',
+    a59: 'Да. Нажмите на иконку трансляции в правом верхнем углу, чтобы увидеть, что слушают другие пользователи на вашем сервере Navidrome, с обновлением каждые 10 секунд.',
   },
-
   queue: {
-
     title: 'Очередь',
-
     savePlaylist: 'Сохранить как плейлист',
-
     updatePlaylist: 'Обновить плейлист',
-
     filterPlaylists: 'Фильтр плейлистов…',
-
     playlistName: 'Название плейлиста',
-
     cancel: 'Отмена',
-
     save: 'Сохранить',
-
     loadPlaylist: 'Загрузить плейлист',
-
     loading: 'Загрузка…',
-
     noPlaylists: 'Плейлистов нет.',
-
     load: 'Заменить очередь и играть',
-
     appendToQueue: 'Добавить в очередь',
-
     delete: 'Удалить',
-
     deleteConfirm: 'Удалить плейлист «{{name}}»?',
-
     clear: 'Очистить',
-
     shuffle: 'Перемешать',
-
     gapless: 'Без пауз',
-
     crossfade: 'Кроссфейд',
-
     infiniteQueue: 'Бесконечная очередь',
-
     autoAdded: '— Добавлено автоматически —',
-
     radioAdded: '— Радио —',
-
     hide: 'Скрыть',
-
     close: 'Закрыть',
-
     nextTracks: 'Дальше',
-
     emptyQueue: 'Очередь пуста.',
-
     trackSingular: 'трек',
-
     trackPlural: 'треков',
-
     showRemaining: 'Осталось',
-
     showTotal: 'Всего',
-
   },
-
   statistics: {
-
     title: 'Статистика',
-
     recentlyPlayed: 'Недавно проиграно',
-
     mostPlayed: 'Самые проигранные альбомы',
-
     highestRated: 'С высоким рейтингом',
-
     genreDistribution: 'Жанры (топ-20)',
-
     loadMore: 'Ещё',
-
     statArtists: 'Исполнители',
-
     statArtistsTooltip: 'Только исполнители альбомов — артисты, присутствующие лишь в треках (фичеринг, гость и т. д.) без собственного альбома, не учитываются.',
-
     statAlbums: 'Альбомы',
-
     statSongs: 'Треки',
-
     statGenres: 'Жанры',
-
     statPlaytime: 'Время звучания',
-
     genreInsights: 'По жанрам',
-
     formatDistribution: 'Форматы',
-
     formatSample: 'Выборка {{n}} треков',
-
     computing: 'Считаем…',
-
     genreSongs_one: '{{count}} композиция',
-
     genreSongs_few: '{{count}} композиции',
-
     genreSongs_many: '{{count}} композиций',
-
     genreSongs_other: '{{count}} композиций',
-
     genreAlbums_one: '{{count}} альбом',
-
     genreAlbums_few: '{{count}} альбома',
-
     genreAlbums_many: '{{count}} альбомов',
-
     genreAlbums_other: '{{count}} альбомов',
-
     recentlyAdded: 'Недавно добавлено',
-
     decadeDistribution: 'Альбомы по десятилетиям',
-
     decadeAlbums_one: '{{count}} альбом',
-
     decadeAlbums_few: '{{count}} альбома',
-
     decadeAlbums_many: '{{count}} альбомов',
-
     decadeAlbums_other: '{{count}} альбомов',
-
     decadeUnknown: 'Неизвестно',
-
     lfmTitle: 'Статистика Last.fm',
-
     lfmTopArtists: 'Топ исполнителей',
-
     lfmTopAlbums: 'Топ альбомов',
-
     lfmTopTracks: 'Топ треков',
-
     lfmPlays_one: '{{count}} прослушивание',
-
     lfmPlays_few: '{{count}} прослушивания',
-
     lfmPlays_many: '{{count}} прослушиваний',
-
     lfmPlays_other: '{{count}} прослушиваний',
-
     lfmPeriodOverall: 'За всё время',
-
     lfmPeriod7day: '7 дней',
-
     lfmPeriod1month: 'Месяц',
-
     lfmPeriod3month: '3 месяца',
-
     lfmPeriod6month: '6 месяцев',
-
     lfmPeriod12month: 'Год',
-
     lfmNotConnected: 'Подключите Last.fm в настройках.',
-
     lfmRecentTracks: 'Последние скробблы',
-
     lfmNowPlaying: 'Сейчас играет',
-
     lfmJustNow: 'только что',
-
     lfmMinutesAgo: '{{n}} мин назад',
-
     lfmHoursAgo: '{{n}} ч назад',
-
     lfmDaysAgo: '{{n}} дн. назад',
-
     topRatedSongs: 'Лучшие по рейтингу треки',
-
     topRatedArtists: 'Лучшие по рейтингу исполнители',
-
     noRatedSongs: 'Нет оценённых треков. Ставьте оценки в альбомах или плейлистах.',
-
     noRatedArtists: 'Нет оценённых исполнителей.',
-
   },
-
   player: {
-
     regionLabel: 'Плеер',
-
     openFullscreen: 'Полноэкранный плеер',
-
     fullscreen: 'Полноэкранный режим',
-
     closeFullscreen: 'Выйти из полноэкранного',
-
     closeTooltip: 'Закрыть (Esc)',
-
     noTitle: 'Без названия',
-
     stop: 'Стоп',
-
     prev: 'Предыдущий трек',
-
     play: 'Играть',
-
     pause: 'Пауза',
-
     next: 'Следующий трек',
-
     repeat: 'Повтор',
-
     repeatOff: 'Выкл.',
-
     repeatAll: 'Все',
-
     repeatOne: 'Один',
-
     progress: 'Прогресс',
-
     volume: 'Громкость',
-
     toggleQueue: 'Очередь',
-
     lyrics: 'Текст',
-
     lyricsLoading: 'Загрузка текста…',
-
     lyricsNotFound: 'Текст не найден',
-
     lyricsSourceNetease: 'Источник: Netease',
-
   },
-
   songInfo: {
-
     title: 'О треке',
-
     songTitle: 'Название',
-
     artist: 'Исполнитель',
-
     album: 'Альбом',
-
     albumArtist: 'Альбомный исполнитель',
-
     year: 'Год',
-
     genre: 'Жанр',
-
     duration: 'Длительность',
-
     track: 'Номер',
-
     format: 'Формат',
-
     bitrate: 'Битрейт',
-
     sampleRate: 'Частота',
-
     bitDepth: 'Разрядность',
-
     channels: 'Каналы',
-
     fileSize: 'Размер файла',
-
     path: 'Путь',
-
     replayGainTrack: 'RG по треку',
-
     replayGainAlbum: 'RG по альбому',
-
     replayGainPeak: 'Пик RG',
-
     mono: 'Моно',
-
     stereo: 'Стерео',
-
   },
-
   playlists: {
-
     title: 'Плейлисты',
-
     newPlaylist: 'Новый плейлист',
-
     unnamed: 'Без названия',
-
     createName: 'Название…',
-
     create: 'Создать',
-
     cancel: 'Отмена',
-
     empty: 'Плейлистов пока нет.',
-
     emptyPlaylist: 'Плейлист пуст.',
-
     addFirstSong: 'Добавьте первый трек',
-
     notFound: 'Плейлист не найден.',
-
     songs: 'Треков: {{n}}',
-
     playAll: 'Воспроизвести всё',
-
     shuffle: 'Перемешать',
-
     addToQueue: 'В очередь',
-
     back: 'К списку плейлистов',
-
     deletePlaylist: 'Удалить',
-
     confirmDelete: 'Нажмите ещё раз для подтверждения',
-
     removeSong: 'Убрать из плейлиста',
-
     addSongs: 'Добавить треки',
-
     searchPlaceholder: 'Поиск по библиотеке…',
-
     noResults: 'Ничего не найдено.',
-
     suggestions: 'Рекомендации',
-
     noSuggestions: 'Пока нет рекомендаций.',
-
     titleBadge: 'Плейлист',
-
     refreshSuggestions: 'Обновить подборку',
-
     addSong: 'В плейлист',
-
     addSelected: 'Добавить выбранные',
-
     cacheOffline: 'Сохранить плейлист офлайн',
-
     offlineCached: 'Плейлист сохранён',
-
     removeOffline: 'Удалить из офлайн-кэша',
-
     offlineDownloading: 'Кэширование… ({{done}} из {{total}} альбомов)',
-
     publicLabel: 'Публичный',
-
     privateLabel: 'Личный',
-
     editMeta: 'Изменить плейлист',
-
     editNamePlaceholder: 'Название…',
-
     editCommentPlaceholder: 'Описание…',
-
     editPublic: 'Публичный плейлист',
-
     editSave: 'Сохранить',
-
     editCancel: 'Отмена',
-
     changeCover: 'Сменить обложку',
-
     changeCoverLabel: 'Сменить фото',
-
     removeCover: 'Убрать фото',
-
     coverUpdated: 'Обложка обновлена',
-
     metaSaved: 'Плейлист сохранён',
-
     downloadZip: 'Скачать (ZIP)',
-
     // Toast notifications for multi-select
-
     addSuccess: '{{count}} треков добавлено в {{playlist}}',
-
     addPartial: '{{added}} добавлено, {{skipped}} пропущено (дубликаты)',
-
     addAllSkipped: 'Все пропущены ({{count}} дубликатов)',
-
     addError: 'Ошибка при добавлении треков',
-
     createAndAddSuccess: 'Плейлист "{{playlist}}" создан с {{count}} треками',
-
     createError: 'Ошибка при создании плейлиста',
-
     deleteSuccess: '{{count}} плейлистов удалено',
-
     deleteFailed: 'Ошибка при удалении {{name}}',
-
     deleteSelected: 'Удалить выбранные',
-
     mergeSuccess: '{{count}} треков объединено в {{playlist}}',
-
     mergeNoNewSongs: 'Нет новых треков для добавления',
-
     mergeError: 'Ошибка при объединении плейлистов',
-
     mergeInto: 'Объединить в',
-
     selectionCount: '{{count}} выбрано',
-
     select: 'Выбрать',
-
     startSelect: 'Включить выбор',
-
     cancelSelect: 'Отмена',
-
     loadingAlbums: 'Загрузка {{count}} альбомов…',
-
     loadingArtists: 'Загрузка {{count}} исполнителей…',
-
     myPlaylists: 'Мои плейлисты',
-
     noOtherPlaylists: 'Нет других доступных плейлистов',
-
     addToPlaylistSuccess: '{{count}} треков добавлено в {{playlist}}',
-
     addToPlaylistNoNew: 'Нет новых треков для {{playlist}}',
-
     addToPlaylistError: 'Ошибка при добавлении в плейлист',
-
     removeSuccess: 'Трек убран из плейлиста',
-
     removeError: 'Ошибка при удалении из плейлиста',
-
     importCSV: 'Импорт CSV',
-
     importCSVTooltip: 'Импорт из CSV Spotify',
-
     csvImportReport: 'Отчёт об импорте CSV',
-
     csvImportTotal: 'Всего',
-
     csvImportAdded: 'Добавлено',
-
     csvImportDuplicates: 'Дубликаты',
-
     csvImportNotFound: 'Не найдено',
-
     csvImportNetworkErrors: 'Ошибки сети',
-
     csvImportDuplicatesTitle: 'Дубликаты (уже в плейлисте):',
-
     csvImportNotFoundTitle: 'Не найденные треки:',
-
     csvImportNetworkErrorsTitle: 'Ошибки сети (можно повторить импорт):',
-
     csvImportDownloadReport: 'Скачать отчёт',
-
     csvImportClose: 'Закрыть',
-
     csvImportNoValidTracks: 'В CSV-файле не найдено действительных треков',
-
     csvImportFailed: 'Не удалось импортировать CSV-файл',
-
     csvImportToast: '{{added}} добавлено, {{notFound}} не найдено, {{duplicates}} дубликатов',
-
   },
-
   mostPlayed: {
-
     title: 'Популярное',
-
     topArtists: 'Топ исполнителей',
-
     topAlbums: 'Топ альбомов',
-
     plays: '{{n}} прослушиваний',
-
     sortMost: 'Сначала популярные',
-
     sortLeast: 'Сначала малоизвестные',
-
     loadMore: 'Загрузить больше альбомов',
-
     noData: 'Пока нет данных о прослушивании. Начните слушать!',
-
     noArtists: 'Все исполнители отфильтрованы.',
-
     filterCompilations: 'Скрыть исполнителей сборников (Various Artists, Soundtracks и др.)',
-
     filterCompilationsShort: 'Скрыть сборники',
-
   },
-
   radio: {
-
     title: 'Онлайн-радио',
-
     empty: 'Радиостанции не настроены.',
-
     addStation: 'Добавить станцию',
-
     editStation: 'Изменить',
-
     deleteStation: 'Удалить станцию',
-
     confirmDelete: 'Нажмите ещё раз для подтверждения',
-
     stationName: 'Название станции…',
-
     streamUrl: 'URL потока…',
-
     homepageUrl: 'Сайт станции (необязательно)',
-
     save: 'Сохранить',
-
     cancel: 'Отмена',
-
     live: 'ЭФИР',
-
     liveStream: 'Онлайн-радио',
-
     openHomepage: 'Открыть сайт',
-
     changeCoverLabel: 'Сменить обложку',
-
     removeCover: 'Убрать обложку',
-
     browseDirectory: 'Каталог станций',
-
     directoryPlaceholder: 'Поиск станций…',
-
     noResults: 'Станции не найдены.',
-
     stationAdded: 'Станция добавлена',
-
     filterAll: 'Все',
-
     filterFavorites: 'Избранное',
-
     sortManual: 'Вручную',
-
     sortAZ: 'А → Я',
-
     sortZA: 'Я → А',
-
     sortNewest: 'Сначала новые',
-
     favorite: 'В избранное',
-
     unfavorite: 'Убрать из избранного',
-
     noFavorites: 'Избранных станций нет.',
-
     listenerCount_one: '{{count}} слушатель',
-
     listenerCount_other: '{{count}} слушателей',
-
     recentlyPlayed: 'Недавно сыгранное',
-
     upNext: 'Следующий',
-
   },
-
   folderBrowser: {
-
     empty: 'Папка пуста',
-
     error: 'Ошибка загрузки',
-
   },
-
   deviceSync: {
-
     title: 'Синхронизация устройства',
-
     targetFolder: 'Папка назначения',
-
     noFolderChosen: 'Папка не выбрана',
-
     selectDrive: 'Выберите диск…',
-
     refreshDrives: 'Обновить диски',
-
     noDrivesDetected: 'Съёмные диски не обнаружены',
-
     browseManual: 'Обзор вручную…',
-
     free: 'свободно',
-
     notMountedVolume: 'Цель не находится на смонтированном томе. Диск мог быть отключён.',
-
     chooseFolder: 'Выбрать…',
-
     filenameTemplate: 'Шаблон имени файла',
-
     targetDevice: 'Целевое устройство',
-
     templateHint: 'Переменные: {artist}, {album}, {title}, {track_number}, {disc_number}, {year}',
-
     cleanupButton: 'Удалить файлы вне выборки',
-
     cleanupNothingToDelete: 'Нечего удалять — устройство уже синхронизировано.',
-
     confirmCleanup: 'Удалить {{count}} файл(ов) с устройства, не входящих в текущую выборку. Продолжить?',
-
     cleanupComplete: '{{count}} файл(ов) удалено с устройства.',
-
     selectedSources: 'Выбранные источники',
-
     noSourcesSelected: 'Источники не выбраны. Нажмите на элементы в браузере, чтобы добавить их.',
-
     clearAll: 'Очистить всё',
-
     tabPlaylists: 'Плейлисты',
-
     tabAlbums: 'Альбомы',
-
     tabArtists: 'Исполнители',
-
     searchPlaceholder: 'Поиск…',
-
     syncButton: 'Синхронизировать на устройство',
-
     actionTransfer: 'Перенести на устройство',
-
     actionDelete: 'Удалить с устройства',
-
     actionApplyAll: 'Применить все изменения',
-
     templatePreview: 'Предпросмотр',
-
+    templatePresetStandard: 'Стандарт',
+    templatePresetMultiDisc: 'Мульти-диск',
+    templatePresetAltFolder: 'Альт. папка',
+    tokenSlashHint: '/ = разделитель папок',
     cancel: 'Отмена',
-
     noTargetDir: 'Сначала выберите папку назначения.',
-
     noSources: 'Выберите хотя бы один источник.',
-
     noTracks: 'В выбранных источниках не найдено треков.',
-
     fetchError: 'Ошибка загрузки треков с сервера.',
-
     syncComplete: 'Синхронизация завершена.',
-
     dismiss: 'Закрыть',
-
+    cancelSync: 'Отмена',
+    syncCancelled: 'Синхронизация отменена ({{done}} / {{total}} перенесено).',
     colName: 'Название',
-
     colType: 'Тип',
-
     colStatus: 'Статус',
-
     onDevice: 'Управление устройством',
-
     addSources: 'Добавить…',
-
     syncResult: '{{done}} перенесено, {{skipped}} уже актуально ({{total}} всего)',
-
     deleteFromDevice: 'Пометить для удаления ({{count}})',
-
     confirmDelete: 'Удалить {{count}} запись(ей) с устройства: {{names}}?',
-
     deleteComplete: '{{count}} запись(ей) удалено с устройства.',
-
+    manifestImported: 'Импортировано {{count}} источник(ов) из манифеста устройства.',
     statusSynced: 'Синхронизировано',
-
     statusPending: 'Ожидает',
-
     statusDeletion: 'Удаление',
-
     markForDeletion: 'Пометить для удаления',
-
     removeSource: 'Удалить',
-
     undoDeletion: 'Отменить удаление',
-
     syncInBackground: 'Синхронизация запущена в фоне — можно перейти в другой раздел.',
-
     syncInProgress: '{{done}} / {{total}} треков…',
-
     syncSummary: 'Сводка синхронизации',
-
     calculating: 'Вычисление необходимых данных…',
-
     filesToAdd: 'Файлы для добавления:',
-
     filesToDelete: 'Файлы для удаления:',
-
     netChange: 'Чистое изменение:',
-
     availableSpace: 'Доступное место на диске:',
-
     spaceWarning: 'Предупреждение: на целевом устройстве недостаточно сообщаемого места.',
-
     proceed: 'Продолжить синхронизацию',
-
     notEnoughSpace: 'Обнаружено недостаточно физического места на диске!',
-
     liveSearch: 'Live',
-
     randomAlbumsLabel: 'Случайные альбомы',
-
   },
-
 };
-

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -1,1157 +1,2252 @@
 export const zhTranslation = {
+
   sidebar: {
+
     library: '音乐库',
+
     mainstage: '主舞台',
+
     newReleases: '新发布',
+
     allAlbums: '全部专辑',
+
     randomAlbums: '随机专辑',
+
     randomPicker: '创建混音',
+
     artists: '艺术家',
+
     randomMix: '随机混音',
+
     favorites: '收藏夹',
+
     nowPlaying: '正在播放',
+
     system: '系统',
+
     statistics: '统计',
+
     settings: '设置',
+
     help: '帮助',
+
     expand: '展开侧边栏',
+
     collapse: '收起侧边栏',
+
     downloadingTracks: '正在缓存 {{n}} 首歌曲…',
+
     syncingTracks: '同步中 {{done}}/{{total}}…',
+
     cancelDownload: '取消下载',
+
     offlineLibrary: '离线音乐库',
+
     genres: '流派',
+
     playlists: '播放列表',
+
     mostPlayed: '最常播放',
+
     radio: '网络电台',
+
     folderBrowser: '文件夹浏览器',
+
     deviceSync: '设备同步',
+
     libraryScope: '资料库范围',
+
     allLibraries: '所有资料库',
+
     expandPlaylists: '展开播放列表',
+
     collapsePlaylists: '收起播放列表',
+
   },
+
   home: {
+
     hero: '精选',
+
     starred: '个人收藏',
+
     recent: '最近添加',
+
     mostPlayed: '最常播放',
+
     recentlyPlayed: '最近播放',
+
     discover: '发现',
+
     loadMore: '加载更多',
+
     discoverMore: '发现更多',
+
     discoverArtists: '发现艺术家',
+
     discoverArtistsMore: '全部艺术家'
+
   },
+
   hero: {
+
     eyebrow: '精选专辑',
+
     playAlbum: '播放专辑',
+
     enqueue: '加入队列',
+
     enqueueTooltip: '将整张专辑添加到播放队列',
+
   },
+
   search: {
+
     placeholder: '搜索艺术家、专辑或歌曲…',
+
     noResults: '未找到 "{{query}}" 的相关结果',
+
     artists: '艺术家',
+
     albums: '专辑',
+
     songs: '歌曲',
+
     clearLabel: '清除搜索',
+
     title: '搜索',
+
     resultsFor: '"{{query}}" 的搜索结果',
+
     album: '专辑',
+
     advanced: '高级搜索',
+
     advancedSearchTerm: '搜索词',
+
     advancedSearchPlaceholder: '标题、专辑、艺术家…',
+
     advancedGenre: '流派',
+
     advancedAllGenres: '所有流派',
+
     advancedYear: '年份',
+
     advancedYearFrom: '从',
+
     advancedYearTo: '至',
+
     advancedAll: '全部',
+
     advancedSearch: '搜索',
+
     advancedEmpty: '请输入搜索词或选择过滤器。',
+
     advancedNoResults: '未找到结果。',
+
     advancedGenreNote: '歌曲从该流派中随机选取。',
+
     recentSearches: '最近搜索',
+
     browse: '浏览',
+
     emptyHint: '你想听什么？',
+
     genres: '流派',
+
   },
+
   nowPlaying: {
+
     tooltip: '谁正在收听？',
+
     title: '谁正在收听？',
+
     loading: '加载中…',
+
     nobody: '当前无人收听。',
+
     minutesAgo: '{{n}} 分钟前',
+
     nothingPlaying: '尚未开始播放。开始播放一首歌曲吧！',
+
     aboutArtist: '关于艺术家',
+
     fromAlbum: '来自此专辑',
+
     viewAlbum: '查看专辑',
+
     goToArtist: '前往艺术家',
+
     readMore: '阅读更多',
+
     showLess: '收起',
+
     genreInfo: '流派',
+
     trackInfo: '曲目信息',
+
   },
+
   contextMenu: {
+
     playNow: '立即播放',
+
     playNext: '下一首播放',
+
     addToQueue: '添加到队列',
+
     enqueueAlbum: '专辑加入队列',
+
     startRadio: '开始电台',
+
     instantMix: '即时混音',
+
     instantMixFailed: '无法生成即时混音 — 服务器或插件出错。',
+
     cliMixNeedsTrack: '当前没有正在播放的内容 — 请先开始播放，然后再执行混音命令。',
+
     lfmLove: '在 Last.fm 上标记喜欢',
+
     lfmUnlove: '取消 Last.fm 喜欢标记',
+
     favorite: '收藏',
+
     favoriteArtist: '收藏艺术家',
+
     favoriteAlbum: '收藏专辑',
+
     unfavorite: '取消收藏',
+
     unfavoriteArtist: '取消收藏艺术家',
+
     unfavoriteAlbum: '取消收藏专辑',
+
     removeFromQueue: '从队列中移除',
+
     openAlbum: '打开专辑',
+
     goToArtist: '前往艺术家',
+
     download: '下载 (ZIP)',
+
     addToPlaylist: '添加到播放列表',
+
     selectedPlaylists: '已选择 {{count}} 个播放列表',
+
     selectedAlbums: '已选择 {{count}} 个专辑',
+
     selectedArtists: '已选择 {{count}} 个艺术家',
+
     songInfo: '歌曲信息',
+
   },
+
   albumDetail: {
+
     back: '返回',
+
     playAll: '全部播放',
+
     enqueue: '加入队列',
+
     enqueueTooltip: '将整张专辑添加到播放队列',
+
     artistBio: '艺术家简介',
+
     download: '下载 (ZIP)',
+
     downloading: '加载中…',
+
     cacheOffline: '设为离线可用',
+
     offlineCached: '已离线缓存',
+
     offlineDownloading: '正在缓存… ({{n}}/{{total}})',
+
     removeOffline: '移除离线缓存',
+
     offlineStorageFull: '离线存储空间已满（限制：{{mb}} MB）。请从离线音乐库中删除专辑以释放空间，或在设置中增加限制。',
+
     offlineStorageGoToLibrary: '离线音乐库',
+
     offlineStorageGoToSettings: '设置',
+
     favoriteAdd: '添加到收藏',
+
     favoriteRemove: '从收藏中移除',
+
     favorite: '收藏',
+
     noBio: '暂无简介。',
+
     moreByArtist: '{{artist}} 的更多作品',
+
     tracksCount: '{{n}} 首曲目',
+
     goToArtist: '前往 {{artist}}',
+
     moreLabelAlbums: '{{label}} 的更多专辑',
+
     trackTitle: '标题',
+
     trackAlbum: '专辑',
+
     trackArtist: '艺术家',
+
     trackGenre: '流派',
+
     trackFormat: '格式',
+
     trackFavorite: '收藏',
+
     trackRating: '评分',
+
     trackDuration: '时长',
+
     trackTotal: '总计',
+
     columns: '列',
-    resetColumns: '重置为默认',
+
     notFound: '未找到专辑。',
+
     bioModal: '艺术家简介',
+
     bioClose: '关闭',
+
     ratingLabel: '评分',
+
     enlargeCover: '放大',
+
     filterSongs: '筛选歌曲…',
+
     sortNatural: '默认顺序',
+
     sortByTitle: 'A–Z（标题）',
+
     sortByArtist: 'A–Z（艺术家）',
+
     sortByAlbum: 'A–Z（专辑）',
+
   },
+
   entityRating: {
+
     albumShort: '专辑评分',
+
     artistShort: '艺人评分',
+
     albumAriaLabel: '专辑评分',
+
     artistAriaLabel: '艺人评分',
+
     saveFailed: '无法保存评分。',
+
   },
+
   artistDetail: {
+
     back: '返回',
+
     albums: '专辑',
+
     album: '专辑',
+
     playAll: '全部播放',
+
     shuffle: '随机播放',
+
     radio: '电台',
+
     loading: '加载中…',
+
     noRadio: '未找到该艺术家的相似曲目。',
+
     notFound: '未找到艺术家。',
+
     albumsBy: '{{name}} 的专辑',
+
     topTracks: '热门曲目',
+
     noAlbums: '未找到专辑。',
+
     trackTitle: '标题',
+
     trackAlbum: '专辑',
+
     trackDuration: '时长',
+
     favoriteAdd: '添加到收藏',
+
     favoriteRemove: '从收藏中移除',
+
     favorite: '收藏',
+
     albumCount_one: '{{count}} 张专辑',
+
     albumCount_other: '{{count}} 张专辑',
+
     openedInBrowser: '已在浏览器中打开',
+
     featuredOn: '还出现在',
+
     similarArtists: '相似艺术家',
+
     cacheOffline: '离线保存全部专辑',
+
     offlineCached: '全部专辑已缓存',
+
     offlineDownloading: '正在缓存… ({{done}}/{{total}} 张专辑)',
+
     uploadImage: '上传艺术家图片',
+
     uploadImageError: '图片上传失败',
+
   },
+
   favorites: {
+
     title: '收藏夹',
+
     empty: '您还没有保存任何收藏。',
+
     artists: '艺术家',
+
     albums: '专辑',
+
     songs: '歌曲',
+
     enqueueAll: '全部加入队列',
+
     playAll: '全部播放',
+
     removeSong: '从收藏中移除',
+
     stations: '广播电台',
+
     showingFiltered: '显示 {{filtered}} / {{total}} ({{artist}})',
+
     showingCount: '显示 {{filtered}} / {{total}}',
+
     clearArtistFilter: '清除艺术家筛选',
+
     noFilterResults: '所选筛选条件下无结果。',
+
     allArtists: '全部艺术家',
+
   },
+
   randomLanding: {
+
     title: '创建混音',
+
     mixByTracks: '按曲目混音',
+
     mixByTracksDesc: '从整个媒体库随机选取曲目',
+
     mixByAlbums: '按专辑混音',
+
     mixByAlbumsDesc: '随机选取专辑，探索新音乐',
+
   },
+
   randomAlbums: {
+
     title: '随机专辑',
+
     refresh: '刷新',
+
   },
+
   genres: {
+
     title: '流派',
+
     genreCount: '个流派',
+
     albumCount_one: '{{count}} 张专辑',
+
     albumCount_other: '{{count}} 张专辑',
+
     loading: '正在加载流派…',
+
     empty: '未找到流派。',
+
     albumsLoading: '正在加载专辑…',
+
     albumsEmpty: '未找到该流派的专辑。',
+
     loadMore: '加载更多',
+
     back: '返回',
+
   },
+
   randomMix: {
+
     title: '随机混音',
+
     remix: '重新混音',
+
     remixTooltip: '加载新的随机歌曲',
+
     remixGenre: '重混 {{genre}}',
+
     remixTooltipGenre: '加载新的{{genre}}歌曲',
+
     playAll: '全部播放',
+
     trackTitle: '标题',
+
     trackArtist: '艺术家',
+
     trackAlbum: '专辑',
+
     trackFavorite: '收藏',
+
     trackDuration: '时长',
+
     favoriteAdd: '添加到收藏',
+
     favoriteRemove: '从收藏中移除',
+
     play: '播放',
+
     trackGenre: '流派',
+
     excludeAudiobooks: '排除有声读物和广播剧',
+
     excludeAudiobooksDesc: '根据流派、标题、专辑和艺术家匹配关键词 — 例如 Hörbuch、Audiobook、Spoken Word 等',
+
     genreBlocked: '关键词已屏蔽',
+
     genreAddedToBlacklist: '已添加到过滤列表',
+
     genreAlreadyBlocked: '已屏蔽',
+
     artistBlocked: '艺术家已屏蔽',
+
     artistAddedToBlacklist: '艺术家已添加到过滤列表',
+
     artistClickHint: '点击屏蔽此艺术家',
+
     blacklistToggle: '关键词过滤',
+
     genreMixTitle: '流派混音',
+
     genreMixDesc: '按歌曲数量排列的前 20 个流派 — 点击获取随机混音',
+
     genreMixAll: '所有歌曲',
+
     genreMixLoadMore: '加载 10 首更多',
+
     genreMixNoGenres: '服务器上未找到流派。',
+
     shuffleGenres: '显示其他流派',
+
     filterPanelTitle: '过滤器',
+
     filterPanelDesc: '点击下方列表中的流派标签或艺术家名称，将其从未来的混音中排除。',
+
     genreClickHint: '点击流派标签将其添加为过滤关键词。\\n匹配流派、标题、专辑和艺术家。',
+
   },
+
   albums: {
+
     title: '全部专辑',
+
     sortByName: '按名称排序 (A-Z)',
+
     sortByArtist: '按艺术家排序 (A-Z)',
+
     sortNewest: '最新优先',
+
     sortRandom: '随机排序',
+
     yearFrom: '从',
+
     yearTo: '到',
+
     yearFilterClear: '清除年份筛选',
+
     yearFilterLabel: '年份',
+
     select: '多选',
+
     startSelect: '启用多选',
+
     cancelSelect: '取消',
+
     selectionCount: '{{count}} 已选择',
+
     downloadZips: '下载 ZIP',
+
     addOffline: '添加离线',
+
     downloadingZip: '正在下载 {{current}}/{{total}}: {{name}}',
+
     downloadZipDone: '已下载 {{count}} 个 ZIP',
+
     downloadZipFailed: '下载 {{name}} 失败',
+
     offlineQueuing: '正在将 {{count}} 张专辑加入离线队列…',
+
     offlineFailed: '添加 {{name}} 离线失败',
+
   },
+
   artists: {
+
     title: '艺术家',
+
     search: '搜索…',
+
     all: '全部',
+
     gridView: '网格视图',
+
     listView: '列表视图',
+
     imagesOn: '艺术家图片已开启 — 可能增加网络和系统负载',
+
     imagesOff: '艺术家图片已关闭 — 仅显示首字母',
+
     loadMore: '加载更多',
+
     notFound: '未找到艺术家。',
+
     albumCount_one: '{{count}} 张专辑',
+
     albumCount_other: '{{count}} 张专辑',
+
     selectionCount: '{{count}} 已选择',
+
     select: '多选',
+
     startSelect: '启用多选',
+
     cancelSelect: '取消',
+
     addToPlaylist: '添加到播放列表',
+
   },
+
   login: {
+
     subtitle: '您的 Navidrome 桌面播放器',
+
     serverName: '服务器名称（可选）',
+
     serverNamePlaceholder: '我的 Navidrome',
+
     serverUrl: '服务器地址',
+
     serverUrlPlaceholder: '192.168.1.100:4533 或 https://music.example.com',
+
     username: '用户名',
+
     usernamePlaceholder: 'admin',
+
     password: '密码',
+
     showPassword: '显示密码',
+
     hidePassword: '隐藏密码',
+
     connect: '连接',
+
     connecting: '正在连接…',
+
     connected: '已连接！',
+
     error: '连接失败 — 请检查您的信息。',
+
     urlRequired: '请输入服务器地址。',
+
     savedServers: '已保存的服务器',
+
     addNew: '或添加新服务器',
+
   },
+
   connection: {
+
     connected: '已连接',
+
     connectedTo: '已连接到 {{server}}',
+
     disconnected: '已断开连接',
+
     disconnectedFrom: '无法连接到 {{server}} — 点击检查设置',
+
     checking: '正在连接…',
+
     extern: '外部',
+
     offlineTitle: '无服务器连接',
+
     offlineSubtitle: '无法连接到 {{server}}。请检查您的网络或服务器。',
+
     offlineModeBanner: '离线模式 — 正在从本地缓存播放',
+
     offlineNoCacheBanner: '无服务器连接 — 无法访问 {{server}}',
+
     offlineLibraryTitle: '离线音乐库',
+
     offlineLibraryEmpty: '尚未缓存任何专辑。请联网，打开专辑并点击"设为离线可用"。',
+
     offlineAlbumCount_one: '{{n}} 张专辑',
+
     offlineAlbumCount_plural: '{{n}} 张专辑',
+
     retry: '重试',
+
     serverSettings: '服务器设置',
+
     switchServerTitle: '切换服务器',
+
     switchServerHint: '点击选择其他已保存的服务器。',
+
     manageServers: '管理服务器…',
+
     switchFailed: '无法切换 — 无法连接服务器。',
+
     lastfmConnected: 'Last.fm 已连接为 @{{user}}',
+
     lastfmSessionInvalid: '会话无效 — 点击重新连接',
+
   },
+
   common: {
+
     albums: '专辑',
+
     album: '专辑',
+
     loading: '加载中…',
+
     loadingMore: '加载中…',
+
     loadingPlaylists: '正在加载播放列表…',
+
     noAlbums: '未找到专辑。',
+
     downloading: '正在下载…',
+
     downloadZip: '下载 (ZIP)',
+
     back: '返回',
+
     cancel: '取消',
+
     save: '保存',
+
     delete: '删除',
+
     use: '使用',
+
     add: '添加',
+
     active: '当前使用',
+
     download: '下载',
+
     chooseDownloadFolder: '选择下载文件夹',
+
     noFolderSelected: '未选择文件夹',
+
     rememberDownloadFolder: '记住此文件夹',
+
     filterGenre: '流派筛选',
+
     filterSearchGenres: '搜索流派…',
+
     filterNoGenres: '未找到匹配流派',
+
     filterClear: '清除',
+
     play: '播放',
+
     bulkSelected: '已选 {{count}} 首',
+
     clearSelection: '清除选择',
+
     bulkAddToPlaylist: '添加到播放列表',
+
     bulkRemoveFromPlaylist: '从播放列表移除',
+
     bulkClear: '取消选择',
+
     updaterAvailable: '有可用更新',
+
     updaterVersion: 'v{{version}} 已发布',
+
     updaterWebsite: '官网',
+
     updaterModalTitle: '有新版本可用',
+
     updaterChangelog: '更新内容',
+
     updaterDownloadBtn: '立即下载',
+
     updaterSkipBtn: '跳过此版本',
+
     updaterRemindBtn: '稍后提醒',
+
     updaterDone: '下载完成',
+
     updaterShowFolder: '在文件夹中显示',
+
     updaterInstallHint: '请关闭 Psysonic 并手动运行安装程序。',
+
     updaterAurHint: '通过 AUR 安装更新：',
+
     updaterErrorMsg: '下载失败',
+
     updaterRetryBtn: '重试',
+
     durationHoursMinutes: '{{hours}}小时{{minutes}}分钟',
+
     durationMinutesOnly: '{{minutes}}分钟',
+
     updaterOpenGitHub: '在 GitHub 上打开',
+
     filters: '筛选器',
+
     more: '更多',
+
     yearRange: '年份范围',
+
     clearAll: '清除全部',
+
   },
+
   settings: {
+
     title: '设置',
+
     language: '语言',
+
     languageEn: '英语',
+
     languageDe: '德语',
+
     languageFr: '法语',
+
     languageNl: '荷兰语',
+
     languageZh: '中文',
+
     languageNb: '挪威',
+
     languageRu: '俄语',
+
     font: '字体',
+
     theme: '主题',
+
     appearance: '外观',
+
     servers: '服务器',
+
     serverName: '服务器名称',
+
     serverUrl: '服务器地址',
+
     serverUrlPlaceholder: '192.168.1.100:4533 或 https://music.example.com',
+
     serverUsername: '用户名',
+
     serverPassword: '密码',
+
     addServer: '添加服务器',
+
     addServerTitle: '添加新服务器',
+
     useServer: '使用',
+
     deleteServer: '删除',
+
     noServers: '未保存任何服务器。',
+
     serverActive: '当前使用',
+
     confirmDeleteServer: '删除服务器 "{{name}}"？',
+
     serverConnecting: '正在连接…',
+
     serverConnected: '已连接！',
+
     serverFailed: '连接失败。',
+
     testBtn: '测试连接',
+
     testingBtn: '正在测试…',
+
     serverCompatible: '兼容：Navidrome · Gonic · Airsonic · Subsonic',
+
     audiomuseTitle: 'AudioMuse-AI（Navidrome）',
+
     audiomuseDesc:
+
       '若此服务器已配置 <pluginLink>AudioMuse-AI Navidrome 插件</pluginLink>请开启。可从曲目启动即时混音，并在艺人页使用服务器返回的相似艺人，而非 Last.fm。',
+
     audiomuseIssueHint:
+
       '近期即时混音失败 — 请检查 Navidrome 插件与 AudioMuse API。若服务器无结果，将回退使用 Last.fm 的相似艺人。',
+
     connected: '已连接',
+
     failed: '失败',
+
     eqTitle: '均衡器',
+
     eqEnabled: '启用均衡器',
+
     eqPreset: '预设',
+
     eqPresetCustom: '自定义',
+
     eqPresetBuiltin: '内置预设',
+
     eqPresetCustomGroup: '我的预设',
+
     eqSavePreset: '保存为预设',
+
     eqPresetName: '预设名称…',
+
     eqDeletePreset: '删除预设',
+
     eqResetBands: '重置为平直',
+
     eqPreGain: '预增益',
+
     eqResetPreGain: '重置预增益',
+
     eqAutoEqTitle: 'AutoEQ 耳机查询',
+
     eqAutoEqPlaceholder: '搜索耳机/入耳式型号…',
+
     eqAutoEqSearching: '搜索中…',
+
     eqAutoEqNoResults: '未找到结果',
+
     eqAutoEqError: '搜索失败',
+
     eqAutoEqRateLimit: 'GitHub 请求限制 — 请一分钟后重试',
+
     eqAutoEqFetchError: '无法获取 EQ 配置',
+
     lfmTitle: 'Last.fm',
+
     lfmConnect: '连接 Last.fm',
+
     lfmConnecting: '等待授权…',
+
     lfmConfirm: '我已完成授权',
+
     lfmConnected: '已连接为',
+
     lfmDisconnect: '断开连接',
+
     lfmConnectDesc: '连接您的 Last.fm 账户以启用歌曲记录和正在播放更新，直接从 Psysonic 发送 — 无需配置 Navidrome。',
+
     lfmOpenBrowser: '将打开浏览器窗口。在 Last.fm 上授权 Psysonic，然后点击下方按钮。',
+
     lfmScrobbles: '{{n}} 次记录',
+
     lfmMemberSince: '{{year}} 年加入',
+
     scrobbleEnabled: '启用歌曲记录',
+
     scrobbleDesc: '播放 50% 后发送歌曲到 Last.fm',
+
     behavior: '应用行为',
+
     cacheTitle: '最大存储大小',
+
     cacheDesc: '封面和艺术家图片。存满时，最旧的条目将自动移除。离线专辑不会自动移除，但手动清除缓存时会被删除。',
+
     cacheUsedImages: '图片：',
+
     cacheUsedOffline: '离线曲目：',
+
     cacheUsedHot: '占用空间：',
+
     hotCacheTrackCount: '缓存曲目数：',
+
     cacheMaxLabel: '最大容量',
+
     cacheClearBtn: '清除缓存',
+
     cacheClearWarning: '这将同时移除音乐库中的所有离线专辑。',
+
     cacheClearConfirm: '全部清除',
+
     cacheClearCancel: '取消',
+
     offlineDirTitle: '离线音乐库（应用内）',
+
     offlineDirDesc: '用于在 Psysonic 中离线可用的曲目存储位置。',
+
     offlineDirDefault: '默认（应用数据）',
+
     offlineDirChange: '更改目录',
+
     offlineDirClear: '重置为默认',
+
     offlineDirHint: '新下载将保存到此位置，现有下载保留在原始路径。',
+
     hotCacheTitle: '热播放缓存',
+
     hotCacheAlphaBadge: '预览',
+
     hotCacheDisclaimer: '预加载队列中即将播放的曲目并保留近期已播放的。开启后占用磁盘与网络。',
+
     hotCacheDirDefault: '默认（应用数据）',
+
     hotCacheDirChange: '更改目录',
+
     hotCacheDirClear: '重置为默认',
+
     hotCacheDirHint: '更换目录会重置应用内索引；已下载的文件仍留在原路径，需自行删除。',
+
     hotCacheEnabled: '启用热播放缓存',
+
     hotCacheMaxMb: '最大缓存大小',
+
     hotCacheDebounce: '队列变更去抖',
+
     hotCacheDebounceImmediate: '立即',
+
     hotCacheDebounceSeconds: '{{n}} 秒',
+
     hotCacheClearBtn: '清空热缓存',
+
     audioOutputDevice: '音频输出设备',
+
     audioOutputDeviceDesc: '选择 Psysonic 播放音频的设备。更改立即生效并重新开始当前曲目。',
+
     audioOutputDeviceDefault: '系统默认',
+
     audioOutputDeviceRefresh: '刷新设备列表',
+
     audioOutputDeviceOsDefaultNow: '当前系统输出',
+
     audioOutputDeviceListError: '无法加载音频设备列表。',
+
     audioOutputDeviceNotInCurrentList: '不在当前列表中',
+
     hiResTitle: '原生高清晰度播放',
+
     hiResEnabled: '启用原生高清晰度播放',
+
     hiResDesc: "默认强制 44.1 kHz 输出以获得最大稳定性。仅在硬件和网络可靠支持高采样率（88.2 kHz+）时启用。",
+
     showArtistImages: '显示艺术家图片',
+
     showArtistImagesDesc: '在艺术家概览中加载并显示艺术家图片。默认关闭以减少大型音乐库的服务器磁盘I/O和网络负载。',
+
     showTrayIcon: '显示托盘图标',
+
     showTrayIconDesc: '在系统通知区域 / 菜单栏显示 Psysonic 图标。',
+
     minimizeToTray: '最小化到托盘',
+
     minimizeToTrayDesc: '关闭窗口时，Psysonic 将继续在系统托盘中运行，而不是退出。',
+
     discordRichPresence: 'Discord Rich Presence',
+
     discordRichPresenceDesc: '在 Discord 个人资料上显示当前播放的曲目。需要 Discord 处于运行状态。',
+
     discordAppleCovers: '通过 Apple Music 为 Discord 获取封面',
+
     discordAppleCoversDesc: '将艺术家和专辑名称发送至 Apple 搜索 API，以为 Discord 个人资料查找封面图片。出于隐私考虑，默认禁用。',
+
+    discordTemplates: '自定义文本模板',
+
+    discordTemplatesDesc: '自定义在 Discord 个人资料上显示的信息。变量：{title}, {artist}, {album}, {paused}',
+
+    discordTemplateDetails: '主行 (details)',
+
+    discordTemplateState: '副行 (state)',
+
+    discordTemplateLargeText: '专辑提示 (largeText)',
+
     nowPlayingEnabled: '在实时窗口中显示',
+
     nowPlayingEnabledDesc: '将当前播放的曲目广播到服务器的实时听众视图。禁用以停止发送播放数据。',
+
     lyricsServerFirst: '优先使用服务器歌词',
+
     lyricsServerFirstDesc: '先查询服务器提供的歌词（内嵌标签、sidecar 文件），再查询 LRCLIB。禁用则优先使用 LRCLIB。',
+
     enableNeteaselyrics: '网易云音乐歌词',
+
     enableNeteaselyricsDesc: '当服务器和 LRCLIB 均无结果时，使用网易云音乐作为最终歌词来源。对亚洲及国际音乐覆盖最佳。',
+
     lyricsSourcesTitle: '歌词来源',
+
     lyricsSourcesDesc: '选择要查询的歌词来源及其顺序。拖动以排序。已禁用的来源将被跳过。',
+
     lyricsSourceServer: '服务器',
+
     lyricsSourceLrclib: 'LRCLIB',
+
     lyricsSourceNetease: '网易云音乐',
+
     downloadsTitle: 'ZIP 导出与归档',
+
     downloadsFolderDesc: '将专辑以 ZIP 文件下载到电脑时的目标文件夹。',
+
     downloadsDefault: '默认下载文件夹',
+
     pickFolder: '选择',
+
     pickFolderTitle: '选择下载文件夹',
+
     clearFolder: '清除下载文件夹',
+
     logout: '退出登录',
+
     aboutTitle: '关于 Psysonic',
+
     aboutDesc: '适用于 Subsonic 兼容服务器（Navidrome、Gonic 等）的现代桌面音乐播放器。基于 Tauri v2 和原生 Rust 音频引擎构建——轻量快速，功能丰富：波形进度条、同步歌词、Last.fm 集成、10 段均衡器、交叉淡入淡出、无缝播放、响度增益、流派浏览以及大量精美主题。',
+
     aboutLicense: '许可证',
+
     aboutLicenseText: 'GNU GPL v3 — 在相同许可证下可自由使用、修改和分发。',
+
     aboutRepo: 'GitHub 上的源代码',
+
     aboutVersion: '版本',
+
     aboutBuiltWith: '使用 Tauri · React · TypeScript · Rust/rodio 构建',
+
     aboutAiCredit: '在 Anthropic 的 Claude Code 支持下开发',
+
     aboutContributorsLabel: '贡献者',
+
     aboutSpecialThanksLabel: '特别感谢',
+
     changelog: '更新日志',
+
     showChangelogOnUpdate: '更新时显示"新功能"',
+
     showChangelogOnUpdateDesc: '新版本首次启动时自动显示更新内容。',
+
     randomMixTitle: '随机混音',
+
     randomMixBlacklistTitle: '自定义过滤关键词',
+
     randomMixBlacklistDesc: '当任何关键词匹配流派、标题、专辑或艺术家时，歌曲将被排除（当上方复选框开启时生效）。',
+
     randomMixBlacklistPlaceholder: '添加关键词…',
+
     randomMixBlacklistAdd: '添加',
+
     randomMixBlacklistEmpty: '尚未添加自定义关键词。',
+
     randomMixHardcodedTitle: '内置关键词（复选框开启时生效）',
+
     tabAudio: '音频',
+
     tabStorage: '存储与下载',
+
     tabAppearance: '外观',
+
     homeCustomizerTitle: '首页',
+
     sidebarTitle: '侧边栏',
+
     sidebarReset: '重置为默认',
+
     sidebarDrag: '拖动以重新排序',
+
     sidebarFixed: '始终显示',
-    randomNavSplitTitle: '拆分混音导航',
-    randomNavSplitDesc: '在侧边栏中将"随机混音"和"随机专辑"显示为独立条目，而非"创建混音"合并入口。',
+
     tabInput: '输入',
+
     tabServer: '服务器',
+
     tabSystem: '系统',
+
     tabGeneral: '通用',
+
     ratingsSectionTitle: '评分',
+
     ratingsSkipStarTitle: '跳过以评 1 星',
+
     ratingsSkipStarDesc:
+
       '连续多次跳过后将曲目设为 1 星。仅适用于此前未评分的曲目。',
+
     ratingsSkipStarThresholdLabel: '跳过次数',
+
     ratingsMixFilterTitle: '按评分筛选',
+
     ratingsMixFilterDesc:
+
       '在{{mix}}与{{albums}}中筛选低评分内容。再次点击所选星标可关闭阈值。',
+
     ratingsMixMinSong: '歌曲',
+
     ratingsMixMinAlbum: '专辑',
+
     ratingsMixMinArtist: '艺人',
+
     ratingsMixMinThresholdAria: '最低星数：{{label}}',
+
     backupTitle: '备份与恢复',
+
     backupExport: '导出设置',
+
     backupExportDesc: '将所有设置、服务器配置、Last.fm 配置、主题、均衡器和快捷键保存到 .psybkp 文件。密码以明文存储——请妥善保管该文件。',
+
     backupImport: '导入设置',
+
     backupImportDesc: '从 .psybkp 文件恢复设置。导入后应用将重新加载。',
+
     backupImportConfirm: '所有当前设置将被覆盖。是否继续？',
+
     backupSuccess: '备份已保存',
+
     backupImportSuccess: '设置已恢复——正在重新加载…',
+
     backupImportError: '备份文件无效或已损坏。',
+
     shortcutsReset: '恢复默认',
+
     shortcutListening: '请按下按键…',
+
     shortcutUnbound: '—',
+
     globalShortcutsTitle: '全局快捷键',
+
     globalShortcutsNote: '即使 Psysonic 在后台也能在系统范围内工作。需要 Ctrl、Alt 或 Super 作为修饰键。',
+
     shortcutClear: '清除',
+
     shortcutPlayPause: '播放 / 暂停',
+
     shortcutNext: '下一首',
+
     shortcutPrev: '上一首',
+
     shortcutVolumeUp: '音量增大',
+
     shortcutVolumeDown: '音量减小',
+
     shortcutSeekForward: '快进 10 秒',
+
     shortcutSeekBackward: '快退 10 秒',
+
     shortcutToggleQueue: '切换队列',
+
     shortcutOpenFolderBrowser: '打开{{folderBrowser}}',
+
     shortcutFullscreenPlayer: '全屏播放器',
+
     shortcutNativeFullscreen: '原生全屏',
+
     playbackTitle: '播放',
+
     replayGain: '回放增益',
+
     replayGainDesc: '使用 ReplayGain 元数据标准化曲目音量',
+
     replayGainMode: '模式',
+
     replayGainTrack: '曲目',
+
     replayGainAlbum: '专辑',
+
     replayGainPreGain: '预增益（有标签文件）',
+
     replayGainFallback: '回退增益（无标签 / 收音机）',
+
     crossfade: '交叉淡入淡出',
+
     crossfadeDesc: '曲目间淡入淡出',
+
     crossfadeSecs: '{{n}} 秒',
+
     notWithGapless: '无缝播放开启时不可用',
+
     notWithCrossfade: '交叉淡入淡出开启时不可用',
+
     gapless: '无缝播放',
+
     gaplessDesc: '预缓冲下一首曲目以消除歌曲间的间隙',
+
     preloadMode: '预加载下一曲目',
+
     preloadModeDesc: '何时开始缓冲队列中的下一曲目',
+
     nextTrackBufferingTitle: '下一曲目缓冲',
+
     preloadHotCacheMutualExclusive: '预加载与热缓存用途相同——两者不能同时启用。启用其中一个会自动禁用另一个。',
+
     preloadOff: '关闭',
+
     preloadBalanced: '均衡（结束前30秒）',
+
     preloadEarly: '提前（播放5秒后）',
+
     preloadCustom: '自定义',
+
     preloadCustomSeconds: '结束前秒数：{{n}}',
+
     infiniteQueue: '无限队列',
+
     infiniteQueueDesc: '队列播完时自动追加随机曲目',
+
     experimental: '实验性',
+
     fsPlayerSection: '全屏播放器',
+
     fsShowArtistPortrait: '显示艺术家照片',
+
     fsShowArtistPortraitDesc: '在全屏播放器右侧显示艺术家照片（或专辑封面）。',
+
     fsPortraitDim: '照片暗化',
+
     seekbarStyle: '进度条样式',
+
     seekbarStyleDesc: '选择播放进度条的外观',
+
     seekbarWaveform: '波形',
+
     seekbarLinedot: '线条与点',
+
     seekbarBar: '条形',
+
     seekbarThick: '粗条形',
+
     seekbarSegmented: '分段式',
+
     seekbarNeon: '霓虹',
+
     seekbarPulsewave: '脉冲波',
+
     seekbarParticletrail: '粒子轨迹',
+
     seekbarLiquidfill: '液体填充',
+
     seekbarRetrotape: '复古磁带',
+
     themeSchedulerTitle: '主题定时切换',
+
     themeSchedulerEnable: '启用主题定时器',
+
     themeSchedulerEnableSub: '根据一天中的时间自动在两个主题之间切换',
+
     themeSchedulerDayTheme: '白天主题',
+
     themeSchedulerDayStart: '白天开始时间',
+
     themeSchedulerNightTheme: '夜晚主题',
+
     themeSchedulerNightStart: '夜晚开始时间',
+
     themeSchedulerActiveHint: '主题定时器已启用 - 主题将自动切换。',
+
     visualOptionsTitle: '视觉选项',
+
     coverArtBackground: '封面背景',
+
     coverArtBackgroundSub: '在专辑/播放列表标题中显示模糊的封面作为背景',
+
     playlistCoverPhoto: '播放列表封面照片',
+
     playlistCoverPhotoSub: '在播放列表详细视图中显示封面照片网格',
+
     showBitrate: '显示比特率',
+
     showBitrateSub: '在曲目列表中显示音频比特率',
+
     uiScaleTitle: '界面缩放',
+
     uiScaleLabel: '缩放',
+
   },
+
   changelog: {
+
     modalTitle: '新功能',
+
     dontShowAgain: '不再显示',
+
     close: '知道了',
+
   },
+
   help: {
+
     title: '帮助',
+
     s1: '入门指南',
+
     q1: '支持哪些服务器？',
+
     a1: 'Psysonic 可与任何 Subsonic 兼容服务器配合使用：Navidrome、Gonic、Subsonic、Airsonic 等。推荐使用 Navidrome。',
+
     q2: '如何连接服务器？',
+
     a2: '打开设置并点击"添加服务器"。输入服务器地址（如 192.168.1.100:4533）、用户名和密码。Psysonic 会在保存前测试连接 — 如果连接失败则不会存储任何信息。',
+
     q3: '可以使用多个服务器吗？',
+
     a3: '可以。您可以在设置中添加任意数量的服务器，并随时切换。同一时间只能有一个服务器处于活动状态。',
+
     s2: '播放',
+
     q4: '如何播放音乐？',
+
     a4: '双击任意曲目即可播放。在专辑和艺术家页面，使用"全部播放"开始播放整张专辑。您也可以将曲目拖入队列面板。',
+
     q5: '有哪些键盘快捷键？',
+
     a5: '空格键 = 播放 / 暂停 · Esc = 关闭全屏播放器。媒体键（播放/暂停、下一首、上一首）在所有平台上都有效。在 Linux 上，请使用播放器栏按钮作为媒体键。应用内快捷键和系统级全局快捷键可在 设置 → 键盘快捷键 / 全局快捷键 中自定义。',
+
     q6: '什么是播放队列？',
+
     a6: '队列显示所有即将播放的曲目。点击右上角标题栏的面板图标（正在播放指示器旁边）打开队列。您可以通过拖拽重新排序，使用随机播放按钮打乱顺序，并将队列保存为播放列表。',
+
     q7: '如何打开全屏播放器？',
+
     a7: '点击底部播放器栏的专辑封面缩略图，或其旁边的展开图标。按 Esc 键关闭。',
+
     q8: '重复播放如何工作？',
+
     a8: '点击播放器栏的重复按钮可在以下模式间循环：关闭 → 重复全部 → 重复单曲。',
+
     s3: '音乐库',
+
     q9: '如何下载专辑？',
+
     a9: '打开专辑详情页并点击"下载 (ZIP)"。服务器会先将专辑压缩为 ZIP 文件 — 对于大型专辑或无损文件（FLAC / WAV），在实际下载开始前可能需要一些时间。这是正常的：进度条会在服务器完成压缩并开始传输后显示。',
+
     q10: '如何收藏曲目和专辑？',
+
     a10: '点击任意曲目行或专辑标题上的星形图标。收藏的项目会显示在侧边栏的收藏夹中。',
+
     q11: '首页的英雄轮播是什么？',
+
     a11: '首页顶部的横幅会随机从您的音乐库中选择专辑，每 10 秒轮换一次。点击圆点可跳转到特定专辑，或点击横幅打开专辑。',
+
     s4: '设置',
+
     q12: '如何更改主题？',
+
     a12: '设置 → 主题。从 8 个分组中的大量主题中选择：Psysonic 主题、媒体播放器、操作系统、游戏、电影、电视剧、社交媒体，以及开源经典（Catppuccin、Nord、Gruvbox、Nightfox）。',
+
     q13: '如何更改语言？',
+
     a13: '设置 → 语言。支持英语、德语、法语、荷兰语和中文。',
+
     q15: '如何设置下载文件夹？',
+
     a15: '设置 → 应用行为 → 下载文件夹。选择任意文件夹 — 下载的专辑将以 ZIP 文件形式保存在那里。未设置自定义文件夹时，将使用浏览器的默认下载位置。',
+
     s5: '歌曲记录',
+
     q16: '歌曲记录如何工作？',
+
     a16: 'Psysonic 直接向 Last.fm 发送记录 — 无需配置 Navidrome。在 设置 → Last.fm 中连接您的 Last.fm 账户并启用记录功能。',
+
     q17: '何时发送记录？',
+
     a17: '在您听完曲目的 50% 后提交记录。',
+
     q22: '播放器栏中的波形是什么？',
+
     a22: '波形进度条取代了传统的进度滑块。点击任意位置跳转到该位置，或拖动进行拖动播放。已播放部分显示蓝到紫的渐变，缓冲区域稍亮，未播放部分则淡化显示。',
+
     q24: '可以随机打乱队列吗？',
+
     a24: '可以。打开队列面板并点击队列标题栏的随机播放图标。当前播放曲目保持在第 1 位 — 其余曲目将随机重新排序。',
+
     q25: '艺术家页面上的 Last.fm 和 Wikipedia 链接会在浏览器中打开吗？',
+
     a25: '是的 — 它们会在您的默认系统浏览器中打开。点击时按钮会短暂显示确认标签。',
+
     s7: '随机混音',
+
     q26: '什么是随机混音？',
+
     a26: '随机混音从您的整个音乐库中构建一个随机曲目的播放列表。通过侧边栏的"随机混音"打开并点击"新混音"。您可以在生成前调整曲目数量。',
+
     q27: '什么是关键词过滤？',
+
     a27: '关键词过滤会排除流派、标题或专辑名称包含特定词汇的曲目。有声读物会被自动过滤。在 设置 → 随机混音 中添加自定义关键词，或点击曲目列表中的任意流派标签即时添加。',
+
     q28: '什么是超级流派混音？',
+
     a28: '超级流派混音将您的音乐库分组为宽泛的类别（摇滚、金属、电子、爵士、古典等），并从该风格构建一个专注的混音。在曲目列表下方选择类别标签。结果会随着每个子流派的获取而逐步显示。',
+
     s6: '故障排除',
+
     q18: '封面和艺术家图片加载缓慢。',
+
     a18: '图片首次加载时从服务器磁盘获取，然后本地缓存 30 天。如果服务器存储较慢，首次访问页面可能需要一些时间。后续访问将瞬间完成。',
+
     q19: '连接测试失败。',
+
     a19: '检查 URL 包括端口（如 http://192.168.1.100:4533）。确保防火墙没有阻止连接。在本地网络上尝试使用 http:// 而非 https://。同时验证用户名和密码是否正确。',
+
     q20: 'Linux 上没有音频。',
+
     a20: 'Psysonic 提供 .deb（Ubuntu/Debian）、.rpm（Fedora/RHEL）版本，以及通过 AUR 在 Arch/CachyOS 上安装（yay -S psysonic）。没有 AppImage。如果没有音频，请确保 PipeWire 或 PulseAudio 正在运行。',
+
     q21: '应用在 Linux 上显示黑屏。',
+
     a21: '这通常是 WebKitGTK 中的 GPU/EGL 驱动问题。使用 GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1 启动。AUR 包和官方 .deb/.rpm 安装程序会自动设置这些环境变量。',
+
     q29: '什么是交叉淡入淡出和无缝播放？',
+
     a29: '两者都是 设置 → 音频 中的实验性音频功能。无缝播放预缓冲下一首曲目以消除歌曲间的静音。交叉淡入淡出让当前曲目淡出同时下一首淡入 — 调整持续时间（1-10 秒）以符合您的喜好。',
+
     q30: 'Psysonic 显示歌词吗？',
+
     a30: '是的。点击播放器栏的麦克风图标可在队列面板中打开歌词标签。Psysonic 自动从 LRCLIB 获取歌词。如果可用同步歌词，活动行会高亮并随歌曲实时滚动。如果只有纯文本歌词，则静态显示完整文本。',
+
     q31: '可以自定义键盘快捷键吗？',
+
     a31: '可以。设置 → 键盘快捷键 允许您重新映射应用内操作（播放/暂停、下一首、上一首、音量增/减、全屏等）到任意按键。设置 → 全局快捷键 允许您分配即使 Psysonic 在后台也能触发的系统级快捷键。',
+
     q32: '可以更改字体吗？',
+
     a32: '可以。设置 → 字体 允许您从 10 种字体中选择，包括 IBM Plex Mono、Fira Code、JetBrains Mono、Courier Prime 等。所选字体将应用于整个界面。',
+
     s8: '离线模式',
+
     q34: '什么是离线模式？',
+
     a34: '离线模式（测试版）允许您将专辑缓存到设备，以便在没有活动服务器连接时收听。缓存的曲目存储在本地并直接从磁盘播放 — 播放期间不进行网络请求。',
+
     q35: '如何缓存专辑以供离线使用？',
+
     a35: '打开任意专辑并点击专辑标题栏的下载图标。Psysonic 会在后台下载所有曲目。按钮上会显示进度。缓存完成后，图标变为绿色。您可以在离线音乐库页面（侧边栏）查看和移除缓存的专辑。',
+
     q36: '离线缓存可以使用多少存储空间？',
+
     a36: '您可以在 设置 → 音乐库 中设置最大缓存大小。达到限制时，专辑页面会显示警告横幅。您可以从离线音乐库中删除单个专辑以释放空间。',
+
     q37: '如何对歌曲、专辑和艺术家评分？',
+
     a37: 'Psysonic 通过 OpenSubsonic API 支持 1–5 星评分（需要 Navidrome ≥ 0.53）。可在专辑或播放列表曲目列表、右键菜单或播放器栏中对歌曲评分。专辑在详情页评分，艺术家在艺术家页评分。',
+
     q38: '可以删除或更改评分吗？',
+
     a38: '可以。再次点击当前激活的星星即可完全删除评分——第二次点击同一颗星即可清除。点击其他星星可更改评分。',
+
     q39: '什么是 Skip-to-1★ 和评分过滤器？',
+
     a39: 'Skip-to-1★ 会在歌曲被连续手动跳过一定次数后自动赋予 1 星评分。在 设置 → 评分 中启用并设置阈值。同样可在此设置随机混音的最低星级过滤条件。',
+
     q40: '什么是文件夹浏览器？',
+
     a40: '文件夹浏览器（侧边栏）使用 Miller 列布局浏览服务器音乐目录。点击文件夹查看内容；点击播放图标直接播放或添加到队列。',
+
     q41: '什么是主题调度器？',
+
     a41: '设置 → 外观 → 自动切换主题：设置日间主题和夜间主题及开始时间，Psysonic 将在指定时间自动切换主题。',
+
     q42: '可以调整界面缩放吗？',
+
     a42: '可以。设置 → 外观 → 界面缩放 可将整个界面缩放至 80%–125%。',
+
     q43: '可以更改进度条样式吗？',
+
     a43: '可以。设置 → 外观 → 进度条样式 提供 10 种样式：波形、线条与点、条形、粗条形、分段、霓虹辉光、脉冲波、粒子轨迹、液体填充和复古磁带。',
+
     q44: '什么是 AutoEQ？',
+
     a44: '设置 → 音频 中的 10 频段均衡器包含 AutoEQ 查找功能。输入耳机型号即可自动加载校正配置文件。',
+
     q45: '什么是 Replay Gain？',
+
     a45: 'Replay Gain 标准化音量，使响亮和安静的专辑以一致的音量播放。在 设置 → 音频 → Replay Gain 中启用；选择曲目模式或专辑模式。',
+
     q46: '什么是热缓存？',
+
     a46: '热缓存（Alpha，设置 → 音乐库）将队列中后续曲目预加载到磁盘，实现即时播放，对于慢速或远程服务器尤为有用。Psysonic 保留当前曲目和后续 5 首，达到大小限制时淘汰旧条目。',
+
     q47: '可以将播放列表缓存到离线吗？',
+
     a47: '可以。在播放列表详情中点击下载图标，所有曲目将在后台下载。完全缓存后图标变为红色垃圾桶；再次点击即可从离线缓存中删除该播放列表。',
-    q48: '什么是无限队列？',
-    a48: '当队列播完且关闭了重复播放时，Psysonic会自动添加随机曲目，确保播放不会中断。自动添加的曲目显示在"— 自动添加 —"分隔符下方。',
-    q49: '可以通过命令行控制Psysonic吗？',
-    a49: '可以。示例：psysonic --player play / pause / next / prev，--player volume 75，--player seek 15，--player mute，--player shuffle，--player repeat off|all|one。还可以切换服务器、音频设备、筛选音乐库和搜索。完整帮助：psysonic --player --help。',
-    q50: '如何管理播放列表？',
-    a50: '通过侧边栏中的"播放列表"进入。点击"新建播放列表"创建。在详情页可拖拽排序、点击×删除曲目、通过搜索添加歌曲，还可使用"建议"获取智能推荐。',
-    q51: '可以备份和恢复设置吗？',
-    a51: '可以。设置→备份与恢复可将所有设置、服务器配置、主题和快捷键导出为JSON文件，在其他设备上导入即可一键恢复。',
-    q52: '如何更改音频输出设备？',
-    a52: '设置→音频→输出设备。Psysonic列出所有可用输出，选择后立即生效。若设备在应用启动后连接，可点击刷新按钮更新列表。',
-    q53: '什么是设备同步？',
-    a53: '设备同步可将专辑、播放列表或艺术家复制到USB或SD卡。通过侧边栏"Device Sync"打开，选择目标文件夹和来源，点击"传输到设备"。',
-    q54: '设备同步中的文件名模板是什么？',
-    a54: '模板控制曲目的命名和组织方式。使用预设或通过可点击的令牌自定义：{artist}、{album}、{title}、{track_number}、{disc_number}、{year}，以及/作为文件夹分隔符。',
-    q55: '设备同步支持跨平台使用吗？',
-    a55: '支持。设备上的清单文件包含同步时使用的模板。在不同系统上，Psysonic能正确识别已存在的文件。',
-    s9: 'Device Sync',
-    q56: '什么是网络电台？',
-    a56: '网络电台页面可在Psysonic中播放任何直播流。电台来自Navidrome服务器，可通过管理面板添加或导入.pls/.m3u文件。播放使用HTML5音频。',
-    q57: '网络电台支持哪些流格式？',
-    a57: 'MP3、AAC、OGG Vorbis及大多数HLS流。MP3和AAC在所有平台均可使用。',
-    s10: '网络电台',
-    q58: 'Psysonic从哪里获取歌词？',
-    a58: '三个可配置来源（设置→歌词）：Navidrome服务器、LRCLIB和网易云音乐。每个来源均可启用/禁用，并可拖拽调整优先级。',
-    q59: '有没有查看其他用户正在听什么的功能？',
-    a59: '有。点击右上角的广播图标，可查看Navidrome服务器上其他用户正在收听的内容，每10秒更新一次。',
+
   },
+
   queue: {
+
     title: '队列',
+
     savePlaylist: '保存为播放列表',
+
     updatePlaylist: '更新播放列表',
+
     filterPlaylists: '筛选播放列表…',
+
     playlistName: '播放列表名称',
+
     cancel: '取消',
+
     save: '保存',
+
     loadPlaylist: '加载播放列表',
+
     loading: '加载中…',
+
     noPlaylists: '未找到播放列表。',
+
     load: '替换队列并播放',
+
     appendToQueue: '追加到队列',
+
     delete: '删除',
+
     deleteConfirm: '删除播放列表 "{{name}}"？',
+
     clear: '清空',
+
     shuffle: '随机打乱队列',
+
     gapless: '无缝播放',
+
     crossfade: '交叉淡入淡出',
+
     infiniteQueue: '无限队列',
+
     autoAdded: '— 自动添加 —',
+
     radioAdded: '— 收音机 —',
+
     hide: '隐藏',
+
     close: '关闭',
+
     nextTracks: '即将播放',
+
     emptyQueue: '队列为空。',
+
     trackSingular: '首曲目',
+
     trackPlural: '首曲目',
+
     showRemaining: '显示剩余时间',
+
     showTotal: '显示总时间',
+
   },
+
   statistics: {
+
     title: '统计',
+
     recentlyPlayed: '最近播放',
+
     mostPlayed: '最常播放的专辑',
+
     highestRated: '评分最高的专辑',
+
     genreDistribution: '流派分布（前 20）',
+
     loadMore: '加载更多',
+
     statArtists: '艺术家',
+
     statArtistsTooltip: '仅限专辑艺术家——仅作为单曲艺术家出现（合唱、客串等）且无自己专辑的艺术家不计入此处。',
+
     statAlbums: '专辑',
+
     statSongs: '歌曲',
+
     statGenres: '流派',
+
     statPlaytime: '音频总时长',
+
     genreInsights: '流派洞察',
+
     formatDistribution: '格式分布',
+
     formatSample: '{{n}} 首曲目的样本',
+
     computing: '计算中…',
+
     genreSongs: '{{count}} 首歌曲',
+
     genreAlbums: '{{count}} 张专辑',
+
     recentlyAdded: '最近添加',
+
     decadeDistribution: '按年代分布的专辑',
+
     decadeAlbums_one: '{{count}} 张专辑',
+
     decadeAlbums_other: '{{count}} 张专辑',
+
     decadeUnknown: '未知',
+
     lfmTitle: 'Last.fm 统计',
+
     lfmTopArtists: '热门艺术家',
+
     lfmTopAlbums: '热门专辑',
+
     lfmTopTracks: '热门曲目',
+
     lfmPlays: '{{count}} 次播放',
+
     lfmPeriodOverall: '全部时间',
+
     lfmPeriod7day: '7 天',
+
     lfmPeriod1month: '1 个月',
+
     lfmPeriod3month: '3 个月',
+
     lfmPeriod6month: '6 个月',
+
     lfmPeriod12month: '12 个月',
+
     lfmNotConnected: '在设置中连接 Last.fm 以查看您的统计。',
+
     lfmRecentTracks: '最近记录',
+
     lfmNowPlaying: '正在播放',
+
     lfmJustNow: '刚刚',
+
     lfmMinutesAgo: '{{n}} 分钟前',
+
     lfmHoursAgo: '{{n}} 小时前',
+
     lfmDaysAgo: '{{n}} 天前',
+
     topRatedSongs: '最高评分歌曲',
+
     topRatedArtists: '最高评分艺人',
+
     noRatedSongs: '暂无已评分歌曲。请在专辑或播放列表中为歌曲评分。',
+
     noRatedArtists: '暂无已评分艺人。',
+
   },
+
   player: {
+
     regionLabel: '音乐播放器',
+
     openFullscreen: '打开全屏播放器',
+
     fullscreen: '全屏播放器',
+
     closeFullscreen: '关闭全屏',
+
     closeTooltip: '关闭 (Esc)',
+
     noTitle: '无标题',
+
     stop: '停止',
+
     prev: '上一首',
+
     play: '播放',
+
     pause: '暂停',
+
     next: '下一首',
+
     repeat: '重复',
+
     repeatOff: '关闭',
+
     repeatAll: '全部',
+
     repeatOne: '单曲',
+
     progress: '播放进度',
+
     volume: '音量',
+
     toggleQueue: '切换队列',
+
     lyrics: '歌词',
+
     fsLyricsToggle: '全屏歌词',
+
     lyricsLoading: '正在加载歌词…',
+
     lyricsNotFound: '未找到此曲目的歌词',
+
     lyricsSourceServer: '来源：服务器',
+
     lyricsSourceLrclib: '来源：LRCLIB',
+
     lyricsSourceNetease: '来源：网易云',
+
   },
+
   songInfo: {
+
     title: '歌曲信息',
+
     songTitle: '标题',
+
     artist: '艺术家',
+
     album: '专辑',
+
     albumArtist: '专辑艺术家',
+
     year: '年份',
+
     genre: '流派',
+
     duration: '时长',
+
     track: '曲目',
+
     format: '格式',
+
     bitrate: '比特率',
+
     sampleRate: '采样率',
+
     bitDepth: '位深度',
+
     channels: '声道',
+
     fileSize: '文件大小',
+
     path: '文件路径',
+
     replayGainTrack: 'RG 曲目增益',
+
     replayGainAlbum: 'RG 专辑增益',
+
     replayGainPeak: 'RG 曲目峰值',
+
     mono: '单声道',
+
     stereo: '立体声',
+
   },
+
   playlists: {
+
     title: '播放列表',
+
     newPlaylist: '新建播放列表',
+
     unnamed: '未命名播放列表',
+
     createName: '播放列表名称…',
+
     create: '创建',
+
     cancel: '取消',
+
     empty: '暂无播放列表。',
+
     emptyPlaylist: '此播放列表为空。',
+
     addFirstSong: '添加第一首歌曲',
+
     notFound: '未找到播放列表。',
+
     songs: '{{n}} 首歌曲',
+
     playAll: '全部播放',
+
     shuffle: '随机播放',
+
     addToQueue: '添加到队列',
+
     back: '返回播放列表',
+
     deletePlaylist: '删除',
+
     confirmDelete: '再次点击确认删除',
+
     removeSong: '从播放列表中移除',
+
     addSongs: '添加歌曲',
+
     searchPlaceholder: '搜索音乐库…',
+
     noResults: '无结果。',
+
     suggestions: '推荐歌曲',
+
     noSuggestions: '暂无推荐。',
+
     titleBadge: '播放列表',
+
     refreshSuggestions: '新建议',
+
     addSong: '添加到播放列表',
+
     addSelected: '添加所选',
+
     cacheOffline: '离线缓存播放列表',
+
     offlineCached: '播放列表已缓存',
+
     removeOffline: '从离线缓存中移除',
+
     offlineDownloading: '正在缓存… ({{done}}/{{total}} 张专辑)',
+
     publicLabel: '公开',
+
     privateLabel: '私有',
+
     editMeta: '编辑播放列表',
+
     editNamePlaceholder: '播放列表名称…',
+
     editCommentPlaceholder: '添加描述…',
+
     editPublic: '公开播放列表',
+
     editSave: '保存',
+
     editCancel: '取消',
+
     changeCover: '更改封面图片',
+
     changeCoverLabel: '更改照片',
+
     removeCover: '删除照片',
+
     coverUpdated: '封面已更新',
+
     metaSaved: '播放列表已更新',
+
     downloadZip: '下载 (ZIP)',
+
     // Toast notifications for multi-select
+
     addSuccess: '{{count}} 首歌曲已添加到 {{playlist}}',
+
     addPartial: '{{added}} 首已添加，{{skipped}} 首跳过（重复）',
+
     addAllSkipped: '全部跳过（{{count}} 首重复）',
+
     addError: '添加歌曲时出错',
+
     createAndAddSuccess: '播放列表 "{{playlist}}" 已创建，包含 {{count}} 首歌曲',
+
     createError: '创建播放列表时出错',
+
     deleteSuccess: '{{count}} 个播放列表已删除',
+
     deleteFailed: '删除 {{name}} 时出错',
+
     deleteSelected: '删除所选',
+
     mergeSuccess: '{{count}} 首歌曲已合并到 {{playlist}}',
+
     mergeNoNewSongs: '没有新歌曲可添加',
+
     mergeError: '合并播放列表时出错',
+
     mergeInto: '合并到',
+
     selectionCount: '{{count}} 已选择',
+
     select: '选择',
+
     startSelect: '启用选择',
+
     cancelSelect: '取消',
+
     loadingAlbums: '正在解析 {{count}} 张专辑…',
+
     loadingArtists: '正在解析 {{count}} 位艺术家…',
+
     myPlaylists: '我的播放列表',
+
     noOtherPlaylists: '没有其他可用播放列表',
+
     addToPlaylistSuccess: '{{count}} 首歌曲已添加到 {{playlist}}',
+
     addToPlaylistNoNew: '{{playlist}} 没有新歌曲',
+
     addToPlaylistError: '添加到播放列表时出错',
+
     importCSV: '导入 CSV',
+
     importCSVTooltip: '从 Spotify CSV 导入',
+
     csvImportReport: 'CSV 导入报告',
+
     csvImportTotal: '总计',
+
     csvImportAdded: '已添加',
+
     csvImportDuplicates: '重复项',
+
     csvImportNotFound: '未找到',
+
     csvImportNetworkErrors: '网络错误',
+
     csvImportDuplicatesTitle: '重复曲目（已在播放列表中）：',
+
     csvImportNotFoundTitle: '未找到的曲目：',
+
     csvImportNetworkErrorsTitle: '网络错误（可重试导入）：',
+
     csvImportDownloadReport: '下载报告',
+
     csvImportClose: '关闭',
+
     csvImportNoValidTracks: 'CSV 文件中未找到有效曲目',
+
     csvImportFailed: 'CSV 文件导入失败',
+
     csvImportToast: '{{added}} 已添加，{{notFound}} 未找到，{{duplicates}} 重复项',
+
   },
+
   mostPlayed: {
+
     title: '最常播放',
+
     topArtists: '热门艺术家',
+
     topAlbums: '热门专辑',
+
     plays: '播放 {{n}} 次',
+
     sortMost: '最多播放在前',
+
     sortLeast: '最少播放在前',
+
     loadMore: '加载更多专辑',
+
     noData: '暂无播放数据。开始收听吧！',
+
     noArtists: '所有艺术家已过滤。',
+
     filterCompilations: '隐藏合辑艺术家（Various Artists、原声带等）',
+
     filterCompilationsShort: '隐藏合辑',
+
   },
+
   radio: {
+
     title: '网络电台',
+
     empty: '未配置任何电台。',
+
     addStation: '添加电台',
+
     editStation: '编辑',
+
     deleteStation: '删除电台',
+
     confirmDelete: '再次点击确认',
+
     stationName: '电台名称…',
+
     streamUrl: '流地址…',
+
     homepageUrl: '主页地址（可选）',
+
     save: '保存',
+
     cancel: '取消',
+
     live: '直播',
+
     liveStream: '网络电台',
+
     openHomepage: '打开主页',
+
     changeCoverLabel: '更换封面',
+
     removeCover: '移除封面',
+
     browseDirectory: '搜索目录',
+
     directoryPlaceholder: '搜索电台…',
+
     noResults: '未找到电台。',
+
     stationAdded: '电台已添加',
+
     filterAll: '全部',
+
     filterFavorites: '收藏',
+
     sortManual: '手动',
+
     sortAZ: 'A → Z',
+
     sortZA: 'Z → A',
+
     sortNewest: '最新',
+
     favorite: '添加到收藏',
+
     unfavorite: '从收藏移除',
+
     noFavorites: '没有收藏的电台。',
+
     listenerCount_one: '{{count}} 位听众',
+
     listenerCount_other: '{{count}} 位听众',
+
     recentlyPlayed: '最近播放',
+
     upNext: '即将播放',
+
   },
+
   folderBrowser: {
+
     empty: '空文件夹',
+
     error: '加载失败',
+
   },
+
   deviceSync: {
+
     title: '设备同步',
+
     targetFolder: '目标文件夹',
+
     noFolderChosen: '未选择文件夹',
+
     selectDrive: '选择驱动器…',
+
     refreshDrives: '刷新驱动器',
+
     noDrivesDetected: '未检测到可移动驱动器',
+
     browseManual: '手动浏览…',
+
     free: '可用',
+
     notMountedVolume: '目标不在已挂载的卷上。驱动器可能已断开。',
+
     chooseFolder: '选择…',
+
     filenameTemplate: '文件名模板',
+
     targetDevice: '目标设备',
+
     templateHint: '变量：{artist}、{album}、{title}、{track_number}、{disc_number}、{year}',
+
     cleanupButton: '删除不在选择范围内的文件',
+
     cleanupNothingToDelete: '无需删除 — 设备已同步。',
+
     confirmCleanup: '将从设备中删除 {{count}} 个不在当前选择范围内的文件。继续？',
+
     cleanupComplete: '已从设备中删除 {{count}} 个文件。',
+
     selectedSources: '已选来源',
+
     noSourcesSelected: '未选择来源。点击浏览器中的项目以添加。',
+
     clearAll: '全部清除',
+
     tabPlaylists: '播放列表',
+
     tabAlbums: '专辑',
+
     tabArtists: '艺术家',
+
     searchPlaceholder: '搜索…',
+
     syncButton: '同步到设备',
+
     actionTransfer: '传输到设备',
+
     actionDelete: '从设备删除',
+
     actionApplyAll: '应用所有更改',
+
     templatePreview: '预览',
-    templatePresetStandard: '标准',
-    templatePresetMultiDisc: '多碟',
-    templatePresetAltFolder: '备用文件夹',
-    tokenSlashHint: '/ = 文件夹分隔符',
+
     cancel: '取消',
+
     noTargetDir: '请先选择目标文件夹。',
+
     noSources: '请至少选择一个来源。',
+
     noTracks: '所选来源中未找到曲目。',
+
     fetchError: '从服务器加载曲目失败。',
+
     syncComplete: '同步完成。',
+
     dismiss: '关闭',
-    cancelSync: '取消',
-    syncCancelled: '同步已取消（已传输 {{done}} / {{total}}）。',
+
     colName: '名称',
+
     colType: '类型',
+
     colStatus: '状态',
+
     onDevice: '设备管理器',
+
     addSources: '添加…',
+
     syncResult: '已传输 {{done}}，{{skipped}} 已是最新（共 {{total}}）',
+
     deleteFromDevice: '标记为删除（{{count}}）',
+
     confirmDelete: '从设备删除 {{count}} 个项目：{{names}}？',
+
     deleteComplete: '已从设备删除 {{count}} 个项目。',
-    manifestImported: '已从设备清单导入 {{count}} 个来源。',
+
     statusSynced: '已同步',
+
     statusPending: '待处理',
+
     statusDeletion: '删除中',
+
     markForDeletion: '标记为删除',
+
     removeSource: '移除',
+
     undoDeletion: '撤销删除',
+
     syncInBackground: '同步已在后台启动 — 您可以离开此页面。',
+
     syncInProgress: '{{done}} / {{total}} 首曲目…',
+
     syncSummary: '同步摘要',
+
     calculating: '正在计算所需数据…',
+
     filesToAdd: '要添加的文件：',
+
     filesToDelete: '要删除的文件：',
+
     netChange: '净变化：',
+
     availableSpace: '可用磁盘空间：',
+
     spaceWarning: '警告：目标设备的可用空间不足。',
+
     proceed: '继续同步',
+
     notEnoughSpace: '检测到物理磁盘空间不足！',
+
     liveSearch: '实时',
+
     randomAlbumsLabel: '随机专辑',
+
   },
+
 };
+

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -533,7 +533,7 @@ export const zhTranslation = {
     discordAppleCovers: '通过 Apple Music 为 Discord 获取封面',
     discordAppleCoversDesc: '将艺术家和专辑名称发送至 Apple 搜索 API，以为 Discord 个人资料查找封面图片。出于隐私考虑，默认禁用。',
     discordTemplates: '自定义文本模板',
-    discordTemplatesDesc: '自定义在 Discord 个人资料上显示的信息。变量：{title}, {artist}, {album}, {paused}',
+    discordTemplatesDesc: '自定义在 Discord 个人资料上显示的信息。变量：{title}, {artist}, {album}',
     discordTemplateDetails: '主行 (details)',
     discordTemplateState: '副行 (state)',
     discordTemplateLargeText: '专辑提示 (largeText)',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -1,2252 +1,1162 @@
 export const zhTranslation = {
-
   sidebar: {
-
     library: '音乐库',
-
     mainstage: '主舞台',
-
     newReleases: '新发布',
-
     allAlbums: '全部专辑',
-
     randomAlbums: '随机专辑',
-
     randomPicker: '创建混音',
-
     artists: '艺术家',
-
     randomMix: '随机混音',
-
     favorites: '收藏夹',
-
     nowPlaying: '正在播放',
-
     system: '系统',
-
     statistics: '统计',
-
     settings: '设置',
-
     help: '帮助',
-
     expand: '展开侧边栏',
-
     collapse: '收起侧边栏',
-
     downloadingTracks: '正在缓存 {{n}} 首歌曲…',
-
     syncingTracks: '同步中 {{done}}/{{total}}…',
-
     cancelDownload: '取消下载',
-
     offlineLibrary: '离线音乐库',
-
     genres: '流派',
-
     playlists: '播放列表',
-
     mostPlayed: '最常播放',
-
     radio: '网络电台',
-
     folderBrowser: '文件夹浏览器',
-
     deviceSync: '设备同步',
-
     libraryScope: '资料库范围',
-
     allLibraries: '所有资料库',
-
     expandPlaylists: '展开播放列表',
-
     collapsePlaylists: '收起播放列表',
-
   },
-
   home: {
-
     hero: '精选',
-
     starred: '个人收藏',
-
     recent: '最近添加',
-
     mostPlayed: '最常播放',
-
     recentlyPlayed: '最近播放',
-
     discover: '发现',
-
     loadMore: '加载更多',
-
     discoverMore: '发现更多',
-
     discoverArtists: '发现艺术家',
-
     discoverArtistsMore: '全部艺术家'
-
   },
-
   hero: {
-
     eyebrow: '精选专辑',
-
     playAlbum: '播放专辑',
-
     enqueue: '加入队列',
-
     enqueueTooltip: '将整张专辑添加到播放队列',
-
   },
-
   search: {
-
     placeholder: '搜索艺术家、专辑或歌曲…',
-
     noResults: '未找到 "{{query}}" 的相关结果',
-
     artists: '艺术家',
-
     albums: '专辑',
-
     songs: '歌曲',
-
     clearLabel: '清除搜索',
-
     title: '搜索',
-
     resultsFor: '"{{query}}" 的搜索结果',
-
     album: '专辑',
-
     advanced: '高级搜索',
-
     advancedSearchTerm: '搜索词',
-
     advancedSearchPlaceholder: '标题、专辑、艺术家…',
-
     advancedGenre: '流派',
-
     advancedAllGenres: '所有流派',
-
     advancedYear: '年份',
-
     advancedYearFrom: '从',
-
     advancedYearTo: '至',
-
     advancedAll: '全部',
-
     advancedSearch: '搜索',
-
     advancedEmpty: '请输入搜索词或选择过滤器。',
-
     advancedNoResults: '未找到结果。',
-
     advancedGenreNote: '歌曲从该流派中随机选取。',
-
     recentSearches: '最近搜索',
-
     browse: '浏览',
-
     emptyHint: '你想听什么？',
-
     genres: '流派',
-
   },
-
   nowPlaying: {
-
     tooltip: '谁正在收听？',
-
     title: '谁正在收听？',
-
     loading: '加载中…',
-
     nobody: '当前无人收听。',
-
     minutesAgo: '{{n}} 分钟前',
-
     nothingPlaying: '尚未开始播放。开始播放一首歌曲吧！',
-
     aboutArtist: '关于艺术家',
-
     fromAlbum: '来自此专辑',
-
     viewAlbum: '查看专辑',
-
     goToArtist: '前往艺术家',
-
     readMore: '阅读更多',
-
     showLess: '收起',
-
     genreInfo: '流派',
-
     trackInfo: '曲目信息',
-
   },
-
   contextMenu: {
-
     playNow: '立即播放',
-
     playNext: '下一首播放',
-
     addToQueue: '添加到队列',
-
     enqueueAlbum: '专辑加入队列',
-
     startRadio: '开始电台',
-
     instantMix: '即时混音',
-
     instantMixFailed: '无法生成即时混音 — 服务器或插件出错。',
-
     cliMixNeedsTrack: '当前没有正在播放的内容 — 请先开始播放，然后再执行混音命令。',
-
     lfmLove: '在 Last.fm 上标记喜欢',
-
     lfmUnlove: '取消 Last.fm 喜欢标记',
-
     favorite: '收藏',
-
     favoriteArtist: '收藏艺术家',
-
     favoriteAlbum: '收藏专辑',
-
     unfavorite: '取消收藏',
-
     unfavoriteArtist: '取消收藏艺术家',
-
     unfavoriteAlbum: '取消收藏专辑',
-
     removeFromQueue: '从队列中移除',
-
     openAlbum: '打开专辑',
-
     goToArtist: '前往艺术家',
-
     download: '下载 (ZIP)',
-
     addToPlaylist: '添加到播放列表',
-
     selectedPlaylists: '已选择 {{count}} 个播放列表',
-
     selectedAlbums: '已选择 {{count}} 个专辑',
-
     selectedArtists: '已选择 {{count}} 个艺术家',
-
     songInfo: '歌曲信息',
-
   },
-
   albumDetail: {
-
     back: '返回',
-
     playAll: '全部播放',
-
     enqueue: '加入队列',
-
     enqueueTooltip: '将整张专辑添加到播放队列',
-
     artistBio: '艺术家简介',
-
     download: '下载 (ZIP)',
-
     downloading: '加载中…',
-
     cacheOffline: '设为离线可用',
-
     offlineCached: '已离线缓存',
-
     offlineDownloading: '正在缓存… ({{n}}/{{total}})',
-
     removeOffline: '移除离线缓存',
-
     offlineStorageFull: '离线存储空间已满（限制：{{mb}} MB）。请从离线音乐库中删除专辑以释放空间，或在设置中增加限制。',
-
     offlineStorageGoToLibrary: '离线音乐库',
-
     offlineStorageGoToSettings: '设置',
-
     favoriteAdd: '添加到收藏',
-
     favoriteRemove: '从收藏中移除',
-
     favorite: '收藏',
-
     noBio: '暂无简介。',
-
     moreByArtist: '{{artist}} 的更多作品',
-
     tracksCount: '{{n}} 首曲目',
-
     goToArtist: '前往 {{artist}}',
-
     moreLabelAlbums: '{{label}} 的更多专辑',
-
     trackTitle: '标题',
-
     trackAlbum: '专辑',
-
     trackArtist: '艺术家',
-
     trackGenre: '流派',
-
     trackFormat: '格式',
-
     trackFavorite: '收藏',
-
     trackRating: '评分',
-
     trackDuration: '时长',
-
     trackTotal: '总计',
-
     columns: '列',
-
+    resetColumns: '重置为默认',
     notFound: '未找到专辑。',
-
     bioModal: '艺术家简介',
-
     bioClose: '关闭',
-
     ratingLabel: '评分',
-
     enlargeCover: '放大',
-
     filterSongs: '筛选歌曲…',
-
     sortNatural: '默认顺序',
-
     sortByTitle: 'A–Z（标题）',
-
     sortByArtist: 'A–Z（艺术家）',
-
     sortByAlbum: 'A–Z（专辑）',
-
   },
-
   entityRating: {
-
     albumShort: '专辑评分',
-
     artistShort: '艺人评分',
-
     albumAriaLabel: '专辑评分',
-
     artistAriaLabel: '艺人评分',
-
     saveFailed: '无法保存评分。',
-
   },
-
   artistDetail: {
-
     back: '返回',
-
     albums: '专辑',
-
     album: '专辑',
-
     playAll: '全部播放',
-
     shuffle: '随机播放',
-
     radio: '电台',
-
     loading: '加载中…',
-
     noRadio: '未找到该艺术家的相似曲目。',
-
     notFound: '未找到艺术家。',
-
     albumsBy: '{{name}} 的专辑',
-
     topTracks: '热门曲目',
-
     noAlbums: '未找到专辑。',
-
     trackTitle: '标题',
-
     trackAlbum: '专辑',
-
     trackDuration: '时长',
-
     favoriteAdd: '添加到收藏',
-
     favoriteRemove: '从收藏中移除',
-
     favorite: '收藏',
-
     albumCount_one: '{{count}} 张专辑',
-
     albumCount_other: '{{count}} 张专辑',
-
     openedInBrowser: '已在浏览器中打开',
-
     featuredOn: '还出现在',
-
     similarArtists: '相似艺术家',
-
     cacheOffline: '离线保存全部专辑',
-
     offlineCached: '全部专辑已缓存',
-
     offlineDownloading: '正在缓存… ({{done}}/{{total}} 张专辑)',
-
     uploadImage: '上传艺术家图片',
-
     uploadImageError: '图片上传失败',
-
   },
-
   favorites: {
-
     title: '收藏夹',
-
     empty: '您还没有保存任何收藏。',
-
     artists: '艺术家',
-
     albums: '专辑',
-
     songs: '歌曲',
-
     enqueueAll: '全部加入队列',
-
     playAll: '全部播放',
-
     removeSong: '从收藏中移除',
-
     stations: '广播电台',
-
     showingFiltered: '显示 {{filtered}} / {{total}} ({{artist}})',
-
     showingCount: '显示 {{filtered}} / {{total}}',
-
     clearArtistFilter: '清除艺术家筛选',
-
     noFilterResults: '所选筛选条件下无结果。',
-
     allArtists: '全部艺术家',
-
   },
-
   randomLanding: {
-
     title: '创建混音',
-
     mixByTracks: '按曲目混音',
-
     mixByTracksDesc: '从整个媒体库随机选取曲目',
-
     mixByAlbums: '按专辑混音',
-
     mixByAlbumsDesc: '随机选取专辑，探索新音乐',
-
   },
-
   randomAlbums: {
-
     title: '随机专辑',
-
     refresh: '刷新',
-
   },
-
   genres: {
-
     title: '流派',
-
     genreCount: '个流派',
-
     albumCount_one: '{{count}} 张专辑',
-
     albumCount_other: '{{count}} 张专辑',
-
     loading: '正在加载流派…',
-
     empty: '未找到流派。',
-
     albumsLoading: '正在加载专辑…',
-
     albumsEmpty: '未找到该流派的专辑。',
-
     loadMore: '加载更多',
-
     back: '返回',
-
   },
-
   randomMix: {
-
     title: '随机混音',
-
     remix: '重新混音',
-
     remixTooltip: '加载新的随机歌曲',
-
     remixGenre: '重混 {{genre}}',
-
     remixTooltipGenre: '加载新的{{genre}}歌曲',
-
     playAll: '全部播放',
-
     trackTitle: '标题',
-
     trackArtist: '艺术家',
-
     trackAlbum: '专辑',
-
     trackFavorite: '收藏',
-
     trackDuration: '时长',
-
     favoriteAdd: '添加到收藏',
-
     favoriteRemove: '从收藏中移除',
-
     play: '播放',
-
     trackGenre: '流派',
-
     excludeAudiobooks: '排除有声读物和广播剧',
-
     excludeAudiobooksDesc: '根据流派、标题、专辑和艺术家匹配关键词 — 例如 Hörbuch、Audiobook、Spoken Word 等',
-
     genreBlocked: '关键词已屏蔽',
-
     genreAddedToBlacklist: '已添加到过滤列表',
-
     genreAlreadyBlocked: '已屏蔽',
-
     artistBlocked: '艺术家已屏蔽',
-
     artistAddedToBlacklist: '艺术家已添加到过滤列表',
-
     artistClickHint: '点击屏蔽此艺术家',
-
     blacklistToggle: '关键词过滤',
-
     genreMixTitle: '流派混音',
-
     genreMixDesc: '按歌曲数量排列的前 20 个流派 — 点击获取随机混音',
-
     genreMixAll: '所有歌曲',
-
     genreMixLoadMore: '加载 10 首更多',
-
     genreMixNoGenres: '服务器上未找到流派。',
-
     shuffleGenres: '显示其他流派',
-
     filterPanelTitle: '过滤器',
-
     filterPanelDesc: '点击下方列表中的流派标签或艺术家名称，将其从未来的混音中排除。',
-
     genreClickHint: '点击流派标签将其添加为过滤关键词。\\n匹配流派、标题、专辑和艺术家。',
-
   },
-
   albums: {
-
     title: '全部专辑',
-
     sortByName: '按名称排序 (A-Z)',
-
     sortByArtist: '按艺术家排序 (A-Z)',
-
     sortNewest: '最新优先',
-
     sortRandom: '随机排序',
-
     yearFrom: '从',
-
     yearTo: '到',
-
     yearFilterClear: '清除年份筛选',
-
     yearFilterLabel: '年份',
-
     select: '多选',
-
     startSelect: '启用多选',
-
     cancelSelect: '取消',
-
     selectionCount: '{{count}} 已选择',
-
     downloadZips: '下载 ZIP',
-
     addOffline: '添加离线',
-
     downloadingZip: '正在下载 {{current}}/{{total}}: {{name}}',
-
     downloadZipDone: '已下载 {{count}} 个 ZIP',
-
     downloadZipFailed: '下载 {{name}} 失败',
-
     offlineQueuing: '正在将 {{count}} 张专辑加入离线队列…',
-
     offlineFailed: '添加 {{name}} 离线失败',
-
   },
-
   artists: {
-
     title: '艺术家',
-
     search: '搜索…',
-
     all: '全部',
-
     gridView: '网格视图',
-
     listView: '列表视图',
-
     imagesOn: '艺术家图片已开启 — 可能增加网络和系统负载',
-
     imagesOff: '艺术家图片已关闭 — 仅显示首字母',
-
     loadMore: '加载更多',
-
     notFound: '未找到艺术家。',
-
     albumCount_one: '{{count}} 张专辑',
-
     albumCount_other: '{{count}} 张专辑',
-
     selectionCount: '{{count}} 已选择',
-
     select: '多选',
-
     startSelect: '启用多选',
-
     cancelSelect: '取消',
-
     addToPlaylist: '添加到播放列表',
-
   },
-
   login: {
-
     subtitle: '您的 Navidrome 桌面播放器',
-
     serverName: '服务器名称（可选）',
-
     serverNamePlaceholder: '我的 Navidrome',
-
     serverUrl: '服务器地址',
-
     serverUrlPlaceholder: '192.168.1.100:4533 或 https://music.example.com',
-
     username: '用户名',
-
     usernamePlaceholder: 'admin',
-
     password: '密码',
-
     showPassword: '显示密码',
-
     hidePassword: '隐藏密码',
-
     connect: '连接',
-
     connecting: '正在连接…',
-
     connected: '已连接！',
-
     error: '连接失败 — 请检查您的信息。',
-
     urlRequired: '请输入服务器地址。',
-
     savedServers: '已保存的服务器',
-
     addNew: '或添加新服务器',
-
   },
-
   connection: {
-
     connected: '已连接',
-
     connectedTo: '已连接到 {{server}}',
-
     disconnected: '已断开连接',
-
     disconnectedFrom: '无法连接到 {{server}} — 点击检查设置',
-
     checking: '正在连接…',
-
     extern: '外部',
-
     offlineTitle: '无服务器连接',
-
     offlineSubtitle: '无法连接到 {{server}}。请检查您的网络或服务器。',
-
     offlineModeBanner: '离线模式 — 正在从本地缓存播放',
-
     offlineNoCacheBanner: '无服务器连接 — 无法访问 {{server}}',
-
     offlineLibraryTitle: '离线音乐库',
-
     offlineLibraryEmpty: '尚未缓存任何专辑。请联网，打开专辑并点击"设为离线可用"。',
-
     offlineAlbumCount_one: '{{n}} 张专辑',
-
     offlineAlbumCount_plural: '{{n}} 张专辑',
-
     retry: '重试',
-
     serverSettings: '服务器设置',
-
     switchServerTitle: '切换服务器',
-
     switchServerHint: '点击选择其他已保存的服务器。',
-
     manageServers: '管理服务器…',
-
     switchFailed: '无法切换 — 无法连接服务器。',
-
     lastfmConnected: 'Last.fm 已连接为 @{{user}}',
-
     lastfmSessionInvalid: '会话无效 — 点击重新连接',
-
   },
-
   common: {
-
     albums: '专辑',
-
     album: '专辑',
-
     loading: '加载中…',
-
     loadingMore: '加载中…',
-
     loadingPlaylists: '正在加载播放列表…',
-
     noAlbums: '未找到专辑。',
-
     downloading: '正在下载…',
-
     downloadZip: '下载 (ZIP)',
-
     back: '返回',
-
     cancel: '取消',
-
     save: '保存',
-
     delete: '删除',
-
     use: '使用',
-
     add: '添加',
-
     active: '当前使用',
-
     download: '下载',
-
     chooseDownloadFolder: '选择下载文件夹',
-
     noFolderSelected: '未选择文件夹',
-
     rememberDownloadFolder: '记住此文件夹',
-
     filterGenre: '流派筛选',
-
     filterSearchGenres: '搜索流派…',
-
     filterNoGenres: '未找到匹配流派',
-
     filterClear: '清除',
-
     play: '播放',
-
     bulkSelected: '已选 {{count}} 首',
-
     clearSelection: '清除选择',
-
     bulkAddToPlaylist: '添加到播放列表',
-
     bulkRemoveFromPlaylist: '从播放列表移除',
-
     bulkClear: '取消选择',
-
     updaterAvailable: '有可用更新',
-
     updaterVersion: 'v{{version}} 已发布',
-
     updaterWebsite: '官网',
-
     updaterModalTitle: '有新版本可用',
-
     updaterChangelog: '更新内容',
-
     updaterDownloadBtn: '立即下载',
-
     updaterSkipBtn: '跳过此版本',
-
     updaterRemindBtn: '稍后提醒',
-
     updaterDone: '下载完成',
-
     updaterShowFolder: '在文件夹中显示',
-
     updaterInstallHint: '请关闭 Psysonic 并手动运行安装程序。',
-
     updaterAurHint: '通过 AUR 安装更新：',
-
     updaterErrorMsg: '下载失败',
-
     updaterRetryBtn: '重试',
-
     durationHoursMinutes: '{{hours}}小时{{minutes}}分钟',
-
     durationMinutesOnly: '{{minutes}}分钟',
-
     updaterOpenGitHub: '在 GitHub 上打开',
-
     filters: '筛选器',
-
     more: '更多',
-
     yearRange: '年份范围',
-
     clearAll: '清除全部',
-
   },
-
   settings: {
-
     title: '设置',
-
     language: '语言',
-
     languageEn: '英语',
-
     languageDe: '德语',
-
     languageFr: '法语',
-
     languageNl: '荷兰语',
-
     languageZh: '中文',
-
     languageNb: '挪威',
-
     languageRu: '俄语',
-
     font: '字体',
-
     theme: '主题',
-
     appearance: '外观',
-
     servers: '服务器',
-
     serverName: '服务器名称',
-
     serverUrl: '服务器地址',
-
     serverUrlPlaceholder: '192.168.1.100:4533 或 https://music.example.com',
-
     serverUsername: '用户名',
-
     serverPassword: '密码',
-
     addServer: '添加服务器',
-
     addServerTitle: '添加新服务器',
-
     useServer: '使用',
-
     deleteServer: '删除',
-
     noServers: '未保存任何服务器。',
-
     serverActive: '当前使用',
-
     confirmDeleteServer: '删除服务器 "{{name}}"？',
-
     serverConnecting: '正在连接…',
-
     serverConnected: '已连接！',
-
     serverFailed: '连接失败。',
-
     testBtn: '测试连接',
-
     testingBtn: '正在测试…',
-
     serverCompatible: '兼容：Navidrome · Gonic · Airsonic · Subsonic',
-
     audiomuseTitle: 'AudioMuse-AI（Navidrome）',
-
     audiomuseDesc:
-
       '若此服务器已配置 <pluginLink>AudioMuse-AI Navidrome 插件</pluginLink>请开启。可从曲目启动即时混音，并在艺人页使用服务器返回的相似艺人，而非 Last.fm。',
-
     audiomuseIssueHint:
-
       '近期即时混音失败 — 请检查 Navidrome 插件与 AudioMuse API。若服务器无结果，将回退使用 Last.fm 的相似艺人。',
-
     connected: '已连接',
-
     failed: '失败',
-
     eqTitle: '均衡器',
-
     eqEnabled: '启用均衡器',
-
     eqPreset: '预设',
-
     eqPresetCustom: '自定义',
-
     eqPresetBuiltin: '内置预设',
-
     eqPresetCustomGroup: '我的预设',
-
     eqSavePreset: '保存为预设',
-
     eqPresetName: '预设名称…',
-
     eqDeletePreset: '删除预设',
-
     eqResetBands: '重置为平直',
-
     eqPreGain: '预增益',
-
     eqResetPreGain: '重置预增益',
-
     eqAutoEqTitle: 'AutoEQ 耳机查询',
-
     eqAutoEqPlaceholder: '搜索耳机/入耳式型号…',
-
     eqAutoEqSearching: '搜索中…',
-
     eqAutoEqNoResults: '未找到结果',
-
     eqAutoEqError: '搜索失败',
-
     eqAutoEqRateLimit: 'GitHub 请求限制 — 请一分钟后重试',
-
     eqAutoEqFetchError: '无法获取 EQ 配置',
-
     lfmTitle: 'Last.fm',
-
     lfmConnect: '连接 Last.fm',
-
     lfmConnecting: '等待授权…',
-
     lfmConfirm: '我已完成授权',
-
     lfmConnected: '已连接为',
-
     lfmDisconnect: '断开连接',
-
     lfmConnectDesc: '连接您的 Last.fm 账户以启用歌曲记录和正在播放更新，直接从 Psysonic 发送 — 无需配置 Navidrome。',
-
     lfmOpenBrowser: '将打开浏览器窗口。在 Last.fm 上授权 Psysonic，然后点击下方按钮。',
-
     lfmScrobbles: '{{n}} 次记录',
-
     lfmMemberSince: '{{year}} 年加入',
-
     scrobbleEnabled: '启用歌曲记录',
-
     scrobbleDesc: '播放 50% 后发送歌曲到 Last.fm',
-
     behavior: '应用行为',
-
     cacheTitle: '最大存储大小',
-
     cacheDesc: '封面和艺术家图片。存满时，最旧的条目将自动移除。离线专辑不会自动移除，但手动清除缓存时会被删除。',
-
     cacheUsedImages: '图片：',
-
     cacheUsedOffline: '离线曲目：',
-
     cacheUsedHot: '占用空间：',
-
     hotCacheTrackCount: '缓存曲目数：',
-
     cacheMaxLabel: '最大容量',
-
     cacheClearBtn: '清除缓存',
-
     cacheClearWarning: '这将同时移除音乐库中的所有离线专辑。',
-
     cacheClearConfirm: '全部清除',
-
     cacheClearCancel: '取消',
-
     offlineDirTitle: '离线音乐库（应用内）',
-
     offlineDirDesc: '用于在 Psysonic 中离线可用的曲目存储位置。',
-
     offlineDirDefault: '默认（应用数据）',
-
     offlineDirChange: '更改目录',
-
     offlineDirClear: '重置为默认',
-
     offlineDirHint: '新下载将保存到此位置，现有下载保留在原始路径。',
-
     hotCacheTitle: '热播放缓存',
-
     hotCacheAlphaBadge: '预览',
-
     hotCacheDisclaimer: '预加载队列中即将播放的曲目并保留近期已播放的。开启后占用磁盘与网络。',
-
     hotCacheDirDefault: '默认（应用数据）',
-
     hotCacheDirChange: '更改目录',
-
     hotCacheDirClear: '重置为默认',
-
     hotCacheDirHint: '更换目录会重置应用内索引；已下载的文件仍留在原路径，需自行删除。',
-
     hotCacheEnabled: '启用热播放缓存',
-
     hotCacheMaxMb: '最大缓存大小',
-
     hotCacheDebounce: '队列变更去抖',
-
     hotCacheDebounceImmediate: '立即',
-
     hotCacheDebounceSeconds: '{{n}} 秒',
-
     hotCacheClearBtn: '清空热缓存',
-
     audioOutputDevice: '音频输出设备',
-
     audioOutputDeviceDesc: '选择 Psysonic 播放音频的设备。更改立即生效并重新开始当前曲目。',
-
     audioOutputDeviceDefault: '系统默认',
-
     audioOutputDeviceRefresh: '刷新设备列表',
-
     audioOutputDeviceOsDefaultNow: '当前系统输出',
-
     audioOutputDeviceListError: '无法加载音频设备列表。',
-
     audioOutputDeviceNotInCurrentList: '不在当前列表中',
-
     hiResTitle: '原生高清晰度播放',
-
     hiResEnabled: '启用原生高清晰度播放',
-
     hiResDesc: "默认强制 44.1 kHz 输出以获得最大稳定性。仅在硬件和网络可靠支持高采样率（88.2 kHz+）时启用。",
-
     showArtistImages: '显示艺术家图片',
-
     showArtistImagesDesc: '在艺术家概览中加载并显示艺术家图片。默认关闭以减少大型音乐库的服务器磁盘I/O和网络负载。',
-
     showTrayIcon: '显示托盘图标',
-
     showTrayIconDesc: '在系统通知区域 / 菜单栏显示 Psysonic 图标。',
-
     minimizeToTray: '最小化到托盘',
-
     minimizeToTrayDesc: '关闭窗口时，Psysonic 将继续在系统托盘中运行，而不是退出。',
-
     discordRichPresence: 'Discord Rich Presence',
-
     discordRichPresenceDesc: '在 Discord 个人资料上显示当前播放的曲目。需要 Discord 处于运行状态。',
-
     discordAppleCovers: '通过 Apple Music 为 Discord 获取封面',
-
     discordAppleCoversDesc: '将艺术家和专辑名称发送至 Apple 搜索 API，以为 Discord 个人资料查找封面图片。出于隐私考虑，默认禁用。',
-
     discordTemplates: '自定义文本模板',
-
     discordTemplatesDesc: '自定义在 Discord 个人资料上显示的信息。变量：{title}, {artist}, {album}, {paused}',
-
     discordTemplateDetails: '主行 (details)',
-
     discordTemplateState: '副行 (state)',
-
     discordTemplateLargeText: '专辑提示 (largeText)',
-
     nowPlayingEnabled: '在实时窗口中显示',
-
     nowPlayingEnabledDesc: '将当前播放的曲目广播到服务器的实时听众视图。禁用以停止发送播放数据。',
-
     lyricsServerFirst: '优先使用服务器歌词',
-
     lyricsServerFirstDesc: '先查询服务器提供的歌词（内嵌标签、sidecar 文件），再查询 LRCLIB。禁用则优先使用 LRCLIB。',
-
     enableNeteaselyrics: '网易云音乐歌词',
-
     enableNeteaselyricsDesc: '当服务器和 LRCLIB 均无结果时，使用网易云音乐作为最终歌词来源。对亚洲及国际音乐覆盖最佳。',
-
     lyricsSourcesTitle: '歌词来源',
-
     lyricsSourcesDesc: '选择要查询的歌词来源及其顺序。拖动以排序。已禁用的来源将被跳过。',
-
     lyricsSourceServer: '服务器',
-
     lyricsSourceLrclib: 'LRCLIB',
-
     lyricsSourceNetease: '网易云音乐',
-
     downloadsTitle: 'ZIP 导出与归档',
-
     downloadsFolderDesc: '将专辑以 ZIP 文件下载到电脑时的目标文件夹。',
-
     downloadsDefault: '默认下载文件夹',
-
     pickFolder: '选择',
-
     pickFolderTitle: '选择下载文件夹',
-
     clearFolder: '清除下载文件夹',
-
     logout: '退出登录',
-
     aboutTitle: '关于 Psysonic',
-
     aboutDesc: '适用于 Subsonic 兼容服务器（Navidrome、Gonic 等）的现代桌面音乐播放器。基于 Tauri v2 和原生 Rust 音频引擎构建——轻量快速，功能丰富：波形进度条、同步歌词、Last.fm 集成、10 段均衡器、交叉淡入淡出、无缝播放、响度增益、流派浏览以及大量精美主题。',
-
     aboutLicense: '许可证',
-
     aboutLicenseText: 'GNU GPL v3 — 在相同许可证下可自由使用、修改和分发。',
-
     aboutRepo: 'GitHub 上的源代码',
-
     aboutVersion: '版本',
-
     aboutBuiltWith: '使用 Tauri · React · TypeScript · Rust/rodio 构建',
-
     aboutAiCredit: '在 Anthropic 的 Claude Code 支持下开发',
-
     aboutContributorsLabel: '贡献者',
-
     aboutSpecialThanksLabel: '特别感谢',
-
     changelog: '更新日志',
-
     showChangelogOnUpdate: '更新时显示"新功能"',
-
     showChangelogOnUpdateDesc: '新版本首次启动时自动显示更新内容。',
-
     randomMixTitle: '随机混音',
-
     randomMixBlacklistTitle: '自定义过滤关键词',
-
     randomMixBlacklistDesc: '当任何关键词匹配流派、标题、专辑或艺术家时，歌曲将被排除（当上方复选框开启时生效）。',
-
     randomMixBlacklistPlaceholder: '添加关键词…',
-
     randomMixBlacklistAdd: '添加',
-
     randomMixBlacklistEmpty: '尚未添加自定义关键词。',
-
     randomMixHardcodedTitle: '内置关键词（复选框开启时生效）',
-
     tabAudio: '音频',
-
     tabStorage: '存储与下载',
-
     tabAppearance: '外观',
-
     homeCustomizerTitle: '首页',
-
     sidebarTitle: '侧边栏',
-
     sidebarReset: '重置为默认',
-
     sidebarDrag: '拖动以重新排序',
-
     sidebarFixed: '始终显示',
-
+    randomNavSplitTitle: '拆分混音导航',
+    randomNavSplitDesc: '在侧边栏中将"随机混音"和"随机专辑"显示为独立条目，而非"创建混音"合并入口。',
     tabInput: '输入',
-
     tabServer: '服务器',
-
     tabSystem: '系统',
-
     tabGeneral: '通用',
-
     ratingsSectionTitle: '评分',
-
     ratingsSkipStarTitle: '跳过以评 1 星',
-
     ratingsSkipStarDesc:
-
       '连续多次跳过后将曲目设为 1 星。仅适用于此前未评分的曲目。',
-
     ratingsSkipStarThresholdLabel: '跳过次数',
-
     ratingsMixFilterTitle: '按评分筛选',
-
     ratingsMixFilterDesc:
-
       '在{{mix}}与{{albums}}中筛选低评分内容。再次点击所选星标可关闭阈值。',
-
     ratingsMixMinSong: '歌曲',
-
     ratingsMixMinAlbum: '专辑',
-
     ratingsMixMinArtist: '艺人',
-
     ratingsMixMinThresholdAria: '最低星数：{{label}}',
-
     backupTitle: '备份与恢复',
-
     backupExport: '导出设置',
-
     backupExportDesc: '将所有设置、服务器配置、Last.fm 配置、主题、均衡器和快捷键保存到 .psybkp 文件。密码以明文存储——请妥善保管该文件。',
-
     backupImport: '导入设置',
-
     backupImportDesc: '从 .psybkp 文件恢复设置。导入后应用将重新加载。',
-
     backupImportConfirm: '所有当前设置将被覆盖。是否继续？',
-
     backupSuccess: '备份已保存',
-
     backupImportSuccess: '设置已恢复——正在重新加载…',
-
     backupImportError: '备份文件无效或已损坏。',
-
     shortcutsReset: '恢复默认',
-
     shortcutListening: '请按下按键…',
-
     shortcutUnbound: '—',
-
     globalShortcutsTitle: '全局快捷键',
-
     globalShortcutsNote: '即使 Psysonic 在后台也能在系统范围内工作。需要 Ctrl、Alt 或 Super 作为修饰键。',
-
     shortcutClear: '清除',
-
     shortcutPlayPause: '播放 / 暂停',
-
     shortcutNext: '下一首',
-
     shortcutPrev: '上一首',
-
     shortcutVolumeUp: '音量增大',
-
     shortcutVolumeDown: '音量减小',
-
     shortcutSeekForward: '快进 10 秒',
-
     shortcutSeekBackward: '快退 10 秒',
-
     shortcutToggleQueue: '切换队列',
-
     shortcutOpenFolderBrowser: '打开{{folderBrowser}}',
-
     shortcutFullscreenPlayer: '全屏播放器',
-
     shortcutNativeFullscreen: '原生全屏',
-
     playbackTitle: '播放',
-
     replayGain: '回放增益',
-
     replayGainDesc: '使用 ReplayGain 元数据标准化曲目音量',
-
     replayGainMode: '模式',
-
     replayGainTrack: '曲目',
-
     replayGainAlbum: '专辑',
-
     replayGainPreGain: '预增益（有标签文件）',
-
     replayGainFallback: '回退增益（无标签 / 收音机）',
-
     crossfade: '交叉淡入淡出',
-
     crossfadeDesc: '曲目间淡入淡出',
-
     crossfadeSecs: '{{n}} 秒',
-
     notWithGapless: '无缝播放开启时不可用',
-
     notWithCrossfade: '交叉淡入淡出开启时不可用',
-
     gapless: '无缝播放',
-
     gaplessDesc: '预缓冲下一首曲目以消除歌曲间的间隙',
-
     preloadMode: '预加载下一曲目',
-
     preloadModeDesc: '何时开始缓冲队列中的下一曲目',
-
     nextTrackBufferingTitle: '下一曲目缓冲',
-
     preloadHotCacheMutualExclusive: '预加载与热缓存用途相同——两者不能同时启用。启用其中一个会自动禁用另一个。',
-
     preloadOff: '关闭',
-
     preloadBalanced: '均衡（结束前30秒）',
-
     preloadEarly: '提前（播放5秒后）',
-
     preloadCustom: '自定义',
-
     preloadCustomSeconds: '结束前秒数：{{n}}',
-
     infiniteQueue: '无限队列',
-
     infiniteQueueDesc: '队列播完时自动追加随机曲目',
-
     experimental: '实验性',
-
     fsPlayerSection: '全屏播放器',
-
     fsShowArtistPortrait: '显示艺术家照片',
-
     fsShowArtistPortraitDesc: '在全屏播放器右侧显示艺术家照片（或专辑封面）。',
-
     fsPortraitDim: '照片暗化',
-
     seekbarStyle: '进度条样式',
-
     seekbarStyleDesc: '选择播放进度条的外观',
-
     seekbarWaveform: '波形',
-
     seekbarLinedot: '线条与点',
-
     seekbarBar: '条形',
-
     seekbarThick: '粗条形',
-
     seekbarSegmented: '分段式',
-
     seekbarNeon: '霓虹',
-
     seekbarPulsewave: '脉冲波',
-
     seekbarParticletrail: '粒子轨迹',
-
     seekbarLiquidfill: '液体填充',
-
     seekbarRetrotape: '复古磁带',
-
     themeSchedulerTitle: '主题定时切换',
-
     themeSchedulerEnable: '启用主题定时器',
-
     themeSchedulerEnableSub: '根据一天中的时间自动在两个主题之间切换',
-
     themeSchedulerDayTheme: '白天主题',
-
     themeSchedulerDayStart: '白天开始时间',
-
     themeSchedulerNightTheme: '夜晚主题',
-
     themeSchedulerNightStart: '夜晚开始时间',
-
     themeSchedulerActiveHint: '主题定时器已启用 - 主题将自动切换。',
-
     visualOptionsTitle: '视觉选项',
-
     coverArtBackground: '封面背景',
-
     coverArtBackgroundSub: '在专辑/播放列表标题中显示模糊的封面作为背景',
-
     playlistCoverPhoto: '播放列表封面照片',
-
     playlistCoverPhotoSub: '在播放列表详细视图中显示封面照片网格',
-
     showBitrate: '显示比特率',
-
     showBitrateSub: '在曲目列表中显示音频比特率',
-
     uiScaleTitle: '界面缩放',
-
     uiScaleLabel: '缩放',
-
   },
-
   changelog: {
-
     modalTitle: '新功能',
-
     dontShowAgain: '不再显示',
-
     close: '知道了',
-
   },
-
   help: {
-
     title: '帮助',
-
     s1: '入门指南',
-
     q1: '支持哪些服务器？',
-
     a1: 'Psysonic 可与任何 Subsonic 兼容服务器配合使用：Navidrome、Gonic、Subsonic、Airsonic 等。推荐使用 Navidrome。',
-
     q2: '如何连接服务器？',
-
     a2: '打开设置并点击"添加服务器"。输入服务器地址（如 192.168.1.100:4533）、用户名和密码。Psysonic 会在保存前测试连接 — 如果连接失败则不会存储任何信息。',
-
     q3: '可以使用多个服务器吗？',
-
     a3: '可以。您可以在设置中添加任意数量的服务器，并随时切换。同一时间只能有一个服务器处于活动状态。',
-
     s2: '播放',
-
     q4: '如何播放音乐？',
-
     a4: '双击任意曲目即可播放。在专辑和艺术家页面，使用"全部播放"开始播放整张专辑。您也可以将曲目拖入队列面板。',
-
     q5: '有哪些键盘快捷键？',
-
     a5: '空格键 = 播放 / 暂停 · Esc = 关闭全屏播放器。媒体键（播放/暂停、下一首、上一首）在所有平台上都有效。在 Linux 上，请使用播放器栏按钮作为媒体键。应用内快捷键和系统级全局快捷键可在 设置 → 键盘快捷键 / 全局快捷键 中自定义。',
-
     q6: '什么是播放队列？',
-
     a6: '队列显示所有即将播放的曲目。点击右上角标题栏的面板图标（正在播放指示器旁边）打开队列。您可以通过拖拽重新排序，使用随机播放按钮打乱顺序，并将队列保存为播放列表。',
-
     q7: '如何打开全屏播放器？',
-
     a7: '点击底部播放器栏的专辑封面缩略图，或其旁边的展开图标。按 Esc 键关闭。',
-
     q8: '重复播放如何工作？',
-
     a8: '点击播放器栏的重复按钮可在以下模式间循环：关闭 → 重复全部 → 重复单曲。',
-
     s3: '音乐库',
-
     q9: '如何下载专辑？',
-
     a9: '打开专辑详情页并点击"下载 (ZIP)"。服务器会先将专辑压缩为 ZIP 文件 — 对于大型专辑或无损文件（FLAC / WAV），在实际下载开始前可能需要一些时间。这是正常的：进度条会在服务器完成压缩并开始传输后显示。',
-
     q10: '如何收藏曲目和专辑？',
-
     a10: '点击任意曲目行或专辑标题上的星形图标。收藏的项目会显示在侧边栏的收藏夹中。',
-
     q11: '首页的英雄轮播是什么？',
-
     a11: '首页顶部的横幅会随机从您的音乐库中选择专辑，每 10 秒轮换一次。点击圆点可跳转到特定专辑，或点击横幅打开专辑。',
-
     s4: '设置',
-
     q12: '如何更改主题？',
-
     a12: '设置 → 主题。从 8 个分组中的大量主题中选择：Psysonic 主题、媒体播放器、操作系统、游戏、电影、电视剧、社交媒体，以及开源经典（Catppuccin、Nord、Gruvbox、Nightfox）。',
-
     q13: '如何更改语言？',
-
     a13: '设置 → 语言。支持英语、德语、法语、荷兰语和中文。',
-
     q15: '如何设置下载文件夹？',
-
     a15: '设置 → 应用行为 → 下载文件夹。选择任意文件夹 — 下载的专辑将以 ZIP 文件形式保存在那里。未设置自定义文件夹时，将使用浏览器的默认下载位置。',
-
     s5: '歌曲记录',
-
     q16: '歌曲记录如何工作？',
-
     a16: 'Psysonic 直接向 Last.fm 发送记录 — 无需配置 Navidrome。在 设置 → Last.fm 中连接您的 Last.fm 账户并启用记录功能。',
-
     q17: '何时发送记录？',
-
     a17: '在您听完曲目的 50% 后提交记录。',
-
     q22: '播放器栏中的波形是什么？',
-
     a22: '波形进度条取代了传统的进度滑块。点击任意位置跳转到该位置，或拖动进行拖动播放。已播放部分显示蓝到紫的渐变，缓冲区域稍亮，未播放部分则淡化显示。',
-
     q24: '可以随机打乱队列吗？',
-
     a24: '可以。打开队列面板并点击队列标题栏的随机播放图标。当前播放曲目保持在第 1 位 — 其余曲目将随机重新排序。',
-
     q25: '艺术家页面上的 Last.fm 和 Wikipedia 链接会在浏览器中打开吗？',
-
     a25: '是的 — 它们会在您的默认系统浏览器中打开。点击时按钮会短暂显示确认标签。',
-
     s7: '随机混音',
-
     q26: '什么是随机混音？',
-
     a26: '随机混音从您的整个音乐库中构建一个随机曲目的播放列表。通过侧边栏的"随机混音"打开并点击"新混音"。您可以在生成前调整曲目数量。',
-
     q27: '什么是关键词过滤？',
-
     a27: '关键词过滤会排除流派、标题或专辑名称包含特定词汇的曲目。有声读物会被自动过滤。在 设置 → 随机混音 中添加自定义关键词，或点击曲目列表中的任意流派标签即时添加。',
-
     q28: '什么是超级流派混音？',
-
     a28: '超级流派混音将您的音乐库分组为宽泛的类别（摇滚、金属、电子、爵士、古典等），并从该风格构建一个专注的混音。在曲目列表下方选择类别标签。结果会随着每个子流派的获取而逐步显示。',
-
     s6: '故障排除',
-
     q18: '封面和艺术家图片加载缓慢。',
-
     a18: '图片首次加载时从服务器磁盘获取，然后本地缓存 30 天。如果服务器存储较慢，首次访问页面可能需要一些时间。后续访问将瞬间完成。',
-
     q19: '连接测试失败。',
-
     a19: '检查 URL 包括端口（如 http://192.168.1.100:4533）。确保防火墙没有阻止连接。在本地网络上尝试使用 http:// 而非 https://。同时验证用户名和密码是否正确。',
-
     q20: 'Linux 上没有音频。',
-
     a20: 'Psysonic 提供 .deb（Ubuntu/Debian）、.rpm（Fedora/RHEL）版本，以及通过 AUR 在 Arch/CachyOS 上安装（yay -S psysonic）。没有 AppImage。如果没有音频，请确保 PipeWire 或 PulseAudio 正在运行。',
-
     q21: '应用在 Linux 上显示黑屏。',
-
     a21: '这通常是 WebKitGTK 中的 GPU/EGL 驱动问题。使用 GDK_BACKEND=x11 WEBKIT_DISABLE_COMPOSITING_MODE=1 WEBKIT_DISABLE_DMABUF_RENDERER=1 启动。AUR 包和官方 .deb/.rpm 安装程序会自动设置这些环境变量。',
-
     q29: '什么是交叉淡入淡出和无缝播放？',
-
     a29: '两者都是 设置 → 音频 中的实验性音频功能。无缝播放预缓冲下一首曲目以消除歌曲间的静音。交叉淡入淡出让当前曲目淡出同时下一首淡入 — 调整持续时间（1-10 秒）以符合您的喜好。',
-
     q30: 'Psysonic 显示歌词吗？',
-
     a30: '是的。点击播放器栏的麦克风图标可在队列面板中打开歌词标签。Psysonic 自动从 LRCLIB 获取歌词。如果可用同步歌词，活动行会高亮并随歌曲实时滚动。如果只有纯文本歌词，则静态显示完整文本。',
-
     q31: '可以自定义键盘快捷键吗？',
-
     a31: '可以。设置 → 键盘快捷键 允许您重新映射应用内操作（播放/暂停、下一首、上一首、音量增/减、全屏等）到任意按键。设置 → 全局快捷键 允许您分配即使 Psysonic 在后台也能触发的系统级快捷键。',
-
     q32: '可以更改字体吗？',
-
     a32: '可以。设置 → 字体 允许您从 10 种字体中选择，包括 IBM Plex Mono、Fira Code、JetBrains Mono、Courier Prime 等。所选字体将应用于整个界面。',
-
     s8: '离线模式',
-
     q34: '什么是离线模式？',
-
     a34: '离线模式（测试版）允许您将专辑缓存到设备，以便在没有活动服务器连接时收听。缓存的曲目存储在本地并直接从磁盘播放 — 播放期间不进行网络请求。',
-
     q35: '如何缓存专辑以供离线使用？',
-
     a35: '打开任意专辑并点击专辑标题栏的下载图标。Psysonic 会在后台下载所有曲目。按钮上会显示进度。缓存完成后，图标变为绿色。您可以在离线音乐库页面（侧边栏）查看和移除缓存的专辑。',
-
     q36: '离线缓存可以使用多少存储空间？',
-
     a36: '您可以在 设置 → 音乐库 中设置最大缓存大小。达到限制时，专辑页面会显示警告横幅。您可以从离线音乐库中删除单个专辑以释放空间。',
-
     q37: '如何对歌曲、专辑和艺术家评分？',
-
     a37: 'Psysonic 通过 OpenSubsonic API 支持 1–5 星评分（需要 Navidrome ≥ 0.53）。可在专辑或播放列表曲目列表、右键菜单或播放器栏中对歌曲评分。专辑在详情页评分，艺术家在艺术家页评分。',
-
     q38: '可以删除或更改评分吗？',
-
     a38: '可以。再次点击当前激活的星星即可完全删除评分——第二次点击同一颗星即可清除。点击其他星星可更改评分。',
-
     q39: '什么是 Skip-to-1★ 和评分过滤器？',
-
     a39: 'Skip-to-1★ 会在歌曲被连续手动跳过一定次数后自动赋予 1 星评分。在 设置 → 评分 中启用并设置阈值。同样可在此设置随机混音的最低星级过滤条件。',
-
     q40: '什么是文件夹浏览器？',
-
     a40: '文件夹浏览器（侧边栏）使用 Miller 列布局浏览服务器音乐目录。点击文件夹查看内容；点击播放图标直接播放或添加到队列。',
-
     q41: '什么是主题调度器？',
-
     a41: '设置 → 外观 → 自动切换主题：设置日间主题和夜间主题及开始时间，Psysonic 将在指定时间自动切换主题。',
-
     q42: '可以调整界面缩放吗？',
-
     a42: '可以。设置 → 外观 → 界面缩放 可将整个界面缩放至 80%–125%。',
-
     q43: '可以更改进度条样式吗？',
-
     a43: '可以。设置 → 外观 → 进度条样式 提供 10 种样式：波形、线条与点、条形、粗条形、分段、霓虹辉光、脉冲波、粒子轨迹、液体填充和复古磁带。',
-
     q44: '什么是 AutoEQ？',
-
     a44: '设置 → 音频 中的 10 频段均衡器包含 AutoEQ 查找功能。输入耳机型号即可自动加载校正配置文件。',
-
     q45: '什么是 Replay Gain？',
-
     a45: 'Replay Gain 标准化音量，使响亮和安静的专辑以一致的音量播放。在 设置 → 音频 → Replay Gain 中启用；选择曲目模式或专辑模式。',
-
     q46: '什么是热缓存？',
-
     a46: '热缓存（Alpha，设置 → 音乐库）将队列中后续曲目预加载到磁盘，实现即时播放，对于慢速或远程服务器尤为有用。Psysonic 保留当前曲目和后续 5 首，达到大小限制时淘汰旧条目。',
-
     q47: '可以将播放列表缓存到离线吗？',
-
     a47: '可以。在播放列表详情中点击下载图标，所有曲目将在后台下载。完全缓存后图标变为红色垃圾桶；再次点击即可从离线缓存中删除该播放列表。',
-
+    q48: '什么是无限队列？',
+    a48: '当队列播完且关闭了重复播放时，Psysonic会自动添加随机曲目，确保播放不会中断。自动添加的曲目显示在"— 自动添加 —"分隔符下方。',
+    q49: '可以通过命令行控制Psysonic吗？',
+    a49: '可以。示例：psysonic --player play / pause / next / prev，--player volume 75，--player seek 15，--player mute，--player shuffle，--player repeat off|all|one。还可以切换服务器、音频设备、筛选音乐库和搜索。完整帮助：psysonic --player --help。',
+    q50: '如何管理播放列表？',
+    a50: '通过侧边栏中的"播放列表"进入。点击"新建播放列表"创建。在详情页可拖拽排序、点击×删除曲目、通过搜索添加歌曲，还可使用"建议"获取智能推荐。',
+    q51: '可以备份和恢复设置吗？',
+    a51: '可以。设置→备份与恢复可将所有设置、服务器配置、主题和快捷键导出为JSON文件，在其他设备上导入即可一键恢复。',
+    q52: '如何更改音频输出设备？',
+    a52: '设置→音频→输出设备。Psysonic列出所有可用输出，选择后立即生效。若设备在应用启动后连接，可点击刷新按钮更新列表。',
+    q53: '什么是设备同步？',
+    a53: '设备同步可将专辑、播放列表或艺术家复制到USB或SD卡。通过侧边栏"Device Sync"打开，选择目标文件夹和来源，点击"传输到设备"。',
+    q54: '设备同步中的文件名模板是什么？',
+    a54: '模板控制曲目的命名和组织方式。使用预设或通过可点击的令牌自定义：{artist}、{album}、{title}、{track_number}、{disc_number}、{year}，以及/作为文件夹分隔符。',
+    q55: '设备同步支持跨平台使用吗？',
+    a55: '支持。设备上的清单文件包含同步时使用的模板。在不同系统上，Psysonic能正确识别已存在的文件。',
+    s9: 'Device Sync',
+    q56: '什么是网络电台？',
+    a56: '网络电台页面可在Psysonic中播放任何直播流。电台来自Navidrome服务器，可通过管理面板添加或导入.pls/.m3u文件。播放使用HTML5音频。',
+    q57: '网络电台支持哪些流格式？',
+    a57: 'MP3、AAC、OGG Vorbis及大多数HLS流。MP3和AAC在所有平台均可使用。',
+    s10: '网络电台',
+    q58: 'Psysonic从哪里获取歌词？',
+    a58: '三个可配置来源（设置→歌词）：Navidrome服务器、LRCLIB和网易云音乐。每个来源均可启用/禁用，并可拖拽调整优先级。',
+    q59: '有没有查看其他用户正在听什么的功能？',
+    a59: '有。点击右上角的广播图标，可查看Navidrome服务器上其他用户正在收听的内容，每10秒更新一次。',
   },
-
   queue: {
-
     title: '队列',
-
     savePlaylist: '保存为播放列表',
-
     updatePlaylist: '更新播放列表',
-
     filterPlaylists: '筛选播放列表…',
-
     playlistName: '播放列表名称',
-
     cancel: '取消',
-
     save: '保存',
-
     loadPlaylist: '加载播放列表',
-
     loading: '加载中…',
-
     noPlaylists: '未找到播放列表。',
-
     load: '替换队列并播放',
-
     appendToQueue: '追加到队列',
-
     delete: '删除',
-
     deleteConfirm: '删除播放列表 "{{name}}"？',
-
     clear: '清空',
-
     shuffle: '随机打乱队列',
-
     gapless: '无缝播放',
-
     crossfade: '交叉淡入淡出',
-
     infiniteQueue: '无限队列',
-
     autoAdded: '— 自动添加 —',
-
     radioAdded: '— 收音机 —',
-
     hide: '隐藏',
-
     close: '关闭',
-
     nextTracks: '即将播放',
-
     emptyQueue: '队列为空。',
-
     trackSingular: '首曲目',
-
     trackPlural: '首曲目',
-
     showRemaining: '显示剩余时间',
-
     showTotal: '显示总时间',
-
   },
-
   statistics: {
-
     title: '统计',
-
     recentlyPlayed: '最近播放',
-
     mostPlayed: '最常播放的专辑',
-
     highestRated: '评分最高的专辑',
-
     genreDistribution: '流派分布（前 20）',
-
     loadMore: '加载更多',
-
     statArtists: '艺术家',
-
     statArtistsTooltip: '仅限专辑艺术家——仅作为单曲艺术家出现（合唱、客串等）且无自己专辑的艺术家不计入此处。',
-
     statAlbums: '专辑',
-
     statSongs: '歌曲',
-
     statGenres: '流派',
-
     statPlaytime: '音频总时长',
-
     genreInsights: '流派洞察',
-
     formatDistribution: '格式分布',
-
     formatSample: '{{n}} 首曲目的样本',
-
     computing: '计算中…',
-
     genreSongs: '{{count}} 首歌曲',
-
     genreAlbums: '{{count}} 张专辑',
-
     recentlyAdded: '最近添加',
-
     decadeDistribution: '按年代分布的专辑',
-
     decadeAlbums_one: '{{count}} 张专辑',
-
     decadeAlbums_other: '{{count}} 张专辑',
-
     decadeUnknown: '未知',
-
     lfmTitle: 'Last.fm 统计',
-
     lfmTopArtists: '热门艺术家',
-
     lfmTopAlbums: '热门专辑',
-
     lfmTopTracks: '热门曲目',
-
     lfmPlays: '{{count}} 次播放',
-
     lfmPeriodOverall: '全部时间',
-
     lfmPeriod7day: '7 天',
-
     lfmPeriod1month: '1 个月',
-
     lfmPeriod3month: '3 个月',
-
     lfmPeriod6month: '6 个月',
-
     lfmPeriod12month: '12 个月',
-
     lfmNotConnected: '在设置中连接 Last.fm 以查看您的统计。',
-
     lfmRecentTracks: '最近记录',
-
     lfmNowPlaying: '正在播放',
-
     lfmJustNow: '刚刚',
-
     lfmMinutesAgo: '{{n}} 分钟前',
-
     lfmHoursAgo: '{{n}} 小时前',
-
     lfmDaysAgo: '{{n}} 天前',
-
     topRatedSongs: '最高评分歌曲',
-
     topRatedArtists: '最高评分艺人',
-
     noRatedSongs: '暂无已评分歌曲。请在专辑或播放列表中为歌曲评分。',
-
     noRatedArtists: '暂无已评分艺人。',
-
   },
-
   player: {
-
     regionLabel: '音乐播放器',
-
     openFullscreen: '打开全屏播放器',
-
     fullscreen: '全屏播放器',
-
     closeFullscreen: '关闭全屏',
-
     closeTooltip: '关闭 (Esc)',
-
     noTitle: '无标题',
-
     stop: '停止',
-
     prev: '上一首',
-
     play: '播放',
-
     pause: '暂停',
-
     next: '下一首',
-
     repeat: '重复',
-
     repeatOff: '关闭',
-
     repeatAll: '全部',
-
     repeatOne: '单曲',
-
     progress: '播放进度',
-
     volume: '音量',
-
     toggleQueue: '切换队列',
-
     lyrics: '歌词',
-
     fsLyricsToggle: '全屏歌词',
-
     lyricsLoading: '正在加载歌词…',
-
     lyricsNotFound: '未找到此曲目的歌词',
-
     lyricsSourceServer: '来源：服务器',
-
     lyricsSourceLrclib: '来源：LRCLIB',
-
     lyricsSourceNetease: '来源：网易云',
-
   },
-
   songInfo: {
-
     title: '歌曲信息',
-
     songTitle: '标题',
-
     artist: '艺术家',
-
     album: '专辑',
-
     albumArtist: '专辑艺术家',
-
     year: '年份',
-
     genre: '流派',
-
     duration: '时长',
-
     track: '曲目',
-
     format: '格式',
-
     bitrate: '比特率',
-
     sampleRate: '采样率',
-
     bitDepth: '位深度',
-
     channels: '声道',
-
     fileSize: '文件大小',
-
     path: '文件路径',
-
     replayGainTrack: 'RG 曲目增益',
-
     replayGainAlbum: 'RG 专辑增益',
-
     replayGainPeak: 'RG 曲目峰值',
-
     mono: '单声道',
-
     stereo: '立体声',
-
   },
-
   playlists: {
-
     title: '播放列表',
-
     newPlaylist: '新建播放列表',
-
     unnamed: '未命名播放列表',
-
     createName: '播放列表名称…',
-
     create: '创建',
-
     cancel: '取消',
-
     empty: '暂无播放列表。',
-
     emptyPlaylist: '此播放列表为空。',
-
     addFirstSong: '添加第一首歌曲',
-
     notFound: '未找到播放列表。',
-
     songs: '{{n}} 首歌曲',
-
     playAll: '全部播放',
-
     shuffle: '随机播放',
-
     addToQueue: '添加到队列',
-
     back: '返回播放列表',
-
     deletePlaylist: '删除',
-
     confirmDelete: '再次点击确认删除',
-
     removeSong: '从播放列表中移除',
-
     addSongs: '添加歌曲',
-
     searchPlaceholder: '搜索音乐库…',
-
     noResults: '无结果。',
-
     suggestions: '推荐歌曲',
-
     noSuggestions: '暂无推荐。',
-
     titleBadge: '播放列表',
-
     refreshSuggestions: '新建议',
-
     addSong: '添加到播放列表',
-
     addSelected: '添加所选',
-
     cacheOffline: '离线缓存播放列表',
-
     offlineCached: '播放列表已缓存',
-
     removeOffline: '从离线缓存中移除',
-
     offlineDownloading: '正在缓存… ({{done}}/{{total}} 张专辑)',
-
     publicLabel: '公开',
-
     privateLabel: '私有',
-
     editMeta: '编辑播放列表',
-
     editNamePlaceholder: '播放列表名称…',
-
     editCommentPlaceholder: '添加描述…',
-
     editPublic: '公开播放列表',
-
     editSave: '保存',
-
     editCancel: '取消',
-
     changeCover: '更改封面图片',
-
     changeCoverLabel: '更改照片',
-
     removeCover: '删除照片',
-
     coverUpdated: '封面已更新',
-
     metaSaved: '播放列表已更新',
-
     downloadZip: '下载 (ZIP)',
-
     // Toast notifications for multi-select
-
     addSuccess: '{{count}} 首歌曲已添加到 {{playlist}}',
-
     addPartial: '{{added}} 首已添加，{{skipped}} 首跳过（重复）',
-
     addAllSkipped: '全部跳过（{{count}} 首重复）',
-
     addError: '添加歌曲时出错',
-
     createAndAddSuccess: '播放列表 "{{playlist}}" 已创建，包含 {{count}} 首歌曲',
-
     createError: '创建播放列表时出错',
-
     deleteSuccess: '{{count}} 个播放列表已删除',
-
     deleteFailed: '删除 {{name}} 时出错',
-
     deleteSelected: '删除所选',
-
     mergeSuccess: '{{count}} 首歌曲已合并到 {{playlist}}',
-
     mergeNoNewSongs: '没有新歌曲可添加',
-
     mergeError: '合并播放列表时出错',
-
     mergeInto: '合并到',
-
     selectionCount: '{{count}} 已选择',
-
     select: '选择',
-
     startSelect: '启用选择',
-
     cancelSelect: '取消',
-
     loadingAlbums: '正在解析 {{count}} 张专辑…',
-
     loadingArtists: '正在解析 {{count}} 位艺术家…',
-
     myPlaylists: '我的播放列表',
-
     noOtherPlaylists: '没有其他可用播放列表',
-
     addToPlaylistSuccess: '{{count}} 首歌曲已添加到 {{playlist}}',
-
     addToPlaylistNoNew: '{{playlist}} 没有新歌曲',
-
     addToPlaylistError: '添加到播放列表时出错',
-
     importCSV: '导入 CSV',
-
     importCSVTooltip: '从 Spotify CSV 导入',
-
     csvImportReport: 'CSV 导入报告',
-
     csvImportTotal: '总计',
-
     csvImportAdded: '已添加',
-
     csvImportDuplicates: '重复项',
-
     csvImportNotFound: '未找到',
-
     csvImportNetworkErrors: '网络错误',
-
     csvImportDuplicatesTitle: '重复曲目（已在播放列表中）：',
-
     csvImportNotFoundTitle: '未找到的曲目：',
-
     csvImportNetworkErrorsTitle: '网络错误（可重试导入）：',
-
     csvImportDownloadReport: '下载报告',
-
     csvImportClose: '关闭',
-
     csvImportNoValidTracks: 'CSV 文件中未找到有效曲目',
-
     csvImportFailed: 'CSV 文件导入失败',
-
     csvImportToast: '{{added}} 已添加，{{notFound}} 未找到，{{duplicates}} 重复项',
-
   },
-
   mostPlayed: {
-
     title: '最常播放',
-
     topArtists: '热门艺术家',
-
     topAlbums: '热门专辑',
-
     plays: '播放 {{n}} 次',
-
     sortMost: '最多播放在前',
-
     sortLeast: '最少播放在前',
-
     loadMore: '加载更多专辑',
-
     noData: '暂无播放数据。开始收听吧！',
-
     noArtists: '所有艺术家已过滤。',
-
     filterCompilations: '隐藏合辑艺术家（Various Artists、原声带等）',
-
     filterCompilationsShort: '隐藏合辑',
-
   },
-
   radio: {
-
     title: '网络电台',
-
     empty: '未配置任何电台。',
-
     addStation: '添加电台',
-
     editStation: '编辑',
-
     deleteStation: '删除电台',
-
     confirmDelete: '再次点击确认',
-
     stationName: '电台名称…',
-
     streamUrl: '流地址…',
-
     homepageUrl: '主页地址（可选）',
-
     save: '保存',
-
     cancel: '取消',
-
     live: '直播',
-
     liveStream: '网络电台',
-
     openHomepage: '打开主页',
-
     changeCoverLabel: '更换封面',
-
     removeCover: '移除封面',
-
     browseDirectory: '搜索目录',
-
     directoryPlaceholder: '搜索电台…',
-
     noResults: '未找到电台。',
-
     stationAdded: '电台已添加',
-
     filterAll: '全部',
-
     filterFavorites: '收藏',
-
     sortManual: '手动',
-
     sortAZ: 'A → Z',
-
     sortZA: 'Z → A',
-
     sortNewest: '最新',
-
     favorite: '添加到收藏',
-
     unfavorite: '从收藏移除',
-
     noFavorites: '没有收藏的电台。',
-
     listenerCount_one: '{{count}} 位听众',
-
     listenerCount_other: '{{count}} 位听众',
-
     recentlyPlayed: '最近播放',
-
     upNext: '即将播放',
-
   },
-
   folderBrowser: {
-
     empty: '空文件夹',
-
     error: '加载失败',
-
   },
-
   deviceSync: {
-
     title: '设备同步',
-
     targetFolder: '目标文件夹',
-
     noFolderChosen: '未选择文件夹',
-
     selectDrive: '选择驱动器…',
-
     refreshDrives: '刷新驱动器',
-
     noDrivesDetected: '未检测到可移动驱动器',
-
     browseManual: '手动浏览…',
-
     free: '可用',
-
     notMountedVolume: '目标不在已挂载的卷上。驱动器可能已断开。',
-
     chooseFolder: '选择…',
-
     filenameTemplate: '文件名模板',
-
     targetDevice: '目标设备',
-
     templateHint: '变量：{artist}、{album}、{title}、{track_number}、{disc_number}、{year}',
-
     cleanupButton: '删除不在选择范围内的文件',
-
     cleanupNothingToDelete: '无需删除 — 设备已同步。',
-
     confirmCleanup: '将从设备中删除 {{count}} 个不在当前选择范围内的文件。继续？',
-
     cleanupComplete: '已从设备中删除 {{count}} 个文件。',
-
     selectedSources: '已选来源',
-
     noSourcesSelected: '未选择来源。点击浏览器中的项目以添加。',
-
     clearAll: '全部清除',
-
     tabPlaylists: '播放列表',
-
     tabAlbums: '专辑',
-
     tabArtists: '艺术家',
-
     searchPlaceholder: '搜索…',
-
     syncButton: '同步到设备',
-
     actionTransfer: '传输到设备',
-
     actionDelete: '从设备删除',
-
     actionApplyAll: '应用所有更改',
-
     templatePreview: '预览',
-
+    templatePresetStandard: '标准',
+    templatePresetMultiDisc: '多碟',
+    templatePresetAltFolder: '备用文件夹',
+    tokenSlashHint: '/ = 文件夹分隔符',
     cancel: '取消',
-
     noTargetDir: '请先选择目标文件夹。',
-
     noSources: '请至少选择一个来源。',
-
     noTracks: '所选来源中未找到曲目。',
-
     fetchError: '从服务器加载曲目失败。',
-
     syncComplete: '同步完成。',
-
     dismiss: '关闭',
-
+    cancelSync: '取消',
+    syncCancelled: '同步已取消（已传输 {{done}} / {{total}}）。',
     colName: '名称',
-
     colType: '类型',
-
     colStatus: '状态',
-
     onDevice: '设备管理器',
-
     addSources: '添加…',
-
     syncResult: '已传输 {{done}}，{{skipped}} 已是最新（共 {{total}}）',
-
     deleteFromDevice: '标记为删除（{{count}}）',
-
     confirmDelete: '从设备删除 {{count}} 个项目：{{names}}？',
-
     deleteComplete: '已从设备删除 {{count}} 个项目。',
-
+    manifestImported: '已从设备清单导入 {{count}} 个来源。',
     statusSynced: '已同步',
-
     statusPending: '待处理',
-
     statusDeletion: '删除中',
-
     markForDeletion: '标记为删除',
-
     removeSource: '移除',
-
     undoDeletion: '撤销删除',
-
     syncInBackground: '同步已在后台启动 — 您可以离开此页面。',
-
     syncInProgress: '{{done}} / {{total}} 首曲目…',
-
     syncSummary: '同步摘要',
-
     calculating: '正在计算所需数据…',
-
     filesToAdd: '要添加的文件：',
-
     filesToDelete: '要删除的文件：',
-
     netChange: '净变化：',
-
     availableSpace: '可用磁盘空间：',
-
     spaceWarning: '警告：目标设备的可用空间不足。',
-
     proceed: '继续同步',
-
     notEnoughSpace: '检测到物理磁盘空间不足！',
-
     liveSearch: '实时',
-
     randomAlbumsLabel: '随机专辑',
-
   },
-
 };
-

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,2897 +1,5742 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+
 import { version as appVersion } from '../../package.json';
+
 import changelogRaw from '../../CHANGELOG.md?raw';
+
 import { useNavigate, useLocation } from 'react-router-dom';
+
 import {
+
   Wifi, WifiOff, Globe, Music2, Sliders, LogOut, CheckCircle2, FolderOpen,
+
   Palette, Server, Plus, Trash2, Eye, EyeOff, Info, ExternalLink, Shuffle, X, Play, Type, Keyboard, ChevronDown,
+
   GripVertical, PanelLeft, RotateCcw, LayoutGrid, AppWindow, HardDrive, Upload, Download, Waves, Star, Clock, ZoomIn, Sparkles, AlertTriangle, Maximize2, AudioLines, User, Lock
+
 } from 'lucide-react';
+
 import i18n from '../i18n';
+
 import { exportBackup, importBackup } from '../utils/backup';
+
 import { showToast } from '../utils/toast';
+
 import { invoke } from '@tauri-apps/api/core';
+
 import { listen } from '@tauri-apps/api/event';
+
 import { open as openUrl } from '@tauri-apps/plugin-shell';
+
 import { getImageCacheSize, clearImageCache } from '../utils/imageCache';
+
 import { useOfflineStore } from '../store/offlineStore';
+
 import { useHotCacheStore } from '../store/hotCacheStore';
+
 import { lastfmGetToken, lastfmAuthUrl, lastfmGetSession, lastfmGetUserInfo, LastfmUserInfo } from '../api/lastfm';
+
 import LastfmIcon from '../components/LastfmIcon';
+
 import CustomSelect from '../components/CustomSelect';
+
 import ThemePicker, { THEME_GROUPS } from '../components/ThemePicker';
+
 import { useShallow } from 'zustand/react/shallow';
+
 import { useAuthStore, ServerProfile, MIX_MIN_RATING_FILTER_MAX_STARS, type SeekbarStyle, type LyricsSourceId, type LyricsSourceConfig } from '../store/authStore';
+
 import { SeekbarPreview } from '../components/WaveformSeek';
+
 import { IS_LINUX } from '../utils/platform';
+
 import { useThemeStore } from '../store/themeStore';
+
 import { useFontStore, FontId } from '../store/fontStore';
+
 import { useKeybindingsStore, KeyAction, formatBinding, buildInAppBinding } from '../store/keybindingsStore';
+
 import { useGlobalShortcutsStore, GlobalAction, buildGlobalShortcut, formatGlobalShortcut } from '../store/globalShortcutsStore';
+
 import { useSidebarStore, DEFAULT_SIDEBAR_ITEMS, SidebarItemConfig } from '../store/sidebarStore';
+
 import { useHomeStore, HomeSectionId } from '../store/homeStore';
+
 import { useDragDrop, useDragSource } from '../contexts/DragDropContext';
+
 import { ALL_NAV_ITEMS } from '../config/navItems';
+
 import { pingWithCredentials, scheduleInstantMixProbeForServer } from '../api/subsonic';
+
 import { switchActiveServer } from '../utils/switchActiveServer';
+
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
+
 import { Trans, useTranslation } from 'react-i18next';
+
 import Equalizer from '../components/Equalizer';
+
 import StarRating from '../components/StarRating';
+
 import { showAudiomuseNavidromeServerSetting } from '../utils/subsonicServerIdentity';
+
+
 
 const AUDIOBOOK_GENRES_DISPLAY = ['Hörbuch', 'Hoerbuch', 'Hörspiel', 'Hoerspiel', 'Audiobook', 'Audio Book', 'Spoken Word', 'Spokenword', 'Podcast', 'Kapitel', 'Thriller', 'Krimi', 'Speech', 'Fantasy', 'Comedy', 'Literature'];
 
+
+
 const AUDIOMUSE_NV_PLUGIN_URL = 'https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin';
 
+
+
 const CONTRIBUTORS = [
+
   {
+
     github: 'jiezhuo',
+
     since: '1.21',
+
     contributions: [
+
       'Chinese (Simplified) translation',
+
     ],
+
   },
+
   {
+
     github: 'nullobject',
+
     since: '1.22.0',
+
     contributions: [
+
       'Seek debounce & race condition fix (PR #7)',
+
       'Waveform seekbar stability on position update (PR #8)',
+
     ],
+
   },
+
   {
+
     github: 'trbn1',
+
     since: '1.22.0',
+
     contributions: [
+
       'Replay Gain metadata propagation (PR #9)',
+
       'songToTrack() — unified track construction across all sources',
+
     ],
+
   },
+
   {
+
     github: 'nisarg-78',
+
     since: '1.29.0',
+
     contributions: [
+
       'Click-to-seek in synced lyrics (PR #38)',
+
       'Volume scroll wheel on volume slider (PR #38)',
+
       'Lyrics line visual states: active / completed / upcoming (PR #38)',
+
       'Queue auto-scroll to keep upcoming tracks in view; fixed re-renders from currentTime in QueuePanel (PR #115)',
+
     ],
+
   },
+
   {
+
     github: 'JulianNymark',
+
     since: '1.29.0',
+
     contributions: [
+
       'OGG/Vorbis container support via symphonia-format-ogg (PR #42)',
+
       'Themed toast notifications for audio playback errors (PR #43)',
+
       'Human-readable audio error messages (PR #44)',
+
     ],
+
   },
+
   {
+
     github: 'zz5zz',
+
     since: '1.32.0',
+
     contributions: [
+
       'Norwegian (Bokmål) translation (PR #101)',
+
     ],
+
   },
+
   {
+
     github: 'cucadmuh',
+
     since: '1.33.0',
+
     contributions: [
+
       'Russian translation & i18n locale split (PR #106)',
+
       'Russian locale refinements using phrasing from ru2 (PR #113)',
+
       'Gapless manual skip: honor user-initiated play over pre-chained track (PR #119)',
+
       'Hot playback cache — queue prefetch (PR #123)',
+
       'Per-server music folder filter and sidebar library picker (PR #124, PR #125)',
+
       'Richer star ratings, skip threshold, and library filtering (PR #130)',
+
       'Statistics: scope album and song totals to selected music library (PR #138)',
+
       'AudioMuse-AI discovery integration for Navidrome (PR #147)',
+
       'Hot playback cache — eviction budgeting, grace period, and live Audio settings readout (PR #153)',
+
       'Folder Browser: keyboard navigation, context menus, now-playing path emphasis, and adaptive column layout (PR #158)',
+
       'Infinite queue: artist-driven candidates via Top Songs + Similar Songs with random fallback (PR #163)',
+
       'Folder Browser: per-column filter with keyboard flow and Shift+Enter queue append (PR #165)',
+
       'Keybindings: modifier + key chords for in-app shortcuts; fixed seek ±10s units (PR #167)',
+
       'Statistics: genre insights scoped to music library, cached Subsonic fetches, localized duration formatting (PR #144)',
+
       'Audio output device picker: clearer ALSA labels, duplicate disambiguation, system-default mark, live refresh (PR #173)',
+
       'Folder Browser: arrow navigation blocked when modifier keys are held (PR #174)',
+
       'Linux audio output device picker: stable watcher (disable false enumeration-miss resets), canonicalize ALSA name drift, ghost entry for unlisted device (PR #176)',
+
       'Opus audio playback via symphonia-adapter-libopus with bundled libopus (PR #183)',
-      'CLI player controls with D-Bus forwarding, shell completions for bash/zsh, library/audio-device/instant-mix CLI commands, active server switcher in header (PR #187)',
+
     ],
+
   },
+
   {
+
     github: 'kilyabin',
+
     since: '1.34.0',
+
     contributions: [
+
       'Russian locale improvements (PR #107, PR #120)',
+
       'Auto-install script for Debian / RHEL (PR #121)',
+
       'Album cover art in Discord Rich Presence via iTunes API (PR #111)',
+
       'Tiling WM detection: hide custom TitleBar on Hyprland/Sway/i3/etc. (PR #134)',
+
       'Russian translation: lyricsServerFirst settings strings (PR #140)',
+
       'Russian translation refinements (PR #148)',
+
       'Merge Random Mix & Albums into a single Build a Mix hub (PR #155)',
+
       'Fullscreen player: software-rendering performance fixes + portrait toggle & dimming setting (PR #156)',
+
       'Fullscreen player: stop mesh blob and portrait animations in no-compositing mode; remove seekbar box-shadow repaint (PR #175)',
+
     ],
+
   },
+
   {
+
     github: 'kveld9',
+
     since: '1.34.4',
+
     contributions: [
+
       'Spanish (es) translation — 964 strings (PR #159)',
+
       'Column-header sorting for albums & playlists (PR #160)',
+
       'Multi-select for albums, artists & playlists with bulk "Add to Playlist"; collapsible sidebar playlist section; infinite scroll on Artists page; "Remove from Playlist" in context menu (PR #168)',
+
       '3 visual toggles: cover art background, playlist cover photo, show bitrate badge (PR #181)',
+
       '8 community themes (AMOLED Black, Monochrome Dark, Amber Night, Phosphor Green, Midnight Blue, Rose Dark, Sepia Dark, Ice Blue) + waveform live theme update (PR #182)',
-      'Favorites redesign: sortable columns, genre filter, age range filter, new columns (PR #184)',
-      'Albums and playlist headers redesign with improved layout and theme integration (PR #186)',
-      'Tracklist column picker overflow fix in AlbumTrackList (PR #188)',
-      'Spotify CSV playlist import (PR #190)',
-      'Context menu for songs in AdvancedSearch and SearchResults (PR #191)',
-      'Tracklist column picker alignment and toggle fix across Favorites and PlaylistDetail (PR #192)',
+
     ],
+
   },
+
   {
+
     github: 'nisrael',
+
     since: '1.34.0',
+
     contributions: [
+
       'Nightfox.nvim theme group in Open Source Classics (PR #114)',
+
       'Switch reqwest to rustls-tls for cross-platform TLS (PR #112)',
+
       'ICY stream metadata & AzuraCast Now Playing support (PR #146)',
+
     ],
+
   },
+
 ] as const;
 
+
+
 const SPECIAL_THANKS = [
+
   {
+
     github: 'netherguy4',
+
     reason: 'Countless constructive feature ideas and thoughtful feedback',
+
   },
+
 ] as const;
+
+
 
 type Tab = 'general' | 'server' | 'audio' | 'storage' | 'appearance' | 'input' | 'system';
 
+
+
 function AddServerForm({ onSave, onCancel }: { onSave: (data: Omit<ServerProfile, 'id'>) => void; onCancel: () => void }) {
+
   const { t } = useTranslation();
+
   const [form, setForm] = useState({ name: '', url: '', username: '', password: '' });
+
   const [showPass, setShowPass] = useState(false);
 
+
+
   const update = (k: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>
+
     setForm(f => ({ ...f, [k]: e.target.value }));
 
+
+
   return (
+
     <div className="settings-card" style={{ marginTop: '1rem' }}>
+
       <h3 style={{ fontWeight: 600, marginBottom: '1rem', fontSize: '14px' }}>{t('settings.addServerTitle')}</h3>
+
       <div className="form-group" style={{ marginBottom: '0.75rem' }}>
+
         <label style={{ fontSize: 13 }}>{t('settings.serverName')}</label>
+
         <input className="input" type="text" value={form.name} onChange={update('name')} placeholder="My Navidrome" autoComplete="off" />
+
       </div>
+
       <div className="form-group" style={{ marginBottom: '0.75rem' }}>
+
         <label style={{ fontSize: 13 }}>{t('settings.serverUrl')}</label>
+
         <input className="input" type="text" value={form.url} onChange={update('url')} placeholder={t('settings.serverUrlPlaceholder')} autoComplete="off" />
+
       </div>
+
       <div className="form-row" style={{ marginBottom: '0.75rem' }}>
+
         <div className="form-group">
+
           <label style={{ fontSize: 13 }}>{t('settings.serverUsername')}</label>
+
           <input className="input" type="text" value={form.username} onChange={update('username')} placeholder="admin" autoComplete="off" />
+
         </div>
+
         <div className="form-group">
+
           <label style={{ fontSize: 13 }}>{t('settings.serverPassword')}</label>
+
           <div style={{ position: 'relative' }}>
+
             <input
+
               className="input"
+
               type={showPass ? 'text' : 'password'}
+
               value={form.password}
+
               onChange={update('password')}
+
               placeholder="••••••••"
+
               style={{ paddingRight: '2.5rem' }}
+
             />
+
             <button
+
               type="button"
+
               style={{ position: 'absolute', right: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }}
+
               onClick={() => setShowPass(v => !v)}
+
             >
+
               {showPass ? <EyeOff size={14} /> : <Eye size={14} />}
+
             </button>
+
           </div>
+
         </div>
+
       </div>
+
       <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+
         <button className="btn btn-ghost" onClick={onCancel}>{t('common.cancel')}</button>
+
         <button
+
           className="btn btn-primary"
+
           onClick={() => form.url.trim() && onSave({ name: form.name.trim() || form.url.trim(), url: form.url.trim(), username: form.username.trim(), password: form.password })}
+
         >
+
           {t('common.add')}
+
         </button>
+
       </div>
+
     </div>
+
   );
+
 }
+
+
 
 function formatBytes(bytes: number): string {
+
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+
   return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+
 }
+
+
 
 /** Align hot-cache size slider (step 32 MB) to valid values. */
+
 function snapHotCacheMb(v: number): number {
+
   const x = Math.min(20000, Math.max(32, Math.round(v)));
+
   return Math.round((x - 32) / 32) * 32 + 32;
+
 }
+
+
 
 /** Makes raw ALSA device names more readable on Linux.
+
  *  Values are kept as-is (rodio needs the ALSA name); only the displayed label is cleaned.
+
  *  e.g. "sysdefault:CARD=U192k" → "U192k"
+
  *       "hw:CARD=U192k,DEV=0"   → "U192k (hw · PCM 0)"
+
  *       "hdmi:CARD=NVidia,DEV=1" → "NVidia (HDMI · DEV 1)"  (same DEV as in ALSA string)
+
  *       "iec958:CARD=PCH,DEV=0" → "PCH (S/PDIF)"
+
  *  Names without ALSA prefix (pipewire, pulse, default…) are returned unchanged. */
+
 function formatAudioDeviceLabel(name: string): string {
+
   const cardMatch = name.match(/CARD=([^,]+)/);
+
   if (!cardMatch) return name;
+
   const card = cardMatch[1];
+
   const devM = name.match(/DEV=(\d+)/);
+
   const devNum = devM ? parseInt(devM[1], 10) : null;
+
   const subM = name.match(/SUBDEV=(\d+)/);
+
   const subNum = subM ? parseInt(subM[1], 10) : null;
 
+
+
   if (name.startsWith('iec958:')) return `${card} (S/PDIF)`;
+
   if (name.startsWith('hdmi:')) {
+
     const d = devNum !== null ? devNum : 0;
+
     return `${card} (HDMI · DEV ${d})`;
+
   }
+
   if (name.startsWith('sysdefault:')) {
+
     if (devNum !== null && devNum > 0) return `${card} (default · PCM ${devNum})`;
+
     return card;
+
   }
+
   if (name.startsWith('plughw:')) {
+
     if (devNum !== null) {
+
       const sub = subNum !== null ? ` · sub ${subNum}` : '';
+
       return `${card} (plug · PCM ${devNum}${sub})`;
+
     }
+
     return card;
+
   }
+
   if (name.startsWith('hw:')) {
+
     if (devNum !== null) {
+
       const sub = subNum !== null ? ` · sub ${subNum}` : '';
+
       return `${card} (hw · PCM ${devNum}${sub})`;
+
     }
+
     return `${card} (hw)`;
+
   }
+
   if (name.startsWith('front:')) return `${card} (Front)`;
+
   if (name.startsWith('surround')) return `${card} (${name.split(':')[0]})`;
+
   // Other ALSA iface:card,dev — show plugin + PCM so identical cards differ
+
   const iface = name.split(':')[0];
+
   if (iface && !['default', 'pulse', 'pipewire'].includes(iface)) {
+
     if (devNum !== null) return `${card} (${iface} · PCM ${devNum})`;
+
     return `${card} (${iface})`;
+
   }
+
   return card;
+
 }
+
+
 
 /** Readable tail when two devices still share the same label (rare after formatAudioDeviceLabel). */
+
 function audioDeviceDuplicateHint(raw: string): string {
+
   const cardM = raw.match(/CARD=([^,]+)/);
+
   const devM = raw.match(/DEV=(\d+)/);
+
   const subM = raw.match(/SUBDEV=(\d+)/);
+
   const iface = raw.split(':')[0] || '';
+
   const parts: string[] = [];
+
   if (iface) parts.push(iface);
+
   if (cardM) parts.push(cardM[1]);
+
   if (devM) parts.push(`PCM ${devM[1]}`);
+
   if (subM) parts.push(`sub ${subM[1]}`);
+
   if (parts.length > 1) return parts.join(' · ');
+
   return raw.length > 56 ? `…${raw.slice(-53)}` : raw;
+
 }
+
+
 
 /** When several devices share the same display label, append a disambiguator. */
+
 function disambiguatedAudioDeviceLabel(raw: string, baseLabel: string, duplicateBase: boolean): string {
+
   if (!duplicateBase) return baseLabel;
+
   return `${baseLabel} · ${audioDeviceDuplicateHint(raw)}`;
+
 }
+
+
 
 /** cpal order is arbitrary; sort by readable label, current OS default first. */
+
 function sortAudioDeviceIds(devices: string[], osDefaultDeviceId: string | null): string[] {
+
   return [...devices].sort((a, b) => {
+
     const aDef = osDefaultDeviceId && a === osDefaultDeviceId;
+
     const bDef = osDefaultDeviceId && b === osDefaultDeviceId;
+
     if (aDef !== bDef) return aDef ? -1 : 1;
+
     const la = formatAudioDeviceLabel(a);
+
     const lb = formatAudioDeviceLabel(b);
+
     const byLabel = la.localeCompare(lb, undefined, { sensitivity: 'base' });
+
     if (byLabel !== 0) return byLabel;
+
     return a.localeCompare(b);
+
   });
+
 }
+
+
 
 function buildAudioDeviceSelectOptions(
+
   devices: string[],
+
   defaultLabel: string,
+
   osDefaultDeviceId: string | null,
+
   osDefaultMark: string,
+
   pinnedDevice: string | null,
+
   notInListSuffix: string,
+
 ): { value: string; label: string }[] {
+
   const baseLabels = devices.map(formatAudioDeviceLabel);
+
   const countByBase = new Map<string, number>();
+
   for (const b of baseLabels) countByBase.set(b, (countByBase.get(b) ?? 0) + 1);
+
   const pinned = pinnedDevice?.trim() || null;
+
   const pinnedNotListed = !!(pinned && !devices.includes(pinned));
+
   const ghost: { value: string; label: string }[] = pinnedNotListed
+
     ? (() => {
+
         const base = formatAudioDeviceLabel(pinned);
+
         let label = `${base} · ${notInListSuffix}`;
+
         if (osDefaultDeviceId && pinned === osDefaultDeviceId) label = `${label} · ${osDefaultMark}`;
+
         return [{ value: pinned, label }];
+
       })()
+
     : [];
+
   return [
+
     { value: '', label: defaultLabel },
+
     ...ghost,
+
     ...devices.map((d, i) => {
+
       const base = baseLabels[i];
+
       const dup = (countByBase.get(base) ?? 0) > 1;
+
       let label = disambiguatedAudioDeviceLabel(d, base, dup);
+
       if (osDefaultDeviceId && d === osDefaultDeviceId) label = `${label} · ${osDefaultMark}`;
+
       return { value: d, label };
+
     }),
+
   ];
+
 }
 
+
+
 export default function Settings() {
+
   const auth = useAuthStore();
+
   const theme = useThemeStore();
+
   const fontStore = useFontStore();
+
   const kb = useKeybindingsStore();
+
   const gs = useGlobalShortcutsStore();
+
   const serverId = auth.activeServerId ?? '';
+
   const clearAllOffline = useOfflineStore(s => s.clearAll);
+
   const clearHotCacheDisk = useHotCacheStore(s => s.clearAllDisk);
+
   const hotCacheEntries = useHotCacheStore(s => s.entries);
+
   const [isTilingWm, setIsTilingWm] = useState(false);
 
+
+
   useEffect(() => {
+
     if (!IS_LINUX) return;
+
     invoke<boolean>('is_tiling_wm_cmd').then(setIsTilingWm).catch(() => {});
+
   }, []);
 
+
+
   const hotCacheTrackCount = useMemo(() => {
+
     if (!serverId) return 0;
+
     const prefix = `${serverId}:`;
+
     return Object.keys(hotCacheEntries).filter(k => k.startsWith(prefix)).length;
+
   }, [hotCacheEntries, serverId]);
+
   const [listeningFor, setListeningFor] = useState<KeyAction | null>(null);
+
   const [listeningForGlobal, setListeningForGlobal] = useState<GlobalAction | null>(null);
+
   const navigate = useNavigate();
+
   const { state: routeState } = useLocation();
+
   const { t, i18n } = useTranslation();
 
+
+
   const [activeTab, setActiveTab] = useState<Tab>((routeState as { tab?: Tab } | null)?.tab ?? 'general');
+
   const [connStatus, setConnStatus] = useState<Record<string, 'idle' | 'testing' | 'ok' | 'error'>>({});
+
   const [showAddForm, setShowAddForm] = useState(false);
+
   const [newGenre, setNewGenre] = useState('');
+
   const [lfmState, setLfmState] = useState<'idle' | 'waiting' | 'error'>('idle');
+
   const [lfmPendingToken, setLfmPendingToken] = useState<string | null>(null);
+
   const [lfmError, setLfmError] = useState<string | null>(null);
+
   const [lfmUserInfo, setLfmUserInfo] = useState<LastfmUserInfo | null>(null);
+
   const [imageCacheBytes, setImageCacheBytes] = useState<number | null>(null);
+
   const [offlineCacheBytes, setOfflineCacheBytes] = useState<number | null>(null);
+
   const [hotCacheBytes, setHotCacheBytes] = useState<number | null>(null);
+
   const [audioDevices, setAudioDevices] = useState<string[]>([]);
+
   const [osDefaultAudioDeviceId, setOsDefaultAudioDeviceId] = useState<string | null>(null);
+
   const [deviceSwitching, setDeviceSwitching] = useState(false);
+
   const [devicesLoading, setDevicesLoading] = useState(false);
+
   const [showClearConfirm, setShowClearConfirm] = useState(false);
+
   const [clearing, setClearing] = useState(false);
+
   const [contributorsOpen, setContributorsOpen] = useState(false);
-  const [fontPickerOpen, setFontPickerOpen] = useState(false);
+
+
 
   useEffect(() => {
+
     if (!auth.lastfmSessionKey || !auth.lastfmUsername) { setLfmUserInfo(null); return; }
+
     lastfmGetUserInfo(auth.lastfmUsername, auth.lastfmSessionKey).then(setLfmUserInfo).catch(() => {});
+
   }, [auth.lastfmSessionKey, auth.lastfmUsername]);
 
+
+
   useEffect(() => {
+
     if (activeTab !== 'storage') return;
+
     getImageCacheSize().then(setImageCacheBytes);
+
     invoke<number>('get_offline_cache_size', { customDir: auth.offlineDownloadDir || null }).then(setOfflineCacheBytes).catch(() => setOfflineCacheBytes(0));
+
     invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null }).then(setHotCacheBytes).catch(() => setHotCacheBytes(0));
+
   }, [activeTab, auth.offlineDownloadDir, auth.hotCacheDownloadDir]);
 
+
+
   const refreshAudioDevices = useCallback((opts?: { silent?: boolean }) => {
+
     const silent = !!opts?.silent;
+
     if (!silent) setDevicesLoading(true);
+
     const listP = invoke<string[]>('audio_list_devices').catch((e) => {
+
       console.error(e);
+
       showToast(t('settings.audioOutputDeviceListError'), 5000, 'error');
+
       return [] as string[];
+
     });
+
     const defP = invoke<string | null>('audio_default_output_device_name').catch(() => null);
+
     Promise.all([listP, defP])
+
       .then(async ([devices, osDefault]) => {
+
         let canon: string | null = null;
+
         try {
+
           canon = await invoke<string | null>('audio_canonicalize_selected_device');
+
           if (canon) useAuthStore.getState().setAudioOutputDevice(canon);
+
         } catch {
+
           /* ignore */
+
         }
+
         const finalList = canon
+
           ? await invoke<string[]>('audio_list_devices').catch(() => devices)
+
           : devices;
+
         const defId = osDefault ?? null;
+
         setAudioDevices(sortAudioDeviceIds(finalList, defId));
+
         setOsDefaultAudioDeviceId(defId);
+
       })
+
       .finally(() => {
+
         if (!silent) setDevicesLoading(false);
+
       });
+
   }, [t]);
 
+
+
   // Load available audio output devices when Audio tab opens.
+
   useEffect(() => {
+
     if (activeTab !== 'audio') return;
+
     refreshAudioDevices();
+
   }, [activeTab, refreshAudioDevices]);
+
+
 
   // Keep device list + "current system output" mark in sync when the backend reopens the stream.
+
   useEffect(() => {
+
     if (activeTab !== 'audio') return;
+
     let cancelled = false;
+
     const unlisteners: Array<() => void> = [];
+
     (async () => {
+
       for (const ev of ['audio:device-changed', 'audio:device-reset'] as const) {
+
         const u = await listen(ev, () => {
+
           if (!cancelled) refreshAudioDevices({ silent: true });
+
         });
+
         if (cancelled) {
+
           u();
+
           return;
+
         }
+
         unlisteners.push(u);
+
       }
+
     })();
+
     return () => {
+
       cancelled = true;
+
       for (const u of unlisteners) u();
+
     };
+
   }, [activeTab, refreshAudioDevices]);
 
+
+
   /** Live disk usage for hot cache while Audio settings are open (interval + refresh when index changes). */
+
   useEffect(() => {
+
     if (activeTab !== 'audio') return;
+
     const customDir = auth.hotCacheDownloadDir || null;
+
     const refresh = () => {
+
       invoke<number>('get_hot_cache_size', { customDir })
+
         .then(setHotCacheBytes)
+
         .catch(() => setHotCacheBytes(0));
+
     };
+
     refresh();
+
     if (!auth.hotCacheEnabled) return;
+
     const interval = window.setInterval(refresh, 2000);
+
     return () => window.clearInterval(interval);
+
   }, [activeTab, auth.hotCacheEnabled, auth.hotCacheDownloadDir]);
 
+
+
   useEffect(() => {
+
     if (activeTab !== 'audio' || !auth.hotCacheEnabled) return;
+
     const t = window.setTimeout(() => {
+
       invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null })
+
         .then(setHotCacheBytes)
+
         .catch(() => setHotCacheBytes(0));
+
     }, 400);
+
     return () => window.clearTimeout(t);
+
   }, [hotCacheEntries, activeTab, auth.hotCacheEnabled, auth.hotCacheDownloadDir]);
 
+
+
   const handleClearCache = useCallback(async () => {
+
     setClearing(true);
+
     await clearImageCache();
+
     await clearAllOffline(serverId);
+
     const [imgBytes, offBytes] = await Promise.all([
+
       getImageCacheSize(),
+
       invoke<number>('get_offline_cache_size', { customDir: auth.offlineDownloadDir || null }).catch(() => 0),
+
     ]);
+
     setImageCacheBytes(imgBytes);
+
     setOfflineCacheBytes(offBytes);
+
     setShowClearConfirm(false);
+
     setClearing(false);
+
   }, [clearAllOffline, serverId]);
 
+
+
   const startLastfmConnect = useCallback(async () => {
+
     setLfmError(null);
+
     let token: string;
+
     try {
+
       token = await lastfmGetToken();
+
       setLfmPendingToken(token);
+
       setLfmState('waiting');
+
       await openUrl(lastfmAuthUrl(token));
+
     } catch (e: any) {
+
       setLfmError(e.message ?? 'Unknown error');
+
       setLfmState('error');
+
       return;
+
     }
+
+
 
     // Poll every 2 s until the user authorises or we time out (2 min)
+
     const deadline = Date.now() + 120_000;
+
     const poll = async () => {
+
       if (Date.now() > deadline) {
+
         setLfmState('error');
+
         setLfmError('Timed out — please try again.');
+
         setLfmPendingToken(null);
+
         return;
+
       }
+
       try {
+
         const { key, name } = await lastfmGetSession(token);
+
         auth.connectLastfm(key, name);
+
         setLfmState('idle');
+
         setLfmPendingToken(null);
+
       } catch (e: any) {
+
         // Error 14 = not yet authorised, keep polling
+
         if (e.message?.includes('14')) {
+
           setTimeout(poll, 2000);
+
         } else {
+
           setLfmState('error');
+
           setLfmError(e.message ?? 'Unknown error');
+
           setLfmPendingToken(null);
+
         }
+
       }
+
     };
+
     setTimeout(poll, 2000);
+
   }, [auth]);
 
+
+
   const testConnection = async (server: ServerProfile) => {
+
     setConnStatus(s => ({ ...s, [server.id]: 'testing' }));
+
     try {
+
       const ping = await pingWithCredentials(server.url, server.username, server.password);
+
       if (ping.ok) {
+
         const identity = {
+
           type: ping.type,
+
           serverVersion: ping.serverVersion,
+
           openSubsonic: ping.openSubsonic,
+
         };
+
         auth.setSubsonicServerIdentity(server.id, identity);
+
         scheduleInstantMixProbeForServer(server.id, server.url, server.username, server.password, identity);
+
       }
+
       setConnStatus(s => ({ ...s, [server.id]: ping.ok ? 'ok' : 'error' }));
+
     } catch {
+
       setConnStatus(s => ({ ...s, [server.id]: 'error' }));
+
     }
+
   };
+
+
 
   const switchToServer = async (server: ServerProfile) => {
+
     setConnStatus(s => ({ ...s, [server.id]: 'testing' }));
+
     const ok = await switchActiveServer(server);
+
     if (ok) {
+
       setConnStatus(s => ({ ...s, [server.id]: 'ok' }));
+
       navigate('/');
+
     } else {
+
       setConnStatus(s => ({ ...s, [server.id]: 'error' }));
+
     }
+
   };
+
+
 
   const deleteServer = (server: ServerProfile) => {
+
     if (confirm(t('settings.confirmDeleteServer', { name: server.name || server.url }))) {
+
       auth.removeServer(server.id);
+
     }
+
   };
+
+
 
   const handleAddServer = async (data: Omit<ServerProfile, 'id'>) => {
+
     setShowAddForm(false);
+
     const tempId = '_new';
+
     setConnStatus(s => ({ ...s, [tempId]: 'testing' }));
+
     try {
+
       const ping = await pingWithCredentials(data.url, data.username, data.password);
+
       if (ping.ok) {
+
         const id = auth.addServer(data);
+
         const identity = {
+
           type: ping.type,
+
           serverVersion: ping.serverVersion,
+
           openSubsonic: ping.openSubsonic,
+
         };
+
         auth.setSubsonicServerIdentity(id, identity);
+
         scheduleInstantMixProbeForServer(id, data.url, data.username, data.password, identity);
+
         auth.setActiveServer(id);
+
         auth.setLoggedIn(true);
+
         setConnStatus(s => ({ ...s, [id]: 'ok' }));
+
       } else {
+
         setConnStatus(s => ({ ...s, [tempId]: 'error' }));
+
       }
+
     } catch {
+
       setConnStatus(s => ({ ...s, [tempId]: 'error' }));
+
     }
+
   };
+
+
 
   const handleLogout = () => {
+
     auth.logout();
+
     navigate('/login');
+
   };
+
+
 
   const pickOfflineDir = async () => {
+
     const selected = await openDialog({ directory: true, multiple: false, title: t('settings.offlineDirChange') });
+
     if (selected && typeof selected === 'string') {
+
       auth.setOfflineDownloadDir(selected);
+
     }
+
   };
+
+
 
   const pickHotCacheDir = async () => {
+
     const selected = await openDialog({ directory: true, multiple: false, title: t('settings.hotCacheDirChange') });
+
     if (selected && typeof selected === 'string') {
+
       auth.setHotCacheDownloadDir(selected);
+
       useHotCacheStore.setState({ entries: {} });
+
       invoke<number>('get_hot_cache_size', { customDir: selected }).then(setHotCacheBytes).catch(() => setHotCacheBytes(0));
+
     }
+
   };
+
+
 
   const pickDownloadFolder = async () => {
+
     const selected = await openDialog({ directory: true, multiple: false, title: t('settings.pickFolderTitle') });
+
     if (selected && typeof selected === 'string') {
+
       auth.setDownloadFolder(selected);
+
     }
+
   };
 
+
+
   const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
+
     { id: 'general',    label: t('settings.tabGeneral'),    icon: <AppWindow size={15} /> },
+
     { id: 'server',     label: t('settings.tabServer'),     icon: <Server size={15} /> },
+
     { id: 'audio',      label: t('settings.tabAudio'),      icon: <Music2 size={15} /> },
+
     { id: 'storage',    label: t('settings.tabStorage'),    icon: <HardDrive size={15} /> },
+
     { id: 'appearance', label: t('settings.tabAppearance'), icon: <Palette size={15} /> },
+
     { id: 'input',      label: t('settings.tabInput'),      icon: <Keyboard size={15} /> },
+
     { id: 'system',     label: t('settings.tabSystem'),     icon: <Info size={15} /> },
+
   ];
 
+
+
   return (
+
     <div className="content-body animate-fade-in">
+
       <h1 className="page-title" style={{ marginBottom: '1.5rem' }}>{t('settings.title')}</h1>
 
+
+
       {/* Tab navigation */}
+
       <nav className="settings-tabs" aria-label="Settings navigation">
+
         {tabs.map(tab => (
+
           <button
+
             key={tab.id}
+
             className={`settings-tab ${activeTab === tab.id ? 'active' : ''}`}
+
             onClick={() => setActiveTab(tab.id)}
+
           >
+
             {tab.icon}
+
             {tab.label}
+
           </button>
+
         ))}
+
       </nav>
 
+
+
       {/* ── Audio ────────────────────────────────────────────────────────────── */}
+
       {activeTab === 'audio' && (
+
         <>
+
           {/* Audio Output Device */}
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <AudioLines size={18} />
+
               <h2>{t('settings.audioOutputDevice')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '0.75rem' }}>
+
                 {t('settings.audioOutputDeviceDesc')}
+
               </div>
+
               <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+
                 <CustomSelect
+
                   style={{ flex: 1 }}
+
                   value={auth.audioOutputDevice ?? ''}
+
                   disabled={deviceSwitching || devicesLoading}
+
                   onChange={async (val) => {
+
                     const device = val || null;
+
                     setDeviceSwitching(true);
+
                     try {
+
                       await invoke('audio_set_device', { deviceName: device });
+
                       auth.setAudioOutputDevice(device);
+
                     } catch { /* device open failed — don't persist */ }
+
                     setDeviceSwitching(false);
+
                   }}
+
                   options={buildAudioDeviceSelectOptions(
+
                     audioDevices,
+
                     t('settings.audioOutputDeviceDefault'),
+
                     osDefaultAudioDeviceId,
+
                     t('settings.audioOutputDeviceOsDefaultNow'),
+
                     auth.audioOutputDevice,
+
                     t('settings.audioOutputDeviceNotInCurrentList'),
+
                   )}
+
                 />
+
                 <button
+
                   className="icon-btn"
+
                   onClick={() => refreshAudioDevices()}
+
                   disabled={devicesLoading || deviceSwitching}
+
                   data-tooltip={t('settings.audioOutputDeviceRefresh')}
+
                 >
+
                   <RotateCcw size={15} className={devicesLoading ? 'spin' : ''} />
+
                 </button>
+
               </div>
+
             </div>
+
           </section>
+
+
 
           {/* Native Hi-Res Playback */}
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Waves size={18} />
+
               <h2>{t('settings.hiResTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.hiResEnabled')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.hiResDesc')}</div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.hiResEnabled')}>
+
                   <input
+
                     type="checkbox"
+
                     checked={auth.enableHiRes}
+
                     onChange={e => auth.setEnableHiRes(e.target.checked)}
+
                     id="hires-enabled-toggle"
+
                   />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
             </div>
+
           </section>
+
+
 
           {/* Equalizer */}
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Sliders size={18} />
+
               <h2>{t('settings.eqTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <Equalizer />
+
             </div>
+
           </section>
+
+
 
           {/* Replay Gain + Crossfade + Gapless */}
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Music2 size={18} />
+
               <h2>{t('settings.playbackTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               {/* Replay Gain */}
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.replayGain')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.replayGainDesc')}</div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.replayGain')}>
+
                   <input type="checkbox" checked={auth.replayGainEnabled} onChange={e => auth.setReplayGainEnabled(e.target.checked)} id="replay-gain-toggle" />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               {auth.replayGainEnabled && (
+
                 <div style={{ paddingLeft: '1rem', marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+
                   <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{t('settings.replayGainMode')}:</span>
+
                   <button
+
                     className={`btn ${auth.replayGainMode === 'track' ? 'btn-primary' : 'btn-ghost'}`}
+
                     style={{ fontSize: 12, padding: '3px 12px' }}
+
                     onClick={() => auth.setReplayGainMode('track')}
+
                   >
+
                     {t('settings.replayGainTrack')}
+
                   </button>
+
                   <button
+
                     className={`btn ${auth.replayGainMode === 'album' ? 'btn-primary' : 'btn-ghost'}`}
+
                     style={{ fontSize: 12, padding: '3px 12px' }}
+
                     onClick={() => auth.setReplayGainMode('album')}
+
                   >
+
                     {t('settings.replayGainAlbum')}
+
                   </button>
+
                 </div>
-              )}
-              {auth.replayGainEnabled && (
-                <div style={{ paddingLeft: '1rem', marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-                    <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 160 }}>
-                      {t('settings.replayGainPreGain')}
-                    </span>
-                    <input
-                      type="range" min={0} max={6} step={0.5}
-                      value={auth.replayGainPreGainDb}
-                      onChange={e => auth.setReplayGainPreGainDb(Number(e.target.value))}
-                      style={{ flex: 1, maxWidth: 160 }}
-                    />
-                    <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 40, textAlign: 'right' }}>
-                      {auth.replayGainPreGainDb > 0 ? `+${auth.replayGainPreGainDb}` : auth.replayGainPreGainDb} dB
-                    </span>
-                  </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-                    <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 160 }}>
-                      {t('settings.replayGainFallback')}
-                    </span>
-                    <input
-                      type="range" min={-6} max={0} step={0.5}
-                      value={auth.replayGainFallbackDb}
-                      onChange={e => auth.setReplayGainFallbackDb(Number(e.target.value))}
-                      style={{ flex: 1, maxWidth: 160 }}
-                    />
-                    <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 40, textAlign: 'right' }}>
-                      {auth.replayGainFallbackDb > 0 ? `+${auth.replayGainFallbackDb}` : auth.replayGainFallbackDb} dB
-                    </span>
-                  </div>
-                </div>
+
               )}
 
+              {auth.replayGainEnabled && (
+
+                <div style={{ paddingLeft: '1rem', marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+
+                    <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 160 }}>
+
+                      {t('settings.replayGainPreGain')}
+
+                    </span>
+
+                    <input
+
+                      type="range" min={0} max={6} step={0.5}
+
+                      value={auth.replayGainPreGainDb}
+
+                      onChange={e => auth.setReplayGainPreGainDb(Number(e.target.value))}
+
+                      style={{ flex: 1, maxWidth: 160 }}
+
+                    />
+
+                    <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 40, textAlign: 'right' }}>
+
+                      {auth.replayGainPreGainDb > 0 ? `+${auth.replayGainPreGainDb}` : auth.replayGainPreGainDb} dB
+
+                    </span>
+
+                  </div>
+
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+
+                    <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 160 }}>
+
+                      {t('settings.replayGainFallback')}
+
+                    </span>
+
+                    <input
+
+                      type="range" min={-6} max={0} step={0.5}
+
+                      value={auth.replayGainFallbackDb}
+
+                      onChange={e => auth.setReplayGainFallbackDb(Number(e.target.value))}
+
+                      style={{ flex: 1, maxWidth: 160 }}
+
+                    />
+
+                    <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 40, textAlign: 'right' }}>
+
+                      {auth.replayGainFallbackDb > 0 ? `+${auth.replayGainFallbackDb}` : auth.replayGainFallbackDb} dB
+
+                    </span>
+
+                  </div>
+
+                </div>
+
+              )}
+
+
+
               <div className="divider" />
+
+
 
               {/* Crossfade */}
+
               <div className="settings-toggle-row" style={auth.gaplessEnabled ? { opacity: 0.45, pointerEvents: 'none' } : undefined}>
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>
+
                     {t('settings.crossfade')}
+
                   </div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+
                     {auth.gaplessEnabled ? t('settings.notWithGapless') : t('settings.crossfadeDesc')}
+
                   </div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.crossfade')}>
+
                   <input type="checkbox" checked={auth.crossfadeEnabled} disabled={auth.gaplessEnabled}
+
                     onChange={e => { auth.setGaplessEnabled(false); auth.setCrossfadeEnabled(e.target.checked); }} id="crossfade-toggle" />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               {auth.crossfadeEnabled && !auth.gaplessEnabled && (
+
                 <div style={{ paddingLeft: '1rem', marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+
                   <input
+
                     type="range"
+
                     min={0.1}
+
                     max={10}
+
                     step={0.1}
+
                     value={auth.crossfadeSecs}
+
                     onChange={e => auth.setCrossfadeSecs(parseFloat(e.target.value))}
+
                     style={{ width: 120 }}
+
                     id="crossfade-secs-slider"
+
                   />
+
                   <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 36 }}>
+
                     {t('settings.crossfadeSecs', { n: auth.crossfadeSecs.toFixed(1) })}
+
                   </span>
+
                 </div>
+
               )}
 
+
+
               <div className="divider" />
+
+
 
               {/* Gapless */}
+
               <div className="settings-toggle-row" style={auth.crossfadeEnabled ? { opacity: 0.45, pointerEvents: 'none' } : undefined}>
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>
+
                     {t('settings.gapless')}
+
                   </div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+
                     {auth.crossfadeEnabled ? t('settings.notWithCrossfade') : t('settings.gaplessDesc')}
+
                   </div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.gapless')}>
+
                   <input type="checkbox" checked={auth.gaplessEnabled} disabled={auth.crossfadeEnabled}
+
                     onChange={e => { auth.setCrossfadeEnabled(false); auth.setGaplessEnabled(e.target.checked); }} id="gapless-toggle" />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
             </div>
+
           </section>
 
+
+
           {/* Next Track Buffering */}
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Download size={18} />
+
               <h2>{t('settings.nextTrackBufferingTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: '0.75rem' }}>
+
                 {t('settings.preloadHotCacheMutualExclusive')}
+
               </div>
 
+
+
               {/* Preload mode */}
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.preloadMode')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.preloadModeDesc')}</div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.preloadMode')}>
+
                   <input
+
                     type="checkbox"
+
                     checked={auth.preloadMode !== 'off'}
+
                     onChange={e => {
+
                       if (e.target.checked) {
+
                         auth.setPreloadMode('balanced');
+
                         if (auth.hotCacheEnabled) auth.setHotCacheEnabled(false);
+
                       } else {
+
                         auth.setPreloadMode('off');
+
                       }
+
                     }}
+
                   />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               {auth.preloadMode !== 'off' && (
+
                 <>
+
                   <div style={{ paddingLeft: '1rem', marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+
                     {(['balanced', 'early', 'custom'] as const).map(mode => (
+
                       <button
+
                         key={mode}
+
                         className={`btn ${auth.preloadMode === mode ? 'btn-primary' : 'btn-surface'}`}
+
                         style={{ fontSize: 12, padding: '3px 12px' }}
+
                         onClick={() => auth.setPreloadMode(mode)}
+
                       >
+
                         {t(`settings.preload${mode.charAt(0).toUpperCase() + mode.slice(1)}` as any)}
+
                       </button>
+
                     ))}
+
                   </div>
+
                   {auth.preloadMode === 'custom' && (
+
                     <div style={{ paddingLeft: '1rem', marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+
                       <input
+
                         type="range"
+
                         min={5} max={120} step={5}
+
                         value={auth.preloadCustomSeconds}
+
                         onChange={e => auth.setPreloadCustomSeconds(parseInt(e.target.value))}
+
                         style={{ width: 120 }}
+
                       />
+
                       <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 36 }}>
+
                         {t('settings.preloadCustomSeconds', { n: auth.preloadCustomSeconds })}
+
                       </span>
+
                     </div>
+
                   )}
+
                 </>
+
               )}
+
+
 
               <div className="divider" />
 
+
+
               {/* Hot Cache */}
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.hotCacheTitle')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.hotCacheDisclaimer')}</div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.hotCacheEnabled')}>
+
                   <input
+
                     type="checkbox"
+
                     checked={auth.hotCacheEnabled}
+
                     onChange={async e => {
+
                       const enabled = e.target.checked;
+
                       if (!enabled) {
+
                         await clearHotCacheDisk(auth.hotCacheDownloadDir || null);
+
                         setHotCacheBytes(0);
+
                         auth.setHotCacheEnabled(false);
+
                       } else {
+
                         auth.setHotCacheEnabled(true);
+
                         if (auth.preloadMode !== 'off') auth.setPreloadMode('off');
+
                         invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null })
+
                           .then(setHotCacheBytes)
+
                           .catch(() => setHotCacheBytes(0));
+
                       }
+
                     }}
+
                     id="hot-cache-enabled-toggle"
+
                   />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
+
 
               {auth.hotCacheEnabled && (
+
                 <div style={{ marginTop: '1.25rem' }}>
+
                   <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+
                     <input
+
                       className="input"
+
                       type="text"
+
                       readOnly
+
                       value={auth.hotCacheDownloadDir || t('settings.hotCacheDirDefault')}
+
                       style={{ flex: 1, fontSize: 13, color: auth.hotCacheDownloadDir ? 'var(--text-primary)' : 'var(--text-muted)', cursor: 'default' }}
+
                     />
+
                     {auth.hotCacheDownloadDir && (
+
                       <button
+
                         type="button"
+
                         className="btn btn-ghost"
+
                         onClick={() => {
+
                           auth.setHotCacheDownloadDir('');
+
                           useHotCacheStore.setState({ entries: {} });
+
                           invoke<number>('get_hot_cache_size', { customDir: null }).then(setHotCacheBytes).catch(() => setHotCacheBytes(0));
+
                         }}
+
                         data-tooltip={t('settings.hotCacheDirClear')}
+
                         style={{ color: 'var(--text-muted)', flexShrink: 0 }}
+
                       >
+
                         <X size={16} />
+
                       </button>
+
                     )}
+
                     <button type="button" className="btn btn-surface" onClick={pickHotCacheDir} style={{ flexShrink: 0 }}>
+
                       <FolderOpen size={16} /> {t('settings.hotCacheDirChange')}
+
                     </button>
+
                   </div>
+
                   {auth.hotCacheDownloadDir && (
+
                     <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 8, lineHeight: 1.4 }}>
+
                       {t('settings.hotCacheDirHint')}
+
                     </div>
+
                   )}
 
+
+
                   <div style={{ borderTop: '1px solid var(--border)', margin: '16px 0' }} />
+
+
 
                   <div style={{ fontSize: 12, marginBottom: 12, display: 'flex', flexDirection: 'column', gap: 3 }}>
+
                     <div style={{ color: 'var(--text-secondary)' }}>
+
                       <span style={{ color: 'var(--text-muted)', marginRight: 4 }}>{t('settings.cacheUsedHot')}</span>
+
                       {hotCacheBytes !== null ? formatBytes(hotCacheBytes) : '…'}
+
                     </div>
+
                     <div style={{ color: 'var(--text-secondary)' }}>
+
                       <span style={{ color: 'var(--text-muted)', marginRight: 4 }}>{t('settings.hotCacheTrackCount')}</span>
+
                       {hotCacheTrackCount}
+
                     </div>
+
                   </div>
+
+
 
                   <div>
+
                     <div style={{ fontWeight: 500, marginBottom: 6 }}>{t('settings.hotCacheMaxMb')}</div>
+
                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+
                       <input type="range" min={32} max={20000} step={32} value={snapHotCacheMb(auth.hotCacheMaxMb)} onChange={e => auth.setHotCacheMaxMb(parseInt(e.target.value, 10))} style={{ width: 140 }} id="hot-cache-max-mb-slider" />
+
                       <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 72 }}>{snapHotCacheMb(auth.hotCacheMaxMb)} MB</span>
+
                     </div>
+
                   </div>
+
                   <div style={{ marginTop: '0.75rem' }}>
+
                     <div style={{ fontWeight: 500, marginBottom: 6 }}>{t('settings.hotCacheDebounce')}</div>
+
                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+
                       <input type="range" min={0} max={600} step={1} value={Math.min(600, Math.max(0, auth.hotCacheDebounceSec))} onChange={e => auth.setHotCacheDebounceSec(parseInt(e.target.value, 10))} style={{ width: 140 }} id="hot-cache-debounce-slider" />
+
                       <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 100 }}>
+
                         {Math.min(600, Math.max(0, auth.hotCacheDebounceSec)) === 0
+
                           ? t('settings.hotCacheDebounceImmediate')
+
                           : t('settings.hotCacheDebounceSeconds', { n: Math.min(600, Math.max(0, auth.hotCacheDebounceSec)) })}
+
                       </span>
+
                     </div>
+
                   </div>
+
+
 
                   <div style={{ borderTop: '1px solid var(--border)', margin: '16px 0' }} />
+
                   <button
+
                     type="button"
+
                     className="btn btn-ghost"
+
                     style={{ fontSize: 13 }}
+
                     onClick={async () => {
+
                       await clearHotCacheDisk(auth.hotCacheDownloadDir || null);
+
                       const b = await invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null }).catch(() => 0);
+
                       setHotCacheBytes(b);
+
                     }}
+
                   >
+
                     <Trash2 size={14} /> {t('settings.hotCacheClearBtn')}
+
                   </button>
+
                 </div>
+
               )}
 
+
+
             </div>
+
           </section>
+
+
 
         </>
+
       )}
 
+
+
       {/* ── General ──────────────────────────────────────────────────────────── */}
+
       {activeTab === 'general' && (
+
         <>
+
           {/* App behaviour */}
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <AppWindow size={18} />
+
               <h2>{t('settings.behavior')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.showTrayIcon')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.showTrayIconDesc')}</div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.showTrayIcon')}>
+
                   <input type="checkbox" checked={auth.showTrayIcon} onChange={e => auth.setShowTrayIcon(e.target.checked)} />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               <div className="settings-section-divider" />
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.minimizeToTray')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.minimizeToTrayDesc')}</div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.minimizeToTray')}>
+
                   <input type="checkbox" checked={auth.minimizeToTray} onChange={e => auth.setMinimizeToTray(e.target.checked)} />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               {IS_LINUX && !isTilingWm && (
+
                 <>
+
                   <div className="settings-section-divider" />
+
                   <div className="settings-toggle-row">
+
                     <div>
+
                       <div style={{ fontWeight: 500 }}>{t('settings.useCustomTitlebar')}</div>
+
                       <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.useCustomTitlebarDesc')}</div>
+
                     </div>
+
                     <label className="toggle-switch" aria-label={t('settings.useCustomTitlebar')}>
+
                       <input type="checkbox" checked={auth.useCustomTitlebar} onChange={e => auth.setUseCustomTitlebar(e.target.checked)} />
+
                       <span className="toggle-track" />
+
                     </label>
+
                   </div>
+
                 </>
+
               )}
+
               <div className="settings-section-divider" />
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.showArtistImages')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.showArtistImagesDesc')}</div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.showArtistImages')}>
+
                   <input type="checkbox" checked={auth.showArtistImages} onChange={e => auth.setShowArtistImages(e.target.checked)} />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               <div className="settings-section-divider" />
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.discordRichPresence')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.discordRichPresenceDesc')}</div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.discordRichPresence')}>
+
                   <input type="checkbox" checked={auth.discordRichPresence} onChange={e => auth.setDiscordRichPresence(e.target.checked)} />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               {auth.discordRichPresence && (
+
                 <>
+
                   <div className="settings-section-divider" />
+
                   <div className="settings-toggle-row" style={{ paddingLeft: 16 }}>
+
                     <div>
+
                       <div style={{ fontWeight: 500 }}>{t('settings.discordAppleCovers')}</div>
+
                       <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.discordAppleCoversDesc')}</div>
+
                     </div>
+
                     <label className="toggle-switch" aria-label={t('settings.discordAppleCovers')}>
+
                       <input type="checkbox" checked={auth.enableAppleMusicCoversDiscord} onChange={e => auth.setEnableAppleMusicCoversDiscord(e.target.checked)} />
+
                       <span className="toggle-track" />
+
                     </label>
+
                   </div>
+
+                  <div className="settings-section-divider" />
+
+                  <div style={{ paddingLeft: 16, paddingTop: 8, paddingBottom: 8 }}>
+
+                    <div style={{ fontWeight: 500, fontSize: 13, marginBottom: 8 }}>{t('settings.discordTemplates')}</div>
+
+                    <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 12 }}>{t('settings.discordTemplatesDesc')}</div>
+
+                    <div className="form-group" style={{ marginBottom: '0.75rem' }}>
+
+                      <label style={{ fontSize: 12 }}>{t('settings.discordTemplateDetails')}</label>
+
+                      <input
+
+                        className="input"
+
+                        type="text"
+
+                        value={auth.discordTemplateDetails}
+
+                        onChange={e => auth.setDiscordTemplateDetails(e.target.value)}
+
+                        placeholder="{artist} - {title}"
+
+                      />
+
+                    </div>
+
+                    <div className="form-group" style={{ marginBottom: '0.75rem' }}>
+
+                      <label style={{ fontSize: 12 }}>{t('settings.discordTemplateState')}</label>
+
+                      <input
+
+                        className="input"
+
+                        type="text"
+
+                        value={auth.discordTemplateState}
+
+                        onChange={e => auth.setDiscordTemplateState(e.target.value)}
+
+                        placeholder="{album}"
+
+                      />
+
+                    </div>
+
+                    <div className="form-group">
+
+                      <label style={{ fontSize: 12 }}>{t('settings.discordTemplateLargeText')}</label>
+
+                      <input
+
+                        className="input"
+
+                        type="text"
+
+                        value={auth.discordTemplateLargeText}
+
+                        onChange={e => auth.setDiscordTemplateLargeText(e.target.value)}
+
+                        placeholder="{album}"
+
+                      />
+
+                    </div>
+
+                  </div>
+
                 </>
+
               )}
+
               <div className="settings-section-divider" />
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.nowPlayingEnabled')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.nowPlayingEnabledDesc')}</div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.nowPlayingEnabled')}>
+
                   <input type="checkbox" checked={auth.nowPlayingEnabled} onChange={e => auth.setNowPlayingEnabled(e.target.checked)} />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
             </div>
+
           </section>
 
+
+
           {/* Lyrics Sources */}
+
           <LyricsSourcesCustomizer />
 
+
+
           {/* Random Mix */}
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Shuffle size={18} />
+
               <h2>{t('settings.randomMixTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: '1rem', lineHeight: 1.5 }}>
+
                 {t('settings.randomMixBlacklistDesc')}
+
               </p>
 
+
+
               <div style={{ fontSize: 13, fontWeight: 500, marginBottom: '0.5rem' }}>{t('settings.randomMixBlacklistTitle')}</div>
+
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginBottom: '0.75rem', minHeight: 32 }}>
+
                 {auth.customGenreBlacklist.length === 0 ? (
+
                   <span style={{ fontSize: 12, color: 'var(--text-muted)', alignSelf: 'center' }}>{t('settings.randomMixBlacklistEmpty')}</span>
+
                 ) : (
+
                   auth.customGenreBlacklist.map(genre => (
+
                     <span key={genre} style={{
+
                       display: 'inline-flex', alignItems: 'center', gap: 4,
+
                       background: 'color-mix(in srgb, var(--accent) 15%, transparent)',
+
                       color: 'var(--accent)', borderRadius: 'var(--radius-sm)',
+
                       padding: '2px 8px', fontSize: 12, fontWeight: 500,
+
                     }}>
+
                       {genre}
+
                       <button
+
                         style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', padding: 0, lineHeight: 1, fontSize: 14 }}
+
                         onClick={() => auth.setCustomGenreBlacklist(auth.customGenreBlacklist.filter(g => g !== genre))}
+
                         aria-label={`Remove ${genre}`}
+
                       >×</button>
+
                     </span>
+
                   ))
+
                 )}
+
               </div>
 
+
+
               <div style={{ display: 'flex', gap: '0.5rem', maxWidth: 400 }}>
+
                 <input
+
                   className="input"
+
                   type="text"
+
                   value={newGenre}
+
                   onChange={e => setNewGenre(e.target.value)}
+
                   onKeyDown={e => {
+
                     if (e.key === 'Enter' && newGenre.trim()) {
+
                       const trimmed = newGenre.trim();
+
                       if (!auth.customGenreBlacklist.includes(trimmed)) {
+
                         auth.setCustomGenreBlacklist([...auth.customGenreBlacklist, trimmed]);
+
                       }
+
                       setNewGenre('');
+
                     }
+
                   }}
+
                   placeholder={t('settings.randomMixBlacklistPlaceholder')}
+
                   style={{ fontSize: 13 }}
+
                 />
+
                 <button
+
                   className="btn btn-ghost"
+
                   onClick={() => {
+
                     const trimmed = newGenre.trim();
+
                     if (trimmed && !auth.customGenreBlacklist.includes(trimmed)) {
+
                       auth.setCustomGenreBlacklist([...auth.customGenreBlacklist, trimmed]);
+
                     }
+
                     setNewGenre('');
+
                   }}
+
                   disabled={!newGenre.trim()}
+
                 >
+
                   {t('settings.randomMixBlacklistAdd')}
+
                 </button>
+
               </div>
+
+
 
               <div className="divider" style={{ margin: '1rem 0' }} />
 
+
+
               <div style={{ fontSize: 13, fontWeight: 500, marginBottom: '0.5rem', color: 'var(--text-muted)' }}>{t('settings.randomMixHardcodedTitle')}</div>
+
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+
                 {AUDIOBOOK_GENRES_DISPLAY.map(genre => (
+
                   <span key={genre} className="genre-keyword-badge" style={{
+
                     display: 'inline-flex', alignItems: 'center',
+
                     background: 'var(--bg-hover)', color: 'var(--text-muted)',
+
                     borderRadius: 'var(--radius-sm)', padding: '2px 8px', fontSize: 12,
+
                   }}>
+
                     {genre}
+
                   </span>
+
                 ))}
+
               </div>
+
             </div>
+
           </section>
 
+
+
           {/* Ratings (single block under Random Mix) */}
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Star size={18} />
+
               <h2>{t('settings.ratingsSectionTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.ratingsSkipStarTitle')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.ratingsSkipStarDesc')}</div>
+
                 </div>
+
                 <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0 }}>
+
                   {auth.skipStarOnManualSkipsEnabled && (
+
                     <>
+
                       <label htmlFor="settings-skip-star-threshold" style={{ fontSize: 13, color: 'var(--text-secondary)', whiteSpace: 'nowrap' }}>
+
                         {t('settings.ratingsSkipStarThresholdLabel')}
+
                       </label>
+
                       <input
+
                         id="settings-skip-star-threshold"
+
                         className="input"
+
                         type="number"
+
                         min={1}
+
                         max={99}
+
                         value={auth.skipStarManualSkipThreshold}
+
                         onChange={e => auth.setSkipStarManualSkipThreshold(Number(e.target.value))}
+
                         style={{ width: 72, padding: '6px 10px', fontSize: 13 }}
+
                         aria-label={t('settings.ratingsSkipStarThresholdLabel')}
+
                       />
+
                     </>
+
                   )}
+
                   <label className="toggle-switch" aria-label={t('settings.ratingsSkipStarTitle')}>
+
                     <input
+
                       type="checkbox"
+
                       checked={auth.skipStarOnManualSkipsEnabled}
+
                       onChange={e => auth.setSkipStarOnManualSkipsEnabled(e.target.checked)}
+
                     />
+
                     <span className="toggle-track" />
+
                   </label>
+
                 </div>
+
               </div>
+
+
 
               <div className="settings-section-divider" />
 
+
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.ratingsMixFilterTitle')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+
                     {t('settings.ratingsMixFilterDesc', {
+
                       mix: t('sidebar.randomMix'),
+
                       albums: t('sidebar.randomAlbums'),
+
                     })}
+
                   </div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.ratingsMixFilterTitle')}>
+
                   <input
+
                     type="checkbox"
+
                     checked={auth.mixMinRatingFilterEnabled}
+
                     onChange={e => auth.setMixMinRatingFilterEnabled(e.target.checked)}
+
                   />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               {auth.mixMinRatingFilterEnabled && (
+
                 <>
+
                   <div className="settings-section-divider" />
+
                   <div
+
                     style={{
+
                       display: 'grid',
+
                       gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+
                       gap: '1rem 0.75rem',
+
                       alignItems: 'start',
+
                     }}
+
                   >
+
                     {([
+
                       { key: 'song', label: t('settings.ratingsMixMinSong'), value: auth.mixMinRatingSong, set: auth.setMixMinRatingSong },
+
                       { key: 'album', label: t('settings.ratingsMixMinAlbum'), value: auth.mixMinRatingAlbum, set: auth.setMixMinRatingAlbum },
+
                       { key: 'artist', label: t('settings.ratingsMixMinArtist'), value: auth.mixMinRatingArtist, set: auth.setMixMinRatingArtist },
+
                     ] as const).map(row => (
+
                       <div
+
                         key={row.key}
+
                         style={{
+
                           display: 'flex',
+
                           flexDirection: 'column',
+
                           alignItems: 'center',
+
                           gap: 8,
+
                           minWidth: 0,
+
                           textAlign: 'center',
+
                         }}
+
                       >
+
                         <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-secondary)' }}>{row.label}</span>
+
                         <StarRating
+
                           maxSelectable={MIX_MIN_RATING_FILTER_MAX_STARS}
+
                           value={row.value}
+
                           onChange={row.set}
+
                           ariaLabel={t('settings.ratingsMixMinThresholdAria', { label: row.label })}
+
                         />
+
                       </div>
+
                     ))}
+
                   </div>
+
                 </>
+
               )}
+
             </div>
+
           </section>
 
+
+
           <HomeCustomizer />
+
         </>
+
       )}
 
+
+
       {/* ── Storage & Downloads ───────────────────────────────────────────────── */}
+
       {activeTab === 'storage' && (
+
         <>
+
           {/* Offline Library (In-App) — includes cache settings */}
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Download size={18} />
+
               <h2>{t('settings.offlineDirTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 14, lineHeight: 1.5 }}>
+
                 {t('settings.offlineDirDesc')}
+
               </div>
+
               <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+
                 <input
+
                   className="input"
+
                   type="text"
+
                   readOnly
+
                   value={auth.offlineDownloadDir || t('settings.offlineDirDefault')}
+
                   style={{ flex: 1, fontSize: 13, color: auth.offlineDownloadDir ? 'var(--text-primary)' : 'var(--text-muted)', cursor: 'default' }}
+
                 />
+
                 {auth.offlineDownloadDir && (
+
                   <button
+
                     className="btn btn-ghost"
+
                     onClick={() => auth.setOfflineDownloadDir('')}
+
                     data-tooltip={t('settings.offlineDirClear')}
+
                     style={{ color: 'var(--text-muted)', flexShrink: 0 }}
+
                   >
+
                     <X size={16} />
+
                   </button>
+
                 )}
+
                 <button className="btn btn-surface" onClick={pickOfflineDir} style={{ flexShrink: 0 }} id="settings-offline-dir-btn">
+
                   <FolderOpen size={16} /> {t('settings.offlineDirChange')}
+
                 </button>
+
               </div>
+
               {auth.offlineDownloadDir && (
+
                 <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 8, lineHeight: 1.4 }}>
+
                   {t('settings.offlineDirHint')}
+
                 </div>
+
               )}
+
+
 
               <div style={{ borderTop: '1px solid var(--border)', margin: '16px 0' }} />
 
+
+
               {(imageCacheBytes !== null || offlineCacheBytes !== null) && (
+
                 <div style={{ fontSize: 12, marginBottom: 12, display: 'flex', flexDirection: 'column', gap: 3 }}>
+
                   <div style={{ color: 'var(--text-secondary)' }}>
+
                     <span style={{ color: 'var(--text-muted)', marginRight: 4 }}>{t('settings.cacheUsedImages')}</span>
+
                     {imageCacheBytes !== null ? formatBytes(imageCacheBytes) : '…'}
+
                   </div>
+
                   <div style={{ color: 'var(--text-secondary)' }}>
+
                     <span style={{ color: 'var(--text-muted)', marginRight: 4 }}>{t('settings.cacheUsedOffline')}</span>
+
                     {offlineCacheBytes !== null ? formatBytes(offlineCacheBytes) : '…'}
+
                   </div>
+
                 </div>
+
               )}
+
+
 
               <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+
                 <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{t('settings.cacheMaxLabel')}</span>
+
                 <input
+
                   className="input"
+
                   type="number"
+
                   min={100}
+
                   max={50000}
+
                   step={100}
+
                   value={auth.maxCacheMb}
+
                   onChange={e => {
+
                     const v = Number(e.target.value);
+
                     if (v >= 100) auth.setMaxCacheMb(v);
+
                   }}
+
                   style={{ width: 80, padding: '4px 8px', fontSize: 13 }}
+
                   id="cache-size-input"
+
                 />
+
                 <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>MB</span>
+
               </div>
+
               {showClearConfirm ? (
+
                 <div style={{ background: 'color-mix(in srgb, var(--color-danger, #e53935) 10%, transparent)', borderRadius: 'var(--radius-sm)', padding: '10px 14px', fontSize: 13, lineHeight: 1.5 }}>
+
                   <div style={{ marginBottom: 8, color: 'var(--text-primary)' }}>{t('settings.cacheClearWarning')}</div>
+
                   <div style={{ display: 'flex', gap: 8 }}>
+
                     <button
+
                       className="btn btn-primary"
+
                       style={{ background: 'var(--color-danger, #e53935)', fontSize: 13 }}
+
                       onClick={handleClearCache}
+
                       disabled={clearing}
+
                     >
+
                       {t('settings.cacheClearConfirm')}
+
                     </button>
+
                     <button className="btn btn-ghost" style={{ fontSize: 13 }} onClick={() => setShowClearConfirm(false)} disabled={clearing}>
+
                       {t('settings.cacheClearCancel')}
+
                     </button>
+
                   </div>
+
                 </div>
+
               ) : (
+
                 <button className="btn btn-ghost" style={{ fontSize: 13 }} onClick={() => setShowClearConfirm(true)}>
+
                   <Trash2 size={14} /> {t('settings.cacheClearBtn')}
+
                 </button>
+
               )}
+
             </div>
+
           </section>
+
+
 
           {/* ZIP Export & Archiving */}
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <FolderOpen size={18} />
+
               <h2>{t('settings.downloadsTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 14, lineHeight: 1.5 }}>
+
                 {t('settings.downloadsFolderDesc')}
+
               </div>
+
               <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+
                 <input
+
                   className="input"
+
                   type="text"
+
                   readOnly
+
                   value={auth.downloadFolder || t('settings.downloadsDefault')}
+
                   style={{ flex: 1, fontSize: 13, color: auth.downloadFolder ? 'var(--text-primary)' : 'var(--text-muted)', cursor: 'default' }}
+
                 />
+
                 {auth.downloadFolder && (
+
                   <button
+
                     className="btn btn-ghost"
+
                     onClick={() => auth.setDownloadFolder('')}
+
                     aria-label={t('settings.clearFolder')}
+
                     data-tooltip={t('settings.clearFolder')}
+
                     style={{ color: 'var(--text-muted)', flexShrink: 0 }}
+
                   >
+
                     <X size={16} />
+
                   </button>
+
                 )}
+
                 <button className="btn btn-surface" onClick={pickDownloadFolder} style={{ flexShrink: 0 }} id="settings-download-folder-btn">
+
                   <FolderOpen size={16} /> {t('settings.pickFolder')}
+
                 </button>
+
               </div>
+
             </div>
+
           </section>
+
         </>
+
       )}
+
+
 
       {/* ── Appearance ───────────────────────────────────────────────────────── */}
+
       {activeTab === 'appearance' && (
+
         <>
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Globe size={18} />
+
               <h2>{t('settings.language')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <div className="form-group" style={{ maxWidth: '300px' }}>
+
                 <CustomSelect
+
                   value={i18n.language}
+
                   onChange={v => i18n.changeLanguage(v)}
+
                   options={[
+
                     { value: 'en', label: t('settings.languageEn') },
+
                     { value: 'de', label: t('settings.languageDe') },
+
                     { value: 'es', label: t('settings.languageEs') },
+
                     { value: 'fr', label: t('settings.languageFr') },
+
                     { value: 'nl', label: t('settings.languageNl') },
+
                     { value: 'nb', label: t('settings.languageNb') },
+
                     { value: 'ru', label: t('settings.languageRu') },
+
                     { value: 'zh', label: t('settings.languageZh') },
+
                   ]}
+
                 />
+
               </div>
+
             </div>
+
           </section>
 
+
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Palette size={18} />
+
               <h2>{t('settings.theme')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               {theme.enableThemeScheduler && (
+
                 <div className="settings-hint settings-hint-info" style={{ marginBottom: '0.75rem' }}>
+
                   {t('settings.themeSchedulerActiveHint')}
+
                 </div>
+
               )}
+
               <ThemePicker value={theme.theme} onChange={v => theme.setTheme(v as any)} />
+
             </div>
+
           </section>
 
+
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Clock size={18} />
+
               <h2>{t('settings.themeSchedulerTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.themeSchedulerEnable')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.themeSchedulerEnableSub')}</div>
+
                 </div>
+
                 <label className="toggle-switch" aria-label={t('settings.themeSchedulerEnable')}>
+
                   <input type="checkbox" checked={theme.enableThemeScheduler} onChange={e => theme.setEnableThemeScheduler(e.target.checked)} />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               {theme.enableThemeScheduler && (() => {
+
                 const themeOptions = THEME_GROUPS.flatMap(g =>
+
                   g.themes.map(th => ({ value: th.id, label: th.label, group: g.group }))
+
                 );
+
                 const use12h = i18n.language === 'en';
+
                 const hourOptions = Array.from({ length: 24 }, (_, i) => {
+
                   const value = String(i).padStart(2, '0');
+
                   const label = use12h
+
                     ? `${i % 12 === 0 ? 12 : i % 12} ${i < 12 ? 'AM' : 'PM'}`
+
                     : value;
+
                   return { value, label };
+
                 });
+
                 const minuteOptions = ['00', '05', '10', '15', '20', '25', '30', '35', '40', '45', '50', '55'].map(m => ({ value: m, label: m }));
+
                 const dayH = theme.timeDayStart.split(':')[0];
+
                 const dayM = theme.timeDayStart.split(':')[1];
+
                 const nightH = theme.timeNightStart.split(':')[0];
+
                 const nightM = theme.timeNightStart.split(':')[1];
+
                 return (
+
                   <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem', marginTop: '1rem' }}>
+
                     <div className="form-group">
+
                       <label className="settings-label" style={{ marginBottom: 6 }}>{t('settings.themeSchedulerDayTheme')}</label>
+
                       <CustomSelect value={theme.themeDay} onChange={theme.setThemeDay} options={themeOptions} />
+
                     </div>
+
                     <div className="form-group">
+
                       <label className="settings-label" style={{ marginBottom: 6 }}>{t('settings.themeSchedulerDayStart')}</label>
+
                       <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+
                         <CustomSelect value={dayH} onChange={v => theme.setTimeDayStart(`${v}:${dayM}`)} options={hourOptions} />
+
                         <span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>:</span>
+
                         <CustomSelect value={dayM} onChange={v => theme.setTimeDayStart(`${dayH}:${v}`)} options={minuteOptions} />
+
                       </div>
+
                     </div>
+
                     <div className="form-group">
+
                       <label className="settings-label" style={{ marginBottom: 6 }}>{t('settings.themeSchedulerNightTheme')}</label>
+
                       <CustomSelect value={theme.themeNight} onChange={theme.setThemeNight} options={themeOptions} />
+
                     </div>
+
                     <div className="form-group">
+
                       <label className="settings-label" style={{ marginBottom: 6 }}>{t('settings.themeSchedulerNightStart')}</label>
+
                       <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+
                         <CustomSelect value={nightH} onChange={v => theme.setTimeNightStart(`${v}:${nightM}`)} options={hourOptions} />
+
                         <span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>:</span>
+
                         <CustomSelect value={nightM} onChange={v => theme.setTimeNightStart(`${nightH}:${v}`)} options={minuteOptions} />
+
                       </div>
+
                     </div>
+
                   </div>
+
                 );
+
               })()}
+
             </div>
+
           </section>
 
+
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Palette size={18} />
+
               <h2>{t('settings.visualOptionsTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.coverArtBackground')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.coverArtBackgroundSub')}</div>
+
                 </div>
+
                 <label className="toggle-switch">
+
                   <input type="checkbox" checked={theme.enableCoverArtBackground} onChange={e => theme.setEnableCoverArtBackground(e.target.checked)} />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               <div className="settings-section-divider" />
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.playlistCoverPhoto')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.playlistCoverPhotoSub')}</div>
+
                 </div>
+
                 <label className="toggle-switch">
+
                   <input type="checkbox" checked={theme.enablePlaylistCoverPhoto} onChange={e => theme.setEnablePlaylistCoverPhoto(e.target.checked)} />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
               <div className="settings-section-divider" />
+
               <div className="settings-toggle-row">
+
                 <div>
+
                   <div style={{ fontWeight: 500 }}>{t('settings.showBitrate')}</div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.showBitrateSub')}</div>
+
                 </div>
+
                 <label className="toggle-switch">
+
                   <input type="checkbox" checked={theme.showBitrate} onChange={e => theme.setShowBitrate(e.target.checked)} />
+
                   <span className="toggle-track" />
+
                 </label>
+
               </div>
+
             </div>
+
           </section>
 
+
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <ZoomIn size={18} />
+
               <h2>{t('settings.uiScaleTitle')}</h2>
+
             </div>
+
             <div className="settings-card">
+
               {/* TODO: UI scaling is being reworked — disabled until fixed */}
+
               <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: 0 }}>
+
                 Interface scaling is currently being reworked and will be available in a future update.
+
               </p>
+
               <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', opacity: 0.4, pointerEvents: 'none', marginTop: 12 }}>
+
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+
                   <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{t('settings.uiScaleLabel')}</span>
+
                   <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--accent)', minWidth: 40, textAlign: 'right' }}>
+
                     {Math.round(fontStore.uiScale * 100)}%
+
                   </span>
+
                 </div>
+
                 <input
+
                   type="range"
+
                   min={0.8}
+
                   max={1.5}
+
                   step={0.05}
+
                   value={fontStore.uiScale}
+
                   onChange={e => fontStore.setUiScale(parseFloat(e.target.value))}
+
                   className="ui-scale-slider"
+
                 />
+
                 <div style={{ position: 'relative', height: 24 }}>
+
                   {[80, 90, 100, 110, 125, 150].map(p => {
+
                     const pct = ((p / 100) - 0.8) / (1.5 - 0.8) * 100;
+
                     const active = Math.round(fontStore.uiScale * 100) === p;
+
                     return (
+
                       <button
+
                         key={p}
+
                         className="btn btn-ghost"
+
                         style={{
+
                           position: 'absolute',
+
                           left: `${pct}%`,
+
                           transform: 'translateX(-50%)',
+
                           fontSize: 11,
+
                           padding: '2px 6px',
+
                           opacity: active ? 1 : 0.5,
+
                           color: active ? 'var(--accent)' : undefined,
+
                         }}
+
                         onClick={() => fontStore.setUiScale(p / 100)}
+
                       >
+
                         {p}%
+
                       </button>
+
                     );
+
                   })}
+
                 </div>
+
               </div>
+
             </div>
+
           </section>
 
+
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Type size={18} />
+
               <h2>{t('settings.font')}</h2>
-            </div>
-            <div className="settings-card">
-              <button
-                className="btn btn-ghost"
-                style={{ justifyContent: 'space-between', width: '100%', fontFamily: 'var(--font-sans)' }}
-                onClick={() => setFontPickerOpen(o => !o)}
-              >
-                <span>{
-                  ([
-                    { id: 'inter',             label: 'Inter' },
-                    { id: 'outfit',            label: 'Outfit' },
-                    { id: 'dm-sans',           label: 'DM Sans' },
-                    { id: 'nunito',            label: 'Nunito' },
-                    { id: 'rubik',             label: 'Rubik' },
-                    { id: 'space-grotesk',     label: 'Space Grotesk' },
-                    { id: 'figtree',           label: 'Figtree' },
-                    { id: 'manrope',           label: 'Manrope' },
-                    { id: 'plus-jakarta-sans', label: 'Plus Jakarta Sans' },
-                    { id: 'lexend',            label: 'Lexend' },
-                    { id: 'geist',             label: 'Geist' },
-                    { id: 'jetbrains-mono',    label: 'JetBrains Mono' },
-                  ] as { id: FontId; label: string }[]).find(f => f.id === fontStore.font)?.label ?? fontStore.font
-                }</span>
-                <ChevronDown size={14} style={{ color: 'var(--text-muted)', transform: fontPickerOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }} />
-              </button>
-              {fontPickerOpen && (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '8px' }}>
-                  {(
-                    [
-                      { id: 'inter',             label: 'Inter',             stack: "'Inter Variable', sans-serif" },
-                      { id: 'outfit',            label: 'Outfit',            stack: "'Outfit Variable', sans-serif" },
-                      { id: 'dm-sans',           label: 'DM Sans',           stack: "'DM Sans Variable', sans-serif" },
-                      { id: 'nunito',            label: 'Nunito',            stack: "'Nunito Variable', sans-serif" },
-                      { id: 'rubik',             label: 'Rubik',             stack: "'Rubik Variable', sans-serif" },
-                      { id: 'space-grotesk',     label: 'Space Grotesk',     stack: "'Space Grotesk Variable', sans-serif" },
-                      { id: 'figtree',           label: 'Figtree',           stack: "'Figtree Variable', sans-serif" },
-                      { id: 'manrope',           label: 'Manrope',           stack: "'Manrope Variable', sans-serif" },
-                      { id: 'plus-jakarta-sans', label: 'Plus Jakarta Sans', stack: "'Plus Jakarta Sans Variable', sans-serif" },
-                      { id: 'lexend',            label: 'Lexend',            stack: "'Lexend Variable', sans-serif" },
-                      { id: 'geist',             label: 'Geist',             stack: "'Geist Variable', sans-serif" },
-                      { id: 'jetbrains-mono',    label: 'JetBrains Mono',    stack: "'JetBrains Mono Variable', monospace" },
-                    ] as { id: FontId; label: string; stack: string }[]
-                  ).map(f => (
-                    <button
-                      key={f.id}
-                      className={`btn ${fontStore.font === f.id ? 'btn-primary' : 'btn-ghost'}`}
-                      style={{ justifyContent: 'flex-start', fontFamily: f.stack }}
-                      onClick={() => { fontStore.setFont(f.id); setFontPickerOpen(false); }}
-                    >
-                      {f.label}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          </section>
 
-          <section className="settings-section">
-            <div className="settings-section-header">
-              <Maximize2 size={18} />
-              <h2>{t('settings.fsPlayerSection')}</h2>
             </div>
-            <div className="settings-card">
-              <div className="settings-toggle-row">
-                <div>
-                  <div style={{ fontWeight: 500 }}>{t('settings.fsShowArtistPortrait')}</div>
-                  <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.fsShowArtistPortraitDesc')}</div>
-                </div>
-                <label className="toggle-switch" aria-label={t('settings.fsShowArtistPortrait')}>
-                  <input type="checkbox" checked={auth.showFsArtistPortrait} onChange={e => auth.setShowFsArtistPortrait(e.target.checked)} />
-                  <span className="toggle-track" />
-                </label>
-              </div>
-              {auth.showFsArtistPortrait && (
-                <div style={{ marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid var(--border)' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
-                    <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{t('settings.fsPortraitDim')}</span>
-                    <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--accent)', minWidth: 36, textAlign: 'right' }}>{auth.fsPortraitDim}%</span>
-                  </div>
-                  <input
-                    type="range"
-                    min={0}
-                    max={80}
-                    step={1}
-                    value={auth.fsPortraitDim}
-                    onChange={e => auth.setFsPortraitDim(parseInt(e.target.value, 10))}
-                    className="ui-scale-slider"
-                  />
-                </div>
-              )}
-            </div>
-          </section>
 
-          <section className="settings-section">
-            <div className="settings-section-header">
-              <Sliders size={18} />
-              <h2>{t('settings.seekbarStyle')}</h2>
-            </div>
             <div className="settings-card">
-              <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '0.75rem' }}>
-                {t('settings.seekbarStyleDesc')}
-              </div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
-                {(['waveform', 'linedot', 'bar', 'thick', 'segmented', 'neon', 'pulsewave', 'particletrail', 'liquidfill', 'retrotape'] as SeekbarStyle[]).map(style => (
-                  <SeekbarPreview
-                    key={style}
-                    style={style}
-                    label={t(`settings.seekbar${style.charAt(0).toUpperCase() + style.slice(1)}` as any)}
-                    selected={auth.seekbarStyle === style}
-                    onClick={() => auth.setSeekbarStyle(style)}
-                  />
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+
+                {(
+
+                  [
+
+                    { id: 'inter',             label: 'Inter',             stack: "'Inter', sans-serif" },
+
+                    { id: 'outfit',            label: 'Outfit',            stack: "'Outfit', sans-serif" },
+
+                    { id: 'dm-sans',           label: 'DM Sans',           stack: "'DM Sans', sans-serif" },
+
+                    { id: 'nunito',            label: 'Nunito',            stack: "'Nunito', sans-serif" },
+
+                    { id: 'rubik',             label: 'Rubik',             stack: "'Rubik', sans-serif" },
+
+                    { id: 'space-grotesk',     label: 'Space Grotesk',     stack: "'Space Grotesk', sans-serif" },
+
+                    { id: 'figtree',           label: 'Figtree',           stack: "'Figtree', sans-serif" },
+
+                    { id: 'manrope',           label: 'Manrope',           stack: "'Manrope', sans-serif" },
+
+                    { id: 'plus-jakarta-sans', label: 'Plus Jakarta Sans', stack: "'Plus Jakarta Sans', sans-serif" },
+
+                    { id: 'lexend',            label: 'Lexend',            stack: "'Lexend', sans-serif" },
+
+                  ] as { id: FontId; label: string; stack: string }[]
+
+                ).map(f => (
+
+                  <button
+
+                    key={f.id}
+
+                    className={`btn ${fontStore.font === f.id ? 'btn-primary' : 'btn-ghost'}`}
+
+                    style={{ justifyContent: 'flex-start', fontFamily: f.stack }}
+
+                    onClick={() => fontStore.setFont(f.id)}
+
+                  >
+
+                    {f.label}
+
+                  </button>
+
                 ))}
+
               </div>
+
             </div>
+
           </section>
+
+
+
+          <section className="settings-section">
+
+            <div className="settings-section-header">
+
+              <Maximize2 size={18} />
+
+              <h2>{t('settings.fsPlayerSection')}</h2>
+
+            </div>
+
+            <div className="settings-card">
+
+              <div className="settings-toggle-row">
+
+                <div>
+
+                  <div style={{ fontWeight: 500 }}>{t('settings.fsShowArtistPortrait')}</div>
+
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.fsShowArtistPortraitDesc')}</div>
+
+                </div>
+
+                <label className="toggle-switch" aria-label={t('settings.fsShowArtistPortrait')}>
+
+                  <input type="checkbox" checked={auth.showFsArtistPortrait} onChange={e => auth.setShowFsArtistPortrait(e.target.checked)} />
+
+                  <span className="toggle-track" />
+
+                </label>
+
+              </div>
+
+              {auth.showFsArtistPortrait && (
+
+                <div style={{ marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid var(--border)' }}>
+
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
+
+                    <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{t('settings.fsPortraitDim')}</span>
+
+                    <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--accent)', minWidth: 36, textAlign: 'right' }}>{auth.fsPortraitDim}%</span>
+
+                  </div>
+
+                  <input
+
+                    type="range"
+
+                    min={0}
+
+                    max={80}
+
+                    step={1}
+
+                    value={auth.fsPortraitDim}
+
+                    onChange={e => auth.setFsPortraitDim(parseInt(e.target.value, 10))}
+
+                    className="ui-scale-slider"
+
+                  />
+
+                </div>
+
+              )}
+
+            </div>
+
+          </section>
+
+
+
+          <section className="settings-section">
+
+            <div className="settings-section-header">
+
+              <Sliders size={18} />
+
+              <h2>{t('settings.seekbarStyle')}</h2>
+
+            </div>
+
+            <div className="settings-card">
+
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '0.75rem' }}>
+
+                {t('settings.seekbarStyleDesc')}
+
+              </div>
+
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+
+                {(['waveform', 'linedot', 'bar', 'thick', 'segmented', 'neon', 'pulsewave', 'particletrail', 'liquidfill', 'retrotape'] as SeekbarStyle[]).map(style => (
+
+                  <SeekbarPreview
+
+                    key={style}
+
+                    style={style}
+
+                    label={t(`settings.seekbar${style.charAt(0).toUpperCase() + style.slice(1)}` as any)}
+
+                    selected={auth.seekbarStyle === style}
+
+                    onClick={() => auth.setSeekbarStyle(style)}
+
+                  />
+
+                ))}
+
+              </div>
+
+            </div>
+
+          </section>
+
+
 
           <SidebarCustomizer />
+
         </>
+
       )}
+
+
 
       {/* ── Input ────────────────────────────────────────────────────────────── */}
+
       {activeTab === 'input' && (
+
         <>
-        <section className="settings-section">
-          <div className="settings-section-header">
-            <Keyboard size={18} />
-            <h2>{t('settings.tabInput')}</h2>
-          </div>
-          <div style={{ position: 'relative' }}>
-            <button
-              className="btn btn-ghost"
-              style={{ position: 'absolute', top: -22, right: 0, fontSize: 12, color: 'var(--text-muted)', padding: '2px 4px' }}
-              onClick={() => { kb.resetToDefaults(); setListeningFor(null); }}
-              data-tooltip={t('settings.shortcutsReset')}
-            >
-              <RotateCcw size={14} />
-            </button>
-          <div className="settings-card">
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-              {([
-                ['play-pause',        t('settings.shortcutPlayPause')],
-                ['next',              t('settings.shortcutNext')],
-                ['prev',              t('settings.shortcutPrev')],
-                ['volume-up',         t('settings.shortcutVolumeUp')],
-                ['volume-down',       t('settings.shortcutVolumeDown')],
-                ['seek-forward',      t('settings.shortcutSeekForward')],
-                ['seek-backward',     t('settings.shortcutSeekBackward')],
-                ['toggle-queue',      t('settings.shortcutToggleQueue')],
-                ['open-folder-browser', t('settings.shortcutOpenFolderBrowser', { folderBrowser: t('sidebar.folderBrowser') })],
-                ['fullscreen-player', t('settings.shortcutFullscreenPlayer')],
-                ['native-fullscreen', t('settings.shortcutNativeFullscreen')],
-              ] as [KeyAction, string][]).map(([action, label]) => {
-                const bound = kb.bindings[action];
-                const isListening = listeningFor === action;
-                return (
-                  <div key={action} style={{
-                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                    padding: '8px 10px', borderRadius: 'var(--radius-sm)',
-                    background: isListening ? 'var(--accent-dim)' : 'transparent',
-                    transition: 'background 0.15s',
-                  }}>
-                    <span style={{ fontSize: 13, color: 'var(--text-primary)' }}>{label}</span>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                      <button
-                        onClick={() => {
-                          if (isListening) { setListeningFor(null); return; }
-                          setListeningFor(action);
-                          const handler = (e: KeyboardEvent) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            if (e.code === 'Escape') {
-                              setListeningFor(null);
-                              window.removeEventListener('keydown', handler, true);
-                              return;
-                            }
-                            const chord = buildInAppBinding(e);
-                            if (!chord) return;
-                            const existing = (Object.entries(kb.bindings) as [KeyAction, string | null][])
-                              .find(([, c]) => c === chord)?.[0];
-                            if (existing && existing !== action) kb.setBinding(existing, null);
-                            kb.setBinding(action, chord);
-                            setListeningFor(null);
-                            window.removeEventListener('keydown', handler, true);
-                          };
-                          window.addEventListener('keydown', handler, true);
-                        }}
-                        className="keybind-badge"
-                        style={{
-                          minWidth: 72, padding: '3px 10px', borderRadius: 'var(--radius-sm)',
-                          fontSize: 12, fontWeight: 600, fontFamily: 'monospace',
-                          background: isListening ? 'var(--accent)' : bound ? 'var(--bg-hover)' : 'var(--bg-card)',
-                          color: isListening ? 'var(--ctp-base)' : bound ? 'var(--text-primary)' : 'var(--text-muted)',
-                          border: `1px solid ${isListening ? 'var(--accent)' : 'var(--border-subtle)'}`,
-                          cursor: 'pointer',
-                        }}
-                      >
-                        {isListening ? t('settings.shortcutListening') : bound ? formatBinding(bound) : t('settings.shortcutUnbound')}
-                      </button>
-                      {bound && !isListening && (
-                        <button
-                          onClick={() => kb.setBinding(action, null)}
-                          style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', padding: '2px 4px', lineHeight: 1 }}
-                          data-tooltip={t('settings.shortcutClear')}
-                        >
-                          <X size={12} />
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-          </div>
-        </section>
 
         <section className="settings-section">
+
           <div className="settings-section-header">
+
             <Keyboard size={18} />
-            <h2>{t('settings.globalShortcutsTitle')}</h2>
+
+            <h2>{t('settings.tabInput')}</h2>
+
           </div>
-          <p style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '12px', lineHeight: 1.5 }}>
-            {t('settings.globalShortcutsNote')}
-          </p>
+
           <div style={{ position: 'relative' }}>
+
             <button
+
               className="btn btn-ghost"
+
               style={{ position: 'absolute', top: -22, right: 0, fontSize: 12, color: 'var(--text-muted)', padding: '2px 4px' }}
-              onClick={() => { gs.resetAll(); setListeningForGlobal(null); }}
+
+              onClick={() => { kb.resetToDefaults(); setListeningFor(null); }}
+
               data-tooltip={t('settings.shortcutsReset')}
+
             >
+
               <RotateCcw size={14} />
+
             </button>
+
           <div className="settings-card">
+
             <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+
               {([
-                ['play-pause',  t('settings.shortcutPlayPause')],
-                ['next',        t('settings.shortcutNext')],
-                ['prev',        t('settings.shortcutPrev')],
-                ['volume-up',   t('settings.shortcutVolumeUp')],
-                ['volume-down', t('settings.shortcutVolumeDown')],
-              ] as [GlobalAction, string][]).map(([action, label]) => {
-                const bound = gs.shortcuts[action] ?? null;
-                const isListening = listeningForGlobal === action;
+
+                ['play-pause',        t('settings.shortcutPlayPause')],
+
+                ['next',              t('settings.shortcutNext')],
+
+                ['prev',              t('settings.shortcutPrev')],
+
+                ['volume-up',         t('settings.shortcutVolumeUp')],
+
+                ['volume-down',       t('settings.shortcutVolumeDown')],
+
+                ['seek-forward',      t('settings.shortcutSeekForward')],
+
+                ['seek-backward',     t('settings.shortcutSeekBackward')],
+
+                ['toggle-queue',      t('settings.shortcutToggleQueue')],
+
+                ['open-folder-browser', t('settings.shortcutOpenFolderBrowser', { folderBrowser: t('sidebar.folderBrowser') })],
+
+                ['fullscreen-player', t('settings.shortcutFullscreenPlayer')],
+
+                ['native-fullscreen', t('settings.shortcutNativeFullscreen')],
+
+              ] as [KeyAction, string][]).map(([action, label]) => {
+
+                const bound = kb.bindings[action];
+
+                const isListening = listeningFor === action;
+
                 return (
+
                   <div key={action} style={{
+
                     display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+
                     padding: '8px 10px', borderRadius: 'var(--radius-sm)',
+
                     background: isListening ? 'var(--accent-dim)' : 'transparent',
+
                     transition: 'background 0.15s',
+
                   }}>
+
                     <span style={{ fontSize: 13, color: 'var(--text-primary)' }}>{label}</span>
+
                     <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+
                       <button
+
                         onClick={() => {
-                          if (isListening) { setListeningForGlobal(null); return; }
-                          setListeningForGlobal(action);
+
+                          if (isListening) { setListeningFor(null); return; }
+
+                          setListeningFor(action);
+
                           const handler = (e: KeyboardEvent) => {
+
                             e.preventDefault();
+
                             e.stopPropagation();
+
                             if (e.code === 'Escape') {
-                              setListeningForGlobal(null);
+
+                              setListeningFor(null);
+
                               window.removeEventListener('keydown', handler, true);
+
                               return;
+
                             }
-                            const shortcut = buildGlobalShortcut(e);
-                            if (shortcut) {
-                              gs.setShortcut(action, shortcut);
-                              setListeningForGlobal(null);
-                              window.removeEventListener('keydown', handler, true);
-                            }
+
+                            const chord = buildInAppBinding(e);
+
+                            if (!chord) return;
+
+                            const existing = (Object.entries(kb.bindings) as [KeyAction, string | null][])
+
+                              .find(([, c]) => c === chord)?.[0];
+
+                            if (existing && existing !== action) kb.setBinding(existing, null);
+
+                            kb.setBinding(action, chord);
+
+                            setListeningFor(null);
+
+                            window.removeEventListener('keydown', handler, true);
+
                           };
+
                           window.addEventListener('keydown', handler, true);
+
                         }}
+
                         className="keybind-badge"
+
                         style={{
-                          minWidth: 120, padding: '3px 10px', borderRadius: 'var(--radius-sm)',
+
+                          minWidth: 72, padding: '3px 10px', borderRadius: 'var(--radius-sm)',
+
                           fontSize: 12, fontWeight: 600, fontFamily: 'monospace',
+
                           background: isListening ? 'var(--accent)' : bound ? 'var(--bg-hover)' : 'var(--bg-card)',
+
                           color: isListening ? 'var(--ctp-base)' : bound ? 'var(--text-primary)' : 'var(--text-muted)',
+
                           border: `1px solid ${isListening ? 'var(--accent)' : 'var(--border-subtle)'}`,
+
                           cursor: 'pointer',
+
                         }}
+
                       >
-                        {isListening ? t('settings.shortcutListening') : bound ? formatGlobalShortcut(bound) : t('settings.shortcutUnbound')}
+
+                        {isListening ? t('settings.shortcutListening') : bound ? formatBinding(bound) : t('settings.shortcutUnbound')}
+
                       </button>
+
                       {bound && !isListening && (
+
                         <button
-                          onClick={() => gs.setShortcut(action, null)}
+
+                          onClick={() => kb.setBinding(action, null)}
+
                           style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', padding: '2px 4px', lineHeight: 1 }}
+
                           data-tooltip={t('settings.shortcutClear')}
+
                         >
+
                           <X size={12} />
+
                         </button>
+
                       )}
+
                     </div>
+
                   </div>
+
                 );
+
               })}
+
             </div>
+
           </div>
+
           </div>
+
         </section>
+
+
+
+        <section className="settings-section">
+
+          <div className="settings-section-header">
+
+            <Keyboard size={18} />
+
+            <h2>{t('settings.globalShortcutsTitle')}</h2>
+
+          </div>
+
+          <p style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '12px', lineHeight: 1.5 }}>
+
+            {t('settings.globalShortcutsNote')}
+
+          </p>
+
+          <div style={{ position: 'relative' }}>
+
+            <button
+
+              className="btn btn-ghost"
+
+              style={{ position: 'absolute', top: -22, right: 0, fontSize: 12, color: 'var(--text-muted)', padding: '2px 4px' }}
+
+              onClick={() => { gs.resetAll(); setListeningForGlobal(null); }}
+
+              data-tooltip={t('settings.shortcutsReset')}
+
+            >
+
+              <RotateCcw size={14} />
+
+            </button>
+
+          <div className="settings-card">
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+
+              {([
+
+                ['play-pause',  t('settings.shortcutPlayPause')],
+
+                ['next',        t('settings.shortcutNext')],
+
+                ['prev',        t('settings.shortcutPrev')],
+
+                ['volume-up',   t('settings.shortcutVolumeUp')],
+
+                ['volume-down', t('settings.shortcutVolumeDown')],
+
+              ] as [GlobalAction, string][]).map(([action, label]) => {
+
+                const bound = gs.shortcuts[action] ?? null;
+
+                const isListening = listeningForGlobal === action;
+
+                return (
+
+                  <div key={action} style={{
+
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+
+                    padding: '8px 10px', borderRadius: 'var(--radius-sm)',
+
+                    background: isListening ? 'var(--accent-dim)' : 'transparent',
+
+                    transition: 'background 0.15s',
+
+                  }}>
+
+                    <span style={{ fontSize: 13, color: 'var(--text-primary)' }}>{label}</span>
+
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+
+                      <button
+
+                        onClick={() => {
+
+                          if (isListening) { setListeningForGlobal(null); return; }
+
+                          setListeningForGlobal(action);
+
+                          const handler = (e: KeyboardEvent) => {
+
+                            e.preventDefault();
+
+                            e.stopPropagation();
+
+                            if (e.code === 'Escape') {
+
+                              setListeningForGlobal(null);
+
+                              window.removeEventListener('keydown', handler, true);
+
+                              return;
+
+                            }
+
+                            const shortcut = buildGlobalShortcut(e);
+
+                            if (shortcut) {
+
+                              gs.setShortcut(action, shortcut);
+
+                              setListeningForGlobal(null);
+
+                              window.removeEventListener('keydown', handler, true);
+
+                            }
+
+                          };
+
+                          window.addEventListener('keydown', handler, true);
+
+                        }}
+
+                        className="keybind-badge"
+
+                        style={{
+
+                          minWidth: 120, padding: '3px 10px', borderRadius: 'var(--radius-sm)',
+
+                          fontSize: 12, fontWeight: 600, fontFamily: 'monospace',
+
+                          background: isListening ? 'var(--accent)' : bound ? 'var(--bg-hover)' : 'var(--bg-card)',
+
+                          color: isListening ? 'var(--ctp-base)' : bound ? 'var(--text-primary)' : 'var(--text-muted)',
+
+                          border: `1px solid ${isListening ? 'var(--accent)' : 'var(--border-subtle)'}`,
+
+                          cursor: 'pointer',
+
+                        }}
+
+                      >
+
+                        {isListening ? t('settings.shortcutListening') : bound ? formatGlobalShortcut(bound) : t('settings.shortcutUnbound')}
+
+                      </button>
+
+                      {bound && !isListening && (
+
+                        <button
+
+                          onClick={() => gs.setShortcut(action, null)}
+
+                          style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', padding: '2px 4px', lineHeight: 1 }}
+
+                          data-tooltip={t('settings.shortcutClear')}
+
+                        >
+
+                          <X size={12} />
+
+                        </button>
+
+                      )}
+
+                    </div>
+
+                  </div>
+
+                );
+
+              })}
+
+            </div>
+
+          </div>
+
+          </div>
+
+        </section>
+
         </>
+
       )}
+
+
 
       {/* ── Server ───────────────────────────────────────────────────────────── */}
+
       {activeTab === 'server' && (
+
         <>
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Server size={18} />
+
               <h2>{t('settings.servers')}</h2>
+
             </div>
+
             <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '0.75rem' }}>
+
               {t('settings.serverCompatible')}
+
             </div>
+
+
 
             {auth.servers.length === 0 && !showAddForm ? (
+
               <div className="settings-card" style={{ color: 'var(--text-muted)', fontSize: 14 }}>
+
                 {t('settings.noServers')}
+
               </div>
+
             ) : (
+
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+
                 {auth.servers.map(srv => {
+
                   const isActive = srv.id === auth.activeServerId;
+
                   const status = connStatus[srv.id];
+
                   return (
+
                     <div key={srv.id} className="settings-card" style={{ border: isActive ? '1px solid var(--accent)' : undefined }}>
+
                       <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '1rem' }}>
+
                         <div style={{ minWidth: 0 }}>
+
                           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '2px' }}>
+
                             <span style={{ fontWeight: 600 }}>{srv.name || srv.url}</span>
+
                             {isActive && (
+
                               <span style={{ fontSize: 11, background: 'var(--accent)', color: 'var(--ctp-crust)', padding: '1px 6px', borderRadius: '10px', fontWeight: 600 }}>
+
                                 {t('settings.serverActive')}
+
                               </span>
+
                             )}
+
                           </div>
+
                           <div style={{ fontSize: 12, color: 'var(--text-muted)', display: 'flex', alignItems: 'center', gap: 4, overflow: 'hidden' }}>
+
                             {srv.url.startsWith('https://') && (
+
                               <Lock size={11} style={{ color: 'var(--positive)', flexShrink: 0 }} />
+
                             )}
+
                             <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+
                               {srv.url.replace(/^https?:\/\//, '')}
+
                             </span>
+
                           </div>
+
                           <div style={{ fontSize: 12, color: 'var(--text-muted)', display: 'flex', alignItems: 'center', gap: 4, marginTop: 1 }}>
+
                             <User size={11} />
+
                             {srv.username}
+
                           </div>
+
                         </div>
+
                         <div style={{ display: 'flex', gap: '6px', flexShrink: 0, alignItems: 'center' }}>
+
                           {status === 'ok' && <CheckCircle2 size={16} style={{ color: 'var(--positive)' }} />}
+
                           {status === 'error' && <WifiOff size={16} style={{ color: 'var(--danger)' }} />}
+
                           {status === 'testing' && <div className="spinner" style={{ width: 16, height: 16 }} />}
+
                           <button
+
                             className="btn btn-surface"
+
                             style={{ fontSize: 12, padding: '4px 10px' }}
+
                             onClick={() => testConnection(srv)}
+
                             disabled={status === 'testing'}
+
                           >
+
                             <Wifi size={13} />
+
                             {t('settings.testBtn')}
+
                           </button>
+
                           {!isActive && (
+
                             <button
+
                               className="btn btn-primary"
+
                               style={{ fontSize: 12, padding: '4px 10px' }}
+
                               onClick={() => switchToServer(srv)}
+
                               disabled={status === 'testing'}
+
                               id={`settings-use-server-${srv.id}`}
+
                             >
+
                               {t('settings.useServer')}
+
                             </button>
+
                           )}
+
                           <button
+
                             className="btn btn-ghost"
+
                             style={{ color: 'var(--danger)', padding: '4px 8px' }}
+
                             onClick={() => deleteServer(srv)}
+
                             data-tooltip={t('settings.deleteServer')}
+
                             id={`settings-delete-server-${srv.id}`}
+
                           >
+
                             <Trash2 size={14} />
+
                           </button>
+
                         </div>
+
                       </div>
+
                       {showAudiomuseNavidromeServerSetting(
+
                         auth.subsonicServerIdentityByServer[srv.id],
+
                         auth.instantMixProbeByServer[srv.id],
+
                       ) && (
+
                         <div
+
                           className="settings-toggle-row"
+
                           style={{ marginTop: '0.75rem', paddingTop: '0.75rem', borderTop: '1px solid color-mix(in srgb, var(--text-muted) 18%, transparent)' }}
+
                         >
+
                           <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', minWidth: 0 }}>
+
                             <Sparkles size={16} style={{ color: 'var(--accent)', flexShrink: 0, marginTop: 2 }} />
+
                             <div>
+
                               <div style={{ fontWeight: 500, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+
                                 {t('settings.audiomuseTitle')}
+
                                 <span
+
                                   style={{
+
                                     fontSize: 10,
+
                                     fontWeight: 600,
+
                                     textTransform: 'uppercase',
+
                                     letterSpacing: '0.04em',
+
                                     padding: '2px 6px',
+
                                     borderRadius: 4,
+
                                     background: 'color-mix(in srgb, var(--color-warning, #f59e0b) 22%, transparent)',
+
                                     color: 'var(--text-primary)',
+
                                   }}
+
                                 >
+
                                   {t('settings.hotCacheAlphaBadge')}
+
                                 </span>
+
                                 {!!auth.audiomuseNavidromeByServer[srv.id] && auth.audiomuseNavidromeIssueByServer[srv.id] && (
+
                                   <AlertTriangle
+
                                     size={16}
+
                                     style={{ color: 'var(--color-warning, #f59e0b)', flexShrink: 0 }}
+
                                     data-tooltip={t('settings.audiomuseIssueHint')}
+
                                     aria-label={t('settings.audiomuseIssueHint')}
+
                                   />
+
                                 )}
+
                               </div>
+
                               <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.45 }}>
+
                                 <Trans
+
                                   i18nKey="settings.audiomuseDesc"
+
                                   components={{
+
                                     pluginLink: (
+
                                       <a
+
                                         href={AUDIOMUSE_NV_PLUGIN_URL}
+
                                         onClick={e => {
+
                                           e.preventDefault();
+
                                           void openUrl(AUDIOMUSE_NV_PLUGIN_URL);
+
                                         }}
+
                                         style={{ color: 'var(--accent)', textDecoration: 'underline' }}
+
                                       />
+
                                     ),
+
                                   }}
+
                                 />
+
                               </div>
+
                             </div>
+
                           </div>
+
                           <label className="toggle-switch" aria-label={t('settings.audiomuseTitle')}>
+
                             <input
+
                               type="checkbox"
+
                               checked={!!auth.audiomuseNavidromeByServer[srv.id]}
+
                               onChange={e => auth.setAudiomuseNavidromeEnabled(srv.id, e.target.checked)}
+
                             />
+
                             <span className="toggle-track" />
+
                           </label>
+
                         </div>
+
                       )}
+
                     </div>
+
                   );
+
                 })}
+
               </div>
+
             )}
+
+
 
             {showAddForm ? (
+
               <AddServerForm onSave={handleAddServer} onCancel={() => setShowAddForm(false)} />
+
             ) : (
+
               <button className="btn btn-surface" style={{ marginTop: '0.75rem' }} onClick={() => setShowAddForm(true)} id="settings-add-server-btn">
+
                 <Plus size={16} /> {t('settings.addServer')}
+
               </button>
+
             )}
+
           </section>
+
+
 
           {/* Last.fm */}
-          <section className="settings-section">
-            <div className="settings-section-header">
-              <LastfmIcon size={18} />
-              <h2>{t('settings.lfmTitle')}</h2>
-            </div>
-            <div className="settings-card">
-              {auth.lastfmSessionKey ? (
-                /* ── Connected state ── */
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', padding: '0.75rem 1rem', borderRadius: '10px', background: 'color-mix(in srgb, var(--accent) 8%, transparent)', border: '1px solid color-mix(in srgb, var(--accent) 20%, transparent)' }}>
-                    <div style={{ flexShrink: 0, color: '#e31c23' }}><LastfmIcon size={20} /></div>
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontWeight: 600, fontSize: 14 }}>@{auth.lastfmUsername}</div>
-                      {lfmUserInfo && (
-                        <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2, display: 'flex', gap: '0.75rem' }}>
-                          <span>{t('settings.lfmScrobbles', { n: lfmUserInfo.playcount.toLocaleString() })}</span>
-                          <span>{t('settings.lfmMemberSince', { year: new Date(lfmUserInfo.registeredAt * 1000).getFullYear() })}</span>
-                        </div>
-                      )}
-                    </div>
-                    <button
-                      className="btn btn-ghost"
-                      style={{ fontSize: 12, padding: '4px 10px', flexShrink: 0 }}
-                      onClick={() => auth.disconnectLastfm()}
-                    >
-                      {t('settings.lfmDisconnect')}
-                    </button>
-                  </div>
-                  <div className="settings-toggle-row">
-                    <div>
-                      <div style={{ fontWeight: 500 }}>{t('settings.scrobbleEnabled')}</div>
-                      <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.scrobbleDesc')}</div>
-                    </div>
-                    <label className="toggle-switch" aria-label={t('settings.scrobbleEnabled')}>
-                      <input type="checkbox" checked={auth.scrobblingEnabled} onChange={e => auth.setScrobblingEnabled(e.target.checked)} id="scrobbling-toggle" />
-                      <span className="toggle-track" />
-                    </label>
-                  </div>
-                </div>
-              ) : lfmState === 'waiting' ? (
-                /* ── Waiting for browser auth — auto-polling ── */
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', fontSize: 13, color: 'var(--text-secondary)' }}>
-                    <div className="spinner" style={{ width: 16, height: 16, borderWidth: 2 }} />
-                    {t('settings.lfmConnecting')}
-                  </div>
-                  <button className="btn btn-ghost" style={{ alignSelf: 'flex-start', fontSize: 12 }}
-                    onClick={() => { setLfmState('idle'); setLfmPendingToken(null); }}>
-                    {t('common.cancel')}
-                  </button>
-                </div>
-              ) : (
-                /* ── Not connected ── */
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-                  <p style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.5 }}>
-                    {t('settings.lfmConnectDesc')}
-                  </p>
-                  {lfmState === 'error' && (
-                    <p style={{ fontSize: 12, color: 'var(--danger)' }}>{lfmError}</p>
-                  )}
-                  <button className="btn btn-primary" style={{ alignSelf: 'flex-start' }} onClick={startLastfmConnect}>
-                    {t('settings.lfmConnect')}
-                  </button>
-                </div>
-              )}
-            </div>
-          </section>
 
           <section className="settings-section">
-            <button className="btn btn-danger" onClick={handleLogout} id="settings-logout-btn">
-              <LogOut size={16} /> {t('settings.logout')}
-            </button>
+
+            <div className="settings-section-header">
+
+              <LastfmIcon size={18} />
+
+              <h2>{t('settings.lfmTitle')}</h2>
+
+            </div>
+
+            <div className="settings-card">
+
+              {auth.lastfmSessionKey ? (
+
+                /* ── Connected state ── */
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', padding: '0.75rem 1rem', borderRadius: '10px', background: 'color-mix(in srgb, var(--accent) 8%, transparent)', border: '1px solid color-mix(in srgb, var(--accent) 20%, transparent)' }}>
+
+                    <div style={{ flexShrink: 0, color: '#e31c23' }}><LastfmIcon size={20} /></div>
+
+                    <div style={{ flex: 1, minWidth: 0 }}>
+
+                      <div style={{ fontWeight: 600, fontSize: 14 }}>@{auth.lastfmUsername}</div>
+
+                      {lfmUserInfo && (
+
+                        <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2, display: 'flex', gap: '0.75rem' }}>
+
+                          <span>{t('settings.lfmScrobbles', { n: lfmUserInfo.playcount.toLocaleString() })}</span>
+
+                          <span>{t('settings.lfmMemberSince', { year: new Date(lfmUserInfo.registeredAt * 1000).getFullYear() })}</span>
+
+                        </div>
+
+                      )}
+
+                    </div>
+
+                    <button
+
+                      className="btn btn-ghost"
+
+                      style={{ fontSize: 12, padding: '4px 10px', flexShrink: 0 }}
+
+                      onClick={() => auth.disconnectLastfm()}
+
+                    >
+
+                      {t('settings.lfmDisconnect')}
+
+                    </button>
+
+                  </div>
+
+                  <div className="settings-toggle-row">
+
+                    <div>
+
+                      <div style={{ fontWeight: 500 }}>{t('settings.scrobbleEnabled')}</div>
+
+                      <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.scrobbleDesc')}</div>
+
+                    </div>
+
+                    <label className="toggle-switch" aria-label={t('settings.scrobbleEnabled')}>
+
+                      <input type="checkbox" checked={auth.scrobblingEnabled} onChange={e => auth.setScrobblingEnabled(e.target.checked)} id="scrobbling-toggle" />
+
+                      <span className="toggle-track" />
+
+                    </label>
+
+                  </div>
+
+                </div>
+
+              ) : lfmState === 'waiting' ? (
+
+                /* ── Waiting for browser auth — auto-polling ── */
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', fontSize: 13, color: 'var(--text-secondary)' }}>
+
+                    <div className="spinner" style={{ width: 16, height: 16, borderWidth: 2 }} />
+
+                    {t('settings.lfmConnecting')}
+
+                  </div>
+
+                  <button className="btn btn-ghost" style={{ alignSelf: 'flex-start', fontSize: 12 }}
+
+                    onClick={() => { setLfmState('idle'); setLfmPendingToken(null); }}>
+
+                    {t('common.cancel')}
+
+                  </button>
+
+                </div>
+
+              ) : (
+
+                /* ── Not connected ── */
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+
+                  <p style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+
+                    {t('settings.lfmConnectDesc')}
+
+                  </p>
+
+                  {lfmState === 'error' && (
+
+                    <p style={{ fontSize: 12, color: 'var(--danger)' }}>{lfmError}</p>
+
+                  )}
+
+                  <button className="btn btn-primary" style={{ alignSelf: 'flex-start' }} onClick={startLastfmConnect}>
+
+                    {t('settings.lfmConnect')}
+
+                  </button>
+
+                </div>
+
+              )}
+
+            </div>
+
           </section>
+
+
+
+          <section className="settings-section">
+
+            <button className="btn btn-danger" onClick={handleLogout} id="settings-logout-btn">
+
+              <LogOut size={16} /> {t('settings.logout')}
+
+            </button>
+
+          </section>
+
+
 
         </>
+
       )}
 
+
+
       {/* ── System ───────────────────────────────────────────────────────────── */}
+
       {activeTab === 'system' && (
+
         <>
+
         <BackupSection />
+
           <section className="settings-section">
+
             <div className="settings-section-header">
+
               <Info size={18} />
+
               <h2>{t('settings.aboutTitle')}</h2>
+
             </div>
+
             <div className="settings-card settings-about">
+
               <div className="settings-about-header">
+
                 <img src="/logo-psysonic.png" width={52} height={52} alt="Psysonic" style={{ borderRadius: 14 }} />
+
                 <div>
+
                   <div style={{ fontFamily: 'var(--font-display)', fontSize: '1.25rem', fontWeight: 700, color: 'var(--text-primary)' }}>
+
                     Psysonic
+
                   </div>
+
                   <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}>
+
                     {t('settings.aboutVersion')} {appVersion}
+
                   </div>
+
                 </div>
+
               </div>
 
+
+
               <p style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.6, margin: '1rem 0 0.5rem' }}>
+
                 {t('settings.aboutDesc')}
+
               </p>
+
+
 
               <div className="divider" style={{ margin: '1rem 0' }} />
 
+
+
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem', fontSize: 13 }}>
+
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
+
                   <span style={{ color: 'var(--text-muted)', minWidth: 56 }}>{t('settings.aboutLicense')}</span>
+
                   <span style={{ color: 'var(--text-secondary)' }}>{t('settings.aboutLicenseText')}</span>
+
                 </div>
+
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
+
                   <span style={{ color: 'var(--text-muted)', minWidth: 56 }}>Stack</span>
+
                   <span style={{ color: 'var(--text-secondary)' }}>{t('settings.aboutBuiltWith')}</span>
+
                 </div>
+
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
+
                   <span style={{ color: 'var(--text-muted)', minWidth: 56 }}>AI</span>
+
                   <span style={{ color: 'var(--text-secondary)' }}>{t('settings.aboutAiCredit')}</span>
+
                 </div>
+
                 <div>
+
                   <button
+
                     style={{ display: 'flex', width: '100%', alignItems: 'center', gap: '0.5rem', background: 'none', border: 'none', cursor: 'pointer', padding: 0, textAlign: 'left' }}
+
                     onClick={() => setContributorsOpen(o => !o)}
+
                   >
+
                     <span style={{ color: 'var(--text-muted)', minWidth: 56, flexShrink: 0 }}>{t('settings.aboutContributorsLabel')}</span>
+
                     <span style={{ color: 'var(--text-secondary)', flex: 1 }}>{CONTRIBUTORS.length}</span>
+
                     <ChevronDown size={13} style={{ color: 'var(--text-muted)', transform: contributorsOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }} />
+
                   </button>
 
+
+
                   {contributorsOpen && (
+
                     <div style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+
                       {CONTRIBUTORS.map(c => (
+
                         <div key={c.github} style={{
+
                           display: 'flex', gap: '0.75rem', alignItems: 'flex-start',
+
                           background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)',
+
                           padding: '0.65rem 0.75rem',
+
                           boxShadow: 'inset 0 0 0 1px var(--border-subtle)',
+
                         }}>
+
                           <img
+
                             src={`https://github.com/${c.github}.png?size=48`}
+
                             width={36} height={36}
+
                             style={{ borderRadius: '50%', flexShrink: 0, marginTop: 2 }}
+
                             alt={c.github}
+
                           />
+
                           <div style={{ flex: 1, minWidth: 0 }}>
+
                             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.3rem' }}>
+
                               <button
+
                                 style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--accent)', fontWeight: 600, fontSize: 13 }}
+
                                 onClick={() => openUrl(`https://github.com/${c.github}`)}
+
                               >
+
                                 @{c.github}
+
                               </button>
+
                               <span style={{ fontSize: 10, background: 'var(--accent-dim)', color: 'var(--accent)', padding: '1px 6px', borderRadius: 99, fontWeight: 600 }}>
+
                                 v{c.since}
+
                               </span>
+
                             </div>
+
                             <ul style={{ margin: 0, padding: '0 0 0 1rem', fontSize: 12, color: 'var(--text-secondary)', lineHeight: 1.8 }}>
+
                               {c.contributions.map(item => <li key={item}>{item}</li>)}
+
                             </ul>
+
                           </div>
+
                         </div>
+
                       ))}
+
                     </div>
+
                   )}
+
                 </div>
+
                 <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'flex-start' }}>
+
                   <span style={{ color: 'var(--text-muted)', minWidth: 56, flexShrink: 0, paddingTop: 2, fontSize: 13 }}>{t('settings.aboutSpecialThanksLabel')}</span>
+
                   <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem', flex: 1 }}>
+
                     {SPECIAL_THANKS.map(s => (
+
                       <div key={s.github} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+
                         <img
+
                           src={`https://github.com/${s.github}.png?size=32`}
+
                           width={22} height={22}
+
                           style={{ borderRadius: '50%', flexShrink: 0 }}
+
                           alt={s.github}
+
                         />
+
                         <button
+
                           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--accent)', fontWeight: 600, fontSize: 13 }}
+
                           onClick={() => openUrl(`https://github.com/${s.github}`)}
+
                         >
+
                           @{s.github}
+
                         </button>
+
                         <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>— {s.reason}</span>
+
                       </div>
+
                     ))}
+
                   </div>
+
                 </div>
+
               </div>
+
+
 
               <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.25rem', flexWrap: 'wrap' }}>
+
                 <button
+
                   className="btn btn-ghost"
+
                   style={{ alignSelf: 'flex-start' }}
+
                   onClick={() => openUrl('https://github.com/Psychotoxical/psysonic')}
+
                 >
+
                   <ExternalLink size={14} />
+
                   {t('settings.aboutRepo')}
+
                 </button>
+
               </div>
+
             </div>
+
           </section>
 
+
+
           <ChangelogSection />
+
         </>
+
       )}
+
     </div>
+
   );
+
 }
+
+
 
 // ─── Changelog renderer ───────────────────────────────────────────────────────
 
+
+
 function renderInline(text: string): React.ReactNode[] {
+
   // Splits on **bold**, *italic*, `code` and renders each part.
+
   const parts = text.split(/(\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`)/g);
+
   return parts.map((part, i) => {
+
     if (part.startsWith('**') && part.endsWith('**'))
+
       return <strong key={i}>{part.slice(2, -2)}</strong>;
+
     if (part.startsWith('*') && part.endsWith('*'))
+
       return <em key={i}>{part.slice(1, -1)}</em>;
+
     if (part.startsWith('`') && part.endsWith('`'))
+
       return <code key={i} className="changelog-code">{part.slice(1, -1)}</code>;
+
     return part;
+
   });
+
 }
+
+
 
 function HomeCustomizer() {
+
   const { t } = useTranslation();
+
   const { sections, toggleSection, reset } = useHomeStore();
 
+
+
   const SECTION_LABELS: Record<HomeSectionId, string> = {
+
     hero:            t('home.hero'),
+
     recent:          t('home.recent'),
+
     discover:        t('home.discover'),
+
     discoverArtists: t('home.discoverArtists'),
+
     recentlyPlayed:  t('home.recentlyPlayed'),
+
     starred:         t('home.starred'),
+
     mostPlayed:      t('home.mostPlayed'),
+
   };
 
+
+
   return (
+
     <section className="settings-section">
+
       <div className="settings-section-header">
+
         <LayoutGrid size={18} />
+
         <h2>{t('settings.homeCustomizerTitle')}</h2>
+
       </div>
+
       <div style={{ position: 'relative' }}>
+
         <button
+
           className="btn btn-ghost"
+
           style={{ position: 'absolute', top: -22, right: 0, fontSize: 12, color: 'var(--text-muted)', padding: '2px 4px' }}
+
           onClick={reset}
+
           data-tooltip={t('settings.sidebarReset')}
+
         >
+
           <RotateCcw size={14} />
+
         </button>
+
         <div className="settings-card" style={{ padding: '4px 0' }}>
+
           {sections.map(sec => (
+
             <div key={sec.id} className="settings-toggle-row" style={{ padding: '8px 16px' }}>
+
               <span style={{ fontSize: 14 }}>{SECTION_LABELS[sec.id]}</span>
+
               <label className="toggle-switch" aria-label={SECTION_LABELS[sec.id]}>
+
                 <input type="checkbox" checked={sec.visible} onChange={() => toggleSection(sec.id)} />
+
                 <span className="toggle-track" />
+
               </label>
+
             </div>
+
           ))}
+
         </div>
+
       </div>
+
     </section>
+
   );
+
 }
 
+
+
 function SidebarGripHandle({ idx, section, label }: { idx: number; section: 'library' | 'system'; label: string }) {
+
   const { t } = useTranslation();
+
   const { onMouseDown } = useDragSource(() => ({
+
     data: JSON.stringify({ type: 'sidebar_reorder', index: idx, section }),
+
     label,
+
   }));
+
   return (
+
     <span
+
       className="sidebar-customizer-grip"
+
       data-tooltip={t('settings.sidebarDrag')}
+
       data-tooltip-pos="right"
+
       onMouseDown={onMouseDown}
+
     >
+
       <GripVertical size={16} />
+
     </span>
+
   );
+
 }
+
+
 
 // ── Lyrics Sources Customizer ──────────────────────────────────────────────
 
+
+
 const LYRICS_SOURCE_LABEL_KEYS: Record<LyricsSourceId, string> = {
+
   server:  'settings.lyricsSourceServer',
+
   lrclib:  'settings.lyricsSourceLrclib',
+
   netease: 'settings.lyricsSourceNetease',
+
 };
+
+
 
 type LyricsDropTarget = { idx: number; before: boolean } | null;
 
+
+
 function LyricsSourceGripHandle({ idx, label }: { idx: number; label: string }) {
+
   const { t } = useTranslation();
+
   const { onMouseDown } = useDragSource(() => ({
+
     data: JSON.stringify({ type: 'lyrics_source_reorder', index: idx }),
+
     label,
+
   }));
+
   return (
+
     <span
+
       className="sidebar-customizer-grip"
+
       data-tooltip={t('settings.sidebarDrag')}
+
       data-tooltip-pos="right"
+
       onMouseDown={onMouseDown}
+
     >
+
       <GripVertical size={16} />
+
     </span>
+
   );
+
 }
+
+
 
 function LyricsSourcesCustomizer() {
+
   const { t } = useTranslation();
+
   const lyricsSources = useAuthStore(useShallow(s => s.lyricsSources));
+
   const setLyricsSources = useAuthStore(s => s.setLyricsSources);
+
   const { isDragging: isPsyDragging } = useDragDrop();
+
   const containerRef = useRef<HTMLDivElement>(null);
+
   const [dropTarget, setDropTarget] = useState<LyricsDropTarget>(null);
+
   const dropTargetRef = useRef<LyricsDropTarget>(null);
+
   const sourcesRef = useRef(lyricsSources);
+
   sourcesRef.current = lyricsSources;
 
+
+
   useEffect(() => {
+
     if (!isPsyDragging) { dropTargetRef.current = null; setDropTarget(null); }
+
   }, [isPsyDragging]);
 
+
+
   useEffect(() => {
+
     const el = containerRef.current;
+
     if (!el) return;
+
     const onPsyDrop = (e: Event) => {
+
       const detail = (e as CustomEvent).detail;
+
       if (!detail?.data) return;
+
       let parsed: { type?: string; index?: number };
+
       try { parsed = JSON.parse(detail.data as string); } catch { return; }
+
       if (parsed.type !== 'lyrics_source_reorder' || parsed.index == null) return;
 
+
+
       const fromIdx = parsed.index;
+
       const target = dropTargetRef.current;
+
       dropTargetRef.current = null; setDropTarget(null);
+
       if (!target) return;
 
+
+
       const insertBefore = target.before ? target.idx : target.idx + 1;
+
       if (insertBefore === fromIdx || insertBefore === fromIdx + 1) return;
 
+
+
       const next = [...sourcesRef.current];
+
       const [moved] = next.splice(fromIdx, 1);
+
       next.splice(insertBefore > fromIdx ? insertBefore - 1 : insertBefore, 0, moved);
+
       setLyricsSources(next);
+
     };
+
     el.addEventListener('psy-drop', onPsyDrop);
+
     return () => el.removeEventListener('psy-drop', onPsyDrop);
+
   }, [setLyricsSources]);
 
+
+
   const handleMouseMove = (e: React.MouseEvent) => {
+
     if (!isPsyDragging || !containerRef.current) return;
+
     const rows = containerRef.current.querySelectorAll<HTMLElement>('[data-lyrics-idx]');
+
     let target: LyricsDropTarget = null;
+
     for (const row of rows) {
+
       const rect = row.getBoundingClientRect();
+
       const idx = Number(row.dataset.lyricsIdx);
+
       if (e.clientY < rect.top + rect.height / 2) { target = { idx, before: true }; break; }
+
       target = { idx, before: false };
+
     }
+
     dropTargetRef.current = target;
+
     setDropTarget(target);
+
   };
+
+
 
   const toggleSource = (id: LyricsSourceId) => {
+
     setLyricsSources(sourcesRef.current.map(s => s.id === id ? { ...s, enabled: !s.enabled } : s));
+
   };
 
+
+
   return (
+
     <section className="settings-section">
+
       <div className="settings-section-header">
+
         <Music2 size={18} />
+
         <h2>{t('settings.lyricsSourcesTitle')}</h2>
+
       </div>
+
       <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: '0.75rem', lineHeight: 1.5 }}>
+
         {t('settings.lyricsSourcesDesc')}
+
       </p>
+
       <div className="settings-card" style={{ padding: '4px 0' }} ref={containerRef} onMouseMove={handleMouseMove}>
+
         {lyricsSources.map((src, i) => {
+
           const label = t(LYRICS_SOURCE_LABEL_KEYS[src.id]);
+
           const isBefore = isPsyDragging && dropTarget?.idx === i && dropTarget.before;
+
           const isAfter  = isPsyDragging && dropTarget?.idx === i && !dropTarget.before;
+
           return (
+
             <div
+
               key={src.id}
+
               data-lyrics-idx={i}
+
               className="sidebar-customizer-row"
+
               style={{
+
                 borderTop:    isBefore ? '2px solid var(--accent)' : undefined,
+
                 borderBottom: isAfter  ? '2px solid var(--accent)' : undefined,
+
               }}
+
             >
+
               <LyricsSourceGripHandle idx={i} label={label} />
+
               <span style={{ flex: 1, fontSize: 14, opacity: src.enabled ? 1 : 0.45 }}>{label}</span>
+
               <label className="toggle-switch" aria-label={label}>
+
                 <input type="checkbox" checked={src.enabled} onChange={() => toggleSource(src.id)} />
+
                 <span className="toggle-track" />
+
               </label>
+
             </div>
+
           );
+
         })}
+
       </div>
+
     </section>
+
   );
+
 }
+
+
 
 // ── Sidebar Customizer ──────────────────────────────────────────────────────
 
+
+
 type DropTarget = { idx: number; before: boolean; section: 'library' | 'system' } | null;
 
-function SidebarCustomizer() {
-  const { t } = useTranslation();
-  const { items, setItems, toggleItem, reset } = useSidebarStore();
-  const { isDragging: isPsyDragging } = useDragDrop();
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [dropTarget, setDropTarget] = useState<DropTarget>(null);
-  const dropTargetRef = useRef<DropTarget>(null);
-  const itemsRef = useRef(items);
-  itemsRef.current = items;
-  const randomNavMode = useAuthStore(s => s.randomNavMode);
-  const setRandomNavMode = useAuthStore(s => s.setRandomNavMode);
 
-  const libraryItems = items.filter(cfg => {
-    if (!ALL_NAV_ITEMS[cfg.id] || ALL_NAV_ITEMS[cfg.id].section !== 'library') return false;
-    if (randomNavMode === 'hub' && (cfg.id === 'randomMix' || cfg.id === 'randomAlbums')) return false;
-    if (randomNavMode === 'separate' && cfg.id === 'randomPicker') return false;
-    return true;
-  });
+
+function SidebarCustomizer() {
+
+  const { t } = useTranslation();
+
+  const { items, setItems, toggleItem, reset } = useSidebarStore();
+
+  const { isDragging: isPsyDragging } = useDragDrop();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const [dropTarget, setDropTarget] = useState<DropTarget>(null);
+
+  const dropTargetRef = useRef<DropTarget>(null);
+
+  const itemsRef = useRef(items);
+
+  itemsRef.current = items;
+
+
+
+  const libraryItems = items.filter(cfg => ALL_NAV_ITEMS[cfg.id]?.section === 'library');
+
   const systemItems  = items.filter(cfg => ALL_NAV_ITEMS[cfg.id]?.section === 'system');
 
+
+
   useEffect(() => {
+
     if (!isPsyDragging) { dropTargetRef.current = null; setDropTarget(null); }
+
   }, [isPsyDragging]);
 
+
+
   useEffect(() => {
+
     const el = containerRef.current;
+
     if (!el) return;
+
     const onPsyDrop = (e: Event) => {
+
       const detail = (e as CustomEvent).detail;
+
       if (!detail?.data) return;
+
       let parsed: { type?: string; index?: number; section?: string };
+
       try { parsed = JSON.parse(detail.data); } catch { return; }
+
       if (parsed.type !== 'sidebar_reorder' || parsed.index == null || !parsed.section) return;
 
+
+
       const fromIdx = parsed.index;
+
       const fromSection = parsed.section as 'library' | 'system';
+
       const target = dropTargetRef.current;
+
       dropTargetRef.current = null; setDropTarget(null);
+
       if (!target || target.section !== fromSection) return;
 
+
+
       const sectionItems = fromSection === 'library' ? [...libraryItems] : [...systemItems];
+
       const insertBefore = target.before ? target.idx : target.idx + 1;
+
       if (insertBefore === fromIdx || insertBefore === fromIdx + 1) return;
 
+
+
       const [moved] = sectionItems.splice(fromIdx, 1);
+
       sectionItems.splice(insertBefore > fromIdx ? insertBefore - 1 : insertBefore, 0, moved);
 
-      // Merge reordered section back into flat items array.
-      // Only update positions of the *visible* items (same filter as libraryItems/systemItems)
-      // so hidden entries like randomMix/randomAlbums are never overwritten with undefined.
+
+
+      // Merge reordered section back into flat items array
+
       const all = [...itemsRef.current];
-      const visibleIds = new Set(sectionItems.map(c => c.id));
+
       const positions = all.map((cfg, i) => ({ cfg, i }))
-        .filter(({ cfg }) => visibleIds.has(cfg.id))
+
+        .filter(({ cfg }) => ALL_NAV_ITEMS[cfg.id]?.section === fromSection)
+
         .map(({ i }) => i);
+
       positions.forEach((pos, i) => { all[pos] = sectionItems[i]; });
+
       setItems(all);
+
     };
+
     el.addEventListener('psy-drop', onPsyDrop);
+
     return () => el.removeEventListener('psy-drop', onPsyDrop);
+
   }, [libraryItems, systemItems, setItems]);
 
+
+
   const handleMouseMove = (e: React.MouseEvent) => {
+
     if (!isPsyDragging || !containerRef.current) return;
+
     const rows = containerRef.current.querySelectorAll<HTMLElement>('[data-sidebar-idx]');
+
     let target: DropTarget = null;
+
     for (const row of rows) {
+
       const rect = row.getBoundingClientRect();
+
       const idx = Number(row.dataset.sidebarIdx);
+
       const section = row.dataset.sidebarSection as 'library' | 'system';
+
       if (e.clientY < rect.top + rect.height / 2) { target = { idx, before: true, section }; break; }
+
       target = { idx, before: false, section };
+
     }
+
     dropTargetRef.current = target;
+
     setDropTarget(target);
+
   };
+
+
 
   const renderRow = (cfg: SidebarItemConfig, localIdx: number, section: 'library' | 'system') => {
+
     const meta = ALL_NAV_ITEMS[cfg.id];
+
     if (!meta) return null;
+
     const Icon = meta.icon;
+
     const isBefore = isPsyDragging && dropTarget?.section === section && dropTarget.idx === localIdx && dropTarget.before;
+
     const isAfter  = isPsyDragging && dropTarget?.section === section && dropTarget.idx === localIdx && !dropTarget.before;
+
     return (
+
       <div
+
         key={cfg.id}
+
         data-sidebar-idx={localIdx}
+
         data-sidebar-section={section}
+
         className="sidebar-customizer-row"
+
         style={{
+
           borderTop:    isBefore ? '2px solid var(--accent)' : undefined,
+
           borderBottom: isAfter  ? '2px solid var(--accent)' : undefined,
+
         }}
+
       >
+
         <SidebarGripHandle idx={localIdx} section={section} label={t(meta.labelKey)} />
+
         <Icon size={16} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
+
         <span style={{ flex: 1, fontSize: 14 }}>{t(meta.labelKey)}</span>
+
         <label className="toggle-switch" aria-label={t(meta.labelKey)}>
+
           <input type="checkbox" checked={cfg.visible} onChange={() => toggleItem(cfg.id)} />
+
           <span className="toggle-track" />
+
         </label>
+
       </div>
+
     );
+
   };
 
+
+
   return (
+
     <section className="settings-section">
+
       <div className="settings-section-header">
+
         <PanelLeft size={18} />
+
         <h2>{t('settings.sidebarTitle')}</h2>
+
         <button
+
           className="btn btn-ghost"
+
           style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--text-muted)' }}
+
           onClick={reset}
+
           data-tooltip={t('settings.sidebarReset')}
+
         >
+
           <RotateCcw size={14} />
+
         </button>
+
       </div>
-      <div className="settings-card" style={{ marginBottom: '1rem' }}>
-        <div className="settings-toggle-row">
-          <div>
-            <div style={{ fontWeight: 500 }}>{t('settings.randomNavSplitTitle')}</div>
-            <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.randomNavSplitDesc')}</div>
-          </div>
-          <label className="toggle-switch" aria-label={t('settings.randomNavSplitTitle')}>
-            <input
-              type="checkbox"
-              checked={randomNavMode === 'separate'}
-              onChange={e => setRandomNavMode(e.target.checked ? 'separate' : 'hub')}
-            />
-            <span className="toggle-track" />
-          </label>
-        </div>
-      </div>
+
       <div ref={containerRef} onMouseMove={handleMouseMove} style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+
         {/* Library block */}
+
         <div className="settings-card" style={{ padding: '4px 0' }}>
+
           <div className="sidebar-customizer-block-label">{t('sidebar.library')}</div>
+
           {libraryItems.map((cfg, i) => renderRow(cfg, i, 'library'))}
+
         </div>
+
         {/* System block */}
+
         <div className="settings-card" style={{ padding: '4px 0' }}>
+
           <div className="sidebar-customizer-block-label">{t('sidebar.system')}</div>
+
           {systemItems.map((cfg, i) => renderRow(cfg, i, 'system'))}
+
           <div className="sidebar-customizer-fixed-hint">
+
             <span>{t('settings.sidebarFixed')}: {t('sidebar.nowPlaying')}, {t('sidebar.settings')}</span>
+
           </div>
+
         </div>
+
       </div>
+
     </section>
+
   );
+
 }
+
+
 
 function BackupSection() {
+
   const { t } = useTranslation();
+
   const [exporting, setExporting] = useState(false);
+
   const [importing, setImporting] = useState(false);
 
+
+
   const handleExport = async () => {
+
     setExporting(true);
+
     try {
+
       const path = await exportBackup();
+
       if (path) showToast(t('settings.backupSuccess'), 3000, 'info');
+
     } catch (e) {
+
       console.error('Export failed', e);
+
       showToast(t('settings.backupImportError'), 4000, 'error');
+
     } finally {
+
       setExporting(false);
+
     }
+
   };
+
+
 
   const handleImport = async () => {
+
     if (!window.confirm(t('settings.backupImportConfirm'))) return;
+
     setImporting(true);
+
     try {
+
       await importBackup();
+
       // importBackup reloads the page — this toast will briefly show before reload
+
       showToast(t('settings.backupImportSuccess'), 3000, 'info');
+
     } catch (e) {
+
       console.error('Import failed', e);
+
       showToast(t('settings.backupImportError'), 4000, 'error');
+
       setImporting(false);
+
     }
+
   };
 
+
+
   return (
+
     <section className="settings-section">
+
       <div className="settings-section-header">
+
         <HardDrive size={18} />
+
         <h2>{t('settings.backupTitle')}</h2>
+
       </div>
+
+
 
       {/* Export */}
+
       <div className="settings-card" style={{ marginBottom: '1rem' }}>
+
         <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '1rem' }}>
+
           <div>
+
             <div style={{ fontWeight: 500, marginBottom: '0.25rem' }}>{t('settings.backupExport')}</div>
+
             <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>{t('settings.backupExportDesc')}</div>
+
           </div>
+
           <button
+
             className="btn btn-primary"
+
             onClick={handleExport}
+
             disabled={exporting}
+
             style={{ flexShrink: 0 }}
+
           >
+
             <Upload size={14} />
+
             {exporting ? '…' : t('settings.backupExport')}
+
           </button>
+
         </div>
+
       </div>
+
+
 
       {/* Import */}
+
       <div className="settings-card">
+
         <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '1rem' }}>
+
           <div>
+
             <div style={{ fontWeight: 500, marginBottom: '0.25rem' }}>{t('settings.backupImport')}</div>
+
             <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>{t('settings.backupImportDesc')}</div>
+
           </div>
+
           <button
+
             className="btn btn-surface"
+
             onClick={handleImport}
+
             disabled={importing}
+
             style={{ flexShrink: 0 }}
+
           >
+
             <Download size={14} />
+
             {importing ? '…' : t('settings.backupImport')}
+
           </button>
+
         </div>
+
       </div>
+
     </section>
+
   );
+
 }
+
+
 
 function ChangelogSection() {
+
   const { t } = useTranslation();
+
   const showChangelogOnUpdate = useAuthStore(s => s.showChangelogOnUpdate);
+
   const setShowChangelogOnUpdate = useAuthStore(s => s.setShowChangelogOnUpdate);
 
+
+
   const versions = useMemo(() => {
+
     const blocks = changelogRaw.split(/\n(?=## \[)/).filter(b => b.startsWith('## ['));
+
     return blocks.map(block => {
+
       const lines = block.split('\n');
+
       const headerLine = lines[0]; // e.g. "## [1.5.0] - 2026-03-18"
+
       const versionMatch = headerLine.match(/## \[([^\]]+)\]/);
+
       const dateMatch = headerLine.match(/- (\d{4}-\d{2}-\d{2})/);
+
       const version = versionMatch?.[1] ?? '';
+
       const date = dateMatch?.[1] ?? '';
 
+
+
       // Parse the rest into rendered lines
+
       const body = lines.slice(1).join('\n').trim();
+
       return { version, date, body };
+
     });
+
   }, []);
 
+
+
   return (
+
     <section className="settings-section">
+
       <div className="settings-section-header">
+
         <Info size={18} />
+
         <h2>{t('settings.changelog')}</h2>
+
       </div>
+
       <div className="settings-toggle-row" style={{ marginBottom: '1rem' }}>
+
         <div>
+
           <div style={{ fontWeight: 500 }}>{t('settings.showChangelogOnUpdate')}</div>
+
           <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.showChangelogOnUpdateDesc')}</div>
+
         </div>
+
         <label className="toggle-switch" aria-label={t('settings.showChangelogOnUpdate')}>
+
           <input type="checkbox" checked={showChangelogOnUpdate} onChange={e => setShowChangelogOnUpdate(e.target.checked)} />
+
           <span className="toggle-track" />
+
         </label>
+
       </div>
+
       <div className="changelog-list">
+
         {versions.slice(0, 3).map(({ version, date, body }) => (
+
           <details key={version} className="changelog-entry" open={version === appVersion}>
+
             <summary className="changelog-summary">
+
               <span className="changelog-version">v{version}</span>
+
               <span className="changelog-date">{date}</span>
+
             </summary>
+
             <div className="changelog-body">
+
               {body.split('\n').map((line, i) => {
+
                 if (line.startsWith('### ')) {
+
                   return <div key={i} className="changelog-h3">{renderInline(line.slice(4))}</div>;
+
                 }
+
                 if (line.startsWith('#### ')) {
+
                   return <div key={i} className="changelog-h4">{renderInline(line.slice(5))}</div>;
+
                 }
+
                 if (line.startsWith('- ')) {
+
                   return <div key={i} className="changelog-item">{renderInline(line.slice(2))}</div>;
+
                 }
+
                 if (line.trim() === '') return null;
+
                 return <div key={i} className="changelog-text">{renderInline(line)}</div>;
+
               })}
+
             </div>
+
           </details>
+
         ))}
+
       </div>
+
     </section>
+
   );
+
 }
+

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5742 +1,2932 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-
 import { version as appVersion } from '../../package.json';
-
 import changelogRaw from '../../CHANGELOG.md?raw';
-
 import { useNavigate, useLocation } from 'react-router-dom';
-
 import {
-
   Wifi, WifiOff, Globe, Music2, Sliders, LogOut, CheckCircle2, FolderOpen,
-
   Palette, Server, Plus, Trash2, Eye, EyeOff, Info, ExternalLink, Shuffle, X, Play, Type, Keyboard, ChevronDown,
-
   GripVertical, PanelLeft, RotateCcw, LayoutGrid, AppWindow, HardDrive, Upload, Download, Waves, Star, Clock, ZoomIn, Sparkles, AlertTriangle, Maximize2, AudioLines, User, Lock
-
 } from 'lucide-react';
-
 import i18n from '../i18n';
-
 import { exportBackup, importBackup } from '../utils/backup';
-
 import { showToast } from '../utils/toast';
-
 import { invoke } from '@tauri-apps/api/core';
-
 import { listen } from '@tauri-apps/api/event';
-
 import { open as openUrl } from '@tauri-apps/plugin-shell';
-
 import { getImageCacheSize, clearImageCache } from '../utils/imageCache';
-
 import { useOfflineStore } from '../store/offlineStore';
-
 import { useHotCacheStore } from '../store/hotCacheStore';
-
 import { lastfmGetToken, lastfmAuthUrl, lastfmGetSession, lastfmGetUserInfo, LastfmUserInfo } from '../api/lastfm';
-
 import LastfmIcon from '../components/LastfmIcon';
-
 import CustomSelect from '../components/CustomSelect';
-
 import ThemePicker, { THEME_GROUPS } from '../components/ThemePicker';
-
 import { useShallow } from 'zustand/react/shallow';
-
 import { useAuthStore, ServerProfile, MIX_MIN_RATING_FILTER_MAX_STARS, type SeekbarStyle, type LyricsSourceId, type LyricsSourceConfig } from '../store/authStore';
-
 import { SeekbarPreview } from '../components/WaveformSeek';
-
 import { IS_LINUX } from '../utils/platform';
-
 import { useThemeStore } from '../store/themeStore';
-
 import { useFontStore, FontId } from '../store/fontStore';
-
 import { useKeybindingsStore, KeyAction, formatBinding, buildInAppBinding } from '../store/keybindingsStore';
-
 import { useGlobalShortcutsStore, GlobalAction, buildGlobalShortcut, formatGlobalShortcut } from '../store/globalShortcutsStore';
-
 import { useSidebarStore, DEFAULT_SIDEBAR_ITEMS, SidebarItemConfig } from '../store/sidebarStore';
-
 import { useHomeStore, HomeSectionId } from '../store/homeStore';
-
 import { useDragDrop, useDragSource } from '../contexts/DragDropContext';
-
 import { ALL_NAV_ITEMS } from '../config/navItems';
-
 import { pingWithCredentials, scheduleInstantMixProbeForServer } from '../api/subsonic';
-
 import { switchActiveServer } from '../utils/switchActiveServer';
-
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
-
 import { Trans, useTranslation } from 'react-i18next';
-
 import Equalizer from '../components/Equalizer';
-
 import StarRating from '../components/StarRating';
-
 import { showAudiomuseNavidromeServerSetting } from '../utils/subsonicServerIdentity';
-
-
 
 const AUDIOBOOK_GENRES_DISPLAY = ['Hörbuch', 'Hoerbuch', 'Hörspiel', 'Hoerspiel', 'Audiobook', 'Audio Book', 'Spoken Word', 'Spokenword', 'Podcast', 'Kapitel', 'Thriller', 'Krimi', 'Speech', 'Fantasy', 'Comedy', 'Literature'];
 
-
-
 const AUDIOMUSE_NV_PLUGIN_URL = 'https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin';
 
-
-
 const CONTRIBUTORS = [
-
   {
-
     github: 'jiezhuo',
-
     since: '1.21',
-
     contributions: [
-
       'Chinese (Simplified) translation',
-
     ],
-
   },
-
   {
-
     github: 'nullobject',
-
     since: '1.22.0',
-
     contributions: [
-
       'Seek debounce & race condition fix (PR #7)',
-
       'Waveform seekbar stability on position update (PR #8)',
-
     ],
-
   },
-
   {
-
     github: 'trbn1',
-
     since: '1.22.0',
-
     contributions: [
-
       'Replay Gain metadata propagation (PR #9)',
-
       'songToTrack() — unified track construction across all sources',
-
     ],
-
   },
-
   {
-
     github: 'nisarg-78',
-
     since: '1.29.0',
-
     contributions: [
-
       'Click-to-seek in synced lyrics (PR #38)',
-
       'Volume scroll wheel on volume slider (PR #38)',
-
       'Lyrics line visual states: active / completed / upcoming (PR #38)',
-
       'Queue auto-scroll to keep upcoming tracks in view; fixed re-renders from currentTime in QueuePanel (PR #115)',
-
     ],
-
   },
-
   {
-
     github: 'JulianNymark',
-
     since: '1.29.0',
-
     contributions: [
-
       'OGG/Vorbis container support via symphonia-format-ogg (PR #42)',
-
       'Themed toast notifications for audio playback errors (PR #43)',
-
       'Human-readable audio error messages (PR #44)',
-
     ],
-
   },
-
   {
-
     github: 'zz5zz',
-
     since: '1.32.0',
-
     contributions: [
-
       'Norwegian (Bokmål) translation (PR #101)',
-
     ],
-
   },
-
   {
-
     github: 'cucadmuh',
-
     since: '1.33.0',
-
     contributions: [
-
       'Russian translation & i18n locale split (PR #106)',
-
       'Russian locale refinements using phrasing from ru2 (PR #113)',
-
       'Gapless manual skip: honor user-initiated play over pre-chained track (PR #119)',
-
       'Hot playback cache — queue prefetch (PR #123)',
-
       'Per-server music folder filter and sidebar library picker (PR #124, PR #125)',
-
       'Richer star ratings, skip threshold, and library filtering (PR #130)',
-
       'Statistics: scope album and song totals to selected music library (PR #138)',
-
       'AudioMuse-AI discovery integration for Navidrome (PR #147)',
-
       'Hot playback cache — eviction budgeting, grace period, and live Audio settings readout (PR #153)',
-
       'Folder Browser: keyboard navigation, context menus, now-playing path emphasis, and adaptive column layout (PR #158)',
-
       'Infinite queue: artist-driven candidates via Top Songs + Similar Songs with random fallback (PR #163)',
-
       'Folder Browser: per-column filter with keyboard flow and Shift+Enter queue append (PR #165)',
-
       'Keybindings: modifier + key chords for in-app shortcuts; fixed seek ±10s units (PR #167)',
-
       'Statistics: genre insights scoped to music library, cached Subsonic fetches, localized duration formatting (PR #144)',
-
       'Audio output device picker: clearer ALSA labels, duplicate disambiguation, system-default mark, live refresh (PR #173)',
-
       'Folder Browser: arrow navigation blocked when modifier keys are held (PR #174)',
-
       'Linux audio output device picker: stable watcher (disable false enumeration-miss resets), canonicalize ALSA name drift, ghost entry for unlisted device (PR #176)',
-
       'Opus audio playback via symphonia-adapter-libopus with bundled libopus (PR #183)',
-
+      'CLI player controls with D-Bus forwarding, shell completions for bash/zsh, library/audio-device/instant-mix CLI commands, active server switcher in header (PR #187)',
     ],
-
   },
-
   {
-
     github: 'kilyabin',
-
     since: '1.34.0',
-
     contributions: [
-
       'Russian locale improvements (PR #107, PR #120)',
-
       'Auto-install script for Debian / RHEL (PR #121)',
-
       'Album cover art in Discord Rich Presence via iTunes API (PR #111)',
-
       'Tiling WM detection: hide custom TitleBar on Hyprland/Sway/i3/etc. (PR #134)',
-
       'Russian translation: lyricsServerFirst settings strings (PR #140)',
-
       'Russian translation refinements (PR #148)',
-
       'Merge Random Mix & Albums into a single Build a Mix hub (PR #155)',
-
       'Fullscreen player: software-rendering performance fixes + portrait toggle & dimming setting (PR #156)',
-
       'Fullscreen player: stop mesh blob and portrait animations in no-compositing mode; remove seekbar box-shadow repaint (PR #175)',
-
     ],
-
   },
-
   {
-
     github: 'kveld9',
-
     since: '1.34.4',
-
     contributions: [
-
       'Spanish (es) translation — 964 strings (PR #159)',
-
       'Column-header sorting for albums & playlists (PR #160)',
-
       'Multi-select for albums, artists & playlists with bulk "Add to Playlist"; collapsible sidebar playlist section; infinite scroll on Artists page; "Remove from Playlist" in context menu (PR #168)',
-
       '3 visual toggles: cover art background, playlist cover photo, show bitrate badge (PR #181)',
-
       '8 community themes (AMOLED Black, Monochrome Dark, Amber Night, Phosphor Green, Midnight Blue, Rose Dark, Sepia Dark, Ice Blue) + waveform live theme update (PR #182)',
-
+      'Favorites redesign: sortable columns, genre filter, age range filter, new columns (PR #184)',
+      'Albums and playlist headers redesign with improved layout and theme integration (PR #186)',
+      'Tracklist column picker overflow fix in AlbumTrackList (PR #188)',
+      'Spotify CSV playlist import (PR #190)',
+      'Context menu for songs in AdvancedSearch and SearchResults (PR #191)',
+      'Tracklist column picker alignment and toggle fix across Favorites and PlaylistDetail (PR #192)',
     ],
-
   },
-
   {
-
     github: 'nisrael',
-
     since: '1.34.0',
-
     contributions: [
-
       'Nightfox.nvim theme group in Open Source Classics (PR #114)',
-
       'Switch reqwest to rustls-tls for cross-platform TLS (PR #112)',
-
       'ICY stream metadata & AzuraCast Now Playing support (PR #146)',
-
     ],
-
   },
-
 ] as const;
-
-
 
 const SPECIAL_THANKS = [
-
   {
-
     github: 'netherguy4',
-
     reason: 'Countless constructive feature ideas and thoughtful feedback',
-
   },
-
 ] as const;
-
-
 
 type Tab = 'general' | 'server' | 'audio' | 'storage' | 'appearance' | 'input' | 'system';
 
-
-
 function AddServerForm({ onSave, onCancel }: { onSave: (data: Omit<ServerProfile, 'id'>) => void; onCancel: () => void }) {
-
   const { t } = useTranslation();
-
   const [form, setForm] = useState({ name: '', url: '', username: '', password: '' });
-
   const [showPass, setShowPass] = useState(false);
 
-
-
   const update = (k: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>
-
     setForm(f => ({ ...f, [k]: e.target.value }));
 
-
-
   return (
-
     <div className="settings-card" style={{ marginTop: '1rem' }}>
-
       <h3 style={{ fontWeight: 600, marginBottom: '1rem', fontSize: '14px' }}>{t('settings.addServerTitle')}</h3>
-
       <div className="form-group" style={{ marginBottom: '0.75rem' }}>
-
         <label style={{ fontSize: 13 }}>{t('settings.serverName')}</label>
-
         <input className="input" type="text" value={form.name} onChange={update('name')} placeholder="My Navidrome" autoComplete="off" />
-
       </div>
-
       <div className="form-group" style={{ marginBottom: '0.75rem' }}>
-
         <label style={{ fontSize: 13 }}>{t('settings.serverUrl')}</label>
-
         <input className="input" type="text" value={form.url} onChange={update('url')} placeholder={t('settings.serverUrlPlaceholder')} autoComplete="off" />
-
       </div>
-
       <div className="form-row" style={{ marginBottom: '0.75rem' }}>
-
         <div className="form-group">
-
           <label style={{ fontSize: 13 }}>{t('settings.serverUsername')}</label>
-
           <input className="input" type="text" value={form.username} onChange={update('username')} placeholder="admin" autoComplete="off" />
-
         </div>
-
         <div className="form-group">
-
           <label style={{ fontSize: 13 }}>{t('settings.serverPassword')}</label>
-
           <div style={{ position: 'relative' }}>
-
             <input
-
               className="input"
-
               type={showPass ? 'text' : 'password'}
-
               value={form.password}
-
               onChange={update('password')}
-
               placeholder="••••••••"
-
               style={{ paddingRight: '2.5rem' }}
-
             />
-
             <button
-
               type="button"
-
               style={{ position: 'absolute', right: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }}
-
               onClick={() => setShowPass(v => !v)}
-
             >
-
               {showPass ? <EyeOff size={14} /> : <Eye size={14} />}
-
             </button>
-
           </div>
-
         </div>
-
       </div>
-
       <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-
         <button className="btn btn-ghost" onClick={onCancel}>{t('common.cancel')}</button>
-
         <button
-
           className="btn btn-primary"
-
           onClick={() => form.url.trim() && onSave({ name: form.name.trim() || form.url.trim(), url: form.url.trim(), username: form.username.trim(), password: form.password })}
-
         >
-
           {t('common.add')}
-
         </button>
-
       </div>
-
     </div>
-
   );
-
 }
-
-
 
 function formatBytes(bytes: number): string {
-
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-
   return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
-
 }
-
-
 
 /** Align hot-cache size slider (step 32 MB) to valid values. */
-
 function snapHotCacheMb(v: number): number {
-
   const x = Math.min(20000, Math.max(32, Math.round(v)));
-
   return Math.round((x - 32) / 32) * 32 + 32;
-
 }
-
-
 
 /** Makes raw ALSA device names more readable on Linux.
-
  *  Values are kept as-is (rodio needs the ALSA name); only the displayed label is cleaned.
-
  *  e.g. "sysdefault:CARD=U192k" → "U192k"
-
  *       "hw:CARD=U192k,DEV=0"   → "U192k (hw · PCM 0)"
-
  *       "hdmi:CARD=NVidia,DEV=1" → "NVidia (HDMI · DEV 1)"  (same DEV as in ALSA string)
-
  *       "iec958:CARD=PCH,DEV=0" → "PCH (S/PDIF)"
-
  *  Names without ALSA prefix (pipewire, pulse, default…) are returned unchanged. */
-
 function formatAudioDeviceLabel(name: string): string {
-
   const cardMatch = name.match(/CARD=([^,]+)/);
-
   if (!cardMatch) return name;
-
   const card = cardMatch[1];
-
   const devM = name.match(/DEV=(\d+)/);
-
   const devNum = devM ? parseInt(devM[1], 10) : null;
-
   const subM = name.match(/SUBDEV=(\d+)/);
-
   const subNum = subM ? parseInt(subM[1], 10) : null;
 
-
-
   if (name.startsWith('iec958:')) return `${card} (S/PDIF)`;
-
   if (name.startsWith('hdmi:')) {
-
     const d = devNum !== null ? devNum : 0;
-
     return `${card} (HDMI · DEV ${d})`;
-
   }
-
   if (name.startsWith('sysdefault:')) {
-
     if (devNum !== null && devNum > 0) return `${card} (default · PCM ${devNum})`;
-
     return card;
-
   }
-
   if (name.startsWith('plughw:')) {
-
     if (devNum !== null) {
-
       const sub = subNum !== null ? ` · sub ${subNum}` : '';
-
       return `${card} (plug · PCM ${devNum}${sub})`;
-
     }
-
     return card;
-
   }
-
   if (name.startsWith('hw:')) {
-
     if (devNum !== null) {
-
       const sub = subNum !== null ? ` · sub ${subNum}` : '';
-
       return `${card} (hw · PCM ${devNum}${sub})`;
-
     }
-
     return `${card} (hw)`;
-
   }
-
   if (name.startsWith('front:')) return `${card} (Front)`;
-
   if (name.startsWith('surround')) return `${card} (${name.split(':')[0]})`;
-
   // Other ALSA iface:card,dev — show plugin + PCM so identical cards differ
-
   const iface = name.split(':')[0];
-
   if (iface && !['default', 'pulse', 'pipewire'].includes(iface)) {
-
     if (devNum !== null) return `${card} (${iface} · PCM ${devNum})`;
-
     return `${card} (${iface})`;
-
   }
-
   return card;
-
 }
-
-
 
 /** Readable tail when two devices still share the same label (rare after formatAudioDeviceLabel). */
-
 function audioDeviceDuplicateHint(raw: string): string {
-
   const cardM = raw.match(/CARD=([^,]+)/);
-
   const devM = raw.match(/DEV=(\d+)/);
-
   const subM = raw.match(/SUBDEV=(\d+)/);
-
   const iface = raw.split(':')[0] || '';
-
   const parts: string[] = [];
-
   if (iface) parts.push(iface);
-
   if (cardM) parts.push(cardM[1]);
-
   if (devM) parts.push(`PCM ${devM[1]}`);
-
   if (subM) parts.push(`sub ${subM[1]}`);
-
   if (parts.length > 1) return parts.join(' · ');
-
   return raw.length > 56 ? `…${raw.slice(-53)}` : raw;
-
 }
-
-
 
 /** When several devices share the same display label, append a disambiguator. */
-
 function disambiguatedAudioDeviceLabel(raw: string, baseLabel: string, duplicateBase: boolean): string {
-
   if (!duplicateBase) return baseLabel;
-
   return `${baseLabel} · ${audioDeviceDuplicateHint(raw)}`;
-
 }
-
-
 
 /** cpal order is arbitrary; sort by readable label, current OS default first. */
-
 function sortAudioDeviceIds(devices: string[], osDefaultDeviceId: string | null): string[] {
-
   return [...devices].sort((a, b) => {
-
     const aDef = osDefaultDeviceId && a === osDefaultDeviceId;
-
     const bDef = osDefaultDeviceId && b === osDefaultDeviceId;
-
     if (aDef !== bDef) return aDef ? -1 : 1;
-
     const la = formatAudioDeviceLabel(a);
-
     const lb = formatAudioDeviceLabel(b);
-
     const byLabel = la.localeCompare(lb, undefined, { sensitivity: 'base' });
-
     if (byLabel !== 0) return byLabel;
-
     return a.localeCompare(b);
-
   });
-
 }
-
-
 
 function buildAudioDeviceSelectOptions(
-
   devices: string[],
-
   defaultLabel: string,
-
   osDefaultDeviceId: string | null,
-
   osDefaultMark: string,
-
   pinnedDevice: string | null,
-
   notInListSuffix: string,
-
 ): { value: string; label: string }[] {
-
   const baseLabels = devices.map(formatAudioDeviceLabel);
-
   const countByBase = new Map<string, number>();
-
   for (const b of baseLabels) countByBase.set(b, (countByBase.get(b) ?? 0) + 1);
-
   const pinned = pinnedDevice?.trim() || null;
-
   const pinnedNotListed = !!(pinned && !devices.includes(pinned));
-
   const ghost: { value: string; label: string }[] = pinnedNotListed
-
     ? (() => {
-
         const base = formatAudioDeviceLabel(pinned);
-
         let label = `${base} · ${notInListSuffix}`;
-
         if (osDefaultDeviceId && pinned === osDefaultDeviceId) label = `${label} · ${osDefaultMark}`;
-
         return [{ value: pinned, label }];
-
       })()
-
     : [];
-
   return [
-
     { value: '', label: defaultLabel },
-
     ...ghost,
-
     ...devices.map((d, i) => {
-
       const base = baseLabels[i];
-
       const dup = (countByBase.get(base) ?? 0) > 1;
-
       let label = disambiguatedAudioDeviceLabel(d, base, dup);
-
       if (osDefaultDeviceId && d === osDefaultDeviceId) label = `${label} · ${osDefaultMark}`;
-
       return { value: d, label };
-
     }),
-
   ];
-
 }
 
-
-
 export default function Settings() {
-
   const auth = useAuthStore();
-
   const theme = useThemeStore();
-
   const fontStore = useFontStore();
-
   const kb = useKeybindingsStore();
-
   const gs = useGlobalShortcutsStore();
-
   const serverId = auth.activeServerId ?? '';
-
   const clearAllOffline = useOfflineStore(s => s.clearAll);
-
   const clearHotCacheDisk = useHotCacheStore(s => s.clearAllDisk);
-
   const hotCacheEntries = useHotCacheStore(s => s.entries);
-
   const [isTilingWm, setIsTilingWm] = useState(false);
 
-
-
   useEffect(() => {
-
     if (!IS_LINUX) return;
-
     invoke<boolean>('is_tiling_wm_cmd').then(setIsTilingWm).catch(() => {});
-
   }, []);
 
-
-
   const hotCacheTrackCount = useMemo(() => {
-
     if (!serverId) return 0;
-
     const prefix = `${serverId}:`;
-
     return Object.keys(hotCacheEntries).filter(k => k.startsWith(prefix)).length;
-
   }, [hotCacheEntries, serverId]);
-
   const [listeningFor, setListeningFor] = useState<KeyAction | null>(null);
-
   const [listeningForGlobal, setListeningForGlobal] = useState<GlobalAction | null>(null);
-
   const navigate = useNavigate();
-
   const { state: routeState } = useLocation();
-
   const { t, i18n } = useTranslation();
 
-
-
   const [activeTab, setActiveTab] = useState<Tab>((routeState as { tab?: Tab } | null)?.tab ?? 'general');
-
   const [connStatus, setConnStatus] = useState<Record<string, 'idle' | 'testing' | 'ok' | 'error'>>({});
-
   const [showAddForm, setShowAddForm] = useState(false);
-
   const [newGenre, setNewGenre] = useState('');
-
   const [lfmState, setLfmState] = useState<'idle' | 'waiting' | 'error'>('idle');
-
   const [lfmPendingToken, setLfmPendingToken] = useState<string | null>(null);
-
   const [lfmError, setLfmError] = useState<string | null>(null);
-
   const [lfmUserInfo, setLfmUserInfo] = useState<LastfmUserInfo | null>(null);
-
   const [imageCacheBytes, setImageCacheBytes] = useState<number | null>(null);
-
   const [offlineCacheBytes, setOfflineCacheBytes] = useState<number | null>(null);
-
   const [hotCacheBytes, setHotCacheBytes] = useState<number | null>(null);
-
   const [audioDevices, setAudioDevices] = useState<string[]>([]);
-
   const [osDefaultAudioDeviceId, setOsDefaultAudioDeviceId] = useState<string | null>(null);
-
   const [deviceSwitching, setDeviceSwitching] = useState(false);
-
   const [devicesLoading, setDevicesLoading] = useState(false);
-
   const [showClearConfirm, setShowClearConfirm] = useState(false);
-
   const [clearing, setClearing] = useState(false);
-
   const [contributorsOpen, setContributorsOpen] = useState(false);
-
-
+  const [fontPickerOpen, setFontPickerOpen] = useState(false);
 
   useEffect(() => {
-
     if (!auth.lastfmSessionKey || !auth.lastfmUsername) { setLfmUserInfo(null); return; }
-
     lastfmGetUserInfo(auth.lastfmUsername, auth.lastfmSessionKey).then(setLfmUserInfo).catch(() => {});
-
   }, [auth.lastfmSessionKey, auth.lastfmUsername]);
 
-
-
   useEffect(() => {
-
     if (activeTab !== 'storage') return;
-
     getImageCacheSize().then(setImageCacheBytes);
-
     invoke<number>('get_offline_cache_size', { customDir: auth.offlineDownloadDir || null }).then(setOfflineCacheBytes).catch(() => setOfflineCacheBytes(0));
-
     invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null }).then(setHotCacheBytes).catch(() => setHotCacheBytes(0));
-
   }, [activeTab, auth.offlineDownloadDir, auth.hotCacheDownloadDir]);
 
-
-
   const refreshAudioDevices = useCallback((opts?: { silent?: boolean }) => {
-
     const silent = !!opts?.silent;
-
     if (!silent) setDevicesLoading(true);
-
     const listP = invoke<string[]>('audio_list_devices').catch((e) => {
-
       console.error(e);
-
       showToast(t('settings.audioOutputDeviceListError'), 5000, 'error');
-
       return [] as string[];
-
     });
-
     const defP = invoke<string | null>('audio_default_output_device_name').catch(() => null);
-
     Promise.all([listP, defP])
-
       .then(async ([devices, osDefault]) => {
-
         let canon: string | null = null;
-
         try {
-
           canon = await invoke<string | null>('audio_canonicalize_selected_device');
-
           if (canon) useAuthStore.getState().setAudioOutputDevice(canon);
-
         } catch {
-
           /* ignore */
-
         }
-
         const finalList = canon
-
           ? await invoke<string[]>('audio_list_devices').catch(() => devices)
-
           : devices;
-
         const defId = osDefault ?? null;
-
         setAudioDevices(sortAudioDeviceIds(finalList, defId));
-
         setOsDefaultAudioDeviceId(defId);
-
       })
-
       .finally(() => {
-
         if (!silent) setDevicesLoading(false);
-
       });
-
   }, [t]);
 
-
-
   // Load available audio output devices when Audio tab opens.
-
   useEffect(() => {
-
     if (activeTab !== 'audio') return;
-
     refreshAudioDevices();
-
   }, [activeTab, refreshAudioDevices]);
-
-
 
   // Keep device list + "current system output" mark in sync when the backend reopens the stream.
-
   useEffect(() => {
-
     if (activeTab !== 'audio') return;
-
     let cancelled = false;
-
     const unlisteners: Array<() => void> = [];
-
     (async () => {
-
       for (const ev of ['audio:device-changed', 'audio:device-reset'] as const) {
-
         const u = await listen(ev, () => {
-
           if (!cancelled) refreshAudioDevices({ silent: true });
-
         });
-
         if (cancelled) {
-
           u();
-
           return;
-
         }
-
         unlisteners.push(u);
-
       }
-
     })();
-
     return () => {
-
       cancelled = true;
-
       for (const u of unlisteners) u();
-
     };
-
   }, [activeTab, refreshAudioDevices]);
 
-
-
   /** Live disk usage for hot cache while Audio settings are open (interval + refresh when index changes). */
-
   useEffect(() => {
-
     if (activeTab !== 'audio') return;
-
     const customDir = auth.hotCacheDownloadDir || null;
-
     const refresh = () => {
-
       invoke<number>('get_hot_cache_size', { customDir })
-
         .then(setHotCacheBytes)
-
         .catch(() => setHotCacheBytes(0));
-
     };
-
     refresh();
-
     if (!auth.hotCacheEnabled) return;
-
     const interval = window.setInterval(refresh, 2000);
-
     return () => window.clearInterval(interval);
-
   }, [activeTab, auth.hotCacheEnabled, auth.hotCacheDownloadDir]);
 
-
-
   useEffect(() => {
-
     if (activeTab !== 'audio' || !auth.hotCacheEnabled) return;
-
     const t = window.setTimeout(() => {
-
       invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null })
-
         .then(setHotCacheBytes)
-
         .catch(() => setHotCacheBytes(0));
-
     }, 400);
-
     return () => window.clearTimeout(t);
-
   }, [hotCacheEntries, activeTab, auth.hotCacheEnabled, auth.hotCacheDownloadDir]);
 
-
-
   const handleClearCache = useCallback(async () => {
-
     setClearing(true);
-
     await clearImageCache();
-
     await clearAllOffline(serverId);
-
     const [imgBytes, offBytes] = await Promise.all([
-
       getImageCacheSize(),
-
       invoke<number>('get_offline_cache_size', { customDir: auth.offlineDownloadDir || null }).catch(() => 0),
-
     ]);
-
     setImageCacheBytes(imgBytes);
-
     setOfflineCacheBytes(offBytes);
-
     setShowClearConfirm(false);
-
     setClearing(false);
-
   }, [clearAllOffline, serverId]);
 
-
-
   const startLastfmConnect = useCallback(async () => {
-
     setLfmError(null);
-
     let token: string;
-
     try {
-
       token = await lastfmGetToken();
-
       setLfmPendingToken(token);
-
       setLfmState('waiting');
-
       await openUrl(lastfmAuthUrl(token));
-
     } catch (e: any) {
-
       setLfmError(e.message ?? 'Unknown error');
-
       setLfmState('error');
-
       return;
-
     }
-
-
 
     // Poll every 2 s until the user authorises or we time out (2 min)
-
     const deadline = Date.now() + 120_000;
-
     const poll = async () => {
-
       if (Date.now() > deadline) {
-
         setLfmState('error');
-
         setLfmError('Timed out — please try again.');
-
         setLfmPendingToken(null);
-
         return;
-
       }
-
       try {
-
         const { key, name } = await lastfmGetSession(token);
-
         auth.connectLastfm(key, name);
-
         setLfmState('idle');
-
         setLfmPendingToken(null);
-
       } catch (e: any) {
-
         // Error 14 = not yet authorised, keep polling
-
         if (e.message?.includes('14')) {
-
           setTimeout(poll, 2000);
-
         } else {
-
           setLfmState('error');
-
           setLfmError(e.message ?? 'Unknown error');
-
           setLfmPendingToken(null);
-
         }
-
       }
-
     };
-
     setTimeout(poll, 2000);
-
   }, [auth]);
 
-
-
   const testConnection = async (server: ServerProfile) => {
-
     setConnStatus(s => ({ ...s, [server.id]: 'testing' }));
-
     try {
-
       const ping = await pingWithCredentials(server.url, server.username, server.password);
-
       if (ping.ok) {
-
         const identity = {
-
           type: ping.type,
-
           serverVersion: ping.serverVersion,
-
           openSubsonic: ping.openSubsonic,
-
         };
-
         auth.setSubsonicServerIdentity(server.id, identity);
-
         scheduleInstantMixProbeForServer(server.id, server.url, server.username, server.password, identity);
-
       }
-
       setConnStatus(s => ({ ...s, [server.id]: ping.ok ? 'ok' : 'error' }));
-
     } catch {
-
       setConnStatus(s => ({ ...s, [server.id]: 'error' }));
-
     }
-
   };
-
-
 
   const switchToServer = async (server: ServerProfile) => {
-
     setConnStatus(s => ({ ...s, [server.id]: 'testing' }));
-
     const ok = await switchActiveServer(server);
-
     if (ok) {
-
       setConnStatus(s => ({ ...s, [server.id]: 'ok' }));
-
       navigate('/');
-
     } else {
-
       setConnStatus(s => ({ ...s, [server.id]: 'error' }));
-
     }
-
   };
-
-
 
   const deleteServer = (server: ServerProfile) => {
-
     if (confirm(t('settings.confirmDeleteServer', { name: server.name || server.url }))) {
-
       auth.removeServer(server.id);
-
     }
-
   };
-
-
 
   const handleAddServer = async (data: Omit<ServerProfile, 'id'>) => {
-
     setShowAddForm(false);
-
     const tempId = '_new';
-
     setConnStatus(s => ({ ...s, [tempId]: 'testing' }));
-
     try {
-
       const ping = await pingWithCredentials(data.url, data.username, data.password);
-
       if (ping.ok) {
-
         const id = auth.addServer(data);
-
         const identity = {
-
           type: ping.type,
-
           serverVersion: ping.serverVersion,
-
           openSubsonic: ping.openSubsonic,
-
         };
-
         auth.setSubsonicServerIdentity(id, identity);
-
         scheduleInstantMixProbeForServer(id, data.url, data.username, data.password, identity);
-
         auth.setActiveServer(id);
-
         auth.setLoggedIn(true);
-
         setConnStatus(s => ({ ...s, [id]: 'ok' }));
-
       } else {
-
         setConnStatus(s => ({ ...s, [tempId]: 'error' }));
-
       }
-
     } catch {
-
       setConnStatus(s => ({ ...s, [tempId]: 'error' }));
-
     }
-
   };
-
-
 
   const handleLogout = () => {
-
     auth.logout();
-
     navigate('/login');
-
   };
-
-
 
   const pickOfflineDir = async () => {
-
     const selected = await openDialog({ directory: true, multiple: false, title: t('settings.offlineDirChange') });
-
     if (selected && typeof selected === 'string') {
-
       auth.setOfflineDownloadDir(selected);
-
     }
-
   };
-
-
 
   const pickHotCacheDir = async () => {
-
     const selected = await openDialog({ directory: true, multiple: false, title: t('settings.hotCacheDirChange') });
-
     if (selected && typeof selected === 'string') {
-
       auth.setHotCacheDownloadDir(selected);
-
       useHotCacheStore.setState({ entries: {} });
-
       invoke<number>('get_hot_cache_size', { customDir: selected }).then(setHotCacheBytes).catch(() => setHotCacheBytes(0));
-
     }
-
   };
-
-
 
   const pickDownloadFolder = async () => {
-
     const selected = await openDialog({ directory: true, multiple: false, title: t('settings.pickFolderTitle') });
-
     if (selected && typeof selected === 'string') {
-
       auth.setDownloadFolder(selected);
-
     }
-
   };
 
-
-
   const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
-
     { id: 'general',    label: t('settings.tabGeneral'),    icon: <AppWindow size={15} /> },
-
     { id: 'server',     label: t('settings.tabServer'),     icon: <Server size={15} /> },
-
     { id: 'audio',      label: t('settings.tabAudio'),      icon: <Music2 size={15} /> },
-
     { id: 'storage',    label: t('settings.tabStorage'),    icon: <HardDrive size={15} /> },
-
     { id: 'appearance', label: t('settings.tabAppearance'), icon: <Palette size={15} /> },
-
     { id: 'input',      label: t('settings.tabInput'),      icon: <Keyboard size={15} /> },
-
     { id: 'system',     label: t('settings.tabSystem'),     icon: <Info size={15} /> },
-
   ];
 
-
-
   return (
-
     <div className="content-body animate-fade-in">
-
       <h1 className="page-title" style={{ marginBottom: '1.5rem' }}>{t('settings.title')}</h1>
 
-
-
       {/* Tab navigation */}
-
       <nav className="settings-tabs" aria-label="Settings navigation">
-
         {tabs.map(tab => (
-
           <button
-
             key={tab.id}
-
             className={`settings-tab ${activeTab === tab.id ? 'active' : ''}`}
-
             onClick={() => setActiveTab(tab.id)}
-
           >
-
             {tab.icon}
-
             {tab.label}
-
           </button>
-
         ))}
-
       </nav>
 
-
-
       {/* ── Audio ────────────────────────────────────────────────────────────── */}
-
       {activeTab === 'audio' && (
-
         <>
-
           {/* Audio Output Device */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <AudioLines size={18} />
-
               <h2>{t('settings.audioOutputDevice')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '0.75rem' }}>
-
                 {t('settings.audioOutputDeviceDesc')}
-
               </div>
-
               <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-
                 <CustomSelect
-
                   style={{ flex: 1 }}
-
                   value={auth.audioOutputDevice ?? ''}
-
                   disabled={deviceSwitching || devicesLoading}
-
                   onChange={async (val) => {
-
                     const device = val || null;
-
                     setDeviceSwitching(true);
-
                     try {
-
                       await invoke('audio_set_device', { deviceName: device });
-
                       auth.setAudioOutputDevice(device);
-
                     } catch { /* device open failed — don't persist */ }
-
                     setDeviceSwitching(false);
-
                   }}
-
                   options={buildAudioDeviceSelectOptions(
-
                     audioDevices,
-
                     t('settings.audioOutputDeviceDefault'),
-
                     osDefaultAudioDeviceId,
-
                     t('settings.audioOutputDeviceOsDefaultNow'),
-
                     auth.audioOutputDevice,
-
                     t('settings.audioOutputDeviceNotInCurrentList'),
-
                   )}
-
                 />
-
                 <button
-
                   className="icon-btn"
-
                   onClick={() => refreshAudioDevices()}
-
                   disabled={devicesLoading || deviceSwitching}
-
                   data-tooltip={t('settings.audioOutputDeviceRefresh')}
-
                 >
-
                   <RotateCcw size={15} className={devicesLoading ? 'spin' : ''} />
-
                 </button>
-
               </div>
-
             </div>
-
           </section>
-
-
 
           {/* Native Hi-Res Playback */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Waves size={18} />
-
               <h2>{t('settings.hiResTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.hiResEnabled')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.hiResDesc')}</div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.hiResEnabled')}>
-
                   <input
-
                     type="checkbox"
-
                     checked={auth.enableHiRes}
-
                     onChange={e => auth.setEnableHiRes(e.target.checked)}
-
                     id="hires-enabled-toggle"
-
                   />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
             </div>
-
           </section>
-
-
 
           {/* Equalizer */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Sliders size={18} />
-
               <h2>{t('settings.eqTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <Equalizer />
-
             </div>
-
           </section>
-
-
 
           {/* Replay Gain + Crossfade + Gapless */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Music2 size={18} />
-
               <h2>{t('settings.playbackTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               {/* Replay Gain */}
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.replayGain')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.replayGainDesc')}</div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.replayGain')}>
-
                   <input type="checkbox" checked={auth.replayGainEnabled} onChange={e => auth.setReplayGainEnabled(e.target.checked)} id="replay-gain-toggle" />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               {auth.replayGainEnabled && (
-
                 <div style={{ paddingLeft: '1rem', marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-
                   <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{t('settings.replayGainMode')}:</span>
-
                   <button
-
                     className={`btn ${auth.replayGainMode === 'track' ? 'btn-primary' : 'btn-ghost'}`}
-
                     style={{ fontSize: 12, padding: '3px 12px' }}
-
                     onClick={() => auth.setReplayGainMode('track')}
-
                   >
-
                     {t('settings.replayGainTrack')}
-
                   </button>
-
                   <button
-
                     className={`btn ${auth.replayGainMode === 'album' ? 'btn-primary' : 'btn-ghost'}`}
-
                     style={{ fontSize: 12, padding: '3px 12px' }}
-
                     onClick={() => auth.setReplayGainMode('album')}
-
                   >
-
                     {t('settings.replayGainAlbum')}
-
                   </button>
-
                 </div>
-
               )}
-
               {auth.replayGainEnabled && (
-
                 <div style={{ paddingLeft: '1rem', marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
-
                   <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-
                     <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 160 }}>
-
                       {t('settings.replayGainPreGain')}
-
                     </span>
-
                     <input
-
                       type="range" min={0} max={6} step={0.5}
-
                       value={auth.replayGainPreGainDb}
-
                       onChange={e => auth.setReplayGainPreGainDb(Number(e.target.value))}
-
                       style={{ flex: 1, maxWidth: 160 }}
-
                     />
-
                     <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 40, textAlign: 'right' }}>
-
                       {auth.replayGainPreGainDb > 0 ? `+${auth.replayGainPreGainDb}` : auth.replayGainPreGainDb} dB
-
                     </span>
-
                   </div>
-
                   <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-
                     <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 160 }}>
-
                       {t('settings.replayGainFallback')}
-
                     </span>
-
                     <input
-
                       type="range" min={-6} max={0} step={0.5}
-
                       value={auth.replayGainFallbackDb}
-
                       onChange={e => auth.setReplayGainFallbackDb(Number(e.target.value))}
-
                       style={{ flex: 1, maxWidth: 160 }}
-
                     />
-
                     <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 40, textAlign: 'right' }}>
-
                       {auth.replayGainFallbackDb > 0 ? `+${auth.replayGainFallbackDb}` : auth.replayGainFallbackDb} dB
-
                     </span>
-
                   </div>
-
                 </div>
-
               )}
-
-
 
               <div className="divider" />
-
-
 
               {/* Crossfade */}
-
               <div className="settings-toggle-row" style={auth.gaplessEnabled ? { opacity: 0.45, pointerEvents: 'none' } : undefined}>
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>
-
                     {t('settings.crossfade')}
-
                   </div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
-
                     {auth.gaplessEnabled ? t('settings.notWithGapless') : t('settings.crossfadeDesc')}
-
                   </div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.crossfade')}>
-
                   <input type="checkbox" checked={auth.crossfadeEnabled} disabled={auth.gaplessEnabled}
-
                     onChange={e => { auth.setGaplessEnabled(false); auth.setCrossfadeEnabled(e.target.checked); }} id="crossfade-toggle" />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               {auth.crossfadeEnabled && !auth.gaplessEnabled && (
-
                 <div style={{ paddingLeft: '1rem', marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-
                   <input
-
                     type="range"
-
                     min={0.1}
-
                     max={10}
-
                     step={0.1}
-
                     value={auth.crossfadeSecs}
-
                     onChange={e => auth.setCrossfadeSecs(parseFloat(e.target.value))}
-
                     style={{ width: 120 }}
-
                     id="crossfade-secs-slider"
-
                   />
-
                   <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 36 }}>
-
                     {t('settings.crossfadeSecs', { n: auth.crossfadeSecs.toFixed(1) })}
-
                   </span>
-
                 </div>
-
               )}
 
-
-
               <div className="divider" />
-
-
 
               {/* Gapless */}
-
               <div className="settings-toggle-row" style={auth.crossfadeEnabled ? { opacity: 0.45, pointerEvents: 'none' } : undefined}>
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>
-
                     {t('settings.gapless')}
-
                   </div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
-
                     {auth.crossfadeEnabled ? t('settings.notWithCrossfade') : t('settings.gaplessDesc')}
-
                   </div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.gapless')}>
-
                   <input type="checkbox" checked={auth.gaplessEnabled} disabled={auth.crossfadeEnabled}
-
                     onChange={e => { auth.setCrossfadeEnabled(false); auth.setGaplessEnabled(e.target.checked); }} id="gapless-toggle" />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
             </div>
-
           </section>
 
-
-
           {/* Next Track Buffering */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Download size={18} />
-
               <h2>{t('settings.nextTrackBufferingTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: '0.75rem' }}>
-
                 {t('settings.preloadHotCacheMutualExclusive')}
-
               </div>
-
-
 
               {/* Preload mode */}
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.preloadMode')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.preloadModeDesc')}</div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.preloadMode')}>
-
                   <input
-
                     type="checkbox"
-
                     checked={auth.preloadMode !== 'off'}
-
                     onChange={e => {
-
                       if (e.target.checked) {
-
                         auth.setPreloadMode('balanced');
-
                         if (auth.hotCacheEnabled) auth.setHotCacheEnabled(false);
-
                       } else {
-
                         auth.setPreloadMode('off');
-
                       }
-
                     }}
-
                   />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               {auth.preloadMode !== 'off' && (
-
                 <>
-
                   <div style={{ paddingLeft: '1rem', marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-
                     {(['balanced', 'early', 'custom'] as const).map(mode => (
-
                       <button
-
                         key={mode}
-
                         className={`btn ${auth.preloadMode === mode ? 'btn-primary' : 'btn-surface'}`}
-
                         style={{ fontSize: 12, padding: '3px 12px' }}
-
                         onClick={() => auth.setPreloadMode(mode)}
-
                       >
-
                         {t(`settings.preload${mode.charAt(0).toUpperCase() + mode.slice(1)}` as any)}
-
                       </button>
-
                     ))}
-
                   </div>
-
                   {auth.preloadMode === 'custom' && (
-
                     <div style={{ paddingLeft: '1rem', marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-
                       <input
-
                         type="range"
-
                         min={5} max={120} step={5}
-
                         value={auth.preloadCustomSeconds}
-
                         onChange={e => auth.setPreloadCustomSeconds(parseInt(e.target.value))}
-
                         style={{ width: 120 }}
-
                       />
-
                       <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 36 }}>
-
                         {t('settings.preloadCustomSeconds', { n: auth.preloadCustomSeconds })}
-
                       </span>
-
                     </div>
-
                   )}
-
                 </>
-
               )}
-
-
 
               <div className="divider" />
 
-
-
               {/* Hot Cache */}
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.hotCacheTitle')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.hotCacheDisclaimer')}</div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.hotCacheEnabled')}>
-
                   <input
-
                     type="checkbox"
-
                     checked={auth.hotCacheEnabled}
-
                     onChange={async e => {
-
                       const enabled = e.target.checked;
-
                       if (!enabled) {
-
                         await clearHotCacheDisk(auth.hotCacheDownloadDir || null);
-
                         setHotCacheBytes(0);
-
                         auth.setHotCacheEnabled(false);
-
                       } else {
-
                         auth.setHotCacheEnabled(true);
-
                         if (auth.preloadMode !== 'off') auth.setPreloadMode('off');
-
                         invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null })
-
                           .then(setHotCacheBytes)
-
                           .catch(() => setHotCacheBytes(0));
-
                       }
-
                     }}
-
                     id="hot-cache-enabled-toggle"
-
                   />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
-
 
               {auth.hotCacheEnabled && (
-
                 <div style={{ marginTop: '1.25rem' }}>
-
                   <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-
                     <input
-
                       className="input"
-
                       type="text"
-
                       readOnly
-
                       value={auth.hotCacheDownloadDir || t('settings.hotCacheDirDefault')}
-
                       style={{ flex: 1, fontSize: 13, color: auth.hotCacheDownloadDir ? 'var(--text-primary)' : 'var(--text-muted)', cursor: 'default' }}
-
                     />
-
                     {auth.hotCacheDownloadDir && (
-
                       <button
-
                         type="button"
-
                         className="btn btn-ghost"
-
                         onClick={() => {
-
                           auth.setHotCacheDownloadDir('');
-
                           useHotCacheStore.setState({ entries: {} });
-
                           invoke<number>('get_hot_cache_size', { customDir: null }).then(setHotCacheBytes).catch(() => setHotCacheBytes(0));
-
                         }}
-
                         data-tooltip={t('settings.hotCacheDirClear')}
-
                         style={{ color: 'var(--text-muted)', flexShrink: 0 }}
-
                       >
-
                         <X size={16} />
-
                       </button>
-
                     )}
-
                     <button type="button" className="btn btn-surface" onClick={pickHotCacheDir} style={{ flexShrink: 0 }}>
-
                       <FolderOpen size={16} /> {t('settings.hotCacheDirChange')}
-
                     </button>
-
                   </div>
-
                   {auth.hotCacheDownloadDir && (
-
                     <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 8, lineHeight: 1.4 }}>
-
                       {t('settings.hotCacheDirHint')}
-
                     </div>
-
                   )}
 
-
-
                   <div style={{ borderTop: '1px solid var(--border)', margin: '16px 0' }} />
-
-
 
                   <div style={{ fontSize: 12, marginBottom: 12, display: 'flex', flexDirection: 'column', gap: 3 }}>
-
                     <div style={{ color: 'var(--text-secondary)' }}>
-
                       <span style={{ color: 'var(--text-muted)', marginRight: 4 }}>{t('settings.cacheUsedHot')}</span>
-
                       {hotCacheBytes !== null ? formatBytes(hotCacheBytes) : '…'}
-
                     </div>
-
                     <div style={{ color: 'var(--text-secondary)' }}>
-
                       <span style={{ color: 'var(--text-muted)', marginRight: 4 }}>{t('settings.hotCacheTrackCount')}</span>
-
                       {hotCacheTrackCount}
-
                     </div>
-
                   </div>
-
-
 
                   <div>
-
                     <div style={{ fontWeight: 500, marginBottom: 6 }}>{t('settings.hotCacheMaxMb')}</div>
-
                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-
                       <input type="range" min={32} max={20000} step={32} value={snapHotCacheMb(auth.hotCacheMaxMb)} onChange={e => auth.setHotCacheMaxMb(parseInt(e.target.value, 10))} style={{ width: 140 }} id="hot-cache-max-mb-slider" />
-
                       <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 72 }}>{snapHotCacheMb(auth.hotCacheMaxMb)} MB</span>
-
                     </div>
-
                   </div>
-
                   <div style={{ marginTop: '0.75rem' }}>
-
                     <div style={{ fontWeight: 500, marginBottom: 6 }}>{t('settings.hotCacheDebounce')}</div>
-
                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-
                       <input type="range" min={0} max={600} step={1} value={Math.min(600, Math.max(0, auth.hotCacheDebounceSec))} onChange={e => auth.setHotCacheDebounceSec(parseInt(e.target.value, 10))} style={{ width: 140 }} id="hot-cache-debounce-slider" />
-
                       <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 100 }}>
-
                         {Math.min(600, Math.max(0, auth.hotCacheDebounceSec)) === 0
-
                           ? t('settings.hotCacheDebounceImmediate')
-
                           : t('settings.hotCacheDebounceSeconds', { n: Math.min(600, Math.max(0, auth.hotCacheDebounceSec)) })}
-
                       </span>
-
                     </div>
-
                   </div>
-
-
 
                   <div style={{ borderTop: '1px solid var(--border)', margin: '16px 0' }} />
-
                   <button
-
                     type="button"
-
                     className="btn btn-ghost"
-
                     style={{ fontSize: 13 }}
-
                     onClick={async () => {
-
                       await clearHotCacheDisk(auth.hotCacheDownloadDir || null);
-
                       const b = await invoke<number>('get_hot_cache_size', { customDir: auth.hotCacheDownloadDir || null }).catch(() => 0);
-
                       setHotCacheBytes(b);
-
                     }}
-
                   >
-
                     <Trash2 size={14} /> {t('settings.hotCacheClearBtn')}
-
                   </button>
-
                 </div>
-
               )}
 
-
-
             </div>
-
           </section>
-
-
 
         </>
-
       )}
 
-
-
       {/* ── General ──────────────────────────────────────────────────────────── */}
-
       {activeTab === 'general' && (
-
         <>
-
           {/* App behaviour */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <AppWindow size={18} />
-
               <h2>{t('settings.behavior')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.showTrayIcon')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.showTrayIconDesc')}</div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.showTrayIcon')}>
-
                   <input type="checkbox" checked={auth.showTrayIcon} onChange={e => auth.setShowTrayIcon(e.target.checked)} />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               <div className="settings-section-divider" />
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.minimizeToTray')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.minimizeToTrayDesc')}</div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.minimizeToTray')}>
-
                   <input type="checkbox" checked={auth.minimizeToTray} onChange={e => auth.setMinimizeToTray(e.target.checked)} />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               {IS_LINUX && !isTilingWm && (
-
                 <>
-
                   <div className="settings-section-divider" />
-
                   <div className="settings-toggle-row">
-
                     <div>
-
                       <div style={{ fontWeight: 500 }}>{t('settings.useCustomTitlebar')}</div>
-
                       <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.useCustomTitlebarDesc')}</div>
-
                     </div>
-
                     <label className="toggle-switch" aria-label={t('settings.useCustomTitlebar')}>
-
                       <input type="checkbox" checked={auth.useCustomTitlebar} onChange={e => auth.setUseCustomTitlebar(e.target.checked)} />
-
                       <span className="toggle-track" />
-
                     </label>
-
                   </div>
-
                 </>
-
               )}
-
               <div className="settings-section-divider" />
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.showArtistImages')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.showArtistImagesDesc')}</div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.showArtistImages')}>
-
                   <input type="checkbox" checked={auth.showArtistImages} onChange={e => auth.setShowArtistImages(e.target.checked)} />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               <div className="settings-section-divider" />
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.discordRichPresence')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.discordRichPresenceDesc')}</div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.discordRichPresence')}>
-
                   <input type="checkbox" checked={auth.discordRichPresence} onChange={e => auth.setDiscordRichPresence(e.target.checked)} />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               {auth.discordRichPresence && (
-
                 <>
-
                   <div className="settings-section-divider" />
-
                   <div className="settings-toggle-row" style={{ paddingLeft: 16 }}>
-
                     <div>
-
                       <div style={{ fontWeight: 500 }}>{t('settings.discordAppleCovers')}</div>
-
                       <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.discordAppleCoversDesc')}</div>
-
                     </div>
-
                     <label className="toggle-switch" aria-label={t('settings.discordAppleCovers')}>
-
                       <input type="checkbox" checked={auth.enableAppleMusicCoversDiscord} onChange={e => auth.setEnableAppleMusicCoversDiscord(e.target.checked)} />
-
                       <span className="toggle-track" />
-
                     </label>
-
                   </div>
-
                   <div className="settings-section-divider" />
-
                   <div style={{ paddingLeft: 16, paddingTop: 8, paddingBottom: 8 }}>
-
                     <div style={{ fontWeight: 500, fontSize: 13, marginBottom: 8 }}>{t('settings.discordTemplates')}</div>
-
                     <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 12 }}>{t('settings.discordTemplatesDesc')}</div>
-
                     <div className="form-group" style={{ marginBottom: '0.75rem' }}>
-
                       <label style={{ fontSize: 12 }}>{t('settings.discordTemplateDetails')}</label>
-
                       <input
-
                         className="input"
-
                         type="text"
-
                         value={auth.discordTemplateDetails}
-
                         onChange={e => auth.setDiscordTemplateDetails(e.target.value)}
-
                         placeholder="{artist} - {title}"
-
                       />
-
                     </div>
-
                     <div className="form-group" style={{ marginBottom: '0.75rem' }}>
-
                       <label style={{ fontSize: 12 }}>{t('settings.discordTemplateState')}</label>
-
                       <input
-
                         className="input"
-
                         type="text"
-
                         value={auth.discordTemplateState}
-
                         onChange={e => auth.setDiscordTemplateState(e.target.value)}
-
                         placeholder="{album}"
-
                       />
-
                     </div>
-
                     <div className="form-group">
-
                       <label style={{ fontSize: 12 }}>{t('settings.discordTemplateLargeText')}</label>
-
                       <input
-
                         className="input"
-
                         type="text"
-
                         value={auth.discordTemplateLargeText}
-
                         onChange={e => auth.setDiscordTemplateLargeText(e.target.value)}
-
                         placeholder="{album}"
-
                       />
-
                     </div>
-
                   </div>
-
                 </>
-
               )}
-
               <div className="settings-section-divider" />
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.nowPlayingEnabled')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.nowPlayingEnabledDesc')}</div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.nowPlayingEnabled')}>
-
                   <input type="checkbox" checked={auth.nowPlayingEnabled} onChange={e => auth.setNowPlayingEnabled(e.target.checked)} />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
             </div>
-
           </section>
 
-
-
           {/* Lyrics Sources */}
-
           <LyricsSourcesCustomizer />
 
-
-
           {/* Random Mix */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Shuffle size={18} />
-
               <h2>{t('settings.randomMixTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: '1rem', lineHeight: 1.5 }}>
-
                 {t('settings.randomMixBlacklistDesc')}
-
               </p>
 
-
-
               <div style={{ fontSize: 13, fontWeight: 500, marginBottom: '0.5rem' }}>{t('settings.randomMixBlacklistTitle')}</div>
-
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginBottom: '0.75rem', minHeight: 32 }}>
-
                 {auth.customGenreBlacklist.length === 0 ? (
-
                   <span style={{ fontSize: 12, color: 'var(--text-muted)', alignSelf: 'center' }}>{t('settings.randomMixBlacklistEmpty')}</span>
-
                 ) : (
-
                   auth.customGenreBlacklist.map(genre => (
-
                     <span key={genre} style={{
-
                       display: 'inline-flex', alignItems: 'center', gap: 4,
-
                       background: 'color-mix(in srgb, var(--accent) 15%, transparent)',
-
                       color: 'var(--accent)', borderRadius: 'var(--radius-sm)',
-
                       padding: '2px 8px', fontSize: 12, fontWeight: 500,
-
                     }}>
-
                       {genre}
-
                       <button
-
                         style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', padding: 0, lineHeight: 1, fontSize: 14 }}
-
                         onClick={() => auth.setCustomGenreBlacklist(auth.customGenreBlacklist.filter(g => g !== genre))}
-
                         aria-label={`Remove ${genre}`}
-
                       >×</button>
-
                     </span>
-
                   ))
-
                 )}
-
               </div>
-
-
 
               <div style={{ display: 'flex', gap: '0.5rem', maxWidth: 400 }}>
-
                 <input
-
                   className="input"
-
                   type="text"
-
                   value={newGenre}
-
                   onChange={e => setNewGenre(e.target.value)}
-
                   onKeyDown={e => {
-
                     if (e.key === 'Enter' && newGenre.trim()) {
-
                       const trimmed = newGenre.trim();
-
                       if (!auth.customGenreBlacklist.includes(trimmed)) {
-
                         auth.setCustomGenreBlacklist([...auth.customGenreBlacklist, trimmed]);
-
                       }
-
                       setNewGenre('');
-
                     }
-
                   }}
-
                   placeholder={t('settings.randomMixBlacklistPlaceholder')}
-
                   style={{ fontSize: 13 }}
-
                 />
-
                 <button
-
                   className="btn btn-ghost"
-
                   onClick={() => {
-
                     const trimmed = newGenre.trim();
-
                     if (trimmed && !auth.customGenreBlacklist.includes(trimmed)) {
-
                       auth.setCustomGenreBlacklist([...auth.customGenreBlacklist, trimmed]);
-
                     }
-
                     setNewGenre('');
-
                   }}
-
                   disabled={!newGenre.trim()}
-
                 >
-
                   {t('settings.randomMixBlacklistAdd')}
-
                 </button>
-
               </div>
-
-
 
               <div className="divider" style={{ margin: '1rem 0' }} />
 
-
-
               <div style={{ fontSize: 13, fontWeight: 500, marginBottom: '0.5rem', color: 'var(--text-muted)' }}>{t('settings.randomMixHardcodedTitle')}</div>
-
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
-
                 {AUDIOBOOK_GENRES_DISPLAY.map(genre => (
-
                   <span key={genre} className="genre-keyword-badge" style={{
-
                     display: 'inline-flex', alignItems: 'center',
-
                     background: 'var(--bg-hover)', color: 'var(--text-muted)',
-
                     borderRadius: 'var(--radius-sm)', padding: '2px 8px', fontSize: 12,
-
                   }}>
-
                     {genre}
-
                   </span>
-
                 ))}
-
               </div>
-
             </div>
-
           </section>
 
-
-
           {/* Ratings (single block under Random Mix) */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Star size={18} />
-
               <h2>{t('settings.ratingsSectionTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.ratingsSkipStarTitle')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.ratingsSkipStarDesc')}</div>
-
                 </div>
-
                 <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0 }}>
-
                   {auth.skipStarOnManualSkipsEnabled && (
-
                     <>
-
                       <label htmlFor="settings-skip-star-threshold" style={{ fontSize: 13, color: 'var(--text-secondary)', whiteSpace: 'nowrap' }}>
-
                         {t('settings.ratingsSkipStarThresholdLabel')}
-
                       </label>
-
                       <input
-
                         id="settings-skip-star-threshold"
-
                         className="input"
-
                         type="number"
-
                         min={1}
-
                         max={99}
-
                         value={auth.skipStarManualSkipThreshold}
-
                         onChange={e => auth.setSkipStarManualSkipThreshold(Number(e.target.value))}
-
                         style={{ width: 72, padding: '6px 10px', fontSize: 13 }}
-
                         aria-label={t('settings.ratingsSkipStarThresholdLabel')}
-
                       />
-
                     </>
-
                   )}
-
                   <label className="toggle-switch" aria-label={t('settings.ratingsSkipStarTitle')}>
-
                     <input
-
                       type="checkbox"
-
                       checked={auth.skipStarOnManualSkipsEnabled}
-
                       onChange={e => auth.setSkipStarOnManualSkipsEnabled(e.target.checked)}
-
                     />
-
                     <span className="toggle-track" />
-
                   </label>
-
                 </div>
-
               </div>
-
-
 
               <div className="settings-section-divider" />
 
-
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.ratingsMixFilterTitle')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
-
                     {t('settings.ratingsMixFilterDesc', {
-
                       mix: t('sidebar.randomMix'),
-
                       albums: t('sidebar.randomAlbums'),
-
                     })}
-
                   </div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.ratingsMixFilterTitle')}>
-
                   <input
-
                     type="checkbox"
-
                     checked={auth.mixMinRatingFilterEnabled}
-
                     onChange={e => auth.setMixMinRatingFilterEnabled(e.target.checked)}
-
                   />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               {auth.mixMinRatingFilterEnabled && (
-
                 <>
-
                   <div className="settings-section-divider" />
-
                   <div
-
                     style={{
-
                       display: 'grid',
-
                       gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-
                       gap: '1rem 0.75rem',
-
                       alignItems: 'start',
-
                     }}
-
                   >
-
                     {([
-
                       { key: 'song', label: t('settings.ratingsMixMinSong'), value: auth.mixMinRatingSong, set: auth.setMixMinRatingSong },
-
                       { key: 'album', label: t('settings.ratingsMixMinAlbum'), value: auth.mixMinRatingAlbum, set: auth.setMixMinRatingAlbum },
-
                       { key: 'artist', label: t('settings.ratingsMixMinArtist'), value: auth.mixMinRatingArtist, set: auth.setMixMinRatingArtist },
-
                     ] as const).map(row => (
-
                       <div
-
                         key={row.key}
-
                         style={{
-
                           display: 'flex',
-
                           flexDirection: 'column',
-
                           alignItems: 'center',
-
                           gap: 8,
-
                           minWidth: 0,
-
                           textAlign: 'center',
-
                         }}
-
                       >
-
                         <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-secondary)' }}>{row.label}</span>
-
                         <StarRating
-
                           maxSelectable={MIX_MIN_RATING_FILTER_MAX_STARS}
-
                           value={row.value}
-
                           onChange={row.set}
-
                           ariaLabel={t('settings.ratingsMixMinThresholdAria', { label: row.label })}
-
                         />
-
                       </div>
-
                     ))}
-
                   </div>
-
                 </>
-
               )}
-
             </div>
-
           </section>
 
-
-
           <HomeCustomizer />
-
         </>
-
       )}
 
-
-
       {/* ── Storage & Downloads ───────────────────────────────────────────────── */}
-
       {activeTab === 'storage' && (
-
         <>
-
           {/* Offline Library (In-App) — includes cache settings */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Download size={18} />
-
               <h2>{t('settings.offlineDirTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 14, lineHeight: 1.5 }}>
-
                 {t('settings.offlineDirDesc')}
-
               </div>
-
               <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-
                 <input
-
                   className="input"
-
                   type="text"
-
                   readOnly
-
                   value={auth.offlineDownloadDir || t('settings.offlineDirDefault')}
-
                   style={{ flex: 1, fontSize: 13, color: auth.offlineDownloadDir ? 'var(--text-primary)' : 'var(--text-muted)', cursor: 'default' }}
-
                 />
-
                 {auth.offlineDownloadDir && (
-
                   <button
-
                     className="btn btn-ghost"
-
                     onClick={() => auth.setOfflineDownloadDir('')}
-
                     data-tooltip={t('settings.offlineDirClear')}
-
                     style={{ color: 'var(--text-muted)', flexShrink: 0 }}
-
                   >
-
                     <X size={16} />
-
                   </button>
-
                 )}
-
                 <button className="btn btn-surface" onClick={pickOfflineDir} style={{ flexShrink: 0 }} id="settings-offline-dir-btn">
-
                   <FolderOpen size={16} /> {t('settings.offlineDirChange')}
-
                 </button>
-
               </div>
-
               {auth.offlineDownloadDir && (
-
                 <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 8, lineHeight: 1.4 }}>
-
                   {t('settings.offlineDirHint')}
-
                 </div>
-
               )}
-
-
 
               <div style={{ borderTop: '1px solid var(--border)', margin: '16px 0' }} />
 
-
-
               {(imageCacheBytes !== null || offlineCacheBytes !== null) && (
-
                 <div style={{ fontSize: 12, marginBottom: 12, display: 'flex', flexDirection: 'column', gap: 3 }}>
-
                   <div style={{ color: 'var(--text-secondary)' }}>
-
                     <span style={{ color: 'var(--text-muted)', marginRight: 4 }}>{t('settings.cacheUsedImages')}</span>
-
                     {imageCacheBytes !== null ? formatBytes(imageCacheBytes) : '…'}
-
                   </div>
-
                   <div style={{ color: 'var(--text-secondary)' }}>
-
                     <span style={{ color: 'var(--text-muted)', marginRight: 4 }}>{t('settings.cacheUsedOffline')}</span>
-
                     {offlineCacheBytes !== null ? formatBytes(offlineCacheBytes) : '…'}
-
                   </div>
-
                 </div>
-
               )}
-
-
 
               <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-
                 <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{t('settings.cacheMaxLabel')}</span>
-
                 <input
-
                   className="input"
-
                   type="number"
-
                   min={100}
-
                   max={50000}
-
                   step={100}
-
                   value={auth.maxCacheMb}
-
                   onChange={e => {
-
                     const v = Number(e.target.value);
-
                     if (v >= 100) auth.setMaxCacheMb(v);
-
                   }}
-
                   style={{ width: 80, padding: '4px 8px', fontSize: 13 }}
-
                   id="cache-size-input"
-
                 />
-
                 <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>MB</span>
-
               </div>
-
               {showClearConfirm ? (
-
                 <div style={{ background: 'color-mix(in srgb, var(--color-danger, #e53935) 10%, transparent)', borderRadius: 'var(--radius-sm)', padding: '10px 14px', fontSize: 13, lineHeight: 1.5 }}>
-
                   <div style={{ marginBottom: 8, color: 'var(--text-primary)' }}>{t('settings.cacheClearWarning')}</div>
-
                   <div style={{ display: 'flex', gap: 8 }}>
-
                     <button
-
                       className="btn btn-primary"
-
                       style={{ background: 'var(--color-danger, #e53935)', fontSize: 13 }}
-
                       onClick={handleClearCache}
-
                       disabled={clearing}
-
                     >
-
                       {t('settings.cacheClearConfirm')}
-
                     </button>
-
                     <button className="btn btn-ghost" style={{ fontSize: 13 }} onClick={() => setShowClearConfirm(false)} disabled={clearing}>
-
                       {t('settings.cacheClearCancel')}
-
                     </button>
-
                   </div>
-
                 </div>
-
               ) : (
-
                 <button className="btn btn-ghost" style={{ fontSize: 13 }} onClick={() => setShowClearConfirm(true)}>
-
                   <Trash2 size={14} /> {t('settings.cacheClearBtn')}
-
                 </button>
-
               )}
-
             </div>
-
           </section>
-
-
 
           {/* ZIP Export & Archiving */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <FolderOpen size={18} />
-
               <h2>{t('settings.downloadsTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 14, lineHeight: 1.5 }}>
-
                 {t('settings.downloadsFolderDesc')}
-
               </div>
-
               <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-
                 <input
-
                   className="input"
-
                   type="text"
-
                   readOnly
-
                   value={auth.downloadFolder || t('settings.downloadsDefault')}
-
                   style={{ flex: 1, fontSize: 13, color: auth.downloadFolder ? 'var(--text-primary)' : 'var(--text-muted)', cursor: 'default' }}
-
                 />
-
                 {auth.downloadFolder && (
-
                   <button
-
                     className="btn btn-ghost"
-
                     onClick={() => auth.setDownloadFolder('')}
-
                     aria-label={t('settings.clearFolder')}
-
                     data-tooltip={t('settings.clearFolder')}
-
                     style={{ color: 'var(--text-muted)', flexShrink: 0 }}
-
                   >
-
                     <X size={16} />
-
                   </button>
-
                 )}
-
                 <button className="btn btn-surface" onClick={pickDownloadFolder} style={{ flexShrink: 0 }} id="settings-download-folder-btn">
-
                   <FolderOpen size={16} /> {t('settings.pickFolder')}
-
                 </button>
-
               </div>
-
             </div>
-
           </section>
-
         </>
-
       )}
-
-
 
       {/* ── Appearance ───────────────────────────────────────────────────────── */}
-
       {activeTab === 'appearance' && (
-
         <>
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Globe size={18} />
-
               <h2>{t('settings.language')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <div className="form-group" style={{ maxWidth: '300px' }}>
-
                 <CustomSelect
-
                   value={i18n.language}
-
                   onChange={v => i18n.changeLanguage(v)}
-
                   options={[
-
                     { value: 'en', label: t('settings.languageEn') },
-
                     { value: 'de', label: t('settings.languageDe') },
-
                     { value: 'es', label: t('settings.languageEs') },
-
                     { value: 'fr', label: t('settings.languageFr') },
-
                     { value: 'nl', label: t('settings.languageNl') },
-
                     { value: 'nb', label: t('settings.languageNb') },
-
                     { value: 'ru', label: t('settings.languageRu') },
-
                     { value: 'zh', label: t('settings.languageZh') },
-
                   ]}
-
                 />
-
               </div>
-
             </div>
-
           </section>
 
-
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Palette size={18} />
-
               <h2>{t('settings.theme')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               {theme.enableThemeScheduler && (
-
                 <div className="settings-hint settings-hint-info" style={{ marginBottom: '0.75rem' }}>
-
                   {t('settings.themeSchedulerActiveHint')}
-
                 </div>
-
               )}
-
               <ThemePicker value={theme.theme} onChange={v => theme.setTheme(v as any)} />
-
             </div>
-
           </section>
 
-
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Clock size={18} />
-
               <h2>{t('settings.themeSchedulerTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.themeSchedulerEnable')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.themeSchedulerEnableSub')}</div>
-
                 </div>
-
                 <label className="toggle-switch" aria-label={t('settings.themeSchedulerEnable')}>
-
                   <input type="checkbox" checked={theme.enableThemeScheduler} onChange={e => theme.setEnableThemeScheduler(e.target.checked)} />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               {theme.enableThemeScheduler && (() => {
-
                 const themeOptions = THEME_GROUPS.flatMap(g =>
-
                   g.themes.map(th => ({ value: th.id, label: th.label, group: g.group }))
-
                 );
-
                 const use12h = i18n.language === 'en';
-
                 const hourOptions = Array.from({ length: 24 }, (_, i) => {
-
                   const value = String(i).padStart(2, '0');
-
                   const label = use12h
-
                     ? `${i % 12 === 0 ? 12 : i % 12} ${i < 12 ? 'AM' : 'PM'}`
-
                     : value;
-
                   return { value, label };
-
                 });
-
                 const minuteOptions = ['00', '05', '10', '15', '20', '25', '30', '35', '40', '45', '50', '55'].map(m => ({ value: m, label: m }));
-
                 const dayH = theme.timeDayStart.split(':')[0];
-
                 const dayM = theme.timeDayStart.split(':')[1];
-
                 const nightH = theme.timeNightStart.split(':')[0];
-
                 const nightM = theme.timeNightStart.split(':')[1];
-
                 return (
-
                   <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem', marginTop: '1rem' }}>
-
                     <div className="form-group">
-
                       <label className="settings-label" style={{ marginBottom: 6 }}>{t('settings.themeSchedulerDayTheme')}</label>
-
                       <CustomSelect value={theme.themeDay} onChange={theme.setThemeDay} options={themeOptions} />
-
                     </div>
-
                     <div className="form-group">
-
                       <label className="settings-label" style={{ marginBottom: 6 }}>{t('settings.themeSchedulerDayStart')}</label>
-
                       <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-
                         <CustomSelect value={dayH} onChange={v => theme.setTimeDayStart(`${v}:${dayM}`)} options={hourOptions} />
-
                         <span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>:</span>
-
                         <CustomSelect value={dayM} onChange={v => theme.setTimeDayStart(`${dayH}:${v}`)} options={minuteOptions} />
-
                       </div>
-
                     </div>
-
                     <div className="form-group">
-
                       <label className="settings-label" style={{ marginBottom: 6 }}>{t('settings.themeSchedulerNightTheme')}</label>
-
                       <CustomSelect value={theme.themeNight} onChange={theme.setThemeNight} options={themeOptions} />
-
                     </div>
-
                     <div className="form-group">
-
                       <label className="settings-label" style={{ marginBottom: 6 }}>{t('settings.themeSchedulerNightStart')}</label>
-
                       <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-
                         <CustomSelect value={nightH} onChange={v => theme.setTimeNightStart(`${v}:${nightM}`)} options={hourOptions} />
-
                         <span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>:</span>
-
                         <CustomSelect value={nightM} onChange={v => theme.setTimeNightStart(`${nightH}:${v}`)} options={minuteOptions} />
-
                       </div>
-
                     </div>
-
                   </div>
-
                 );
-
               })()}
-
             </div>
-
           </section>
 
-
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Palette size={18} />
-
               <h2>{t('settings.visualOptionsTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.coverArtBackground')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.coverArtBackgroundSub')}</div>
-
                 </div>
-
                 <label className="toggle-switch">
-
                   <input type="checkbox" checked={theme.enableCoverArtBackground} onChange={e => theme.setEnableCoverArtBackground(e.target.checked)} />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               <div className="settings-section-divider" />
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.playlistCoverPhoto')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.playlistCoverPhotoSub')}</div>
-
                 </div>
-
                 <label className="toggle-switch">
-
                   <input type="checkbox" checked={theme.enablePlaylistCoverPhoto} onChange={e => theme.setEnablePlaylistCoverPhoto(e.target.checked)} />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
               <div className="settings-section-divider" />
-
               <div className="settings-toggle-row">
-
                 <div>
-
                   <div style={{ fontWeight: 500 }}>{t('settings.showBitrate')}</div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.showBitrateSub')}</div>
-
                 </div>
-
                 <label className="toggle-switch">
-
                   <input type="checkbox" checked={theme.showBitrate} onChange={e => theme.setShowBitrate(e.target.checked)} />
-
                   <span className="toggle-track" />
-
                 </label>
-
               </div>
-
             </div>
-
           </section>
 
-
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <ZoomIn size={18} />
-
               <h2>{t('settings.uiScaleTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               {/* TODO: UI scaling is being reworked — disabled until fixed */}
-
               <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: 0 }}>
-
                 Interface scaling is currently being reworked and will be available in a future update.
-
               </p>
-
               <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', opacity: 0.4, pointerEvents: 'none', marginTop: 12 }}>
-
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-
                   <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{t('settings.uiScaleLabel')}</span>
-
                   <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--accent)', minWidth: 40, textAlign: 'right' }}>
-
                     {Math.round(fontStore.uiScale * 100)}%
-
                   </span>
-
                 </div>
-
                 <input
-
                   type="range"
-
                   min={0.8}
-
                   max={1.5}
-
                   step={0.05}
-
                   value={fontStore.uiScale}
-
                   onChange={e => fontStore.setUiScale(parseFloat(e.target.value))}
-
                   className="ui-scale-slider"
-
                 />
-
                 <div style={{ position: 'relative', height: 24 }}>
-
                   {[80, 90, 100, 110, 125, 150].map(p => {
-
                     const pct = ((p / 100) - 0.8) / (1.5 - 0.8) * 100;
-
                     const active = Math.round(fontStore.uiScale * 100) === p;
-
                     return (
-
                       <button
-
                         key={p}
-
                         className="btn btn-ghost"
-
                         style={{
-
                           position: 'absolute',
-
                           left: `${pct}%`,
-
                           transform: 'translateX(-50%)',
-
                           fontSize: 11,
-
                           padding: '2px 6px',
-
                           opacity: active ? 1 : 0.5,
-
                           color: active ? 'var(--accent)' : undefined,
-
                         }}
-
                         onClick={() => fontStore.setUiScale(p / 100)}
-
                       >
-
                         {p}%
-
                       </button>
-
                     );
-
                   })}
-
                 </div>
-
               </div>
-
             </div>
-
           </section>
 
-
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Type size={18} />
-
               <h2>{t('settings.font')}</h2>
-
             </div>
-
             <div className="settings-card">
-
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-
-                {(
-
-                  [
-
-                    { id: 'inter',             label: 'Inter',             stack: "'Inter', sans-serif" },
-
-                    { id: 'outfit',            label: 'Outfit',            stack: "'Outfit', sans-serif" },
-
-                    { id: 'dm-sans',           label: 'DM Sans',           stack: "'DM Sans', sans-serif" },
-
-                    { id: 'nunito',            label: 'Nunito',            stack: "'Nunito', sans-serif" },
-
-                    { id: 'rubik',             label: 'Rubik',             stack: "'Rubik', sans-serif" },
-
-                    { id: 'space-grotesk',     label: 'Space Grotesk',     stack: "'Space Grotesk', sans-serif" },
-
-                    { id: 'figtree',           label: 'Figtree',           stack: "'Figtree', sans-serif" },
-
-                    { id: 'manrope',           label: 'Manrope',           stack: "'Manrope', sans-serif" },
-
-                    { id: 'plus-jakarta-sans', label: 'Plus Jakarta Sans', stack: "'Plus Jakarta Sans', sans-serif" },
-
-                    { id: 'lexend',            label: 'Lexend',            stack: "'Lexend', sans-serif" },
-
-                  ] as { id: FontId; label: string; stack: string }[]
-
-                ).map(f => (
-
-                  <button
-
-                    key={f.id}
-
-                    className={`btn ${fontStore.font === f.id ? 'btn-primary' : 'btn-ghost'}`}
-
-                    style={{ justifyContent: 'flex-start', fontFamily: f.stack }}
-
-                    onClick={() => fontStore.setFont(f.id)}
-
-                  >
-
-                    {f.label}
-
-                  </button>
-
-                ))}
-
-              </div>
-
-            </div>
-
-          </section>
-
-
-
-          <section className="settings-section">
-
-            <div className="settings-section-header">
-
-              <Maximize2 size={18} />
-
-              <h2>{t('settings.fsPlayerSection')}</h2>
-
-            </div>
-
-            <div className="settings-card">
-
-              <div className="settings-toggle-row">
-
-                <div>
-
-                  <div style={{ fontWeight: 500 }}>{t('settings.fsShowArtistPortrait')}</div>
-
-                  <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.fsShowArtistPortraitDesc')}</div>
-
+              <button
+                className="btn btn-ghost"
+                style={{ justifyContent: 'space-between', width: '100%', fontFamily: 'var(--font-sans)' }}
+                onClick={() => setFontPickerOpen(o => !o)}
+              >
+                <span>{
+                  ([
+                    { id: 'inter',             label: 'Inter' },
+                    { id: 'outfit',            label: 'Outfit' },
+                    { id: 'dm-sans',           label: 'DM Sans' },
+                    { id: 'nunito',            label: 'Nunito' },
+                    { id: 'rubik',             label: 'Rubik' },
+                    { id: 'space-grotesk',     label: 'Space Grotesk' },
+                    { id: 'figtree',           label: 'Figtree' },
+                    { id: 'manrope',           label: 'Manrope' },
+                    { id: 'plus-jakarta-sans', label: 'Plus Jakarta Sans' },
+                    { id: 'lexend',            label: 'Lexend' },
+                    { id: 'geist',             label: 'Geist' },
+                    { id: 'jetbrains-mono',    label: 'JetBrains Mono' },
+                  ] as { id: FontId; label: string }[]).find(f => f.id === fontStore.font)?.label ?? fontStore.font
+                }</span>
+                <ChevronDown size={14} style={{ color: 'var(--text-muted)', transform: fontPickerOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }} />
+              </button>
+              {fontPickerOpen && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '8px' }}>
+                  {(
+                    [
+                      { id: 'inter',             label: 'Inter',             stack: "'Inter Variable', sans-serif" },
+                      { id: 'outfit',            label: 'Outfit',            stack: "'Outfit Variable', sans-serif" },
+                      { id: 'dm-sans',           label: 'DM Sans',           stack: "'DM Sans Variable', sans-serif" },
+                      { id: 'nunito',            label: 'Nunito',            stack: "'Nunito Variable', sans-serif" },
+                      { id: 'rubik',             label: 'Rubik',             stack: "'Rubik Variable', sans-serif" },
+                      { id: 'space-grotesk',     label: 'Space Grotesk',     stack: "'Space Grotesk Variable', sans-serif" },
+                      { id: 'figtree',           label: 'Figtree',           stack: "'Figtree Variable', sans-serif" },
+                      { id: 'manrope',           label: 'Manrope',           stack: "'Manrope Variable', sans-serif" },
+                      { id: 'plus-jakarta-sans', label: 'Plus Jakarta Sans', stack: "'Plus Jakarta Sans Variable', sans-serif" },
+                      { id: 'lexend',            label: 'Lexend',            stack: "'Lexend Variable', sans-serif" },
+                      { id: 'geist',             label: 'Geist',             stack: "'Geist Variable', sans-serif" },
+                      { id: 'jetbrains-mono',    label: 'JetBrains Mono',    stack: "'JetBrains Mono Variable', monospace" },
+                    ] as { id: FontId; label: string; stack: string }[]
+                  ).map(f => (
+                    <button
+                      key={f.id}
+                      className={`btn ${fontStore.font === f.id ? 'btn-primary' : 'btn-ghost'}`}
+                      style={{ justifyContent: 'flex-start', fontFamily: f.stack }}
+                      onClick={() => { fontStore.setFont(f.id); setFontPickerOpen(false); }}
+                    >
+                      {f.label}
+                    </button>
+                  ))}
                 </div>
-
-                <label className="toggle-switch" aria-label={t('settings.fsShowArtistPortrait')}>
-
-                  <input type="checkbox" checked={auth.showFsArtistPortrait} onChange={e => auth.setShowFsArtistPortrait(e.target.checked)} />
-
-                  <span className="toggle-track" />
-
-                </label>
-
-              </div>
-
-              {auth.showFsArtistPortrait && (
-
-                <div style={{ marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid var(--border)' }}>
-
-                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
-
-                    <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{t('settings.fsPortraitDim')}</span>
-
-                    <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--accent)', minWidth: 36, textAlign: 'right' }}>{auth.fsPortraitDim}%</span>
-
-                  </div>
-
-                  <input
-
-                    type="range"
-
-                    min={0}
-
-                    max={80}
-
-                    step={1}
-
-                    value={auth.fsPortraitDim}
-
-                    onChange={e => auth.setFsPortraitDim(parseInt(e.target.value, 10))}
-
-                    className="ui-scale-slider"
-
-                  />
-
-                </div>
-
               )}
-
             </div>
-
           </section>
-
-
 
           <section className="settings-section">
-
             <div className="settings-section-header">
-
-              <Sliders size={18} />
-
-              <h2>{t('settings.seekbarStyle')}</h2>
-
+              <Maximize2 size={18} />
+              <h2>{t('settings.fsPlayerSection')}</h2>
             </div>
-
             <div className="settings-card">
-
-              <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '0.75rem' }}>
-
-                {t('settings.seekbarStyleDesc')}
-
+              <div className="settings-toggle-row">
+                <div>
+                  <div style={{ fontWeight: 500 }}>{t('settings.fsShowArtistPortrait')}</div>
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.fsShowArtistPortraitDesc')}</div>
+                </div>
+                <label className="toggle-switch" aria-label={t('settings.fsShowArtistPortrait')}>
+                  <input type="checkbox" checked={auth.showFsArtistPortrait} onChange={e => auth.setShowFsArtistPortrait(e.target.checked)} />
+                  <span className="toggle-track" />
+                </label>
               </div>
-
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
-
-                {(['waveform', 'linedot', 'bar', 'thick', 'segmented', 'neon', 'pulsewave', 'particletrail', 'liquidfill', 'retrotape'] as SeekbarStyle[]).map(style => (
-
-                  <SeekbarPreview
-
-                    key={style}
-
-                    style={style}
-
-                    label={t(`settings.seekbar${style.charAt(0).toUpperCase() + style.slice(1)}` as any)}
-
-                    selected={auth.seekbarStyle === style}
-
-                    onClick={() => auth.setSeekbarStyle(style)}
-
+              {auth.showFsArtistPortrait && (
+                <div style={{ marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid var(--border)' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
+                    <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{t('settings.fsPortraitDim')}</span>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--accent)', minWidth: 36, textAlign: 'right' }}>{auth.fsPortraitDim}%</span>
+                  </div>
+                  <input
+                    type="range"
+                    min={0}
+                    max={80}
+                    step={1}
+                    value={auth.fsPortraitDim}
+                    onChange={e => auth.setFsPortraitDim(parseInt(e.target.value, 10))}
+                    className="ui-scale-slider"
                   />
-
-                ))}
-
-              </div>
-
+                </div>
+              )}
             </div>
-
           </section>
 
-
+          <section className="settings-section">
+            <div className="settings-section-header">
+              <Sliders size={18} />
+              <h2>{t('settings.seekbarStyle')}</h2>
+            </div>
+            <div className="settings-card">
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '0.75rem' }}>
+                {t('settings.seekbarStyleDesc')}
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+                {(['waveform', 'linedot', 'bar', 'thick', 'segmented', 'neon', 'pulsewave', 'particletrail', 'liquidfill', 'retrotape'] as SeekbarStyle[]).map(style => (
+                  <SeekbarPreview
+                    key={style}
+                    style={style}
+                    label={t(`settings.seekbar${style.charAt(0).toUpperCase() + style.slice(1)}` as any)}
+                    selected={auth.seekbarStyle === style}
+                    onClick={() => auth.setSeekbarStyle(style)}
+                  />
+                ))}
+              </div>
+            </div>
+          </section>
 
           <SidebarCustomizer />
-
         </>
-
       )}
-
-
 
       {/* ── Input ────────────────────────────────────────────────────────────── */}
-
       {activeTab === 'input' && (
-
         <>
-
         <section className="settings-section">
-
           <div className="settings-section-header">
-
             <Keyboard size={18} />
-
             <h2>{t('settings.tabInput')}</h2>
-
           </div>
-
           <div style={{ position: 'relative' }}>
-
             <button
-
               className="btn btn-ghost"
-
               style={{ position: 'absolute', top: -22, right: 0, fontSize: 12, color: 'var(--text-muted)', padding: '2px 4px' }}
-
               onClick={() => { kb.resetToDefaults(); setListeningFor(null); }}
-
               data-tooltip={t('settings.shortcutsReset')}
-
             >
-
               <RotateCcw size={14} />
-
             </button>
-
           <div className="settings-card">
-
             <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-
               {([
-
                 ['play-pause',        t('settings.shortcutPlayPause')],
-
                 ['next',              t('settings.shortcutNext')],
-
                 ['prev',              t('settings.shortcutPrev')],
-
                 ['volume-up',         t('settings.shortcutVolumeUp')],
-
                 ['volume-down',       t('settings.shortcutVolumeDown')],
-
                 ['seek-forward',      t('settings.shortcutSeekForward')],
-
                 ['seek-backward',     t('settings.shortcutSeekBackward')],
-
                 ['toggle-queue',      t('settings.shortcutToggleQueue')],
-
                 ['open-folder-browser', t('settings.shortcutOpenFolderBrowser', { folderBrowser: t('sidebar.folderBrowser') })],
-
                 ['fullscreen-player', t('settings.shortcutFullscreenPlayer')],
-
                 ['native-fullscreen', t('settings.shortcutNativeFullscreen')],
-
               ] as [KeyAction, string][]).map(([action, label]) => {
-
                 const bound = kb.bindings[action];
-
                 const isListening = listeningFor === action;
-
                 return (
-
                   <div key={action} style={{
-
                     display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-
                     padding: '8px 10px', borderRadius: 'var(--radius-sm)',
-
                     background: isListening ? 'var(--accent-dim)' : 'transparent',
-
                     transition: 'background 0.15s',
-
                   }}>
-
                     <span style={{ fontSize: 13, color: 'var(--text-primary)' }}>{label}</span>
-
                     <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-
                       <button
-
                         onClick={() => {
-
                           if (isListening) { setListeningFor(null); return; }
-
                           setListeningFor(action);
-
                           const handler = (e: KeyboardEvent) => {
-
                             e.preventDefault();
-
                             e.stopPropagation();
-
                             if (e.code === 'Escape') {
-
                               setListeningFor(null);
-
                               window.removeEventListener('keydown', handler, true);
-
                               return;
-
                             }
-
                             const chord = buildInAppBinding(e);
-
                             if (!chord) return;
-
                             const existing = (Object.entries(kb.bindings) as [KeyAction, string | null][])
-
                               .find(([, c]) => c === chord)?.[0];
-
                             if (existing && existing !== action) kb.setBinding(existing, null);
-
                             kb.setBinding(action, chord);
-
                             setListeningFor(null);
-
                             window.removeEventListener('keydown', handler, true);
-
                           };
-
                           window.addEventListener('keydown', handler, true);
-
                         }}
-
                         className="keybind-badge"
-
                         style={{
-
                           minWidth: 72, padding: '3px 10px', borderRadius: 'var(--radius-sm)',
-
                           fontSize: 12, fontWeight: 600, fontFamily: 'monospace',
-
                           background: isListening ? 'var(--accent)' : bound ? 'var(--bg-hover)' : 'var(--bg-card)',
-
                           color: isListening ? 'var(--ctp-base)' : bound ? 'var(--text-primary)' : 'var(--text-muted)',
-
                           border: `1px solid ${isListening ? 'var(--accent)' : 'var(--border-subtle)'}`,
-
                           cursor: 'pointer',
-
                         }}
-
                       >
-
                         {isListening ? t('settings.shortcutListening') : bound ? formatBinding(bound) : t('settings.shortcutUnbound')}
-
                       </button>
-
                       {bound && !isListening && (
-
                         <button
-
                           onClick={() => kb.setBinding(action, null)}
-
                           style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', padding: '2px 4px', lineHeight: 1 }}
-
                           data-tooltip={t('settings.shortcutClear')}
-
                         >
-
                           <X size={12} />
-
                         </button>
-
                       )}
-
                     </div>
-
                   </div>
-
                 );
-
               })}
-
             </div>
-
           </div>
-
           </div>
-
         </section>
-
-
 
         <section className="settings-section">
-
           <div className="settings-section-header">
-
             <Keyboard size={18} />
-
             <h2>{t('settings.globalShortcutsTitle')}</h2>
-
           </div>
-
           <p style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '12px', lineHeight: 1.5 }}>
-
             {t('settings.globalShortcutsNote')}
-
           </p>
-
           <div style={{ position: 'relative' }}>
-
             <button
-
               className="btn btn-ghost"
-
               style={{ position: 'absolute', top: -22, right: 0, fontSize: 12, color: 'var(--text-muted)', padding: '2px 4px' }}
-
               onClick={() => { gs.resetAll(); setListeningForGlobal(null); }}
-
               data-tooltip={t('settings.shortcutsReset')}
-
             >
-
               <RotateCcw size={14} />
-
             </button>
-
           <div className="settings-card">
-
             <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-
               {([
-
                 ['play-pause',  t('settings.shortcutPlayPause')],
-
                 ['next',        t('settings.shortcutNext')],
-
                 ['prev',        t('settings.shortcutPrev')],
-
                 ['volume-up',   t('settings.shortcutVolumeUp')],
-
                 ['volume-down', t('settings.shortcutVolumeDown')],
-
               ] as [GlobalAction, string][]).map(([action, label]) => {
-
                 const bound = gs.shortcuts[action] ?? null;
-
                 const isListening = listeningForGlobal === action;
-
                 return (
-
                   <div key={action} style={{
-
                     display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-
                     padding: '8px 10px', borderRadius: 'var(--radius-sm)',
-
                     background: isListening ? 'var(--accent-dim)' : 'transparent',
-
                     transition: 'background 0.15s',
-
                   }}>
-
                     <span style={{ fontSize: 13, color: 'var(--text-primary)' }}>{label}</span>
-
                     <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-
                       <button
-
                         onClick={() => {
-
                           if (isListening) { setListeningForGlobal(null); return; }
-
                           setListeningForGlobal(action);
-
                           const handler = (e: KeyboardEvent) => {
-
                             e.preventDefault();
-
                             e.stopPropagation();
-
                             if (e.code === 'Escape') {
-
                               setListeningForGlobal(null);
-
                               window.removeEventListener('keydown', handler, true);
-
                               return;
-
                             }
-
                             const shortcut = buildGlobalShortcut(e);
-
                             if (shortcut) {
-
                               gs.setShortcut(action, shortcut);
-
                               setListeningForGlobal(null);
-
                               window.removeEventListener('keydown', handler, true);
-
                             }
-
                           };
-
                           window.addEventListener('keydown', handler, true);
-
                         }}
-
                         className="keybind-badge"
-
                         style={{
-
                           minWidth: 120, padding: '3px 10px', borderRadius: 'var(--radius-sm)',
-
                           fontSize: 12, fontWeight: 600, fontFamily: 'monospace',
-
                           background: isListening ? 'var(--accent)' : bound ? 'var(--bg-hover)' : 'var(--bg-card)',
-
                           color: isListening ? 'var(--ctp-base)' : bound ? 'var(--text-primary)' : 'var(--text-muted)',
-
                           border: `1px solid ${isListening ? 'var(--accent)' : 'var(--border-subtle)'}`,
-
                           cursor: 'pointer',
-
                         }}
-
                       >
-
                         {isListening ? t('settings.shortcutListening') : bound ? formatGlobalShortcut(bound) : t('settings.shortcutUnbound')}
-
                       </button>
-
                       {bound && !isListening && (
-
                         <button
-
                           onClick={() => gs.setShortcut(action, null)}
-
                           style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', padding: '2px 4px', lineHeight: 1 }}
-
                           data-tooltip={t('settings.shortcutClear')}
-
                         >
-
                           <X size={12} />
-
                         </button>
-
                       )}
-
                     </div>
-
                   </div>
-
                 );
-
               })}
-
             </div>
-
           </div>
-
           </div>
-
         </section>
-
         </>
-
       )}
-
-
 
       {/* ── Server ───────────────────────────────────────────────────────────── */}
-
       {activeTab === 'server' && (
-
         <>
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Server size={18} />
-
               <h2>{t('settings.servers')}</h2>
-
             </div>
-
             <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: '0.75rem' }}>
-
               {t('settings.serverCompatible')}
-
             </div>
-
-
 
             {auth.servers.length === 0 && !showAddForm ? (
-
               <div className="settings-card" style={{ color: 'var(--text-muted)', fontSize: 14 }}>
-
                 {t('settings.noServers')}
-
               </div>
-
             ) : (
-
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-
                 {auth.servers.map(srv => {
-
                   const isActive = srv.id === auth.activeServerId;
-
                   const status = connStatus[srv.id];
-
                   return (
-
                     <div key={srv.id} className="settings-card" style={{ border: isActive ? '1px solid var(--accent)' : undefined }}>
-
                       <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '1rem' }}>
-
                         <div style={{ minWidth: 0 }}>
-
                           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '2px' }}>
-
                             <span style={{ fontWeight: 600 }}>{srv.name || srv.url}</span>
-
                             {isActive && (
-
                               <span style={{ fontSize: 11, background: 'var(--accent)', color: 'var(--ctp-crust)', padding: '1px 6px', borderRadius: '10px', fontWeight: 600 }}>
-
                                 {t('settings.serverActive')}
-
                               </span>
-
                             )}
-
                           </div>
-
                           <div style={{ fontSize: 12, color: 'var(--text-muted)', display: 'flex', alignItems: 'center', gap: 4, overflow: 'hidden' }}>
-
                             {srv.url.startsWith('https://') && (
-
                               <Lock size={11} style={{ color: 'var(--positive)', flexShrink: 0 }} />
-
                             )}
-
                             <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-
                               {srv.url.replace(/^https?:\/\//, '')}
-
                             </span>
-
                           </div>
-
                           <div style={{ fontSize: 12, color: 'var(--text-muted)', display: 'flex', alignItems: 'center', gap: 4, marginTop: 1 }}>
-
                             <User size={11} />
-
                             {srv.username}
-
                           </div>
-
                         </div>
-
                         <div style={{ display: 'flex', gap: '6px', flexShrink: 0, alignItems: 'center' }}>
-
                           {status === 'ok' && <CheckCircle2 size={16} style={{ color: 'var(--positive)' }} />}
-
                           {status === 'error' && <WifiOff size={16} style={{ color: 'var(--danger)' }} />}
-
                           {status === 'testing' && <div className="spinner" style={{ width: 16, height: 16 }} />}
-
                           <button
-
                             className="btn btn-surface"
-
                             style={{ fontSize: 12, padding: '4px 10px' }}
-
                             onClick={() => testConnection(srv)}
-
                             disabled={status === 'testing'}
-
                           >
-
                             <Wifi size={13} />
-
                             {t('settings.testBtn')}
-
                           </button>
-
                           {!isActive && (
-
                             <button
-
                               className="btn btn-primary"
-
                               style={{ fontSize: 12, padding: '4px 10px' }}
-
                               onClick={() => switchToServer(srv)}
-
                               disabled={status === 'testing'}
-
                               id={`settings-use-server-${srv.id}`}
-
                             >
-
                               {t('settings.useServer')}
-
                             </button>
-
                           )}
-
                           <button
-
                             className="btn btn-ghost"
-
                             style={{ color: 'var(--danger)', padding: '4px 8px' }}
-
                             onClick={() => deleteServer(srv)}
-
                             data-tooltip={t('settings.deleteServer')}
-
                             id={`settings-delete-server-${srv.id}`}
-
                           >
-
                             <Trash2 size={14} />
-
                           </button>
-
                         </div>
-
                       </div>
-
                       {showAudiomuseNavidromeServerSetting(
-
                         auth.subsonicServerIdentityByServer[srv.id],
-
                         auth.instantMixProbeByServer[srv.id],
-
                       ) && (
-
                         <div
-
                           className="settings-toggle-row"
-
                           style={{ marginTop: '0.75rem', paddingTop: '0.75rem', borderTop: '1px solid color-mix(in srgb, var(--text-muted) 18%, transparent)' }}
-
                         >
-
                           <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', minWidth: 0 }}>
-
                             <Sparkles size={16} style={{ color: 'var(--accent)', flexShrink: 0, marginTop: 2 }} />
-
                             <div>
-
                               <div style={{ fontWeight: 500, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-
                                 {t('settings.audiomuseTitle')}
-
                                 <span
-
                                   style={{
-
                                     fontSize: 10,
-
                                     fontWeight: 600,
-
                                     textTransform: 'uppercase',
-
                                     letterSpacing: '0.04em',
-
                                     padding: '2px 6px',
-
                                     borderRadius: 4,
-
                                     background: 'color-mix(in srgb, var(--color-warning, #f59e0b) 22%, transparent)',
-
                                     color: 'var(--text-primary)',
-
                                   }}
-
                                 >
-
                                   {t('settings.hotCacheAlphaBadge')}
-
                                 </span>
-
                                 {!!auth.audiomuseNavidromeByServer[srv.id] && auth.audiomuseNavidromeIssueByServer[srv.id] && (
-
                                   <AlertTriangle
-
                                     size={16}
-
                                     style={{ color: 'var(--color-warning, #f59e0b)', flexShrink: 0 }}
-
                                     data-tooltip={t('settings.audiomuseIssueHint')}
-
                                     aria-label={t('settings.audiomuseIssueHint')}
-
                                   />
-
                                 )}
-
                               </div>
-
                               <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.45 }}>
-
                                 <Trans
-
                                   i18nKey="settings.audiomuseDesc"
-
                                   components={{
-
                                     pluginLink: (
-
                                       <a
-
                                         href={AUDIOMUSE_NV_PLUGIN_URL}
-
                                         onClick={e => {
-
                                           e.preventDefault();
-
                                           void openUrl(AUDIOMUSE_NV_PLUGIN_URL);
-
                                         }}
-
                                         style={{ color: 'var(--accent)', textDecoration: 'underline' }}
-
                                       />
-
                                     ),
-
                                   }}
-
                                 />
-
                               </div>
-
                             </div>
-
                           </div>
-
                           <label className="toggle-switch" aria-label={t('settings.audiomuseTitle')}>
-
                             <input
-
                               type="checkbox"
-
                               checked={!!auth.audiomuseNavidromeByServer[srv.id]}
-
                               onChange={e => auth.setAudiomuseNavidromeEnabled(srv.id, e.target.checked)}
-
                             />
-
                             <span className="toggle-track" />
-
                           </label>
-
                         </div>
-
                       )}
-
                     </div>
-
                   );
-
                 })}
-
               </div>
-
             )}
-
-
 
             {showAddForm ? (
-
               <AddServerForm onSave={handleAddServer} onCancel={() => setShowAddForm(false)} />
-
             ) : (
-
               <button className="btn btn-surface" style={{ marginTop: '0.75rem' }} onClick={() => setShowAddForm(true)} id="settings-add-server-btn">
-
                 <Plus size={16} /> {t('settings.addServer')}
-
               </button>
-
             )}
-
           </section>
-
-
 
           {/* Last.fm */}
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <LastfmIcon size={18} />
-
               <h2>{t('settings.lfmTitle')}</h2>
-
             </div>
-
             <div className="settings-card">
-
               {auth.lastfmSessionKey ? (
-
                 /* ── Connected state ── */
-
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-
                   <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', padding: '0.75rem 1rem', borderRadius: '10px', background: 'color-mix(in srgb, var(--accent) 8%, transparent)', border: '1px solid color-mix(in srgb, var(--accent) 20%, transparent)' }}>
-
                     <div style={{ flexShrink: 0, color: '#e31c23' }}><LastfmIcon size={20} /></div>
-
                     <div style={{ flex: 1, minWidth: 0 }}>
-
                       <div style={{ fontWeight: 600, fontSize: 14 }}>@{auth.lastfmUsername}</div>
-
                       {lfmUserInfo && (
-
                         <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2, display: 'flex', gap: '0.75rem' }}>
-
                           <span>{t('settings.lfmScrobbles', { n: lfmUserInfo.playcount.toLocaleString() })}</span>
-
                           <span>{t('settings.lfmMemberSince', { year: new Date(lfmUserInfo.registeredAt * 1000).getFullYear() })}</span>
-
                         </div>
-
                       )}
-
                     </div>
-
                     <button
-
                       className="btn btn-ghost"
-
                       style={{ fontSize: 12, padding: '4px 10px', flexShrink: 0 }}
-
                       onClick={() => auth.disconnectLastfm()}
-
                     >
-
                       {t('settings.lfmDisconnect')}
-
                     </button>
-
                   </div>
-
                   <div className="settings-toggle-row">
-
                     <div>
-
                       <div style={{ fontWeight: 500 }}>{t('settings.scrobbleEnabled')}</div>
-
                       <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.scrobbleDesc')}</div>
-
                     </div>
-
                     <label className="toggle-switch" aria-label={t('settings.scrobbleEnabled')}>
-
                       <input type="checkbox" checked={auth.scrobblingEnabled} onChange={e => auth.setScrobblingEnabled(e.target.checked)} id="scrobbling-toggle" />
-
                       <span className="toggle-track" />
-
                     </label>
-
                   </div>
-
                 </div>
-
               ) : lfmState === 'waiting' ? (
-
                 /* ── Waiting for browser auth — auto-polling ── */
-
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-
                   <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', fontSize: 13, color: 'var(--text-secondary)' }}>
-
                     <div className="spinner" style={{ width: 16, height: 16, borderWidth: 2 }} />
-
                     {t('settings.lfmConnecting')}
-
                   </div>
-
                   <button className="btn btn-ghost" style={{ alignSelf: 'flex-start', fontSize: 12 }}
-
                     onClick={() => { setLfmState('idle'); setLfmPendingToken(null); }}>
-
                     {t('common.cancel')}
-
                   </button>
-
                 </div>
-
               ) : (
-
                 /* ── Not connected ── */
-
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-
                   <p style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.5 }}>
-
                     {t('settings.lfmConnectDesc')}
-
                   </p>
-
                   {lfmState === 'error' && (
-
                     <p style={{ fontSize: 12, color: 'var(--danger)' }}>{lfmError}</p>
-
                   )}
-
                   <button className="btn btn-primary" style={{ alignSelf: 'flex-start' }} onClick={startLastfmConnect}>
-
                     {t('settings.lfmConnect')}
-
                   </button>
-
                 </div>
-
               )}
-
             </div>
-
           </section>
-
-
 
           <section className="settings-section">
-
             <button className="btn btn-danger" onClick={handleLogout} id="settings-logout-btn">
-
               <LogOut size={16} /> {t('settings.logout')}
-
             </button>
-
           </section>
-
-
 
         </>
-
       )}
 
-
-
       {/* ── System ───────────────────────────────────────────────────────────── */}
-
       {activeTab === 'system' && (
-
         <>
-
         <BackupSection />
-
           <section className="settings-section">
-
             <div className="settings-section-header">
-
               <Info size={18} />
-
               <h2>{t('settings.aboutTitle')}</h2>
-
             </div>
-
             <div className="settings-card settings-about">
-
               <div className="settings-about-header">
-
                 <img src="/logo-psysonic.png" width={52} height={52} alt="Psysonic" style={{ borderRadius: 14 }} />
-
                 <div>
-
                   <div style={{ fontFamily: 'var(--font-display)', fontSize: '1.25rem', fontWeight: 700, color: 'var(--text-primary)' }}>
-
                     Psysonic
-
                   </div>
-
                   <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}>
-
                     {t('settings.aboutVersion')} {appVersion}
-
                   </div>
-
                 </div>
-
               </div>
 
-
-
               <p style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.6, margin: '1rem 0 0.5rem' }}>
-
                 {t('settings.aboutDesc')}
-
               </p>
-
-
 
               <div className="divider" style={{ margin: '1rem 0' }} />
 
-
-
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem', fontSize: 13 }}>
-
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
-
                   <span style={{ color: 'var(--text-muted)', minWidth: 56 }}>{t('settings.aboutLicense')}</span>
-
                   <span style={{ color: 'var(--text-secondary)' }}>{t('settings.aboutLicenseText')}</span>
-
                 </div>
-
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
-
                   <span style={{ color: 'var(--text-muted)', minWidth: 56 }}>Stack</span>
-
                   <span style={{ color: 'var(--text-secondary)' }}>{t('settings.aboutBuiltWith')}</span>
-
                 </div>
-
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
-
                   <span style={{ color: 'var(--text-muted)', minWidth: 56 }}>AI</span>
-
                   <span style={{ color: 'var(--text-secondary)' }}>{t('settings.aboutAiCredit')}</span>
-
                 </div>
-
                 <div>
-
                   <button
-
                     style={{ display: 'flex', width: '100%', alignItems: 'center', gap: '0.5rem', background: 'none', border: 'none', cursor: 'pointer', padding: 0, textAlign: 'left' }}
-
                     onClick={() => setContributorsOpen(o => !o)}
-
                   >
-
                     <span style={{ color: 'var(--text-muted)', minWidth: 56, flexShrink: 0 }}>{t('settings.aboutContributorsLabel')}</span>
-
                     <span style={{ color: 'var(--text-secondary)', flex: 1 }}>{CONTRIBUTORS.length}</span>
-
                     <ChevronDown size={13} style={{ color: 'var(--text-muted)', transform: contributorsOpen ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }} />
-
                   </button>
 
-
-
                   {contributorsOpen && (
-
                     <div style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-
                       {CONTRIBUTORS.map(c => (
-
                         <div key={c.github} style={{
-
                           display: 'flex', gap: '0.75rem', alignItems: 'flex-start',
-
                           background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)',
-
                           padding: '0.65rem 0.75rem',
-
                           boxShadow: 'inset 0 0 0 1px var(--border-subtle)',
-
                         }}>
-
                           <img
-
                             src={`https://github.com/${c.github}.png?size=48`}
-
                             width={36} height={36}
-
                             style={{ borderRadius: '50%', flexShrink: 0, marginTop: 2 }}
-
                             alt={c.github}
-
                           />
-
                           <div style={{ flex: 1, minWidth: 0 }}>
-
                             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.3rem' }}>
-
                               <button
-
                                 style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--accent)', fontWeight: 600, fontSize: 13 }}
-
                                 onClick={() => openUrl(`https://github.com/${c.github}`)}
-
                               >
-
                                 @{c.github}
-
                               </button>
-
                               <span style={{ fontSize: 10, background: 'var(--accent-dim)', color: 'var(--accent)', padding: '1px 6px', borderRadius: 99, fontWeight: 600 }}>
-
                                 v{c.since}
-
                               </span>
-
                             </div>
-
                             <ul style={{ margin: 0, padding: '0 0 0 1rem', fontSize: 12, color: 'var(--text-secondary)', lineHeight: 1.8 }}>
-
                               {c.contributions.map(item => <li key={item}>{item}</li>)}
-
                             </ul>
-
                           </div>
-
                         </div>
-
                       ))}
-
                     </div>
-
                   )}
-
                 </div>
-
                 <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'flex-start' }}>
-
                   <span style={{ color: 'var(--text-muted)', minWidth: 56, flexShrink: 0, paddingTop: 2, fontSize: 13 }}>{t('settings.aboutSpecialThanksLabel')}</span>
-
                   <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem', flex: 1 }}>
-
                     {SPECIAL_THANKS.map(s => (
-
                       <div key={s.github} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-
                         <img
-
                           src={`https://github.com/${s.github}.png?size=32`}
-
                           width={22} height={22}
-
                           style={{ borderRadius: '50%', flexShrink: 0 }}
-
                           alt={s.github}
-
                         />
-
                         <button
-
                           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--accent)', fontWeight: 600, fontSize: 13 }}
-
                           onClick={() => openUrl(`https://github.com/${s.github}`)}
-
                         >
-
                           @{s.github}
-
                         </button>
-
                         <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>— {s.reason}</span>
-
                       </div>
-
                     ))}
-
                   </div>
-
                 </div>
-
               </div>
-
-
 
               <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.25rem', flexWrap: 'wrap' }}>
-
                 <button
-
                   className="btn btn-ghost"
-
                   style={{ alignSelf: 'flex-start' }}
-
                   onClick={() => openUrl('https://github.com/Psychotoxical/psysonic')}
-
                 >
-
                   <ExternalLink size={14} />
-
                   {t('settings.aboutRepo')}
-
                 </button>
-
               </div>
-
             </div>
-
           </section>
 
-
-
           <ChangelogSection />
-
         </>
-
       )}
-
     </div>
-
   );
-
 }
-
-
 
 // ─── Changelog renderer ───────────────────────────────────────────────────────
 
-
-
 function renderInline(text: string): React.ReactNode[] {
-
   // Splits on **bold**, *italic*, `code` and renders each part.
-
   const parts = text.split(/(\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`)/g);
-
   return parts.map((part, i) => {
-
     if (part.startsWith('**') && part.endsWith('**'))
-
       return <strong key={i}>{part.slice(2, -2)}</strong>;
-
     if (part.startsWith('*') && part.endsWith('*'))
-
       return <em key={i}>{part.slice(1, -1)}</em>;
-
     if (part.startsWith('`') && part.endsWith('`'))
-
       return <code key={i} className="changelog-code">{part.slice(1, -1)}</code>;
-
     return part;
-
   });
-
 }
-
-
 
 function HomeCustomizer() {
-
   const { t } = useTranslation();
-
   const { sections, toggleSection, reset } = useHomeStore();
 
-
-
   const SECTION_LABELS: Record<HomeSectionId, string> = {
-
     hero:            t('home.hero'),
-
     recent:          t('home.recent'),
-
     discover:        t('home.discover'),
-
     discoverArtists: t('home.discoverArtists'),
-
     recentlyPlayed:  t('home.recentlyPlayed'),
-
     starred:         t('home.starred'),
-
     mostPlayed:      t('home.mostPlayed'),
-
   };
 
-
-
   return (
-
     <section className="settings-section">
-
       <div className="settings-section-header">
-
         <LayoutGrid size={18} />
-
         <h2>{t('settings.homeCustomizerTitle')}</h2>
-
       </div>
-
       <div style={{ position: 'relative' }}>
-
         <button
-
           className="btn btn-ghost"
-
           style={{ position: 'absolute', top: -22, right: 0, fontSize: 12, color: 'var(--text-muted)', padding: '2px 4px' }}
-
           onClick={reset}
-
           data-tooltip={t('settings.sidebarReset')}
-
         >
-
           <RotateCcw size={14} />
-
         </button>
-
         <div className="settings-card" style={{ padding: '4px 0' }}>
-
           {sections.map(sec => (
-
             <div key={sec.id} className="settings-toggle-row" style={{ padding: '8px 16px' }}>
-
               <span style={{ fontSize: 14 }}>{SECTION_LABELS[sec.id]}</span>
-
               <label className="toggle-switch" aria-label={SECTION_LABELS[sec.id]}>
-
                 <input type="checkbox" checked={sec.visible} onChange={() => toggleSection(sec.id)} />
-
                 <span className="toggle-track" />
-
               </label>
-
             </div>
-
           ))}
-
         </div>
-
       </div>
-
     </section>
-
   );
-
 }
-
-
 
 function SidebarGripHandle({ idx, section, label }: { idx: number; section: 'library' | 'system'; label: string }) {
-
   const { t } = useTranslation();
-
   const { onMouseDown } = useDragSource(() => ({
-
     data: JSON.stringify({ type: 'sidebar_reorder', index: idx, section }),
-
     label,
-
   }));
-
   return (
-
     <span
-
       className="sidebar-customizer-grip"
-
       data-tooltip={t('settings.sidebarDrag')}
-
       data-tooltip-pos="right"
-
       onMouseDown={onMouseDown}
-
     >
-
       <GripVertical size={16} />
-
     </span>
-
   );
-
 }
-
-
 
 // ── Lyrics Sources Customizer ──────────────────────────────────────────────
 
-
-
 const LYRICS_SOURCE_LABEL_KEYS: Record<LyricsSourceId, string> = {
-
   server:  'settings.lyricsSourceServer',
-
   lrclib:  'settings.lyricsSourceLrclib',
-
   netease: 'settings.lyricsSourceNetease',
-
 };
-
-
 
 type LyricsDropTarget = { idx: number; before: boolean } | null;
 
-
-
 function LyricsSourceGripHandle({ idx, label }: { idx: number; label: string }) {
-
   const { t } = useTranslation();
-
   const { onMouseDown } = useDragSource(() => ({
-
     data: JSON.stringify({ type: 'lyrics_source_reorder', index: idx }),
-
     label,
-
   }));
-
   return (
-
     <span
-
       className="sidebar-customizer-grip"
-
       data-tooltip={t('settings.sidebarDrag')}
-
       data-tooltip-pos="right"
-
       onMouseDown={onMouseDown}
-
     >
-
       <GripVertical size={16} />
-
     </span>
-
   );
-
 }
-
-
 
 function LyricsSourcesCustomizer() {
-
   const { t } = useTranslation();
-
   const lyricsSources = useAuthStore(useShallow(s => s.lyricsSources));
-
   const setLyricsSources = useAuthStore(s => s.setLyricsSources);
-
   const { isDragging: isPsyDragging } = useDragDrop();
-
   const containerRef = useRef<HTMLDivElement>(null);
-
   const [dropTarget, setDropTarget] = useState<LyricsDropTarget>(null);
-
   const dropTargetRef = useRef<LyricsDropTarget>(null);
-
   const sourcesRef = useRef(lyricsSources);
-
   sourcesRef.current = lyricsSources;
 
-
-
   useEffect(() => {
-
     if (!isPsyDragging) { dropTargetRef.current = null; setDropTarget(null); }
-
   }, [isPsyDragging]);
 
-
-
   useEffect(() => {
-
     const el = containerRef.current;
-
     if (!el) return;
-
     const onPsyDrop = (e: Event) => {
-
       const detail = (e as CustomEvent).detail;
-
       if (!detail?.data) return;
-
       let parsed: { type?: string; index?: number };
-
       try { parsed = JSON.parse(detail.data as string); } catch { return; }
-
       if (parsed.type !== 'lyrics_source_reorder' || parsed.index == null) return;
 
-
-
       const fromIdx = parsed.index;
-
       const target = dropTargetRef.current;
-
       dropTargetRef.current = null; setDropTarget(null);
-
       if (!target) return;
 
-
-
       const insertBefore = target.before ? target.idx : target.idx + 1;
-
       if (insertBefore === fromIdx || insertBefore === fromIdx + 1) return;
 
-
-
       const next = [...sourcesRef.current];
-
       const [moved] = next.splice(fromIdx, 1);
-
       next.splice(insertBefore > fromIdx ? insertBefore - 1 : insertBefore, 0, moved);
-
       setLyricsSources(next);
-
     };
-
     el.addEventListener('psy-drop', onPsyDrop);
-
     return () => el.removeEventListener('psy-drop', onPsyDrop);
-
   }, [setLyricsSources]);
 
-
-
   const handleMouseMove = (e: React.MouseEvent) => {
-
     if (!isPsyDragging || !containerRef.current) return;
-
     const rows = containerRef.current.querySelectorAll<HTMLElement>('[data-lyrics-idx]');
-
     let target: LyricsDropTarget = null;
-
     for (const row of rows) {
-
       const rect = row.getBoundingClientRect();
-
       const idx = Number(row.dataset.lyricsIdx);
-
       if (e.clientY < rect.top + rect.height / 2) { target = { idx, before: true }; break; }
-
       target = { idx, before: false };
-
     }
-
     dropTargetRef.current = target;
-
     setDropTarget(target);
-
   };
-
-
 
   const toggleSource = (id: LyricsSourceId) => {
-
     setLyricsSources(sourcesRef.current.map(s => s.id === id ? { ...s, enabled: !s.enabled } : s));
-
   };
 
-
-
   return (
-
     <section className="settings-section">
-
       <div className="settings-section-header">
-
         <Music2 size={18} />
-
         <h2>{t('settings.lyricsSourcesTitle')}</h2>
-
       </div>
-
       <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: '0.75rem', lineHeight: 1.5 }}>
-
         {t('settings.lyricsSourcesDesc')}
-
       </p>
-
       <div className="settings-card" style={{ padding: '4px 0' }} ref={containerRef} onMouseMove={handleMouseMove}>
-
         {lyricsSources.map((src, i) => {
-
           const label = t(LYRICS_SOURCE_LABEL_KEYS[src.id]);
-
           const isBefore = isPsyDragging && dropTarget?.idx === i && dropTarget.before;
-
           const isAfter  = isPsyDragging && dropTarget?.idx === i && !dropTarget.before;
-
           return (
-
             <div
-
               key={src.id}
-
               data-lyrics-idx={i}
-
               className="sidebar-customizer-row"
-
               style={{
-
                 borderTop:    isBefore ? '2px solid var(--accent)' : undefined,
-
                 borderBottom: isAfter  ? '2px solid var(--accent)' : undefined,
-
               }}
-
             >
-
               <LyricsSourceGripHandle idx={i} label={label} />
-
               <span style={{ flex: 1, fontSize: 14, opacity: src.enabled ? 1 : 0.45 }}>{label}</span>
-
               <label className="toggle-switch" aria-label={label}>
-
                 <input type="checkbox" checked={src.enabled} onChange={() => toggleSource(src.id)} />
-
                 <span className="toggle-track" />
-
               </label>
-
             </div>
-
           );
-
         })}
-
       </div>
-
     </section>
-
   );
-
 }
-
-
 
 // ── Sidebar Customizer ──────────────────────────────────────────────────────
 
-
-
 type DropTarget = { idx: number; before: boolean; section: 'library' | 'system' } | null;
 
-
-
 function SidebarCustomizer() {
-
   const { t } = useTranslation();
-
   const { items, setItems, toggleItem, reset } = useSidebarStore();
-
   const { isDragging: isPsyDragging } = useDragDrop();
-
   const containerRef = useRef<HTMLDivElement>(null);
-
   const [dropTarget, setDropTarget] = useState<DropTarget>(null);
-
   const dropTargetRef = useRef<DropTarget>(null);
-
   const itemsRef = useRef(items);
-
   itemsRef.current = items;
+  const randomNavMode = useAuthStore(s => s.randomNavMode);
+  const setRandomNavMode = useAuthStore(s => s.setRandomNavMode);
 
-
-
-  const libraryItems = items.filter(cfg => ALL_NAV_ITEMS[cfg.id]?.section === 'library');
-
+  const libraryItems = items.filter(cfg => {
+    if (!ALL_NAV_ITEMS[cfg.id] || ALL_NAV_ITEMS[cfg.id].section !== 'library') return false;
+    if (randomNavMode === 'hub' && (cfg.id === 'randomMix' || cfg.id === 'randomAlbums')) return false;
+    if (randomNavMode === 'separate' && cfg.id === 'randomPicker') return false;
+    return true;
+  });
   const systemItems  = items.filter(cfg => ALL_NAV_ITEMS[cfg.id]?.section === 'system');
 
-
-
   useEffect(() => {
-
     if (!isPsyDragging) { dropTargetRef.current = null; setDropTarget(null); }
-
   }, [isPsyDragging]);
 
-
-
   useEffect(() => {
-
     const el = containerRef.current;
-
     if (!el) return;
-
     const onPsyDrop = (e: Event) => {
-
       const detail = (e as CustomEvent).detail;
-
       if (!detail?.data) return;
-
       let parsed: { type?: string; index?: number; section?: string };
-
       try { parsed = JSON.parse(detail.data); } catch { return; }
-
       if (parsed.type !== 'sidebar_reorder' || parsed.index == null || !parsed.section) return;
 
-
-
       const fromIdx = parsed.index;
-
       const fromSection = parsed.section as 'library' | 'system';
-
       const target = dropTargetRef.current;
-
       dropTargetRef.current = null; setDropTarget(null);
-
       if (!target || target.section !== fromSection) return;
 
-
-
       const sectionItems = fromSection === 'library' ? [...libraryItems] : [...systemItems];
-
       const insertBefore = target.before ? target.idx : target.idx + 1;
-
       if (insertBefore === fromIdx || insertBefore === fromIdx + 1) return;
 
-
-
       const [moved] = sectionItems.splice(fromIdx, 1);
-
       sectionItems.splice(insertBefore > fromIdx ? insertBefore - 1 : insertBefore, 0, moved);
 
-
-
-      // Merge reordered section back into flat items array
-
+      // Merge reordered section back into flat items array.
+      // Only update positions of the *visible* items (same filter as libraryItems/systemItems)
+      // so hidden entries like randomMix/randomAlbums are never overwritten with undefined.
       const all = [...itemsRef.current];
-
+      const visibleIds = new Set(sectionItems.map(c => c.id));
       const positions = all.map((cfg, i) => ({ cfg, i }))
-
-        .filter(({ cfg }) => ALL_NAV_ITEMS[cfg.id]?.section === fromSection)
-
+        .filter(({ cfg }) => visibleIds.has(cfg.id))
         .map(({ i }) => i);
-
       positions.forEach((pos, i) => { all[pos] = sectionItems[i]; });
-
       setItems(all);
-
     };
-
     el.addEventListener('psy-drop', onPsyDrop);
-
     return () => el.removeEventListener('psy-drop', onPsyDrop);
-
   }, [libraryItems, systemItems, setItems]);
 
-
-
   const handleMouseMove = (e: React.MouseEvent) => {
-
     if (!isPsyDragging || !containerRef.current) return;
-
     const rows = containerRef.current.querySelectorAll<HTMLElement>('[data-sidebar-idx]');
-
     let target: DropTarget = null;
-
     for (const row of rows) {
-
       const rect = row.getBoundingClientRect();
-
       const idx = Number(row.dataset.sidebarIdx);
-
       const section = row.dataset.sidebarSection as 'library' | 'system';
-
       if (e.clientY < rect.top + rect.height / 2) { target = { idx, before: true, section }; break; }
-
       target = { idx, before: false, section };
-
     }
-
     dropTargetRef.current = target;
-
     setDropTarget(target);
-
   };
-
-
 
   const renderRow = (cfg: SidebarItemConfig, localIdx: number, section: 'library' | 'system') => {
-
     const meta = ALL_NAV_ITEMS[cfg.id];
-
     if (!meta) return null;
-
     const Icon = meta.icon;
-
     const isBefore = isPsyDragging && dropTarget?.section === section && dropTarget.idx === localIdx && dropTarget.before;
-
     const isAfter  = isPsyDragging && dropTarget?.section === section && dropTarget.idx === localIdx && !dropTarget.before;
-
     return (
-
       <div
-
         key={cfg.id}
-
         data-sidebar-idx={localIdx}
-
         data-sidebar-section={section}
-
         className="sidebar-customizer-row"
-
         style={{
-
           borderTop:    isBefore ? '2px solid var(--accent)' : undefined,
-
           borderBottom: isAfter  ? '2px solid var(--accent)' : undefined,
-
         }}
-
       >
-
         <SidebarGripHandle idx={localIdx} section={section} label={t(meta.labelKey)} />
-
         <Icon size={16} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
-
         <span style={{ flex: 1, fontSize: 14 }}>{t(meta.labelKey)}</span>
-
         <label className="toggle-switch" aria-label={t(meta.labelKey)}>
-
           <input type="checkbox" checked={cfg.visible} onChange={() => toggleItem(cfg.id)} />
-
           <span className="toggle-track" />
-
         </label>
-
       </div>
-
     );
-
   };
 
-
-
   return (
-
     <section className="settings-section">
-
       <div className="settings-section-header">
-
         <PanelLeft size={18} />
-
         <h2>{t('settings.sidebarTitle')}</h2>
-
         <button
-
           className="btn btn-ghost"
-
           style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--text-muted)' }}
-
           onClick={reset}
-
           data-tooltip={t('settings.sidebarReset')}
-
         >
-
           <RotateCcw size={14} />
-
         </button>
-
       </div>
-
-      <div ref={containerRef} onMouseMove={handleMouseMove} style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-
-        {/* Library block */}
-
-        <div className="settings-card" style={{ padding: '4px 0' }}>
-
-          <div className="sidebar-customizer-block-label">{t('sidebar.library')}</div>
-
-          {libraryItems.map((cfg, i) => renderRow(cfg, i, 'library'))}
-
-        </div>
-
-        {/* System block */}
-
-        <div className="settings-card" style={{ padding: '4px 0' }}>
-
-          <div className="sidebar-customizer-block-label">{t('sidebar.system')}</div>
-
-          {systemItems.map((cfg, i) => renderRow(cfg, i, 'system'))}
-
-          <div className="sidebar-customizer-fixed-hint">
-
-            <span>{t('settings.sidebarFixed')}: {t('sidebar.nowPlaying')}, {t('sidebar.settings')}</span>
-
+      <div className="settings-card" style={{ marginBottom: '1rem' }}>
+        <div className="settings-toggle-row">
+          <div>
+            <div style={{ fontWeight: 500 }}>{t('settings.randomNavSplitTitle')}</div>
+            <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.randomNavSplitDesc')}</div>
           </div>
-
+          <label className="toggle-switch" aria-label={t('settings.randomNavSplitTitle')}>
+            <input
+              type="checkbox"
+              checked={randomNavMode === 'separate'}
+              onChange={e => setRandomNavMode(e.target.checked ? 'separate' : 'hub')}
+            />
+            <span className="toggle-track" />
+          </label>
         </div>
-
       </div>
-
+      <div ref={containerRef} onMouseMove={handleMouseMove} style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        {/* Library block */}
+        <div className="settings-card" style={{ padding: '4px 0' }}>
+          <div className="sidebar-customizer-block-label">{t('sidebar.library')}</div>
+          {libraryItems.map((cfg, i) => renderRow(cfg, i, 'library'))}
+        </div>
+        {/* System block */}
+        <div className="settings-card" style={{ padding: '4px 0' }}>
+          <div className="sidebar-customizer-block-label">{t('sidebar.system')}</div>
+          {systemItems.map((cfg, i) => renderRow(cfg, i, 'system'))}
+          <div className="sidebar-customizer-fixed-hint">
+            <span>{t('settings.sidebarFixed')}: {t('sidebar.nowPlaying')}, {t('sidebar.settings')}</span>
+          </div>
+        </div>
+      </div>
     </section>
-
   );
-
 }
-
-
 
 function BackupSection() {
-
   const { t } = useTranslation();
-
   const [exporting, setExporting] = useState(false);
-
   const [importing, setImporting] = useState(false);
 
-
-
   const handleExport = async () => {
-
     setExporting(true);
-
     try {
-
       const path = await exportBackup();
-
       if (path) showToast(t('settings.backupSuccess'), 3000, 'info');
-
     } catch (e) {
-
       console.error('Export failed', e);
-
       showToast(t('settings.backupImportError'), 4000, 'error');
-
     } finally {
-
       setExporting(false);
-
     }
-
   };
-
-
 
   const handleImport = async () => {
-
     if (!window.confirm(t('settings.backupImportConfirm'))) return;
-
     setImporting(true);
-
     try {
-
       await importBackup();
-
       // importBackup reloads the page — this toast will briefly show before reload
-
       showToast(t('settings.backupImportSuccess'), 3000, 'info');
-
     } catch (e) {
-
       console.error('Import failed', e);
-
       showToast(t('settings.backupImportError'), 4000, 'error');
-
       setImporting(false);
-
     }
-
   };
 
-
-
   return (
-
     <section className="settings-section">
-
       <div className="settings-section-header">
-
         <HardDrive size={18} />
-
         <h2>{t('settings.backupTitle')}</h2>
-
       </div>
-
-
 
       {/* Export */}
-
       <div className="settings-card" style={{ marginBottom: '1rem' }}>
-
         <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '1rem' }}>
-
           <div>
-
             <div style={{ fontWeight: 500, marginBottom: '0.25rem' }}>{t('settings.backupExport')}</div>
-
             <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>{t('settings.backupExportDesc')}</div>
-
           </div>
-
           <button
-
             className="btn btn-primary"
-
             onClick={handleExport}
-
             disabled={exporting}
-
             style={{ flexShrink: 0 }}
-
           >
-
             <Upload size={14} />
-
             {exporting ? '…' : t('settings.backupExport')}
-
           </button>
-
         </div>
-
       </div>
-
-
 
       {/* Import */}
-
       <div className="settings-card">
-
         <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '1rem' }}>
-
           <div>
-
             <div style={{ fontWeight: 500, marginBottom: '0.25rem' }}>{t('settings.backupImport')}</div>
-
             <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>{t('settings.backupImportDesc')}</div>
-
           </div>
-
           <button
-
             className="btn btn-surface"
-
             onClick={handleImport}
-
             disabled={importing}
-
             style={{ flexShrink: 0 }}
-
           >
-
             <Download size={14} />
-
             {importing ? '…' : t('settings.backupImport')}
-
           </button>
-
         </div>
-
       </div>
-
     </section>
-
   );
-
 }
-
-
 
 function ChangelogSection() {
-
   const { t } = useTranslation();
-
   const showChangelogOnUpdate = useAuthStore(s => s.showChangelogOnUpdate);
-
   const setShowChangelogOnUpdate = useAuthStore(s => s.setShowChangelogOnUpdate);
 
-
-
   const versions = useMemo(() => {
-
     const blocks = changelogRaw.split(/\n(?=## \[)/).filter(b => b.startsWith('## ['));
-
     return blocks.map(block => {
-
       const lines = block.split('\n');
-
       const headerLine = lines[0]; // e.g. "## [1.5.0] - 2026-03-18"
-
       const versionMatch = headerLine.match(/## \[([^\]]+)\]/);
-
       const dateMatch = headerLine.match(/- (\d{4}-\d{2}-\d{2})/);
-
       const version = versionMatch?.[1] ?? '';
-
       const date = dateMatch?.[1] ?? '';
 
-
-
       // Parse the rest into rendered lines
-
       const body = lines.slice(1).join('\n').trim();
-
       return { version, date, body };
-
     });
-
   }, []);
 
-
-
   return (
-
     <section className="settings-section">
-
       <div className="settings-section-header">
-
         <Info size={18} />
-
         <h2>{t('settings.changelog')}</h2>
-
       </div>
-
       <div className="settings-toggle-row" style={{ marginBottom: '1rem' }}>
-
         <div>
-
           <div style={{ fontWeight: 500 }}>{t('settings.showChangelogOnUpdate')}</div>
-
           <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.showChangelogOnUpdateDesc')}</div>
-
         </div>
-
         <label className="toggle-switch" aria-label={t('settings.showChangelogOnUpdate')}>
-
           <input type="checkbox" checked={showChangelogOnUpdate} onChange={e => setShowChangelogOnUpdate(e.target.checked)} />
-
           <span className="toggle-track" />
-
         </label>
-
       </div>
-
       <div className="changelog-list">
-
         {versions.slice(0, 3).map(({ version, date, body }) => (
-
           <details key={version} className="changelog-entry" open={version === appVersion}>
-
             <summary className="changelog-summary">
-
               <span className="changelog-version">v{version}</span>
-
               <span className="changelog-date">{date}</span>
-
             </summary>
-
             <div className="changelog-body">
-
               {body.split('\n').map((line, i) => {
-
                 if (line.startsWith('### ')) {
-
                   return <div key={i} className="changelog-h3">{renderInline(line.slice(4))}</div>;
-
                 }
-
                 if (line.startsWith('#### ')) {
-
                   return <div key={i} className="changelog-h4">{renderInline(line.slice(5))}</div>;
-
                 }
-
                 if (line.startsWith('- ')) {
-
                   return <div key={i} className="changelog-item">{renderInline(line.slice(2))}</div>;
-
                 }
-
                 if (line.trim() === '') return null;
-
                 return <div key={i} className="changelog-text">{renderInline(line)}</div>;
-
               })}
-
             </div>
-
           </details>
-
         ))}
-
       </div>
-
     </section>
-
   );
-
 }
-

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,607 +1,1224 @@
 import { create } from 'zustand';
+
 import { persist, createJSONStorage } from 'zustand/middleware';
+
 import { invoke } from '@tauri-apps/api/core';
+
 import type { EntityRatingSupportLevel } from '../api/subsonic';
+
 import {
+
   isNavidromeAudiomuseSoftwareEligible,
+
   type InstantMixProbeResult,
+
   type SubsonicServerIdentity,
+
 } from '../utils/subsonicServerIdentity';
+
 import { usePlayerStore } from './playerStore';
 
+
+
 export interface ServerProfile {
+
   id: string;
+
   name: string;
+
   url: string;
+
   username: string;
+
   password: string;
+
 }
+
+
 
 export type SeekbarStyle = 'waveform' | 'linedot' | 'bar' | 'thick' | 'segmented' | 'neon' | 'pulsewave' | 'particletrail' | 'liquidfill' | 'retrotape';
 
+
+
 export type LyricsSourceId = 'server' | 'lrclib' | 'netease';
+
 export interface LyricsSourceConfig { id: LyricsSourceId; enabled: boolean; }
 
+
+
 const DEFAULT_LYRICS_SOURCES: LyricsSourceConfig[] = [
+
   { id: 'server',  enabled: true  },
+
   { id: 'lrclib',  enabled: true  },
+
   { id: 'netease', enabled: false },
+
 ];
 
+
+
 interface AuthState {
+
   // Multi-server
+
   servers: ServerProfile[];
+
   activeServerId: string | null;
 
+
+
   // Last.fm (global)
+
   lastfmApiKey: string;
+
   lastfmApiSecret: string;
+
   lastfmSessionKey: string;
+
   lastfmUsername: string;
 
+
+
   // Settings (global)
+
   scrobblingEnabled: boolean;
+
   maxCacheMb: number;
+
   downloadFolder: string;
+
   offlineDownloadDir: string;
+
   excludeAudiobooks: boolean;
+
   customGenreBlacklist: string[];
+
   replayGainEnabled: boolean;
+
   replayGainMode: 'track' | 'album';
+
   replayGainPreGainDb: number;   // added to RG gain for tagged files (0…+6 dB)
+
   replayGainFallbackDb: number;  // gain for untagged files / radio (-6…0 dB)
+
   crossfadeEnabled: boolean;
+
   crossfadeSecs: number;
+
   gaplessEnabled: boolean;
+
   preloadMode: 'off' | 'balanced' | 'early' | 'custom';
+
   preloadCustomSeconds: number;
+
   infiniteQueueEnabled: boolean;
+
   showArtistImages: boolean;
+
   showTrayIcon: boolean;
+
   minimizeToTray: boolean;
+
   discordRichPresence: boolean;
+
   enableAppleMusicCoversDiscord: boolean;
+
+  discordTemplateDetails: string;
+
+  discordTemplateState: string;
+
+  discordTemplateLargeText: string;
+
   useCustomTitlebar: boolean;
+
   nowPlayingEnabled: boolean;
+
   lyricsServerFirst: boolean;
+
   enableNeteaselyrics: boolean;
+
   lyricsSources: LyricsSourceConfig[];
+
   showFullscreenLyrics: boolean;
+
   showFsArtistPortrait: boolean;
+
   /** Portrait dimming 0–100 (percent), applied as CSS rgba alpha */
+
   fsPortraitDim: number;
+
   showChangelogOnUpdate: boolean;
+
   lastSeenChangelogVersion: string;
+
+
 
   seekbarStyle: SeekbarStyle;
 
+
+
   /** Alpha: native hi-res sample rate output (disabled = safe 44.1 kHz mode) */
+
   enableHiRes: boolean;
+
   /** Selected audio output device name. null = system default. */
+
   audioOutputDevice: string | null;
 
+
+
   /** Alpha: ephemeral queue prefetch cache on disk */
+
   hotCacheEnabled: boolean;
+
   hotCacheMaxMb: number;
+
   hotCacheDebounceSec: number;
+
   /** Parent directory; actual cache is `<dir>/psysonic-hot-cache/`. Empty = app data. */
+
   hotCacheDownloadDir: string;
 
+
+
   /** After this many manual skips of the same track, set track rating to 1 if still unrated (below 1 star). */
+
   skipStarOnManualSkipsEnabled: boolean;
+
   /** Manual skips per track before applying rating 1 (when enabled). */
+
   skipStarManualSkipThreshold: number;
+
   /**
+
    * Manual Next-count per track for skip→1★. Key = `${serverId}\\u001f${trackId}`
+
    * (empty serverId when none). Persisted; cleared when the track finishes naturally or when threshold is reached.
+
    */
+
   skipStarManualSkipCountsByKey: Record<string, number>;
+
   /** Increment skip count for current server + track; clears stored count when threshold reached. */
+
   recordSkipStarManualAdvance: (trackId: string) => { crossedThreshold: boolean } | null;
+
   /** Drop persisted skip count for this track on the active server (e.g. natural playback end). */
+
   clearSkipStarManualCountForTrack: (trackId: string) => void;
 
+
+
   /** Random mixes, random albums, home hero: drop non‑zero ratings at or below per‑axis thresholds (0 = unrated, kept). */
+
   mixMinRatingFilterEnabled: boolean;
+
   /** 0 = ignore; 1–3 = cutoff (UI); exclude track rating r when 0 < r ≤ cutoff. */
+
   mixMinRatingSong: number;
+
   /** 0 = ignore; album entity rating from payload or `getAlbum` when missing. */
+
   mixMinRatingAlbum: number;
+
   /** 0 = ignore; artist rating from payload / nested OpenSubsonic fields or `getArtist`. */
+
   mixMinRatingArtist: number;
 
+
+
   /** Subsonic music folders for the active server (not persisted; refetched on login / server change). */
+
   musicFolders: Array<{ id: string; name: string }>;
+
   /**
+
    * Per server: `all` = no musicFolderId param; otherwise a single folder id.
+
    * Only one library or all — no multi-folder merge.
+
    */
+
   musicLibraryFilterByServer: Record<string, 'all' | string>;
+
   /** Bumps when `setMusicLibraryFilter` runs so pages refetch catalog data. */
+
   musicLibraryFilterVersion: number;
 
+
+
   /**
+
    * Per server: whether `setRating` is assumed to work for album/artist ids (OpenSubsonic-style).
+
    * Absent key = not probed yet (`unknown` in UI).
+
    */
+
   entityRatingSupportByServer: Record<string, EntityRatingSupportLevel>;
+
   setEntityRatingSupport: (serverId: string, level: EntityRatingSupportLevel) => void;
 
+
+
   /**
+
    * Per server: Navidrome has the AudioMuse-AI plugin — use `getSimilarSongs` (Instant Mix) and
+
    * `getArtistInfo2` similar artists instead of Last.fm for discovery on this server.
+
    */
+
   audiomuseNavidromeByServer: Record<string, boolean>;
+
   setAudiomuseNavidromeEnabled: (serverId: string, enabled: boolean) => void;
 
+
+
   /** From `ping` — used to show the AudioMuse toggle only on Navidrome ≥ 0.60. */
+
   subsonicServerIdentityByServer: Record<string, SubsonicServerIdentity>;
+
   setSubsonicServerIdentity: (serverId: string, identity: SubsonicServerIdentity) => void;
 
+
+
   /** Instant Mix / similar path failed while this server had AudioMuse enabled (cleared on success or toggle off). */
+
   audiomuseNavidromeIssueByServer: Record<string, boolean>;
+
   setAudiomuseNavidromeIssue: (serverId: string, hasIssue: boolean) => void;
 
+
+
   /**
+
    * `getSimilarSongs` probe per server (after ping). `empty` hides the AudioMuse row; re-run by testing connection.
+
    */
+
   instantMixProbeByServer: Record<string, InstantMixProbeResult>;
+
   setInstantMixProbe: (serverId: string, result: InstantMixProbeResult) => void;
 
+
+
   // Status
+
   isLoggedIn: boolean;
+
   isConnecting: boolean;
+
   connectionError: string | null;
+
   lastfmSessionError: boolean;
 
-  // Actions
-  addServer: (profile: Omit<ServerProfile, 'id'>) => string;
-  updateServer: (id: string, data: Partial<Omit<ServerProfile, 'id'>>) => void;
-  removeServer: (id: string) => void;
-  setActiveServer: (id: string) => void;
-  setLoggedIn: (v: boolean) => void;
-  setConnecting: (v: boolean) => void;
-  setConnectionError: (e: string | null) => void;
-  setLastfm: (apiKey: string, apiSecret: string, sessionKey: string, username: string) => void;
-  connectLastfm: (sessionKey: string, username: string) => void;
-  disconnectLastfm: () => void;
-  setLastfmSessionError: (v: boolean) => void;
-  setScrobblingEnabled: (v: boolean) => void;
-  setMaxCacheMb: (v: number) => void;
-  setDownloadFolder: (v: string) => void;
-  setOfflineDownloadDir: (v: string) => void;
-  setExcludeAudiobooks: (v: boolean) => void;
-  setCustomGenreBlacklist: (v: string[]) => void;
-  setReplayGainEnabled: (v: boolean) => void;
-  setReplayGainMode: (v: 'track' | 'album') => void;
-  setReplayGainPreGainDb: (v: number) => void;
-  setReplayGainFallbackDb: (v: number) => void;
-  setCrossfadeEnabled: (v: boolean) => void;
-  setCrossfadeSecs: (v: number) => void;
-  setGaplessEnabled: (v: boolean) => void;
-  setPreloadMode: (v: 'off' | 'balanced' | 'early' | 'custom') => void;
-  setPreloadCustomSeconds: (v: number) => void;
-  setInfiniteQueueEnabled: (v: boolean) => void;
-  setShowArtistImages: (v: boolean) => void;
-  setShowTrayIcon: (v: boolean) => void;
-  setMinimizeToTray: (v: boolean) => void;
-  setDiscordRichPresence: (v: boolean) => void;
-  setEnableAppleMusicCoversDiscord: (v: boolean) => void;
-  setUseCustomTitlebar: (v: boolean) => void;
-  setNowPlayingEnabled: (v: boolean) => void;
-  setLyricsServerFirst: (v: boolean) => void;
-  setEnableNeteaselyrics: (v: boolean) => void;
-  setLyricsSources: (sources: LyricsSourceConfig[]) => void;
-  setShowFullscreenLyrics: (v: boolean) => void;
-  setShowFsArtistPortrait: (v: boolean) => void;
-  setFsPortraitDim: (v: number) => void;
-  setShowChangelogOnUpdate: (v: boolean) => void;
-  setLastSeenChangelogVersion: (v: string) => void;
-  setSeekbarStyle: (v: SeekbarStyle) => void;
-  setEnableHiRes: (v: boolean) => void;
-  setAudioOutputDevice: (v: string | null) => void;
-  setHotCacheEnabled: (v: boolean) => void;
-  setHotCacheMaxMb: (v: number) => void;
-  setHotCacheDebounceSec: (v: number) => void;
-  setHotCacheDownloadDir: (v: string) => void;
-  setSkipStarOnManualSkipsEnabled: (v: boolean) => void;
-  setSkipStarManualSkipThreshold: (v: number) => void;
-  setMixMinRatingFilterEnabled: (v: boolean) => void;
-  setMixMinRatingSong: (v: number) => void;
-  setMixMinRatingAlbum: (v: number) => void;
-  setMixMinRatingArtist: (v: number) => void;
-  setMusicFolders: (folders: Array<{ id: string; name: string }>) => void;
-  setMusicLibraryFilter: (folderId: 'all' | string) => void;
 
-  /** Navigation style for Mix pages: single hub ('hub') or separate sidebar entries ('separate'). */
-  randomNavMode: 'hub' | 'separate';
-  setRandomNavMode: (v: 'hub' | 'separate') => void;
+
+  // Actions
+
+  addServer: (profile: Omit<ServerProfile, 'id'>) => string;
+
+  updateServer: (id: string, data: Partial<Omit<ServerProfile, 'id'>>) => void;
+
+  removeServer: (id: string) => void;
+
+  setActiveServer: (id: string) => void;
+
+  setLoggedIn: (v: boolean) => void;
+
+  setConnecting: (v: boolean) => void;
+
+  setConnectionError: (e: string | null) => void;
+
+  setLastfm: (apiKey: string, apiSecret: string, sessionKey: string, username: string) => void;
+
+  connectLastfm: (sessionKey: string, username: string) => void;
+
+  disconnectLastfm: () => void;
+
+  setLastfmSessionError: (v: boolean) => void;
+
+  setScrobblingEnabled: (v: boolean) => void;
+
+  setMaxCacheMb: (v: number) => void;
+
+  setDownloadFolder: (v: string) => void;
+
+  setOfflineDownloadDir: (v: string) => void;
+
+  setExcludeAudiobooks: (v: boolean) => void;
+
+  setCustomGenreBlacklist: (v: string[]) => void;
+
+  setReplayGainEnabled: (v: boolean) => void;
+
+  setReplayGainMode: (v: 'track' | 'album') => void;
+
+  setReplayGainPreGainDb: (v: number) => void;
+
+  setReplayGainFallbackDb: (v: number) => void;
+
+  setCrossfadeEnabled: (v: boolean) => void;
+
+  setCrossfadeSecs: (v: number) => void;
+
+  setGaplessEnabled: (v: boolean) => void;
+
+  setPreloadMode: (v: 'off' | 'balanced' | 'early' | 'custom') => void;
+
+  setPreloadCustomSeconds: (v: number) => void;
+
+  setInfiniteQueueEnabled: (v: boolean) => void;
+
+  setShowArtistImages: (v: boolean) => void;
+
+  setShowTrayIcon: (v: boolean) => void;
+
+  setMinimizeToTray: (v: boolean) => void;
+
+  setDiscordRichPresence: (v: boolean) => void;
+
+  setEnableAppleMusicCoversDiscord: (v: boolean) => void;
+
+  setDiscordTemplateDetails: (v: string) => void;
+
+  setDiscordTemplateState: (v: string) => void;
+
+  setDiscordTemplateLargeText: (v: string) => void;
+
+  setUseCustomTitlebar: (v: boolean) => void;
+
+  setNowPlayingEnabled: (v: boolean) => void;
+
+  setLyricsServerFirst: (v: boolean) => void;
+
+  setEnableNeteaselyrics: (v: boolean) => void;
+
+  setLyricsSources: (sources: LyricsSourceConfig[]) => void;
+
+  setShowFullscreenLyrics: (v: boolean) => void;
+
+  setShowFsArtistPortrait: (v: boolean) => void;
+
+  setFsPortraitDim: (v: number) => void;
+
+  setShowChangelogOnUpdate: (v: boolean) => void;
+
+  setLastSeenChangelogVersion: (v: string) => void;
+
+  setSeekbarStyle: (v: SeekbarStyle) => void;
+
+  setEnableHiRes: (v: boolean) => void;
+
+  setAudioOutputDevice: (v: string | null) => void;
+
+  setHotCacheEnabled: (v: boolean) => void;
+
+  setHotCacheMaxMb: (v: number) => void;
+
+  setHotCacheDebounceSec: (v: number) => void;
+
+  setHotCacheDownloadDir: (v: string) => void;
+
+  setSkipStarOnManualSkipsEnabled: (v: boolean) => void;
+
+  setSkipStarManualSkipThreshold: (v: number) => void;
+
+  setMixMinRatingFilterEnabled: (v: boolean) => void;
+
+  setMixMinRatingSong: (v: number) => void;
+
+  setMixMinRatingAlbum: (v: number) => void;
+
+  setMixMinRatingArtist: (v: number) => void;
+
+  setMusicFolders: (folders: Array<{ id: string; name: string }>) => void;
+
+  setMusicLibraryFilter: (folderId: 'all' | string) => void;
 
   logout: () => void;
 
+
+
   // Derived
+
   getBaseUrl: () => string;
+
   getActiveServer: () => ServerProfile | undefined;
+
 }
+
+
 
 function generateId(): string {
+
   return Date.now().toString(36) + Math.random().toString(36).slice(2);
+
 }
+
+
 
 /** Upper bound for mix min-rating thresholds (UI shows five stars, only 1…this many are selectable). */
+
 export const MIX_MIN_RATING_FILTER_MAX_STARS = 3;
 
+
+
 function clampMixFilterMinStars(v: number): number {
+
   if (!Number.isFinite(v)) return 0;
+
   return Math.max(0, Math.min(MIX_MIN_RATING_FILTER_MAX_STARS, Math.round(v)));
+
 }
+
+
 
 function clampSkipStarThreshold(v: number): number {
+
   if (!Number.isFinite(v)) return 3;
+
   return Math.max(1, Math.min(99, Math.round(v)));
+
 }
+
+
 
 function skipStarCountStorageKey(serverId: string | null | undefined, trackId: string): string {
+
   return `${serverId ?? ''}\u001f${trackId}`;
+
 }
+
+
 
 function sanitizeSkipStarCounts(raw: unknown): Record<string, number> {
+
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+
   const next: Record<string, number> = {};
+
   for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+
     const n = Number(v);
+
     if (Number.isFinite(n) && n > 0) next[k] = Math.min(Math.floor(n), 1_000_000);
+
   }
+
   return next;
+
 }
 
+
+
 export const useAuthStore = create<AuthState>()(
+
   persist(
+
     (set, get) => ({
+
       servers: [],
+
       activeServerId: null,
+
       lastfmApiKey: '',
+
       lastfmApiSecret: '',
+
       lastfmSessionKey: '',
+
       lastfmUsername: '',
+
       scrobblingEnabled: true,
+
       maxCacheMb: 500,
+
       downloadFolder: '',
+
       offlineDownloadDir: '',
+
       excludeAudiobooks: false,
+
       customGenreBlacklist: [],
+
       replayGainEnabled: false,
+
       replayGainMode: 'track',
+
       replayGainPreGainDb: 0,
+
       replayGainFallbackDb: 0,
+
       crossfadeEnabled: false,
+
       crossfadeSecs: 3,
+
       gaplessEnabled: false,
+
       preloadMode: 'balanced',
+
       preloadCustomSeconds: 30,
+
       infiniteQueueEnabled: false,
+
       showArtistImages: false,
+
       showTrayIcon: true,
+
       minimizeToTray: false,
+
       discordRichPresence: false,
+
       enableAppleMusicCoversDiscord: false,
+
+      discordTemplateDetails: '{artist} - {title}',
+
+      discordTemplateState: '{album}',
+
+      discordTemplateLargeText: '{album}',
+
       useCustomTitlebar: false,
+
       nowPlayingEnabled: false,
+
       lyricsServerFirst: true,
+
       enableNeteaselyrics: false,
+
       lyricsSources: DEFAULT_LYRICS_SOURCES,
+
       showFullscreenLyrics: true,
+
       showFsArtistPortrait: true,
+
       fsPortraitDim: 28,
+
       showChangelogOnUpdate: true,
+
       lastSeenChangelogVersion: '',
+
       seekbarStyle: 'waveform',
+
       enableHiRes: false,
+
       audioOutputDevice: null,
+
       hotCacheEnabled: false,
+
       hotCacheMaxMb: 256,
+
       hotCacheDebounceSec: 30,
+
       hotCacheDownloadDir: '',
+
       skipStarOnManualSkipsEnabled: false,
+
       skipStarManualSkipThreshold: 3,
+
       skipStarManualSkipCountsByKey: {},
+
       mixMinRatingFilterEnabled: false,
+
       mixMinRatingSong: 0,
+
       mixMinRatingAlbum: 0,
+
       mixMinRatingArtist: 0,
-      randomNavMode: 'hub',
+
       musicFolders: [],
+
       musicLibraryFilterByServer: {},
+
       musicLibraryFilterVersion: 0,
+
       entityRatingSupportByServer: {},
+
       audiomuseNavidromeByServer: {},
+
       subsonicServerIdentityByServer: {},
+
       audiomuseNavidromeIssueByServer: {},
+
       instantMixProbeByServer: {},
+
       isLoggedIn: false,
+
       isConnecting: false,
+
       connectionError: null,
+
       lastfmSessionError: false,
 
+
+
       addServer: (profile) => {
+
         const id = generateId();
+
         set(s => ({ servers: [...s.servers, { ...profile, id }] }));
+
         return id;
+
       },
+
+
 
       updateServer: (id, data) => {
+
         set(s => ({
+
           servers: s.servers.map(srv => srv.id === id ? { ...srv, ...data } : srv),
+
         }));
+
       },
 
+
+
       removeServer: (id) => {
+
         set(s => {
+
           const newServers = s.servers.filter(srv => srv.id !== id);
+
           const switchedAway = s.activeServerId === id;
+
           const { [id]: _r, ...entityRatingRest } = s.entityRatingSupportByServer;
+
           const { [id]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
+
           const { [id]: _idn, ...identityRest } = s.subsonicServerIdentityByServer;
+
           const { [id]: _iss, ...issueRest } = s.audiomuseNavidromeIssueByServer;
+
           const { [id]: _pr, ...probeRest } = s.instantMixProbeByServer;
+
           return {
+
             servers: newServers,
+
             activeServerId: switchedAway ? (newServers[0]?.id ?? null) : s.activeServerId,
+
             isLoggedIn: switchedAway ? false : s.isLoggedIn,
+
             entityRatingSupportByServer: entityRatingRest,
+
             audiomuseNavidromeByServer: audiomuseRest,
+
             subsonicServerIdentityByServer: identityRest,
+
             audiomuseNavidromeIssueByServer: issueRest,
+
             instantMixProbeByServer: probeRest,
+
           };
+
         });
+
       },
+
+
 
       setActiveServer: (id) => set({ activeServerId: id, musicFolders: [] }),
 
+
+
       setLoggedIn: (v) => set({ isLoggedIn: v }),
+
       setConnecting: (v) => set({ isConnecting: v }),
+
       setConnectionError: (e) => set({ connectionError: e }),
 
+
+
       setLastfm: (apiKey, apiSecret, sessionKey, username) =>
+
         set({ lastfmApiKey: apiKey, lastfmApiSecret: apiSecret, lastfmSessionKey: sessionKey, lastfmUsername: username }),
 
+
+
       connectLastfm: (sessionKey, username) =>
+
         set({ lastfmSessionKey: sessionKey, lastfmUsername: username }),
 
+
+
       disconnectLastfm: () =>
+
         set({ lastfmSessionKey: '', lastfmUsername: '', lastfmSessionError: false }),
+
+
 
       setLastfmSessionError: (v) => set({ lastfmSessionError: v }),
 
+
+
       setScrobblingEnabled: (v) => set({ scrobblingEnabled: v }),
+
       setMaxCacheMb: (v) => set({ maxCacheMb: v }),
+
       setDownloadFolder: (v) => set({ downloadFolder: v }),
+
       setOfflineDownloadDir: (v) => set({ offlineDownloadDir: v }),
+
       setExcludeAudiobooks: (v) => set({ excludeAudiobooks: v }),
+
       setCustomGenreBlacklist: (v) => set({ customGenreBlacklist: v }),
+
       setReplayGainEnabled: (v) => {
+
         set({ replayGainEnabled: v });
+
         usePlayerStore.getState().updateReplayGainForCurrentTrack();
+
       },
+
       setReplayGainMode: (v) => {
+
         set({ replayGainMode: v });
+
         usePlayerStore.getState().updateReplayGainForCurrentTrack();
+
       },
+
       setReplayGainPreGainDb: (v) => {
+
         set({ replayGainPreGainDb: v });
+
         usePlayerStore.getState().updateReplayGainForCurrentTrack();
+
       },
+
       setReplayGainFallbackDb: (v) => {
+
         set({ replayGainFallbackDb: v });
+
         usePlayerStore.getState().updateReplayGainForCurrentTrack();
+
       },
+
       setCrossfadeEnabled: (v) => set({ crossfadeEnabled: v }),
+
       setCrossfadeSecs: (v) => set({ crossfadeSecs: v }),
+
       setGaplessEnabled: (v) => set({ gaplessEnabled: v }),
+
       setPreloadMode: (v: 'off' | 'balanced' | 'early' | 'custom') => set({ preloadMode: v }),
+
       setPreloadCustomSeconds: (v: number) => set({ preloadCustomSeconds: v }),
+
       setInfiniteQueueEnabled: (v) => set({ infiniteQueueEnabled: v }),
+
       setShowArtistImages: (v) => set({ showArtistImages: v }),
+
       setShowTrayIcon: (v) => set({ showTrayIcon: v }),
+
       setMinimizeToTray: (v) => set({ minimizeToTray: v }),
+
       setDiscordRichPresence: (v) => set({ discordRichPresence: v }),
+
       setEnableAppleMusicCoversDiscord: (v) => set({ enableAppleMusicCoversDiscord: v }),
+
+      setDiscordTemplateDetails: (v) => set({ discordTemplateDetails: v }),
+
+      setDiscordTemplateState: (v) => set({ discordTemplateState: v }),
+
+      setDiscordTemplateLargeText: (v) => set({ discordTemplateLargeText: v }),
+
       setUseCustomTitlebar: (v) => set({ useCustomTitlebar: v }),
+
       setNowPlayingEnabled: (v) => set({ nowPlayingEnabled: v }),
+
       setLyricsServerFirst: (v: boolean) => set({ lyricsServerFirst: v }),
+
       setEnableNeteaselyrics: (v: boolean) => set({ enableNeteaselyrics: v }),
+
       setLyricsSources: (sources) => set({ lyricsSources: sources }),
+
       setShowFullscreenLyrics: (v: boolean) => set({ showFullscreenLyrics: v }),
+
       setShowFsArtistPortrait: (v: boolean) => set({ showFsArtistPortrait: v }),
+
       setFsPortraitDim: (v: number) => set({ fsPortraitDim: v }),
+
       setShowChangelogOnUpdate: (v) => set({ showChangelogOnUpdate: v }),
+
       setLastSeenChangelogVersion: (v) => set({ lastSeenChangelogVersion: v }),
 
+
+
       setSeekbarStyle: (v) => set({ seekbarStyle: v }),
+
       setEnableHiRes: (v) => set({ enableHiRes: v }),
+
       setAudioOutputDevice: (v) => set({ audioOutputDevice: v }),
+
       setHotCacheEnabled: (v) => set({ hotCacheEnabled: v }),
+
       setHotCacheMaxMb: (v) => set({ hotCacheMaxMb: v }),
+
       setHotCacheDebounceSec: (v) => set({ hotCacheDebounceSec: v }),
+
       setHotCacheDownloadDir: (v) => set({ hotCacheDownloadDir: v }),
 
+
+
       setSkipStarOnManualSkipsEnabled: (v) =>
+
         set({
+
           skipStarOnManualSkipsEnabled: v,
+
           ...(v ? {} : { skipStarManualSkipCountsByKey: {} }),
+
         }),
+
       setSkipStarManualSkipThreshold: (v) => set({ skipStarManualSkipThreshold: clampSkipStarThreshold(v) }),
 
+
+
       recordSkipStarManualAdvance: (trackId: string) => {
+
         const s = get();
+
         if (!s.skipStarOnManualSkipsEnabled || s.skipStarManualSkipThreshold < 1) return null;
+
         const key = skipStarCountStorageKey(s.activeServerId, trackId);
+
         const prev = s.skipStarManualSkipCountsByKey[key] ?? 0;
+
         const threshold = s.skipStarManualSkipThreshold;
+
         const next = prev + 1;
+
         if (next >= threshold) {
+
           const { [key]: _removed, ...rest } = s.skipStarManualSkipCountsByKey;
+
           set({ skipStarManualSkipCountsByKey: rest });
+
           return { crossedThreshold: true };
+
         }
+
         set({
+
           skipStarManualSkipCountsByKey: { ...s.skipStarManualSkipCountsByKey, [key]: next },
+
         });
+
         return { crossedThreshold: false };
+
       },
+
+
 
       clearSkipStarManualCountForTrack: (trackId: string) => {
+
         const s = get();
+
         const key = skipStarCountStorageKey(s.activeServerId, trackId);
+
         if (s.skipStarManualSkipCountsByKey[key] === undefined) return;
+
         const { [key]: _removed, ...rest } = s.skipStarManualSkipCountsByKey;
+
         set({ skipStarManualSkipCountsByKey: rest });
+
       },
+
+
 
       setMixMinRatingFilterEnabled: (v) => set({ mixMinRatingFilterEnabled: v }),
+
       setMixMinRatingSong: (v) => set({ mixMinRatingSong: clampMixFilterMinStars(v) }),
+
       setMixMinRatingAlbum: (v) => set({ mixMinRatingAlbum: clampMixFilterMinStars(v) }),
+
       setMixMinRatingArtist: (v) => set({ mixMinRatingArtist: clampMixFilterMinStars(v) }),
-      setRandomNavMode: (v) => set({ randomNavMode: v }),
+
+
 
       setMusicFolders: (folders) => {
+
         const sid = get().activeServerId;
+
         set(s => {
+
           const f = sid ? s.musicLibraryFilterByServer[sid] : undefined;
+
           const invalidFilter = f && f !== 'all' && !folders.some(x => x.id === f);
+
           return {
+
             musicFolders: folders,
+
             ...(sid && invalidFilter
+
               ? { musicLibraryFilterByServer: { ...s.musicLibraryFilterByServer, [sid]: 'all' } }
+
               : {}),
+
           };
+
         });
+
       },
+
+
 
       setMusicLibraryFilter: (folderId) => {
+
         const sid = get().activeServerId;
+
         if (!sid) return;
+
         set(s => ({
+
           musicLibraryFilterByServer: { ...s.musicLibraryFilterByServer, [sid]: folderId },
+
           musicLibraryFilterVersion: s.musicLibraryFilterVersion + 1,
+
         }));
+
       },
 
+
+
       setEntityRatingSupport: (serverId, level) =>
+
         set(s => ({
+
           entityRatingSupportByServer: { ...s.entityRatingSupportByServer, [serverId]: level },
+
         })),
 
+
+
       setAudiomuseNavidromeEnabled: (serverId, enabled) =>
+
         set(s => {
+
           const audiomuseNavidromeByServer = enabled
+
             ? { ...s.audiomuseNavidromeByServer, [serverId]: true }
+
             : (() => {
+
                 const { [serverId]: _removed, ...rest } = s.audiomuseNavidromeByServer;
+
                 return rest;
+
               })();
+
           const { [serverId]: _issueRm, ...issueRest } = s.audiomuseNavidromeIssueByServer;
+
           return { audiomuseNavidromeByServer, audiomuseNavidromeIssueByServer: issueRest };
+
         }),
+
+
 
       setSubsonicServerIdentity: (serverId, identity) =>
+
         set(s => {
+
           const subsonicServerIdentityByServer = { ...s.subsonicServerIdentityByServer, [serverId]: { ...identity } };
+
           if (!isNavidromeAudiomuseSoftwareEligible(identity)) {
+
             const { [serverId]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
+
             const { [serverId]: _i, ...issueRest } = s.audiomuseNavidromeIssueByServer;
+
             const { [serverId]: _p, ...probeRest } = s.instantMixProbeByServer;
+
             return {
+
               subsonicServerIdentityByServer,
+
               audiomuseNavidromeByServer: audiomuseRest,
+
               audiomuseNavidromeIssueByServer: issueRest,
+
               instantMixProbeByServer: probeRest,
+
             };
+
           }
+
           return { subsonicServerIdentityByServer };
+
         }),
+
+
 
       setInstantMixProbe: (serverId, result) =>
+
         set(s => {
+
           const instantMixProbeByServer = { ...s.instantMixProbeByServer, [serverId]: result };
+
           if (result === 'empty') {
+
             const { [serverId]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
+
             const { [serverId]: _i, ...issueRest } = s.audiomuseNavidromeIssueByServer;
+
             return {
+
               instantMixProbeByServer,
+
               audiomuseNavidromeByServer: audiomuseRest,
+
               audiomuseNavidromeIssueByServer: issueRest,
+
             };
+
           }
+
           return { instantMixProbeByServer };
+
         }),
 
+
+
       setAudiomuseNavidromeIssue: (serverId, hasIssue) =>
+
         set(s =>
+
           hasIssue
+
             ? { audiomuseNavidromeIssueByServer: { ...s.audiomuseNavidromeIssueByServer, [serverId]: true } }
+
             : (() => {
+
                 const { [serverId]: _rm, ...rest } = s.audiomuseNavidromeIssueByServer;
+
                 return { audiomuseNavidromeIssueByServer: rest };
+
               })(),
+
         ),
+
+
 
       logout: () => set({ isLoggedIn: false, musicFolders: [] }),
 
+
+
       getBaseUrl: () => {
+
         const s = get();
+
         const server = s.servers.find(srv => srv.id === s.activeServerId);
+
         if (!server?.url) return '';
+
         const base = server.url.startsWith('http') ? server.url : `http://${server.url}`;
+
         return base.replace(/\/$/, '');
+
       },
+
+
 
       getActiveServer: () => {
+
         const s = get();
+
         return s.servers.find(srv => srv.id === s.activeServerId);
+
       },
+
     }),
+
     {
+
       name: 'psysonic-auth',
+
       storage: createJSONStorage(() => localStorage),
+
       partialize: state => {
+
         const { musicFolders: _mf, musicLibraryFilterVersion: _fv, ...rest } = state;
+
         return rest;
+
       },
+
       onRehydrateStorage: () => (state, error) => {
+
         if (error || !state) return;
+
         // If both hot cache and preload were enabled before mutual exclusion was enforced, reset both.
+
         const conflictingLegacyState =
+
           state.hotCacheEnabled && state.preloadMode !== 'off'
+
             ? { hotCacheEnabled: false, preloadMode: 'off' as const }
+
             : {};
 
+
+
         // Migrate lyricsServerFirst + enableNeteaselyrics → lyricsSources (one-time).
+
         let lyricsSourcesMigrated: { lyricsSources?: LyricsSourceConfig[] } = {};
+
         try {
+
           const raw = JSON.parse(localStorage.getItem('psysonic-auth') ?? '{}') as { state?: Record<string, unknown> };
+
           if (!raw?.state?.lyricsSources) {
+
             const serverFirst = (raw?.state?.lyricsServerFirst as boolean | undefined) ?? true;
+
             const neteaseOn   = (raw?.state?.enableNeteaselyrics as boolean | undefined) ?? false;
+
             const migrated: LyricsSourceConfig[] = serverFirst
+
               ? [{ id: 'server', enabled: true }, { id: 'lrclib', enabled: true }, { id: 'netease', enabled: neteaseOn }]
+
               : [{ id: 'lrclib', enabled: true }, { id: 'server', enabled: true }, { id: 'netease', enabled: neteaseOn }];
+
             lyricsSourcesMigrated = { lyricsSources: migrated };
+
           }
+
         } catch { /* ignore */ }
 
+
+
         useAuthStore.setState({
+
           mixMinRatingSong: clampMixFilterMinStars(state.mixMinRatingSong as number),
+
           mixMinRatingAlbum: clampMixFilterMinStars(state.mixMinRatingAlbum as number),
+
           mixMinRatingArtist: clampMixFilterMinStars(state.mixMinRatingArtist as number),
+
           skipStarManualSkipCountsByKey: sanitizeSkipStarCounts(
+
             (state as { skipStarManualSkipCountsByKey?: unknown }).skipStarManualSkipCountsByKey,
+
           ),
+
           ...conflictingLegacyState,
+
           ...lyricsSourcesMigrated,
+
         });
+
       },
+
     }
+
   )
+
 );
+

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,1224 +1,619 @@
 import { create } from 'zustand';
-
 import { persist, createJSONStorage } from 'zustand/middleware';
-
 import { invoke } from '@tauri-apps/api/core';
-
 import type { EntityRatingSupportLevel } from '../api/subsonic';
-
 import {
-
   isNavidromeAudiomuseSoftwareEligible,
-
   type InstantMixProbeResult,
-
   type SubsonicServerIdentity,
-
 } from '../utils/subsonicServerIdentity';
-
 import { usePlayerStore } from './playerStore';
 
-
-
 export interface ServerProfile {
-
   id: string;
-
   name: string;
-
   url: string;
-
   username: string;
-
   password: string;
-
 }
-
-
 
 export type SeekbarStyle = 'waveform' | 'linedot' | 'bar' | 'thick' | 'segmented' | 'neon' | 'pulsewave' | 'particletrail' | 'liquidfill' | 'retrotape';
 
-
-
 export type LyricsSourceId = 'server' | 'lrclib' | 'netease';
-
 export interface LyricsSourceConfig { id: LyricsSourceId; enabled: boolean; }
 
-
-
 const DEFAULT_LYRICS_SOURCES: LyricsSourceConfig[] = [
-
   { id: 'server',  enabled: true  },
-
   { id: 'lrclib',  enabled: true  },
-
   { id: 'netease', enabled: false },
-
 ];
 
-
-
 interface AuthState {
-
   // Multi-server
-
   servers: ServerProfile[];
-
   activeServerId: string | null;
 
-
-
   // Last.fm (global)
-
   lastfmApiKey: string;
-
   lastfmApiSecret: string;
-
   lastfmSessionKey: string;
-
   lastfmUsername: string;
 
-
-
   // Settings (global)
-
   scrobblingEnabled: boolean;
-
   maxCacheMb: number;
-
   downloadFolder: string;
-
   offlineDownloadDir: string;
-
   excludeAudiobooks: boolean;
-
   customGenreBlacklist: string[];
-
   replayGainEnabled: boolean;
-
   replayGainMode: 'track' | 'album';
-
   replayGainPreGainDb: number;   // added to RG gain for tagged files (0…+6 dB)
-
   replayGainFallbackDb: number;  // gain for untagged files / radio (-6…0 dB)
-
   crossfadeEnabled: boolean;
-
   crossfadeSecs: number;
-
   gaplessEnabled: boolean;
-
   preloadMode: 'off' | 'balanced' | 'early' | 'custom';
-
   preloadCustomSeconds: number;
-
   infiniteQueueEnabled: boolean;
-
   showArtistImages: boolean;
-
   showTrayIcon: boolean;
-
   minimizeToTray: boolean;
-
   discordRichPresence: boolean;
-
   enableAppleMusicCoversDiscord: boolean;
-
   discordTemplateDetails: string;
-
   discordTemplateState: string;
-
   discordTemplateLargeText: string;
-
   useCustomTitlebar: boolean;
-
   nowPlayingEnabled: boolean;
-
   lyricsServerFirst: boolean;
-
   enableNeteaselyrics: boolean;
-
   lyricsSources: LyricsSourceConfig[];
-
   showFullscreenLyrics: boolean;
-
   showFsArtistPortrait: boolean;
-
   /** Portrait dimming 0–100 (percent), applied as CSS rgba alpha */
-
   fsPortraitDim: number;
-
   showChangelogOnUpdate: boolean;
-
   lastSeenChangelogVersion: string;
-
-
 
   seekbarStyle: SeekbarStyle;
 
-
-
   /** Alpha: native hi-res sample rate output (disabled = safe 44.1 kHz mode) */
-
   enableHiRes: boolean;
-
   /** Selected audio output device name. null = system default. */
-
   audioOutputDevice: string | null;
 
-
-
   /** Alpha: ephemeral queue prefetch cache on disk */
-
   hotCacheEnabled: boolean;
-
   hotCacheMaxMb: number;
-
   hotCacheDebounceSec: number;
-
   /** Parent directory; actual cache is `<dir>/psysonic-hot-cache/`. Empty = app data. */
-
   hotCacheDownloadDir: string;
 
-
-
   /** After this many manual skips of the same track, set track rating to 1 if still unrated (below 1 star). */
-
   skipStarOnManualSkipsEnabled: boolean;
-
   /** Manual skips per track before applying rating 1 (when enabled). */
-
   skipStarManualSkipThreshold: number;
-
   /**
-
    * Manual Next-count per track for skip→1★. Key = `${serverId}\\u001f${trackId}`
-
    * (empty serverId when none). Persisted; cleared when the track finishes naturally or when threshold is reached.
-
    */
-
   skipStarManualSkipCountsByKey: Record<string, number>;
-
   /** Increment skip count for current server + track; clears stored count when threshold reached. */
-
   recordSkipStarManualAdvance: (trackId: string) => { crossedThreshold: boolean } | null;
-
   /** Drop persisted skip count for this track on the active server (e.g. natural playback end). */
-
   clearSkipStarManualCountForTrack: (trackId: string) => void;
 
-
-
   /** Random mixes, random albums, home hero: drop non‑zero ratings at or below per‑axis thresholds (0 = unrated, kept). */
-
   mixMinRatingFilterEnabled: boolean;
-
   /** 0 = ignore; 1–3 = cutoff (UI); exclude track rating r when 0 < r ≤ cutoff. */
-
   mixMinRatingSong: number;
-
   /** 0 = ignore; album entity rating from payload or `getAlbum` when missing. */
-
   mixMinRatingAlbum: number;
-
   /** 0 = ignore; artist rating from payload / nested OpenSubsonic fields or `getArtist`. */
-
   mixMinRatingArtist: number;
 
-
-
   /** Subsonic music folders for the active server (not persisted; refetched on login / server change). */
-
   musicFolders: Array<{ id: string; name: string }>;
-
   /**
-
    * Per server: `all` = no musicFolderId param; otherwise a single folder id.
-
    * Only one library or all — no multi-folder merge.
-
    */
-
   musicLibraryFilterByServer: Record<string, 'all' | string>;
-
   /** Bumps when `setMusicLibraryFilter` runs so pages refetch catalog data. */
-
   musicLibraryFilterVersion: number;
 
-
-
   /**
-
    * Per server: whether `setRating` is assumed to work for album/artist ids (OpenSubsonic-style).
-
    * Absent key = not probed yet (`unknown` in UI).
-
    */
-
   entityRatingSupportByServer: Record<string, EntityRatingSupportLevel>;
-
   setEntityRatingSupport: (serverId: string, level: EntityRatingSupportLevel) => void;
 
-
-
   /**
-
    * Per server: Navidrome has the AudioMuse-AI plugin — use `getSimilarSongs` (Instant Mix) and
-
    * `getArtistInfo2` similar artists instead of Last.fm for discovery on this server.
-
    */
-
   audiomuseNavidromeByServer: Record<string, boolean>;
-
   setAudiomuseNavidromeEnabled: (serverId: string, enabled: boolean) => void;
 
-
-
   /** From `ping` — used to show the AudioMuse toggle only on Navidrome ≥ 0.60. */
-
   subsonicServerIdentityByServer: Record<string, SubsonicServerIdentity>;
-
   setSubsonicServerIdentity: (serverId: string, identity: SubsonicServerIdentity) => void;
 
-
-
   /** Instant Mix / similar path failed while this server had AudioMuse enabled (cleared on success or toggle off). */
-
   audiomuseNavidromeIssueByServer: Record<string, boolean>;
-
   setAudiomuseNavidromeIssue: (serverId: string, hasIssue: boolean) => void;
 
-
-
   /**
-
    * `getSimilarSongs` probe per server (after ping). `empty` hides the AudioMuse row; re-run by testing connection.
-
    */
-
   instantMixProbeByServer: Record<string, InstantMixProbeResult>;
-
   setInstantMixProbe: (serverId: string, result: InstantMixProbeResult) => void;
 
-
-
   // Status
-
   isLoggedIn: boolean;
-
   isConnecting: boolean;
-
   connectionError: string | null;
-
   lastfmSessionError: boolean;
 
-
-
   // Actions
-
   addServer: (profile: Omit<ServerProfile, 'id'>) => string;
-
   updateServer: (id: string, data: Partial<Omit<ServerProfile, 'id'>>) => void;
-
   removeServer: (id: string) => void;
-
   setActiveServer: (id: string) => void;
-
   setLoggedIn: (v: boolean) => void;
-
   setConnecting: (v: boolean) => void;
-
   setConnectionError: (e: string | null) => void;
-
   setLastfm: (apiKey: string, apiSecret: string, sessionKey: string, username: string) => void;
-
   connectLastfm: (sessionKey: string, username: string) => void;
-
   disconnectLastfm: () => void;
-
   setLastfmSessionError: (v: boolean) => void;
-
   setScrobblingEnabled: (v: boolean) => void;
-
   setMaxCacheMb: (v: number) => void;
-
   setDownloadFolder: (v: string) => void;
-
   setOfflineDownloadDir: (v: string) => void;
-
   setExcludeAudiobooks: (v: boolean) => void;
-
   setCustomGenreBlacklist: (v: string[]) => void;
-
   setReplayGainEnabled: (v: boolean) => void;
-
   setReplayGainMode: (v: 'track' | 'album') => void;
-
   setReplayGainPreGainDb: (v: number) => void;
-
   setReplayGainFallbackDb: (v: number) => void;
-
   setCrossfadeEnabled: (v: boolean) => void;
-
   setCrossfadeSecs: (v: number) => void;
-
   setGaplessEnabled: (v: boolean) => void;
-
   setPreloadMode: (v: 'off' | 'balanced' | 'early' | 'custom') => void;
-
   setPreloadCustomSeconds: (v: number) => void;
-
   setInfiniteQueueEnabled: (v: boolean) => void;
-
   setShowArtistImages: (v: boolean) => void;
-
   setShowTrayIcon: (v: boolean) => void;
-
   setMinimizeToTray: (v: boolean) => void;
-
   setDiscordRichPresence: (v: boolean) => void;
-
   setEnableAppleMusicCoversDiscord: (v: boolean) => void;
-
   setDiscordTemplateDetails: (v: string) => void;
-
   setDiscordTemplateState: (v: string) => void;
-
   setDiscordTemplateLargeText: (v: string) => void;
-
   setUseCustomTitlebar: (v: boolean) => void;
-
   setNowPlayingEnabled: (v: boolean) => void;
-
   setLyricsServerFirst: (v: boolean) => void;
-
   setEnableNeteaselyrics: (v: boolean) => void;
-
   setLyricsSources: (sources: LyricsSourceConfig[]) => void;
-
   setShowFullscreenLyrics: (v: boolean) => void;
-
   setShowFsArtistPortrait: (v: boolean) => void;
-
   setFsPortraitDim: (v: number) => void;
-
   setShowChangelogOnUpdate: (v: boolean) => void;
-
   setLastSeenChangelogVersion: (v: string) => void;
-
   setSeekbarStyle: (v: SeekbarStyle) => void;
-
   setEnableHiRes: (v: boolean) => void;
-
   setAudioOutputDevice: (v: string | null) => void;
-
   setHotCacheEnabled: (v: boolean) => void;
-
   setHotCacheMaxMb: (v: number) => void;
-
   setHotCacheDebounceSec: (v: number) => void;
-
   setHotCacheDownloadDir: (v: string) => void;
-
   setSkipStarOnManualSkipsEnabled: (v: boolean) => void;
-
   setSkipStarManualSkipThreshold: (v: number) => void;
-
   setMixMinRatingFilterEnabled: (v: boolean) => void;
-
   setMixMinRatingSong: (v: number) => void;
-
   setMixMinRatingAlbum: (v: number) => void;
-
   setMixMinRatingArtist: (v: number) => void;
-
   setMusicFolders: (folders: Array<{ id: string; name: string }>) => void;
-
   setMusicLibraryFilter: (folderId: 'all' | string) => void;
+
+  /** Navigation style for Mix pages: single hub ('hub') or separate sidebar entries ('separate'). */
+  randomNavMode: 'hub' | 'separate';
+  setRandomNavMode: (v: 'hub' | 'separate') => void;
 
   logout: () => void;
 
-
-
   // Derived
-
   getBaseUrl: () => string;
-
   getActiveServer: () => ServerProfile | undefined;
-
 }
-
-
 
 function generateId(): string {
-
   return Date.now().toString(36) + Math.random().toString(36).slice(2);
-
 }
-
-
 
 /** Upper bound for mix min-rating thresholds (UI shows five stars, only 1…this many are selectable). */
-
 export const MIX_MIN_RATING_FILTER_MAX_STARS = 3;
 
-
-
 function clampMixFilterMinStars(v: number): number {
-
   if (!Number.isFinite(v)) return 0;
-
   return Math.max(0, Math.min(MIX_MIN_RATING_FILTER_MAX_STARS, Math.round(v)));
-
 }
-
-
 
 function clampSkipStarThreshold(v: number): number {
-
   if (!Number.isFinite(v)) return 3;
-
   return Math.max(1, Math.min(99, Math.round(v)));
-
 }
-
-
 
 function skipStarCountStorageKey(serverId: string | null | undefined, trackId: string): string {
-
   return `${serverId ?? ''}\u001f${trackId}`;
-
 }
-
-
 
 function sanitizeSkipStarCounts(raw: unknown): Record<string, number> {
-
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
-
   const next: Record<string, number> = {};
-
   for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-
     const n = Number(v);
-
     if (Number.isFinite(n) && n > 0) next[k] = Math.min(Math.floor(n), 1_000_000);
-
   }
-
   return next;
-
 }
 
-
-
 export const useAuthStore = create<AuthState>()(
-
   persist(
-
     (set, get) => ({
-
       servers: [],
-
       activeServerId: null,
-
       lastfmApiKey: '',
-
       lastfmApiSecret: '',
-
       lastfmSessionKey: '',
-
       lastfmUsername: '',
-
       scrobblingEnabled: true,
-
       maxCacheMb: 500,
-
       downloadFolder: '',
-
       offlineDownloadDir: '',
-
       excludeAudiobooks: false,
-
       customGenreBlacklist: [],
-
       replayGainEnabled: false,
-
       replayGainMode: 'track',
-
       replayGainPreGainDb: 0,
-
       replayGainFallbackDb: 0,
-
       crossfadeEnabled: false,
-
       crossfadeSecs: 3,
-
       gaplessEnabled: false,
-
       preloadMode: 'balanced',
-
       preloadCustomSeconds: 30,
-
       infiniteQueueEnabled: false,
-
       showArtistImages: false,
-
       showTrayIcon: true,
-
       minimizeToTray: false,
-
       discordRichPresence: false,
-
       enableAppleMusicCoversDiscord: false,
-
       discordTemplateDetails: '{artist} - {title}',
-
       discordTemplateState: '{album}',
-
       discordTemplateLargeText: '{album}',
-
       useCustomTitlebar: false,
-
       nowPlayingEnabled: false,
-
       lyricsServerFirst: true,
-
       enableNeteaselyrics: false,
-
       lyricsSources: DEFAULT_LYRICS_SOURCES,
-
       showFullscreenLyrics: true,
-
       showFsArtistPortrait: true,
-
       fsPortraitDim: 28,
-
       showChangelogOnUpdate: true,
-
       lastSeenChangelogVersion: '',
-
       seekbarStyle: 'waveform',
-
       enableHiRes: false,
-
       audioOutputDevice: null,
-
       hotCacheEnabled: false,
-
       hotCacheMaxMb: 256,
-
       hotCacheDebounceSec: 30,
-
       hotCacheDownloadDir: '',
-
       skipStarOnManualSkipsEnabled: false,
-
       skipStarManualSkipThreshold: 3,
-
       skipStarManualSkipCountsByKey: {},
-
       mixMinRatingFilterEnabled: false,
-
       mixMinRatingSong: 0,
-
       mixMinRatingAlbum: 0,
-
       mixMinRatingArtist: 0,
-
+      randomNavMode: 'hub',
       musicFolders: [],
-
       musicLibraryFilterByServer: {},
-
       musicLibraryFilterVersion: 0,
-
       entityRatingSupportByServer: {},
-
       audiomuseNavidromeByServer: {},
-
       subsonicServerIdentityByServer: {},
-
       audiomuseNavidromeIssueByServer: {},
-
       instantMixProbeByServer: {},
-
       isLoggedIn: false,
-
       isConnecting: false,
-
       connectionError: null,
-
       lastfmSessionError: false,
 
-
-
       addServer: (profile) => {
-
         const id = generateId();
-
         set(s => ({ servers: [...s.servers, { ...profile, id }] }));
-
         return id;
-
       },
-
-
 
       updateServer: (id, data) => {
-
         set(s => ({
-
           servers: s.servers.map(srv => srv.id === id ? { ...srv, ...data } : srv),
-
         }));
-
       },
-
-
 
       removeServer: (id) => {
-
         set(s => {
-
           const newServers = s.servers.filter(srv => srv.id !== id);
-
           const switchedAway = s.activeServerId === id;
-
           const { [id]: _r, ...entityRatingRest } = s.entityRatingSupportByServer;
-
           const { [id]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
-
           const { [id]: _idn, ...identityRest } = s.subsonicServerIdentityByServer;
-
           const { [id]: _iss, ...issueRest } = s.audiomuseNavidromeIssueByServer;
-
           const { [id]: _pr, ...probeRest } = s.instantMixProbeByServer;
-
           return {
-
             servers: newServers,
-
             activeServerId: switchedAway ? (newServers[0]?.id ?? null) : s.activeServerId,
-
             isLoggedIn: switchedAway ? false : s.isLoggedIn,
-
             entityRatingSupportByServer: entityRatingRest,
-
             audiomuseNavidromeByServer: audiomuseRest,
-
             subsonicServerIdentityByServer: identityRest,
-
             audiomuseNavidromeIssueByServer: issueRest,
-
             instantMixProbeByServer: probeRest,
-
           };
-
         });
-
       },
-
-
 
       setActiveServer: (id) => set({ activeServerId: id, musicFolders: [] }),
 
-
-
       setLoggedIn: (v) => set({ isLoggedIn: v }),
-
       setConnecting: (v) => set({ isConnecting: v }),
-
       setConnectionError: (e) => set({ connectionError: e }),
 
-
-
       setLastfm: (apiKey, apiSecret, sessionKey, username) =>
-
         set({ lastfmApiKey: apiKey, lastfmApiSecret: apiSecret, lastfmSessionKey: sessionKey, lastfmUsername: username }),
 
-
-
       connectLastfm: (sessionKey, username) =>
-
         set({ lastfmSessionKey: sessionKey, lastfmUsername: username }),
 
-
-
       disconnectLastfm: () =>
-
         set({ lastfmSessionKey: '', lastfmUsername: '', lastfmSessionError: false }),
-
-
 
       setLastfmSessionError: (v) => set({ lastfmSessionError: v }),
 
-
-
       setScrobblingEnabled: (v) => set({ scrobblingEnabled: v }),
-
       setMaxCacheMb: (v) => set({ maxCacheMb: v }),
-
       setDownloadFolder: (v) => set({ downloadFolder: v }),
-
       setOfflineDownloadDir: (v) => set({ offlineDownloadDir: v }),
-
       setExcludeAudiobooks: (v) => set({ excludeAudiobooks: v }),
-
       setCustomGenreBlacklist: (v) => set({ customGenreBlacklist: v }),
-
       setReplayGainEnabled: (v) => {
-
         set({ replayGainEnabled: v });
-
         usePlayerStore.getState().updateReplayGainForCurrentTrack();
-
       },
-
       setReplayGainMode: (v) => {
-
         set({ replayGainMode: v });
-
         usePlayerStore.getState().updateReplayGainForCurrentTrack();
-
       },
-
       setReplayGainPreGainDb: (v) => {
-
         set({ replayGainPreGainDb: v });
-
         usePlayerStore.getState().updateReplayGainForCurrentTrack();
-
       },
-
       setReplayGainFallbackDb: (v) => {
-
         set({ replayGainFallbackDb: v });
-
         usePlayerStore.getState().updateReplayGainForCurrentTrack();
-
       },
-
       setCrossfadeEnabled: (v) => set({ crossfadeEnabled: v }),
-
       setCrossfadeSecs: (v) => set({ crossfadeSecs: v }),
-
       setGaplessEnabled: (v) => set({ gaplessEnabled: v }),
-
       setPreloadMode: (v: 'off' | 'balanced' | 'early' | 'custom') => set({ preloadMode: v }),
-
       setPreloadCustomSeconds: (v: number) => set({ preloadCustomSeconds: v }),
-
       setInfiniteQueueEnabled: (v) => set({ infiniteQueueEnabled: v }),
-
       setShowArtistImages: (v) => set({ showArtistImages: v }),
-
       setShowTrayIcon: (v) => set({ showTrayIcon: v }),
-
       setMinimizeToTray: (v) => set({ minimizeToTray: v }),
-
       setDiscordRichPresence: (v) => set({ discordRichPresence: v }),
-
       setEnableAppleMusicCoversDiscord: (v) => set({ enableAppleMusicCoversDiscord: v }),
-
       setDiscordTemplateDetails: (v) => set({ discordTemplateDetails: v }),
-
       setDiscordTemplateState: (v) => set({ discordTemplateState: v }),
-
       setDiscordTemplateLargeText: (v) => set({ discordTemplateLargeText: v }),
-
       setUseCustomTitlebar: (v) => set({ useCustomTitlebar: v }),
-
       setNowPlayingEnabled: (v) => set({ nowPlayingEnabled: v }),
-
       setLyricsServerFirst: (v: boolean) => set({ lyricsServerFirst: v }),
-
       setEnableNeteaselyrics: (v: boolean) => set({ enableNeteaselyrics: v }),
-
       setLyricsSources: (sources) => set({ lyricsSources: sources }),
-
       setShowFullscreenLyrics: (v: boolean) => set({ showFullscreenLyrics: v }),
-
       setShowFsArtistPortrait: (v: boolean) => set({ showFsArtistPortrait: v }),
-
       setFsPortraitDim: (v: number) => set({ fsPortraitDim: v }),
-
       setShowChangelogOnUpdate: (v) => set({ showChangelogOnUpdate: v }),
-
       setLastSeenChangelogVersion: (v) => set({ lastSeenChangelogVersion: v }),
 
-
-
       setSeekbarStyle: (v) => set({ seekbarStyle: v }),
-
       setEnableHiRes: (v) => set({ enableHiRes: v }),
-
       setAudioOutputDevice: (v) => set({ audioOutputDevice: v }),
-
       setHotCacheEnabled: (v) => set({ hotCacheEnabled: v }),
-
       setHotCacheMaxMb: (v) => set({ hotCacheMaxMb: v }),
-
       setHotCacheDebounceSec: (v) => set({ hotCacheDebounceSec: v }),
-
       setHotCacheDownloadDir: (v) => set({ hotCacheDownloadDir: v }),
 
-
-
       setSkipStarOnManualSkipsEnabled: (v) =>
-
         set({
-
           skipStarOnManualSkipsEnabled: v,
-
           ...(v ? {} : { skipStarManualSkipCountsByKey: {} }),
-
         }),
-
       setSkipStarManualSkipThreshold: (v) => set({ skipStarManualSkipThreshold: clampSkipStarThreshold(v) }),
 
-
-
       recordSkipStarManualAdvance: (trackId: string) => {
-
         const s = get();
-
         if (!s.skipStarOnManualSkipsEnabled || s.skipStarManualSkipThreshold < 1) return null;
-
         const key = skipStarCountStorageKey(s.activeServerId, trackId);
-
         const prev = s.skipStarManualSkipCountsByKey[key] ?? 0;
-
         const threshold = s.skipStarManualSkipThreshold;
-
         const next = prev + 1;
-
         if (next >= threshold) {
-
           const { [key]: _removed, ...rest } = s.skipStarManualSkipCountsByKey;
-
           set({ skipStarManualSkipCountsByKey: rest });
-
           return { crossedThreshold: true };
-
         }
-
         set({
-
           skipStarManualSkipCountsByKey: { ...s.skipStarManualSkipCountsByKey, [key]: next },
-
         });
-
         return { crossedThreshold: false };
-
       },
-
-
 
       clearSkipStarManualCountForTrack: (trackId: string) => {
-
         const s = get();
-
         const key = skipStarCountStorageKey(s.activeServerId, trackId);
-
         if (s.skipStarManualSkipCountsByKey[key] === undefined) return;
-
         const { [key]: _removed, ...rest } = s.skipStarManualSkipCountsByKey;
-
         set({ skipStarManualSkipCountsByKey: rest });
-
       },
-
-
 
       setMixMinRatingFilterEnabled: (v) => set({ mixMinRatingFilterEnabled: v }),
-
       setMixMinRatingSong: (v) => set({ mixMinRatingSong: clampMixFilterMinStars(v) }),
-
       setMixMinRatingAlbum: (v) => set({ mixMinRatingAlbum: clampMixFilterMinStars(v) }),
-
       setMixMinRatingArtist: (v) => set({ mixMinRatingArtist: clampMixFilterMinStars(v) }),
-
-
+      setRandomNavMode: (v) => set({ randomNavMode: v }),
 
       setMusicFolders: (folders) => {
-
         const sid = get().activeServerId;
-
         set(s => {
-
           const f = sid ? s.musicLibraryFilterByServer[sid] : undefined;
-
           const invalidFilter = f && f !== 'all' && !folders.some(x => x.id === f);
-
           return {
-
             musicFolders: folders,
-
             ...(sid && invalidFilter
-
               ? { musicLibraryFilterByServer: { ...s.musicLibraryFilterByServer, [sid]: 'all' } }
-
               : {}),
-
           };
-
         });
-
       },
-
-
 
       setMusicLibraryFilter: (folderId) => {
-
         const sid = get().activeServerId;
-
         if (!sid) return;
-
         set(s => ({
-
           musicLibraryFilterByServer: { ...s.musicLibraryFilterByServer, [sid]: folderId },
-
           musicLibraryFilterVersion: s.musicLibraryFilterVersion + 1,
-
         }));
-
       },
 
-
-
       setEntityRatingSupport: (serverId, level) =>
-
         set(s => ({
-
           entityRatingSupportByServer: { ...s.entityRatingSupportByServer, [serverId]: level },
-
         })),
 
-
-
       setAudiomuseNavidromeEnabled: (serverId, enabled) =>
-
         set(s => {
-
           const audiomuseNavidromeByServer = enabled
-
             ? { ...s.audiomuseNavidromeByServer, [serverId]: true }
-
             : (() => {
-
                 const { [serverId]: _removed, ...rest } = s.audiomuseNavidromeByServer;
-
                 return rest;
-
               })();
-
           const { [serverId]: _issueRm, ...issueRest } = s.audiomuseNavidromeIssueByServer;
-
           return { audiomuseNavidromeByServer, audiomuseNavidromeIssueByServer: issueRest };
-
         }),
-
-
 
       setSubsonicServerIdentity: (serverId, identity) =>
-
         set(s => {
-
           const subsonicServerIdentityByServer = { ...s.subsonicServerIdentityByServer, [serverId]: { ...identity } };
-
           if (!isNavidromeAudiomuseSoftwareEligible(identity)) {
-
             const { [serverId]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
-
             const { [serverId]: _i, ...issueRest } = s.audiomuseNavidromeIssueByServer;
-
             const { [serverId]: _p, ...probeRest } = s.instantMixProbeByServer;
-
             return {
-
               subsonicServerIdentityByServer,
-
               audiomuseNavidromeByServer: audiomuseRest,
-
               audiomuseNavidromeIssueByServer: issueRest,
-
               instantMixProbeByServer: probeRest,
-
             };
-
           }
-
           return { subsonicServerIdentityByServer };
-
         }),
-
-
 
       setInstantMixProbe: (serverId, result) =>
-
         set(s => {
-
           const instantMixProbeByServer = { ...s.instantMixProbeByServer, [serverId]: result };
-
           if (result === 'empty') {
-
             const { [serverId]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
-
             const { [serverId]: _i, ...issueRest } = s.audiomuseNavidromeIssueByServer;
-
             return {
-
               instantMixProbeByServer,
-
               audiomuseNavidromeByServer: audiomuseRest,
-
               audiomuseNavidromeIssueByServer: issueRest,
-
             };
-
           }
-
           return { instantMixProbeByServer };
-
         }),
 
-
-
       setAudiomuseNavidromeIssue: (serverId, hasIssue) =>
-
         set(s =>
-
           hasIssue
-
             ? { audiomuseNavidromeIssueByServer: { ...s.audiomuseNavidromeIssueByServer, [serverId]: true } }
-
             : (() => {
-
                 const { [serverId]: _rm, ...rest } = s.audiomuseNavidromeIssueByServer;
-
                 return { audiomuseNavidromeIssueByServer: rest };
-
               })(),
-
         ),
-
-
 
       logout: () => set({ isLoggedIn: false, musicFolders: [] }),
 
-
-
       getBaseUrl: () => {
-
         const s = get();
-
         const server = s.servers.find(srv => srv.id === s.activeServerId);
-
         if (!server?.url) return '';
-
         const base = server.url.startsWith('http') ? server.url : `http://${server.url}`;
-
         return base.replace(/\/$/, '');
-
       },
-
-
 
       getActiveServer: () => {
-
         const s = get();
-
         return s.servers.find(srv => srv.id === s.activeServerId);
-
       },
-
     }),
-
     {
-
       name: 'psysonic-auth',
-
       storage: createJSONStorage(() => localStorage),
-
       partialize: state => {
-
         const { musicFolders: _mf, musicLibraryFilterVersion: _fv, ...rest } = state;
-
         return rest;
-
       },
-
       onRehydrateStorage: () => (state, error) => {
-
         if (error || !state) return;
-
         // If both hot cache and preload were enabled before mutual exclusion was enforced, reset both.
-
         const conflictingLegacyState =
-
           state.hotCacheEnabled && state.preloadMode !== 'off'
-
             ? { hotCacheEnabled: false, preloadMode: 'off' as const }
-
             : {};
 
-
-
         // Migrate lyricsServerFirst + enableNeteaselyrics → lyricsSources (one-time).
-
         let lyricsSourcesMigrated: { lyricsSources?: LyricsSourceConfig[] } = {};
-
         try {
-
           const raw = JSON.parse(localStorage.getItem('psysonic-auth') ?? '{}') as { state?: Record<string, unknown> };
-
           if (!raw?.state?.lyricsSources) {
-
             const serverFirst = (raw?.state?.lyricsServerFirst as boolean | undefined) ?? true;
-
             const neteaseOn   = (raw?.state?.enableNeteaselyrics as boolean | undefined) ?? false;
-
             const migrated: LyricsSourceConfig[] = serverFirst
-
               ? [{ id: 'server', enabled: true }, { id: 'lrclib', enabled: true }, { id: 'netease', enabled: neteaseOn }]
-
               : [{ id: 'lrclib', enabled: true }, { id: 'server', enabled: true }, { id: 'netease', enabled: neteaseOn }];
-
             lyricsSourcesMigrated = { lyricsSources: migrated };
-
           }
-
         } catch { /* ignore */ }
 
-
-
         useAuthStore.setState({
-
           mixMinRatingSong: clampMixFilterMinStars(state.mixMinRatingSong as number),
-
           mixMinRatingAlbum: clampMixFilterMinStars(state.mixMinRatingAlbum as number),
-
           mixMinRatingArtist: clampMixFilterMinStars(state.mixMinRatingArtist as number),
-
           skipStarManualSkipCountsByKey: sanitizeSkipStarCounts(
-
             (state as { skipStarManualSkipCountsByKey?: unknown }).skipStarManualSkipCountsByKey,
-
           ),
-
           ...conflictingLegacyState,
-
           ...lyricsSourcesMigrated,
-
         });
-
       },
-
     }
-
   )
-
 );
-

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -689,16 +689,28 @@ export function initAudioListeners(): () => void {
   let discordPrevTrackId: string | null = null;
   let discordPrevIsPlaying: boolean | null = null;
   let discordPrevFetchCovers: boolean | null = null;
+  let discordPrevTemplateDetails: string | null = null;
+  let discordPrevTemplateState: string | null = null;
+  let discordPrevTemplateLargeText: string | null = null;
 
   function syncDiscord() {
     const { currentTrack, isPlaying, currentTime } = usePlayerStore.getState();
-    const { discordRichPresence, enableAppleMusicCoversDiscord } = useAuthStore.getState();
+    const {
+      discordRichPresence,
+      enableAppleMusicCoversDiscord,
+      discordTemplateDetails,
+      discordTemplateState,
+      discordTemplateLargeText,
+    } = useAuthStore.getState();
 
     if (!discordRichPresence || !currentTrack) {
       if (discordPrevTrackId !== null) {
         discordPrevTrackId = null;
         discordPrevIsPlaying = null;
         discordPrevFetchCovers = null;
+        discordPrevTemplateDetails = null;
+        discordPrevTemplateState = null;
+        discordPrevTemplateLargeText = null;
         invoke('discord_clear_presence').catch(() => {});
       }
       return;
@@ -707,11 +719,17 @@ export function initAudioListeners(): () => void {
     const trackChanged = currentTrack.id !== discordPrevTrackId;
     const playingChanged = isPlaying !== discordPrevIsPlaying;
     const coversSettingChanged = enableAppleMusicCoversDiscord !== discordPrevFetchCovers;
-    if (!trackChanged && !playingChanged && !coversSettingChanged) return;
+    const detailsTemplateChanged = discordTemplateDetails !== discordPrevTemplateDetails;
+    const stateTemplateChanged = discordTemplateState !== discordPrevTemplateState;
+    const largeTextTemplateChanged = discordTemplateLargeText !== discordPrevTemplateLargeText;
+    if (!trackChanged && !playingChanged && !coversSettingChanged && !detailsTemplateChanged && !stateTemplateChanged && !largeTextTemplateChanged) return;
 
     discordPrevTrackId = currentTrack.id;
     discordPrevIsPlaying = isPlaying;
     discordPrevFetchCovers = enableAppleMusicCoversDiscord;
+    discordPrevTemplateDetails = discordTemplateDetails;
+    discordPrevTemplateState = discordTemplateState;
+    discordPrevTemplateLargeText = discordTemplateLargeText;
 
     invoke('discord_update_presence', {
       title: currentTrack.title,
@@ -725,6 +743,9 @@ export function initAudioListeners(): () => void {
       // iTunes cover fetching is only done when explicitly opted in.
       coverArtUrl: null,
       fetchItunesCovers: enableAppleMusicCoversDiscord,
+      detailsTemplate: discordTemplateDetails,
+      stateTemplate: discordTemplateState,
+      largeTextTemplate: discordTemplateLargeText,
     }).catch(() => {});
   }
 

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -692,6 +692,7 @@ export function initAudioListeners(): () => void {
   let discordPrevTemplateDetails: string | null = null;
   let discordPrevTemplateState: string | null = null;
   let discordPrevTemplateLargeText: string | null = null;
+  let discordPrevCurrentTime: number | null = null;
 
   function syncDiscord() {
     const { currentTrack, isPlaying, currentTime } = usePlayerStore.getState();
@@ -722,7 +723,8 @@ export function initAudioListeners(): () => void {
     const detailsTemplateChanged = discordTemplateDetails !== discordPrevTemplateDetails;
     const stateTemplateChanged = discordTemplateState !== discordPrevTemplateState;
     const largeTextTemplateChanged = discordTemplateLargeText !== discordPrevTemplateLargeText;
-    if (!trackChanged && !playingChanged && !coversSettingChanged && !detailsTemplateChanged && !stateTemplateChanged && !largeTextTemplateChanged) return;
+    const timeChanged = Math.abs(currentTime - (discordPrevCurrentTime ?? -1)) > 1; // Only update if time changed by more than 1 second
+    if (!trackChanged && !playingChanged && !coversSettingChanged && !detailsTemplateChanged && !stateTemplateChanged && !largeTextTemplateChanged && !timeChanged) return;
 
     discordPrevTrackId = currentTrack.id;
     discordPrevIsPlaying = isPlaying;
@@ -730,15 +732,17 @@ export function initAudioListeners(): () => void {
     discordPrevTemplateDetails = discordTemplateDetails;
     discordPrevTemplateState = discordTemplateState;
     discordPrevTemplateLargeText = discordTemplateLargeText;
+    discordPrevCurrentTime = currentTime;
 
     invoke('discord_update_presence', {
       title: currentTrack.title,
       artist: currentTrack.artist ?? 'Unknown Artist',
       album: currentTrack.album ?? null,
       isPlaying,
-      // Pass elapsed when playing so Discord shows a live running timer.
-      // Pass null when paused — Discord clears the timer.
-      elapsedSecs: isPlaying ? currentTime : null,
+      // Always pass elapsedSecs so backend can handle both playing and paused states.
+      // Backend will freeze timer when paused using end timestamp.
+      elapsedSecs: currentTime,
+      durationSecs: currentTrack.duration,
       // coverArtUrl is intentionally not passed — Subsonic URLs require auth.
       // iTunes cover fetching is only done when explicitly opted in.
       coverArtUrl: null,

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -692,7 +692,6 @@ export function initAudioListeners(): () => void {
   let discordPrevTemplateDetails: string | null = null;
   let discordPrevTemplateState: string | null = null;
   let discordPrevTemplateLargeText: string | null = null;
-  let discordPrevCurrentTime: number | null = null;
 
   function syncDiscord() {
     const { currentTrack, isPlaying, currentTime } = usePlayerStore.getState();
@@ -723,8 +722,7 @@ export function initAudioListeners(): () => void {
     const detailsTemplateChanged = discordTemplateDetails !== discordPrevTemplateDetails;
     const stateTemplateChanged = discordTemplateState !== discordPrevTemplateState;
     const largeTextTemplateChanged = discordTemplateLargeText !== discordPrevTemplateLargeText;
-    const timeChanged = Math.abs(currentTime - (discordPrevCurrentTime ?? -1)) > 1; // Only update if time changed by more than 1 second
-    if (!trackChanged && !playingChanged && !coversSettingChanged && !detailsTemplateChanged && !stateTemplateChanged && !largeTextTemplateChanged && !timeChanged) return;
+    if (!trackChanged && !playingChanged && !coversSettingChanged && !detailsTemplateChanged && !stateTemplateChanged && !largeTextTemplateChanged) return;
 
     discordPrevTrackId = currentTrack.id;
     discordPrevIsPlaying = isPlaying;
@@ -732,17 +730,13 @@ export function initAudioListeners(): () => void {
     discordPrevTemplateDetails = discordTemplateDetails;
     discordPrevTemplateState = discordTemplateState;
     discordPrevTemplateLargeText = discordTemplateLargeText;
-    discordPrevCurrentTime = currentTime;
 
     invoke('discord_update_presence', {
       title: currentTrack.title,
       artist: currentTrack.artist ?? 'Unknown Artist',
       album: currentTrack.album ?? null,
       isPlaying,
-      // Always pass elapsedSecs so backend can handle both playing and paused states.
-      // Backend will freeze timer when paused using end timestamp.
-      elapsedSecs: currentTime,
-      durationSecs: currentTrack.duration,
+      elapsedSecs: isPlaying ? currentTime : null,
       // coverArtUrl is intentionally not passed — Subsonic URLs require auth.
       // iTunes cover fetching is only done when explicitly opted in.
       coverArtUrl: null,


### PR DESCRIPTION
# Add Customizable Discord Rich Presence Templates

## Summary
This PR adds support for **customizable text templates** for Discord Rich Presence, allowing users to configure exactly what information is displayed on their Discord profile when listening to music. Three text fields are now customizable with template variables.

## Changes Made

### 1. Backend (Rust)

**File:** [`src-tauri/src/discord.rs`](cci:7://file:///c:/Users/kveld/Documents/psysonic/src-tauri/src/discord.rs:0:0-0:0)

- Added [`apply_template()`](cci:1://file:///c:/Users/kveld/Documents/psysonic/src-tauri/src/discord.rs:218:0-229:1) helper function that replaces template variables with actual track metadata
- Added three new optional parameters to [`discord_update_presence`](cci:1://file:///c:/Users/kveld/Documents/psysonic/src-tauri/src/discord.rs:231:0-354:1) command:
  - `details_template`: Template for the primary visible line
  - `state_template`: Template for the secondary visible line  
  - `large_text_template`: Template for the album art tooltip
- Updated documentation comments explaining the new parameters
- Defaults when templates are not provided:
  - `details`: `"{artist} - {title}"`
  - `state`: `"{album}"`
  - `large_text`: `"{album}"`

**Available template variables:**
- `{title}` - Track title
- `{artist}` - Artist name
- `{album}` - Album name (empty string if not available)
- `{paused}` - Shows "Paused — " prefix when playback is paused (empty when playing)

### 2. Frontend State

**File:** [`src/store/authStore.ts`](cci:7://file:///c:/Users/kveld/Documents/psysonic/src/store/authStore.ts:0:0-0:0)

Added three new state properties with their setters:

```typescript
// In AuthState interface:
discordTemplateDetails: string;    // Default: "{artist} - {title}"
discordTemplateState: string;      // Default: "{album}"
discordTemplateLargeText: string;  // Default: "{album}"

// Setter functions:
setDiscordTemplateDetails: (v: string) => void;
setDiscordTemplateState: (v: string) => void;
setDiscordTemplateLargeText: (v: string) => void;
```

### 3. Player Store Integration

**File:** [`src/store/playerStore.ts`](cci:7://file:///c:/Users/kveld/Documents/psysonic/src/store/playerStore.ts:0:0-0:0)

- Added tracking variables for all three template values to detect changes
- Modified [`syncDiscord()`](cci:1://file:///c:/Users/kveld/Documents/psysonic/src/store/playerStore.ts:695:2-749:3) to:
  - Read all three templates from `authStore`
  - Include them in the `discord_update_presence` invoke call
  - Trigger updates when any template changes
- Templates are passed to the backend as:
  - `detailsTemplate`
  - `stateTemplate`
  - `largeTextTemplate`

### 4. Settings UI

**File:** [`src/pages/Settings.tsx`](cci:7://file:///c:/Users/kveld/Documents/psysonic/src/pages/Settings.tsx:0:0-0:0)

Added UI section under "Discord Rich Presence" toggle with three text inputs:

```typescript
// Section appears when discordRichPresence is enabled:
{
  discordTemplates: "Custom text templates",
  discordTemplatesDesc: "Customize what information is shown on your Discord profile. Variables: {title}, {artist}, {album}, {paused}",
  discordTemplateDetails: "Primary line (details)",
  discordTemplateState: "Secondary line (state)",
  discordTemplateLargeText: "Album tooltip (largeText)"
}
```

Each input has appropriate placeholders showing the default template format.

**Also fixed:**
- Corrected import path for `ALL_NAV_ITEMS` (changed from `../components/Sidebar` to `../config/navItems`)

### 5. Internationalization (i18n)

Added translation strings in all 8 supported languages:

| Language | File |
|----------|------|
| English | `src/locales/en.ts` |
| Spanish | `src/locales/es.ts` |
| German | `src/locales/de.ts` |
| French | `src/locales/fr.ts` |
| Norwegian | `src/locales/nb.ts` |
| Dutch | `src/locales/nl.ts` |
| Russian | `src/locales/ru.ts` |
| Chinese | `src/locales/zh.ts` |

**Strings added per language:**
- `discordTemplates` - Section title
- `discordTemplatesDesc` - Description with available variables
- `discordTemplateDetails` - Primary line label
- `discordTemplateState` - Secondary line label
- `discordTemplateLargeText` - Album tooltip label

## Usage Examples

Users can now customize their Discord presence with templates like:

**Example 1: Minimal**
```
Details: {title}
State: {artist}
Tooltip: {album}
```
Shows: "Song Title" / "Artist Name"

**Example 2: With pause indicator**
```
Details: {paused}{title}
State: {artist} — {album}
Tooltip: Psysonic
```
Shows: "Paused — Song Title" / "Artist — Album" when paused

**Example 3: Emoji styling**
```
Details: 🎵 {artist} - {title}
State: 💿 {album}
Tooltip: 🎶 {title} • {artist}
```

## Default Behavior

If users don't customize the templates, the behavior remains unchanged from before:
- Details: Artist - Title
- State: Album name
- Tooltip: Album name

---

## **Solution to Discord timer bug:**

**Problem:** When pausing the song, Discord displayed "Playing" and started a new timer instead of freezing the time or disappearing.

**Solution implemented in [src-tauri/src/discord.rs](cci:7://file:///c:/Users/kveld/Documents/psysonic/src-tauri/src/discord.rs:0:0-0:0):**

```rust
// When paused: clear activity completely
if !is_playing {
    client.clear_activity();
    return Ok(());  // Don't show anything on Discord
}

// When playing: show normal activity with timer
let activity = Activity::new()
    .activity_type(ActivityType::Listening)
    .details(&details_text)
    .state(&state_text)
    .assets(assets)
    .timestamps(Timestamps::new().start(start));
```

**Result:**
- ✅ Playing: "Listening to Psysonic" + correct animated timer
- ✅ Paused: Disappears from Discord (cleared, no fake timers)
- ✅ Resume: Reappears with correct timer from where it left off