### PR TITLE
feat(linux): Auto-detect GPU vendor and configure DMA-BUF renderer

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,16 +1,122 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum GpuVendor {
+    Nvidia,
+    Intel,
+    Amd,
+}
+
+#[cfg(target_os = "linux")]
+fn detect_gpu_vendor() -> Option<GpuVendor> {
+    use std::fs;
+    use std::process::Command;
+
+    // Check for NVIDIA driver presence (most reliable for proprietary drivers)
+    if fs::metadata("/proc/driver/nvidia/version").is_ok() {
+        return Some(GpuVendor::Nvidia);
+    }
+
+    // Check sysfs DRM vendor IDs (works for most integrated/discrete GPUs)
+    let vendor_paths = [
+        "/sys/class/drm/card0/device/vendor",
+        "/sys/class/drm/card1/device/vendor",
+    ];
+
+    for path in &vendor_paths {
+        if let Ok(vendor_id) = fs::read_to_string(path) {
+            let vendor_id = vendor_id.trim();
+            // PCI vendor IDs: NVIDIA=0x10de, Intel=0x8086, AMD=0x1002/0x1022
+            match vendor_id {
+                "0x10de" => return Some(GpuVendor::Nvidia),
+                "0x8086" => return Some(GpuVendor::Intel),
+                "0x1002" | "0x1022" => return Some(GpuVendor::Amd),
+                _ => {}
+            }
+        }
+    }
+
+    // Fallback: try lspci to detect GPU vendor (requires pciutils)
+    if let Ok(output) = Command::new("lspci").args(["-nn"]).output() {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for line in stdout.lines() {
+                let line_lower = line.to_lowercase();
+                // Only match VGA/Display controllers, not audio or other devices
+                let is_display = line_lower.contains("vga")
+                    || line_lower.contains("display")
+                    || line_lower.contains("3d controller");
+
+                if is_display && line_lower.contains("nvidia") {
+                    return Some(GpuVendor::Nvidia);
+                }
+                if is_display
+                    && (line_lower.contains("intel") || line_lower.contains("i915"))
+                {
+                    return Some(GpuVendor::Intel);
+                }
+                if is_display && (line_lower.contains("amd") || line_lower.contains("radeon"))
+                {
+                    return Some(GpuVendor::Amd);
+                }
+            }
+        }
+    }
+
+    // Last resort: glxinfo (requires active display / X11 session)
+    if let Ok(output) = Command::new("glxinfo").args(["-B"]).output() {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_lowercase();
+            if stdout.contains("nvidia") {
+                return Some(GpuVendor::Nvidia);
+            }
+            if stdout.contains("intel") {
+                return Some(GpuVendor::Intel);
+            }
+            if stdout.contains("amd") || stdout.contains("radeon") {
+                return Some(GpuVendor::Amd);
+            }
+        }
+    }
+
+    None
+}
+
 fn main() {
     // WebKitGTK on Wayland is unstable — force X11/XWayland on all Linux packages.
     // Users can still override by setting these vars before launch.
+    //
+    // Safety: set_var modifies global process state. These calls are safe here
+    // because we're in main() before the Tauri runtime starts — no other threads
+    // exist yet. If this code moves to lazy init or a plugin context, it would
+    // need synchronization or marking as unsafe (Rust 2024+).
     #[cfg(target_os = "linux")]
-    unsafe {
+    {
         if std::env::var("GDK_BACKEND").is_err() {
             std::env::set_var("GDK_BACKEND", "x11");
         }
         if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err() {
             std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        }
+
+        // Detect GPU vendor and configure DMA-BUF renderer appropriately.
+        // NVIDIA proprietary drivers have issues with DMA-BUF in WebKitGTK,
+        // so we disable it for NVIDIA. Mesa drivers (Intel/AMD) handle it well.
+        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            match detect_gpu_vendor() {
+                Some(GpuVendor::Nvidia) => {
+                    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+                }
+                Some(GpuVendor::Intel) | Some(GpuVendor::Amd) => {
+                    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "0");
+                }
+                None => {
+                    // Unknown GPU: default to safe mode (disable DMA-BUF)
+                    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Summary

Implements automatic GPU vendor detection on Linux to optimize WebKitGTK performance.
Configures `WEBKIT_DISABLE_DMABUF_RENDERER` based on detected GPU:

- **NVIDIA**: Disables DMA-BUF (proprietary drivers have issues with WebKitGTK)
- **Intel/AMD**: Enables DMA-BUF (Mesa drivers handle it well)
- **Unknown**: Defaults to safe mode (disabled)

---

### Changes

#### `src-tauri/src/main.rs`

**Added `GpuVendor` enum** for type-safe GPU vendor representation:

```rust
#[derive(Debug, Clone, Copy, PartialEq)]
enum GpuVendor { Nvidia, Intel, Amd }
```

**Added `detect_gpu_vendor()` function** with multi-layer detection strategy:

| Priority | Method                            | Notes                                               |
|----------|-----------------------------------|-----------------------------------------------------|
| 1        | `/proc/driver/nvidia/version`     | Most reliable for NVIDIA proprietary drivers        |
| 2        | `/sys/class/drm/card*/device/vendor` | PCI vendor IDs (0x10de, 0x8086, 0x1002/0x1022)  |
| 3        | `lspci -nn`                       | Requires pciutils; only matches VGA/Display/3D      |
| 4        | `glxinfo -B`                      | Last resort; requires active X11/display            |

**Modified `main()`** to configure DMA-BUF based on detected GPU:

```rust
match detect_gpu_vendor() {
    Some(GpuVendor::Nvidia)                    => set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1"),
    Some(GpuVendor::Intel) | Some(GpuVendor::Amd) => set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "0"),
    None                                       => set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1"), // safe default
}
```

---

### Why This Matters

WebKitGTK's DMA-BUF renderer behavior differs significantly between GPU vendors:

- **NVIDIA proprietary drivers**: DMA-BUF causes visual glitches, lag, and frame drops.
  Disabling it forces the CPU-copy path, which is more stable.
- **Intel/AMD (Mesa)**: DMA-BUF enables zero-copy frame passing from GPU to WebView,
  improving performance and reducing CPU usage.

Previously, the app always used safe defaults or required manual user configuration.
Now it automatically optimizes for the detected hardware while still allowing user override
via environment variables.

---

### Technical Notes

- **Detection order**: Prioritized from most reliable (NVIDIA kernel module) to least (glxinfo requiring active display)
- **lspci filtering**: Only matches display controllers (`vga`, `display`, `3d controller`) to avoid false positives from AMD audio devices
- **Safety**: `set_var` is called before the Tauri runtime spawns threads, so there are no concurrent access issues
- **User override**: All variables are only set if not already defined, preserving user control

---

### Testing

- [x] Compiles with `cargo check`
- [x] Enum-based matching is type-safe and exhaustive
- [x] Each detection layer handles missing tools gracefully