### PR TITLE
feat: timer toggle player bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psysonic",
-  "version": "1.34.13",
+  "version": "1.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "psysonic",
-      "version": "1.34.13",
+      "version": "1.41.0",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "@fontsource-variable/figtree": "^5.2.10",

--- a/src/components/PlayerBar.tsx
+++ b/src/components/PlayerBar.tsx
@@ -3,12 +3,13 @@ import { createPortal } from 'react-dom';
 import {
   Play, Pause, SkipBack, SkipForward, Volume2, VolumeX, Music,
   Square, Repeat, Repeat1, Maximize2, SlidersVertical, X, Heart, Cast,
-  PictureInPicture2,
+  PictureInPicture2, ArrowLeftRight,
 } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { usePlayerStore } from '../store/playerStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useAuthStore } from '../store/authStore';
+import { useThemeStore } from '../store/themeStore';
 import { buildCoverArtUrl, coverArtCacheKey, star, unstar, setRating } from '../api/subsonic';
 import CachedImage from './CachedImage';
 import WaveformSeek from './WaveformSeek';
@@ -43,11 +44,28 @@ const PlaybackTime = memo(function PlaybackTime({ className }: { className?: str
   return <span className={className} ref={spanRef} />;
 });
 
+// Renders the remaining time (duration - currentTime) without causing PlayerBar to re-render.
+const RemainingTime = memo(function RemainingTime({ duration, className }: { duration: number; className?: string }) {
+  const spanRef = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    const updateRemaining = () => {
+      if (spanRef.current) {
+        const remaining = Math.max(0, duration - usePlayerStore.getState().currentTime);
+        spanRef.current.textContent = `-${formatTime(remaining)}`;
+      }
+    };
+    updateRemaining();
+    return usePlayerStore.subscribe(updateRemaining);
+  }, [duration]);
+  return <span className={className} ref={spanRef} />;
+});
+
 export default function PlayerBar() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [eqOpen, setEqOpen] = useState(false);
   const [showVolPct, setShowVolPct] = useState(false);
+  const [localShowRemaining, setLocalShowRemaining] = useState(() => useThemeStore.getState().showRemainingTime);
   const premuteVolumeRef = useRef(1);
   const showLyrics   = useLyricsStore(s => s.showLyrics);
   const activeTab    = useLyricsStore(s => s.activeTab);
