### PR TITLE
fix: csv import improvements

### DIFF
--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1037,6 +1037,8 @@ export const deTranslation = {
     csvImportNoValidTracks: 'Keine gültigen Titel in CSV-Datei gefunden',
     csvImportFailed: 'CSV-Import fehlgeschlagen',
     csvImportToast: '{{added}} hinzugefügt, {{notFound}} nicht gefunden, {{duplicates}} Duplikate',
+    csvImportDownloadSuccess: 'Bericht erfolgreich heruntergeladen',
+    csvImportDownloadError: 'Bericht konnte nicht heruntergeladen werden',
   },
   mostPlayed: {
     title: 'Meistgehört',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1039,6 +1039,8 @@ export const enTranslation = {
     csvImportNoValidTracks: 'No valid tracks found in CSV file',
     csvImportFailed: 'Failed to import CSV file',
     csvImportToast: '{{added}} added, {{notFound}} not found, {{duplicates}} duplicates',
+    csvImportDownloadSuccess: 'Report downloaded successfully',
+    csvImportDownloadError: 'Failed to download report',
   },
   mostPlayed: {
     title: 'Most Played',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1040,6 +1040,8 @@ export const esTranslation = {
     csvImportNoValidTracks: 'No se encontraron canciones válidas en el archivo CSV',
     csvImportFailed: 'Error al importar el archivo CSV',
     csvImportToast: '{{added}} agregadas, {{notFound}} no encontradas, {{duplicates}} duplicadas',
+    csvImportDownloadSuccess: 'Reporte descargado exitosamente',
+    csvImportDownloadError: 'Error al descargar el reporte',
   },
   mostPlayed: {
     title: 'Más Reproducidos',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -1035,6 +1035,8 @@ export const frTranslation = {
     csvImportNoValidTracks: 'Aucun titre valide trouvé dans le fichier CSV',
     csvImportFailed: 'Échec de l\'import CSV',
     csvImportToast: '{{added}} ajoutés, {{notFound}} non trouvés, {{duplicates}} doublons',
+    csvImportDownloadSuccess: 'Rapport téléchargé avec succès',
+    csvImportDownloadError: 'Échec du téléchargement du rapport',
   },
   mostPlayed: {
     title: 'Les plus joués',

--- a/src/locales/nb.ts
+++ b/src/locales/nb.ts
@@ -1034,6 +1034,8 @@ export const nbTranslation = {
     csvImportNoValidTracks: 'Ingen gyldige spor funnet i CSV-filen',
     csvImportFailed: 'Kunne ikke importere CSV-fil',
     csvImportToast: '{{added}} lagt til, {{notFound}} ikke funnet, {{duplicates}} duplikater',
+    csvImportDownloadSuccess: 'Rapport lastet ned',
+    csvImportDownloadError: 'Kunne ikke laste ned rapport',
   },
   mostPlayed: {
     title: 'Mest spilt',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -1034,6 +1034,8 @@ export const nlTranslation = {
     csvImportNoValidTracks: 'Geen geldige nummers gevonden in CSV-bestand',
     csvImportFailed: 'CSV-import mislukt',
     csvImportToast: '{{added}} toegevoegd, {{notFound}} niet gevonden, {{duplicates}} duplicaten',
+    csvImportDownloadSuccess: 'Rapport succesvol gedownload',
+    csvImportDownloadError: 'Rapport downloaden mislukt',
   },
   mostPlayed: {
     title: 'Meest gespeeld',

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -1093,6 +1093,8 @@ export const ruTranslation = {
     csvImportNoValidTracks: 'В CSV-файле не найдено действительных треков',
     csvImportFailed: 'Не удалось импортировать CSV-файл',
     csvImportToast: '{{added}} добавлено, {{notFound}} не найдено, {{duplicates}} дубликатов',
+    csvImportDownloadSuccess: 'Отчёт успешно скачан',
+    csvImportDownloadError: 'Не удалось скачать отчёт',
   },
   mostPlayed: {
     title: 'Популярное',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -1028,6 +1028,8 @@ export const zhTranslation = {
     csvImportNoValidTracks: 'CSV 文件中未找到有效曲目',
     csvImportFailed: 'CSV 文件导入失败',
     csvImportToast: '{{added}} 已添加，{{notFound}} 未找到，{{duplicates}} 重复项',
+    csvImportDownloadSuccess: '报告下载成功',
+    csvImportDownloadError: '报告下载失败',
   },
   mostPlayed: {
     title: '最常播放',

--- a/src/pages/PlaylistDetail.tsx
+++ b/src/pages/PlaylistDetail.tsx
@@ -69,6 +69,8 @@ interface SpotifyCsvTrack {
   artistNames: string[];  // Array of all artists for better matching
   albumName: string;
   isrc?: string;
+  score?: number;           // Match score when track not found
+  thresholdNeeded?: number; // Threshold required to pass
 }
 
 // Header mapping to canonical fields (supports English and Spanish)
@@ -651,6 +653,29 @@ export default function PlaylistDetail() {
     return 1 - dist / maxLen;
   };
 
+  // Calculate dynamic threshold based on match quality signals
+  const calculateDynamicThreshold = (
+    bestMatch: { score: number; artistScore: number },
+    secondMatch: { score: number } | undefined,
+    titleWords: number
+  ): number => {
+    const baseThreshold = 0.6; // Minimum acceptable score
+
+    // Bonus if there's a large gap between best and second match (clear winner)
+    const gap = secondMatch ? bestMatch.score - secondMatch.score : 0.3;
+    const gapBonus = gap > 0.15 ? 0.1 : gap > 0.08 ? 0.05 : 0;
+
+    // Short titles (< 3 words) are more ambiguous, need higher threshold
+    // Long titles (> 4 words) are more specific, can use lower threshold
+    const lengthBonus = titleWords > 4 ? 0.05 : titleWords < 3 ? -0.05 : 0;
+
+    // Strong artist match gives confidence to accept lower overall score
+    const artistBonus = bestMatch.artistScore > 0.85 ? 0.08 : bestMatch.artistScore > 0.7 ? 0.04 : 0;
+
+    // Calculate final threshold, clamp between 0.55 and 0.75
+    return Math.max(0.55, Math.min(0.75, baseThreshold - gapBonus - lengthBonus - artistBonus));
+  };
+
   // Process searches in batches to avoid overloading the server
   const processBatch = async <T, R>(
     items: T[],
@@ -703,9 +728,12 @@ export default function PlaylistDetail() {
           let attempts = 0;
           const maxAttempts = 2;
 
+          // Clean title before search to find matches despite version suffixes
+          const cleanTitleForSearch = cleanTrackTitle(track.trackName);
+
           while (attempts < maxAttempts) {
             try {
-              searchResult = await search(track.trackName, { songCount: 40, artistCount: 0, albumCount: 0 });
+              searchResult = await search(cleanTitleForSearch, { songCount: 40, artistCount: 0, albumCount: 0 });
               break;
             } catch (err) {
               attempts++;
@@ -716,7 +744,11 @@ export default function PlaylistDetail() {
           }
 
           if (!searchResult || searchResult.songs.length === 0) {
-            notFound.push(track);
+            notFound.push({
+              ...track,
+              score: 0,
+              thresholdNeeded: 0.6, // Minimum threshold, nothing to compare
+            });
             return null;
           }
 
@@ -756,11 +788,19 @@ export default function PlaylistDetail() {
             return { song: s, score: totalScore, titleScore, artistScore, albumScore, isrcMatch: false };
           }).sort((a, b) => b.score - a.score);
 
-          // Only accept if score is >= 0.7 (70% confidence)
+          // Use dynamic threshold based on match quality signals
           const bestMatch = scoredMatches[0];
+          const secondMatch = scoredMatches[1];
+          const titleWords = cleanCsvTitle.split(/\s+/).length;
 
-          if (bestMatch.score < 0.7) {
-            notFound.push({ ...track, albumName: `${track.albumName} (score: ${bestMatch.score.toFixed(2)})` });
+          const threshold = calculateDynamicThreshold(bestMatch, secondMatch, titleWords);
+
+          if (bestMatch.score < threshold) {
+            notFound.push({
+              ...track,
+              score: bestMatch.score,
+              thresholdNeeded: threshold,
+            });
             return null;
           }
 
@@ -1937,7 +1977,7 @@ function CsvImportReportModal({ report, playlistName, onClose }: CsvReportModalP
         `Total: ${report.total}, Added: ${report.added}, Duplicates: ${report.duplicates}, Not Found: ${report.notFound.length}${report.searchErrors ? `, Network Errors: ${report.searchErrors.length}` : ''}`,
         '',
         ...(report.duplicateTracks.length > 0 ? ['Duplicate Tracks (skipped):', ...report.duplicateTracks.map(t => `- ${t.trackName} by ${t.artistName}${t.albumName ? ` (${t.albumName})` : ''}`), ''] : []),
-        ...(report.notFound.length > 0 ? ['Not Found Tracks:', ...report.notFound.map(t => `- ${t.trackName} by ${t.artistName}${t.albumName ? ` (${t.albumName})` : ''}`), ''] : []),
+        ...(report.notFound.length > 0 ? ['Not Found Tracks:', ...report.notFound.map(t => `  - ${t.trackName} | ${t.artistName} | ${t.albumName || 'N/A'} | Score: ${(t.score ?? 0).toFixed(2)} (threshold: ${(t.thresholdNeeded ?? 0).toFixed(2)})`), ''] : []),
         ...(report.searchErrors && report.searchErrors.length > 0 ? ['Network Error Tracks (may retry):', ...report.searchErrors.map(t => `- ${t.trackName} by ${t.artistName}`), ''] : []),
       ].join('\n');
 
@@ -1956,10 +1996,10 @@ function CsvImportReportModal({ report, playlistName, onClose }: CsvReportModalP
       a.click();
       URL.revokeObjectURL(url);
 
-      showToast('Report downloaded successfully', 3000, 'info');
+      showToast(t('playlists.csvImportDownloadSuccess'), 3000, 'info');
     } catch (err) {
       console.error('Failed to download report:', err);
-      showToast('Failed to download report', 3000, 'error');
+      showToast(t('playlists.csvImportDownloadError'), 3000, 'error');
     }
   };
 
@@ -2044,6 +2084,16 @@ function CsvImportReportModal({ report, playlistName, onClose }: CsvReportModalP
                 <div key={i} style={{ padding: '8px 12px', borderBottom: '1px solid var(--surface)', fontSize: 13 }}>
                   <div style={{ fontWeight: 500 }}>{track.trackName}</div>
                   <div style={{ color: 'var(--text-muted)' }}>{track.artistName}</div>
+                  {track.albumName && <div style={{ color: 'var(--text-muted)', fontSize: 11 }}>{track.albumName}</div>}
+                  {track.score !== undefined && (
+                    <div style={{ fontSize: 11, marginTop: 2 }}>
+                      <span style={{ color: 'var(--text-muted)' }}>Score: </span>
+                      <span style={{ color: track.score >= (track.thresholdNeeded ?? 0.6) ? '#4ade80' : '#f87171' }}>
+                        {track.score.toFixed(2)}
+                      </span>
+                      <span style={{ color: 'var(--text-muted)' }}> (threshold: {(track.thresholdNeeded ?? 0.6).toFixed(2)})</span>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## CSV Import Matching Improvements

### Changes

#### 1. Dynamic Threshold for Track Matching

Added `calculateDynamicThreshold()` function that adjusts the minimum confidence score based on:

- Gap between best and second match (clear winner = lower threshold)
- Title word count (long specific titles can use lower threshold)
- Artist match strength (strong artist match allows lower overall score)

**File:** `src/pages/PlaylistDetail.tsx`

---

#### 2. Clean Title Before Search

Search now uses cleaned track titles (removing suffixes like "Remaster", "Live", etc.) to improve match rates between CSV data and server tracks.

**File:** `src/pages/PlaylistDetail.tsx`

---

#### 3. Score Data Structure

Extended `SpotifyCsvTrack` interface with optional `score` and `thresholdNeeded` fields instead of concatenating into `albumName`.

**File:** `src/pages/PlaylistDetail.tsx`

---

#### 4. Report Formatting

Updated both downloaded report and UI display to show clean format:

```
Track | Artist | Album | Score: X.XX (threshold: X.XX)
```

**File:** `src/pages/PlaylistDetail.tsx`

---

#### 5. Missing i18n Keys

Added translation keys to all 8 language files:

- `csvImportDownloadSuccess`
- `csvImportDownloadError`

**Files:** `src/locales/{en,es,de,fr,zh,ru,nl,nb}.ts`