@@ -297,7 +315,18 @@ export default function PlayerBar() {
             <div className="player-waveform-wrap">
               <WaveformSeek trackId={currentTrack?.id} />
             </div>
-            <span className="player-time">{formatTime(duration)}</span>
+            <span
+              className="player-time player-time-toggle"
+              onClick={() => {
+                const newVal = !localShowRemaining;
+                setLocalShowRemaining(newVal);
+                useThemeStore.getState().setShowRemainingTime(newVal);
+              }}
+              title={localShowRemaining ? t('player.showDuration') : t('player.showRemainingTime')}
+            >
+              {localShowRemaining ? <RemainingTime duration={duration} /> : formatTime(duration)}
+              <ArrowLeftRight size={10} style={{ marginLeft: 4, opacity: 0.6 }} />
+            </span>
           </>
         )}
       </div>

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -985,6 +985,8 @@ export const deTranslation = {
     lyricsSourceLrclib: 'Quelle: LRCLIB',
     lyricsSourceNetease: 'Quelle: Netease',
     lyricsSourceLyricsplus: 'Quelle: YouLyPlus',
+    showDuration: 'Dauer anzeigen',
+    showRemainingTime: 'Verbleibende Zeit anzeigen',
   },
   songInfo: {
     title: 'Song-Infos',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -987,6 +987,8 @@ export const enTranslation = {
     lyricsSourceLrclib: 'Source: LRCLIB',
     lyricsSourceNetease: 'Source: Netease',
     lyricsSourceLyricsplus: 'Source: YouLyPlus',
+    showDuration: 'Show duration',
+    showRemainingTime: 'Show remaining time',
   },
   songInfo: {
     title: 'Song Info',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -978,6 +978,8 @@ export const esTranslation = {
     lyricsSourceLrclib: 'Fuente: LRCLIB',
     lyricsSourceNetease: 'Fuente: Netease',
     lyricsSourceLyricsplus: 'Fuente: YouLyPlus',
+    showDuration: 'Mostrar duración',
+    showRemainingTime: 'Mostrar tiempo restante',
   },
   songInfo: {
     title: 'Información de Canción',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -973,6 +973,8 @@ export const frTranslation = {
     lyricsSourceLrclib: 'Source : LRCLIB',
     lyricsSourceNetease: 'Source : Netease',
     lyricsSourceLyricsplus: 'Source : YouLyPlus',
+    showDuration: 'Afficher la durée',
+    showRemainingTime: 'Afficher le temps restant',
   },
   songInfo: {
     title: 'Infos du morceau',

--- a/src/locales/nb.ts
+++ b/src/locales/nb.ts
@@ -972,6 +972,8 @@ export const nbTranslation = {
     lyricsSourceLrclib: 'Kilde: LRCLIB',
     lyricsSourceNetease: 'Kilde: Netease',
     lyricsSourceLyricsplus: 'Kilde: YouLyPlus',
+    showDuration: 'Vis varighet',
+    showRemainingTime: 'Vis gjenværende tid',
   },
   songInfo: {
     title: 'Sanginfo',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -972,6 +972,8 @@ export const nlTranslation = {
     lyricsSourceLrclib: 'Bron: LRCLIB',
     lyricsSourceNetease: 'Bron: Netease',
     lyricsSourceLyricsplus: 'Bron: YouLyPlus',
+    showDuration: 'Toon duur',
+    showRemainingTime: 'Toon resterende tijd',
   },
   songInfo: {
     title: 'Nummerinfo',

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -1033,6 +1033,8 @@ export const ruTranslation = {
     lyricsNotFound: 'Текст не найден',
     lyricsSourceNetease: 'Источник: Netease',
     lyricsSourceLyricsplus: 'Источник: YouLyPlus',
+    showDuration: 'Показать длительность',
+    showRemainingTime: 'Показать оставшееся время',
   },
   songInfo: {
     title: 'О треке',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -968,6 +968,8 @@ export const zhTranslation = {
     lyricsSourceLrclib: '来源：LRCLIB',
     lyricsSourceNetease: '来源：网易云',
     lyricsSourceLyricsplus: '来源：YouLyPlus',
+    showDuration: '显示时长',
+    showRemainingTime: '显示剩余时间',
   },
   songInfo: {
     title: '歌曲信息',

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -22,6 +22,8 @@ interface ThemeState {
   setEnablePlaylistCoverPhoto: (v: boolean) => void;
   showBitrate: boolean;
   setShowBitrate: (v: boolean) => void;
+  showRemainingTime: boolean;
+  setShowRemainingTime: (v: boolean) => void;
 }
 
 export function getScheduledTheme(state: Pick<ThemeState, 'enableThemeScheduler' | 'theme' | 'themeDay' | 'themeNight' | 'timeDayStart' | 'timeNightStart'>): string {
@@ -59,6 +61,8 @@ export const useThemeStore = create<ThemeState>()(
       setEnablePlaylistCoverPhoto: (v) => set({ enablePlaylistCoverPhoto: v }),
       showBitrate: true,
       setShowBitrate: (v) => set({ showBitrate: v }),
+      showRemainingTime: false,
+      setShowRemainingTime: (v) => set({ showRemainingTime: v }),
     }),
     {
       name: 'psysonic_theme',

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1353,6 +1353,25 @@
   text-align: left;
 }
 
+/* Clickable time toggle with swap indicator */
+.player-time-toggle {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.player-time-toggle:hover {
+  background-color: var(--surface-hover, rgba(128, 128, 128, 0.2));
+  color: var(--text-primary);
+}
+
+.player-time-toggle:active {
+  background-color: var(--surface-active, rgba(128, 128, 128, 0.3));
+}
+
 /* Volume section */
 .player-volume-section {
   display: flex;


### PR DESCRIPTION
# Add Click-to-Toggle Duration/Remaining Time in Player Bar

## Summary
Adds an interactive time display in the player bar that allows users to toggle between **total track duration** and **remaining time** by clicking on the time readout. The preference is persisted across sessions.

## Changes Overview

### Core Functionality
- **Click to toggle**: Switch between `3:45` (duration) and `-2:34` (remaining time)
- **Real-time updates**: Remaining time updates live as the track progresses
- **Persistent preference**: Selected mode saved to localStorage via `themeStore`

### Files Modified

#### `src/store/themeStore.ts`
- Added `showRemainingTime: boolean` state with setter and default `false`
- Persistence via `zustand/middleware`

#### `src/components/PlayerBar.tsx`
- Added `RemainingTime` component — updates DOM directly via refs (same pattern as `PlaybackTime`) to avoid re-renders on every tick
- Added click handler to toggle between modes
- Added `ArrowLeftRight` icon and hover/tooltip to indicate interactivity

```tsx
const RemainingTime = memo(function RemainingTime({ duration, className }) {
  const spanRef = useRef<HTMLSpanElement>(null);
  useEffect(() => {
    const updateRemaining = () => {
      if (spanRef.current) {
        const remaining = Math.max(0, duration - usePlayerStore.getState().currentTime);
        spanRef.current.textContent = `-${formatTime(remaining)}`;
      }
    };
    updateRemaining();
    return usePlayerStore.subscribe(updateRemaining);
  }, [duration]);
  return <span className={className} ref={spanRef} />;
});
```

#### `src/styles/layout.css`
- Added `.player-time-toggle` styles with hover/active states using CSS variables

#### `src/locales/*.ts`
- Added `player.showDuration` and `player.showRemainingTime` keys for 8 languages (en, es, de, fr, nl, nb, ru, zh)

## User Experience

| | Before | After |
|---|---|---|
| Time display | Duration only (`3:45`) | Duration by default, click to toggle |
| Remaining time | Requires mental math | Shows `-2:34`, updates in real-time |
| Discoverability | — | Swap icon (⇄) + hover highlight + tooltip |

## Testing Checklist
- [ ] Toggle works in both directions
- [ ] Remaining time updates in real-time
- [ ] Preference persists after app restart
- [ ] Hover effect and tooltip visible
- [ ] Works across all themes
- [ ] All 8 languages show correct translations