### PR TITLE
fix(player): stabilize seekbar backward seeking on uncached streams

### DIFF
--- a/src/components/WaveformSeek.tsx
+++ b/src/components/WaveformSeek.tsx
@@ -832,6 +832,9 @@ export default function WaveformSeek({ trackId }: Props) {
   useEffect(() => {
     return usePlayerStore.subscribe((state, prev) => {
       if (state.progress === prev.progress && state.buffered === prev.buffered) return;
+      // While user drags, keep the local preview stable. External progress ticks
+      // during streaming/recovery would otherwise fight the cursor and flicker.
+      if (isDragging.current) return;
       progressRef.current = state.progress;
       bufferedRef.current = state.buffered;
       if (!ANIMATED_STYLES.has(styleRef.current)) {
@@ -890,15 +893,23 @@ export default function WaveformSeek({ trackId }: Props) {
   trackIdRef.current = trackId;
   const seekRef = useRef(seek);
   seekRef.current = seek;
+  const pendingSeekRef = useRef<number | null>(null);
 
   // Seek to a 0–1 fraction: draw immediately for 1:1 responsiveness, then
   // let the store + Rust catch up asynchronously.
-  const seekToFraction = (fraction: number) => {
+  const previewFraction = (fraction: number) => {
     progressRef.current = fraction;
+    pendingSeekRef.current = fraction;
     const canvas = canvasRef.current;
     if (canvas && !ANIMATED_STYLES.has(styleRef.current)) {
       drawSeekbar(canvas, styleRef.current, heightsRef.current, fraction, bufferedRef.current);
     }
+  };
+
+  const commitSeek = () => {
+    const fraction = pendingSeekRef.current;
+    if (fraction === null) return;
+    pendingSeekRef.current = null;
     seekRef.current(fraction);
   };
 
@@ -907,10 +918,14 @@ export default function WaveformSeek({ trackId }: Props) {
       const canvas = canvasRef.current;
       if (!canvas || !trackIdRef.current) return;
       const rect = canvas.getBoundingClientRect();
-      seekToFraction(Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)));
+      previewFraction(Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)));
     };
     const onMove = (e: MouseEvent) => { if (isDragging.current) seekFromX(e.clientX); };
-    const onUp   = () => { isDragging.current = false; };
+    const onUp   = () => {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+      commitSeek();
+    };
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup',   onUp);
     return () => {
@@ -935,7 +950,7 @@ export default function WaveformSeek({ trackId }: Props) {
         onMouseDown={e => {
           isDragging.current = true;
           const rect = e.currentTarget.getBoundingClientRect();
-          seekToFraction(Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)));
+          previewFraction(Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)));
         }}
         onMouseMove={e => {
           if (!trackId) return;

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -220,10 +220,15 @@ let seekDebounce: ReturnType<typeof setTimeout> | null = null;
 // Target time of the last seek — blocks stale Rust progress ticks until the
 // engine has actually caught up to the new position.
 let seekTarget: number | null = null;
-// Streaming fallback seek guard: coalesce repeated "not seekable" recoveries.
+// Streaming seek fallback state:
+// - coalesces rapid slider moves into a single restart/seek cycle
+// - keeps only the latest requested target
 let seekFallbackRetryTimer: ReturnType<typeof setTimeout> | null = null;
-let seekFallbackTrackId: string | null = null;
-let seekFallbackRestartAt = 0;
+let seekFallbackPendingAfterRestart: { trackId: string; seconds: number; attemptsLeft: number } | null = null;
+let seekFallbackRestartInFlightTrackId: string | null = null;
+let seekFallbackLastRestartAt = 0;
+const SEEK_FALLBACK_MAX_RETRIES = 8;
+const SEEK_BACKWARD_STREAM_EPS = 0.75;
 
 // Guard against rapid double-click play/pause sending two state transitions
 // to the Rust backend before it has finished the previous one.
@@ -377,6 +382,35 @@ function syncQueueToServer(queue: Track[], currentTrack: Track | null, currentTi
 function handleAudioPlaying(_duration: number) {
   setDeferHotCachePrefetch(false);
   usePlayerStore.setState({ isPlaying: true });
+  const pending = seekFallbackPendingAfterRestart;
+  if (!pending) return;
+  const cur = usePlayerStore.getState().currentTrack;
+  if (!cur || cur.id !== pending.trackId) {
+    seekFallbackPendingAfterRestart = null;
+    seekFallbackRestartInFlightTrackId = null;
+    return;
+  }
+  invoke('audio_seek', { seconds: pending.seconds }).then(() => {
+    seekTarget = pending.seconds;
+    seekFallbackPendingAfterRestart = null;
+    seekFallbackRestartInFlightTrackId = null;
+  }).catch(() => {
+    if (pending.attemptsLeft <= 0) {
+      seekFallbackPendingAfterRestart = null;
+      seekFallbackRestartInFlightTrackId = null;
+      return;
+    }
+    seekFallbackPendingAfterRestart = {
+      trackId: pending.trackId,
+      seconds: pending.seconds,
+      attemptsLeft: pending.attemptsLeft - 1,
+    };
+    if (seekFallbackRetryTimer) clearTimeout(seekFallbackRetryTimer);
+    seekFallbackRetryTimer = setTimeout(() => {
+      seekFallbackRetryTimer = null;
+      handleAudioPlaying(0);
+    }, 250);
+  });
 }
 
 function handleAudioProgress(current_time: number, duration: number) {
@@ -1030,8 +1064,8 @@ export const usePlayerStore = create<PlayerState>()(
         gaplessPreloadingId = null; bytePreloadingId = null; // new track — allow fresh preload for next
         if (seekDebounce) { clearTimeout(seekDebounce); seekDebounce = null; } seekTarget = null;
         if (seekFallbackRetryTimer) { clearTimeout(seekFallbackRetryTimer); seekFallbackRetryTimer = null; }
-        seekFallbackTrackId = null;
-        seekFallbackRestartAt = 0;
+        seekFallbackLastRestartAt = 0;
+        seekFallbackRestartInFlightTrackId = null;
 
         // If a radio stream is active, stop it before the new track starts so
         // the PlayerBar clears radio mode immediately and the stream is released.
@@ -1046,6 +1080,15 @@ export const usePlayerStore = create<PlayerState>()(
         const prevTrack = state.currentTrack;
         const newQueue = queue ?? state.queue;
         const idx = newQueue.findIndex(t => t.id === track.id);
+        if (seekFallbackPendingAfterRestart?.trackId !== track.id) {
+          seekFallbackPendingAfterRestart = null;
+        }
+        const pendingSeekTarget = seekFallbackPendingAfterRestart?.trackId === track.id
+          ? seekFallbackPendingAfterRestart.seconds
+          : null;
+        const initialTime = pendingSeekTarget !== null ? Math.max(0, Math.min(pendingSeekTarget, track.duration || pendingSeekTarget)) : 0;
+        const initialProgress =
+          track.duration && track.duration > 0 ? Math.max(0, Math.min(1, initialTime / track.duration)) : 0;
 
         const authState = useAuthStore.getState();
         const url = resolvePlaybackUrl(track.id, authState.activeServerId ?? '');
@@ -1073,9 +1116,9 @@ export const usePlayerStore = create<PlayerState>()(
           currentRadio: null,
           queue: newQueue,
           queueIndex: idx >= 0 ? idx : 0,
-          progress: 0,
+          progress: initialProgress,
           buffered: 0,
-          currentTime: 0,
+          currentTime: initialTime,
           scrobbled: false,
           lastfmLoved: false,
           isPlaying: true, // optimistic — reverted on error
@@ -1113,6 +1156,9 @@ export const usePlayerStore = create<PlayerState>()(
         })
           .then(() => {
             if (playGeneration !== gen) return;
+            if (seekFallbackRestartInFlightTrackId === track.id) {
+              seekFallbackRestartInFlightTrackId = null;
+            }
             if (keepPreloadHint) {
               usePlayerStore.setState({ enginePreloadedTrackId: null });
             }
@@ -1122,6 +1168,9 @@ export const usePlayerStore = create<PlayerState>()(
             setDeferHotCachePrefetch(false);
             console.error('[psysonic] audio_play failed:', err);
             set({ isPlaying: false });
+            if (seekFallbackRestartInFlightTrackId === track.id) {
+              seekFallbackRestartInFlightTrackId = null;
+            }
             setTimeout(() => {
               if (playGeneration !== gen) return;
               get().next(false);
@@ -1416,7 +1465,8 @@ export const usePlayerStore = create<PlayerState>()(
       // ── seek ─────────────────────────────────────────────────────────────────
       // 100 ms debounce collapses rapid slider drags into one actual seek.
       seek: (progress) => {
-        const { currentTrack } = get();
+        const s0 = get();
+        const { currentTrack } = s0;
         if (!currentTrack) return;
         const dur = currentTrack.duration;
         if (!dur || !isFinite(dur)) return;
@@ -1425,32 +1475,56 @@ export const usePlayerStore = create<PlayerState>()(
         if (seekDebounce) clearTimeout(seekDebounce);
         seekDebounce = setTimeout(() => {
           seekDebounce = null;
+          const s = get();
+          const isBackwardOnStream =
+            s.currentPlaybackSource === 'stream'
+            && time < s.currentTime - SEEK_BACKWARD_STREAM_EPS;
+          if (isBackwardOnStream && s.currentTrack) {
+            // Keep only the latest target while dragging.
+            seekFallbackPendingAfterRestart = {
+              trackId: s.currentTrack.id,
+              seconds: time,
+              attemptsLeft: SEEK_FALLBACK_MAX_RETRIES,
+            };
+            const now = Date.now();
+            const restartBusy = seekFallbackRestartInFlightTrackId === s.currentTrack.id;
+            const restartCooldown = now - seekFallbackLastRestartAt < 450;
+            if (!restartBusy && !restartCooldown) {
+              seekFallbackLastRestartAt = now;
+              seekFallbackRestartInFlightTrackId = s.currentTrack.id;
+              s.playTrack(s.currentTrack, s.queue, false);
+            }
+            return;
+          }
           seekTarget = time;
           invoke('audio_seek', { seconds: time }).catch((err: unknown) => {
             const msg = String(err ?? '');
-            if (!msg.includes('not seekable')) {
+            const recoverable =
+              msg.includes('not seekable')
+              || msg.toLowerCase().includes('seek')
+              || get().currentPlaybackSource === 'stream';
+            if (!recoverable) {
               console.error(err);
               return;
             }
-            // Streaming-start path can be non-seekable until the download finishes.
-            // Fallback: at most one restart burst per track, then keep only the latest retry seek.
+            // Streaming-start path can be non-seekable until enough data is loaded.
+            // Keep only the latest target and allow at most one in-flight restart.
             const s = get();
             if (!s.currentTrack) return;
+            seekFallbackPendingAfterRestart = {
+              trackId: s.currentTrack.id,
+              seconds: time,
+              attemptsLeft: SEEK_FALLBACK_MAX_RETRIES,
+            };
             const now = Date.now();
-            const sameBurst =
-              seekFallbackTrackId === s.currentTrack.id
-              && now - seekFallbackRestartAt < 600;
-            if (!sameBurst) {
-              seekFallbackTrackId = s.currentTrack.id;
-              seekFallbackRestartAt = now;
-              // Keep manual semantics (no crossfade) for seek recovery restarts.
-              s.playTrack(s.currentTrack, s.queue, true);
+            const restartBusy = seekFallbackRestartInFlightTrackId === s.currentTrack.id;
+            const restartCooldown = now - seekFallbackLastRestartAt < 450;
+            if (!restartBusy && !restartCooldown) {
+              seekFallbackLastRestartAt = now;
+              seekFallbackRestartInFlightTrackId = s.currentTrack.id;
+              // Force byte path for recovery (seekable), not streaming path.
+              s.playTrack(s.currentTrack, s.queue, false);
             }
-            if (seekFallbackRetryTimer) clearTimeout(seekFallbackRetryTimer);
-            seekFallbackRetryTimer = setTimeout(() => {
-              seekFallbackRetryTimer = null;
-              invoke('audio_seek', { seconds: time }).catch(() => {});
-            }, 220);
           });
         }, 100);
       },

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -223,12 +223,27 @@ let seekTarget: number | null = null;
 // Streaming seek fallback state:
 // - coalesces rapid slider moves into a single restart/seek cycle
 // - keeps only the latest requested target
-let seekFallbackRetryTimer: ReturnType<typeof setTimeout> | null = null;
 let seekFallbackPendingAfterRestart: { trackId: string; seconds: number; attemptsLeft: number } | null = null;
 let seekFallbackRestartInFlightTrackId: string | null = null;
-let seekFallbackLastRestartAt = 0;
+let seekFallbackLastAttemptAt = 0;
+let seekFallbackVolumeDucked = false;
+let seekStreamProbeTimer: ReturnType<typeof setTimeout> | null = null;
+let seekStreamProbeSeq = 0;
 const SEEK_FALLBACK_MAX_RETRIES = 8;
-const SEEK_BACKWARD_STREAM_EPS = 0.75;
+const SEEK_STREAM_DIRECT_TIMEOUT_MS = 450;
+
+function seekFallbackDuckVolume() {
+  if (seekFallbackVolumeDucked) return;
+  seekFallbackVolumeDucked = true;
+  invoke('audio_set_volume', { volume: 0 }).catch(() => {});
+}
+
+function seekFallbackRestoreVolume() {
+  if (!seekFallbackVolumeDucked) return;
+  seekFallbackVolumeDucked = false;
+  const volume = usePlayerStore.getState().volume;
+  invoke('audio_set_volume', { volume }).catch(() => {});
+}
 
 // Guard against rapid double-click play/pause sending two state transitions
 // to the Rust backend before it has finished the previous one.
@@ -388,16 +403,20 @@ function handleAudioPlaying(_duration: number) {
   if (!cur || cur.id !== pending.trackId) {
     seekFallbackPendingAfterRestart = null;
     seekFallbackRestartInFlightTrackId = null;
+    seekFallbackRestoreVolume();
     return;
   }
   invoke('audio_seek', { seconds: pending.seconds }).then(() => {
     seekTarget = pending.seconds;
     seekFallbackPendingAfterRestart = null;
     seekFallbackRestartInFlightTrackId = null;
+    seekFallbackRestoreVolume();
+    seekFallbackLastAttemptAt = Date.now();
   }).catch(() => {
     if (pending.attemptsLeft <= 0) {
       seekFallbackPendingAfterRestart = null;
       seekFallbackRestartInFlightTrackId = null;
+      seekFallbackRestoreVolume();
       return;
     }
     seekFallbackPendingAfterRestart = {
@@ -405,34 +424,61 @@ function handleAudioPlaying(_duration: number) {
       seconds: pending.seconds,
       attemptsLeft: pending.attemptsLeft - 1,
     };
-    if (seekFallbackRetryTimer) clearTimeout(seekFallbackRetryTimer);
-    seekFallbackRetryTimer = setTimeout(() => {
-      seekFallbackRetryTimer = null;
-      handleAudioPlaying(0);
-    }, 250);
+    // Avoid tight retry loops while network/chunk loading is still in progress.
+    // Next retries happen from real progress ticks in handleAudioProgress.
   });
 }
 
 function handleAudioProgress(current_time: number, duration: number) {
+  const store = usePlayerStore.getState();
+  const track = store.currentTrack;
+  if (!track) return;
+  const pending = seekFallbackPendingAfterRestart;
+
   // While a seek is pending, the store already holds the optimistic target
-  // position.  Accepting stale progress from the Rust engine would briefly
+  // position. Accepting stale progress from the Rust engine would briefly
   // snap the waveform back to the old position before the seek completes.
   if (seekDebounce) return;
   // After the debounce fires, Rust may still emit 1–2 ticks with the old
-  // position before the seek takes effect.  Block until current_time is
-  // within 2 s of the requested target, then clear the guard.
+  // position before the seek takes effect.
   if (seekTarget !== null) {
     if (Math.abs(current_time - seekTarget) > 2.0) return;
     seekTarget = null;
   }
 
-  const store = usePlayerStore.getState();
-  const track = store.currentTrack;
-  if (!track) return;
   const dur = duration > 0 ? duration : track.duration;
   if (dur <= 0) return;
   const progress = current_time / dur;
   usePlayerStore.setState({ currentTime: current_time, progress, buffered: 0 });
+
+  if (
+    pending
+    && pending.trackId === track.id
+    && pending.attemptsLeft > 0
+    && Date.now() - seekFallbackLastAttemptAt >= 700
+  ) {
+    seekFallbackLastAttemptAt = Date.now();
+    invoke('audio_seek', { seconds: pending.seconds }).then(() => {
+      seekTarget = pending.seconds;
+      seekFallbackPendingAfterRestart = null;
+      seekFallbackRestartInFlightTrackId = null;
+      seekFallbackRestoreVolume();
+    }).catch(() => {
+      const curPending = seekFallbackPendingAfterRestart;
+      if (!curPending || curPending.trackId !== track.id) return;
+      if (curPending.attemptsLeft <= 1) {
+        seekFallbackPendingAfterRestart = null;
+        seekFallbackRestartInFlightTrackId = null;
+        seekFallbackRestoreVolume();
+        return;
+      }
+      seekFallbackPendingAfterRestart = {
+        trackId: curPending.trackId,
+        seconds: curPending.seconds,
+        attemptsLeft: curPending.attemptsLeft - 1,
+      };
+    });
+  }
 
   // Scrobble at 50%: Last.fm + Navidrome (updates play_date / recently played)
   if (progress >= 0.5 && !store.scrobbled) {
@@ -1063,8 +1109,9 @@ export const usePlayerStore = create<PlayerState>()(
         isAudioPaused = false;
         gaplessPreloadingId = null; bytePreloadingId = null; // new track — allow fresh preload for next
         if (seekDebounce) { clearTimeout(seekDebounce); seekDebounce = null; } seekTarget = null;
-        if (seekFallbackRetryTimer) { clearTimeout(seekFallbackRetryTimer); seekFallbackRetryTimer = null; }
-        seekFallbackLastRestartAt = 0;
+        if (seekStreamProbeTimer) { clearTimeout(seekStreamProbeTimer); seekStreamProbeTimer = null; }
+        seekStreamProbeSeq += 1;
+        seekFallbackLastAttemptAt = 0;
         seekFallbackRestartInFlightTrackId = null;
 
         // If a radio stream is active, stop it before the new track starts so
@@ -1083,10 +1130,15 @@ export const usePlayerStore = create<PlayerState>()(
         if (seekFallbackPendingAfterRestart?.trackId !== track.id) {
           seekFallbackPendingAfterRestart = null;
         }
+        if (!seekFallbackPendingAfterRestart) {
+          seekFallbackRestoreVolume();
+        }
         const pendingSeekTarget = seekFallbackPendingAfterRestart?.trackId === track.id
           ? seekFallbackPendingAfterRestart.seconds
           : null;
-        const initialTime = pendingSeekTarget !== null ? Math.max(0, Math.min(pendingSeekTarget, track.duration || pendingSeekTarget)) : 0;
+        const initialTime = pendingSeekTarget !== null
+          ? Math.max(0, Math.min(pendingSeekTarget, track.duration || pendingSeekTarget))
+          : 0;
         const initialProgress =
           track.duration && track.duration > 0 ? Math.max(0, Math.min(1, initialTime / track.duration)) : 0;
 
@@ -1143,9 +1195,10 @@ export const usePlayerStore = create<PlayerState>()(
           ? (authState.replayGainMode === 'album' ? (track.replayGainAlbumDb ?? track.replayGainTrackDb) : track.replayGainTrackDb) ?? null
           : null;
         const replayGainPeak = authState.replayGainEnabled ? (track.replayGainPeak ?? null) : null;
+        const playVolume = seekFallbackVolumeDucked ? 0 : state.volume;
         invoke('audio_play', {
           url,
-          volume: state.volume,
+          volume: playVolume,
           durationHint: track.duration,
           replayGainDb,
           replayGainPeak,
@@ -1190,7 +1243,7 @@ export const usePlayerStore = create<PlayerState>()(
             }));
           });
         }
-        syncQueueToServer(newQueue, track, 0);
+        syncQueueToServer(newQueue, track, initialTime);
         touchHotCacheOnPlayback(track.id, authState.activeServerId ?? '');
       },
 
@@ -1475,29 +1528,52 @@ export const usePlayerStore = create<PlayerState>()(
         if (seekDebounce) clearTimeout(seekDebounce);
         seekDebounce = setTimeout(() => {
           seekDebounce = null;
+          if (seekStreamProbeTimer) { clearTimeout(seekStreamProbeTimer); seekStreamProbeTimer = null; }
+          seekStreamProbeSeq += 1;
           const s = get();
-          const isBackwardOnStream =
-            s.currentPlaybackSource === 'stream'
-            && time < s.currentTime - SEEK_BACKWARD_STREAM_EPS;
-          if (isBackwardOnStream && s.currentTrack) {
-            // Keep only the latest target while dragging.
-            seekFallbackPendingAfterRestart = {
-              trackId: s.currentTrack.id,
-              seconds: time,
-              attemptsLeft: SEEK_FALLBACK_MAX_RETRIES,
+          const isStreamSource = s.currentPlaybackSource === 'stream';
+          if (isStreamSource && s.currentTrack) {
+            // Fast path: try direct stream seek first. If it does not complete
+            // quickly, fall back to byte-path restart.
+            seekTarget = time;
+            seekFallbackPendingAfterRestart = null;
+            seekFallbackRestartInFlightTrackId = null;
+            const probeSeq = seekStreamProbeSeq;
+            const fallbackToByteRestart = () => {
+              if (probeSeq !== seekStreamProbeSeq) return;
+              const cur = get();
+              if (!cur.currentTrack) return;
+              seekFallbackDuckVolume();
+              seekFallbackPendingAfterRestart = {
+                trackId: cur.currentTrack.id,
+                seconds: time,
+                attemptsLeft: SEEK_FALLBACK_MAX_RETRIES,
+              };
+              const restartBusy = seekFallbackRestartInFlightTrackId === cur.currentTrack.id;
+              if (!restartBusy) {
+                seekFallbackRestartInFlightTrackId = cur.currentTrack.id;
+                cur.playTrack(cur.currentTrack, cur.queue, false);
+              }
             };
-            const now = Date.now();
-            const restartBusy = seekFallbackRestartInFlightTrackId === s.currentTrack.id;
-            const restartCooldown = now - seekFallbackLastRestartAt < 450;
-            if (!restartBusy && !restartCooldown) {
-              seekFallbackLastRestartAt = now;
-              seekFallbackRestartInFlightTrackId = s.currentTrack.id;
-              s.playTrack(s.currentTrack, s.queue, false);
-            }
+            seekStreamProbeTimer = setTimeout(() => {
+              seekStreamProbeTimer = null;
+              fallbackToByteRestart();
+            }, SEEK_STREAM_DIRECT_TIMEOUT_MS);
+            invoke('audio_seek', { seconds: time }).then(() => {
+              if (probeSeq !== seekStreamProbeSeq) return;
+              if (seekStreamProbeTimer) { clearTimeout(seekStreamProbeTimer); seekStreamProbeTimer = null; }
+            }).catch(() => {
+              if (probeSeq !== seekStreamProbeSeq) return;
+              if (seekStreamProbeTimer) { clearTimeout(seekStreamProbeTimer); seekStreamProbeTimer = null; }
+              fallbackToByteRestart();
+            });
             return;
           }
           seekTarget = time;
           invoke('audio_seek', { seconds: time }).catch((err: unknown) => {
+            // If seek failed, do not freeze progress updates waiting for an
+            // unattainable target position while network/stream recovers.
+            seekTarget = null;
             const msg = String(err ?? '');
             const recoverable =
               msg.includes('not seekable')
@@ -1516,14 +1592,12 @@ export const usePlayerStore = create<PlayerState>()(
               seconds: time,
               attemptsLeft: SEEK_FALLBACK_MAX_RETRIES,
             };
-            const now = Date.now();
             const restartBusy = seekFallbackRestartInFlightTrackId === s.currentTrack.id;
-            const restartCooldown = now - seekFallbackLastRestartAt < 450;
-            if (!restartBusy && !restartCooldown) {
-              seekFallbackLastRestartAt = now;
+            if (!restartBusy) {
               seekFallbackRestartInFlightTrackId = s.currentTrack.id;
-              // Force byte path for recovery (seekable), not streaming path.
-              s.playTrack(s.currentTrack, s.queue, false);
+              const shouldByteRestart = s.currentPlaybackSource === 'stream';
+              if (shouldByteRestart) seekFallbackDuckVolume();
+              s.playTrack(s.currentTrack, s.queue, shouldByteRestart ? false : true);
             }
           });
         }, 100);


### PR DESCRIPTION
Related issue: [#218 — BUG: Issue when trying to go backwards in a song using the seekbar](https://github.com/Psychotoxical/psysonic/issues/218).

Closes #218.

## What changed

- Reworked stream seek recovery logic in `playerStore` for cold/unbuffered track starts.
- Updated `WaveformSeek` interaction flow to commit seeks more predictably and avoid drag/progress race artifacts.
- Added a fast path for stream sources: try direct `audio_seek` first with a short timeout window.
- Added automatic fallback to byte-path restart when direct stream seek does not complete in time.
- Added guarded retry flow after restart so backward seeks are eventually applied even under unstable network/chunk loading.
- Prevented UI/progress regressions during recovery by keeping seek target guards and coalescing repeated seek attempts.

## Why

- Issue #218 reproduces most often right after track start when data is not yet buffered: forward seek may work while backward seek can fail or stick.
- A direct-seek probe keeps interaction snappy when enough data is already available.
- Deterministic fallback keeps behavior stable when the stream path is not yet seekable, without reintroducing freezes and audio artifacts.

## Files

- `src/components/WaveformSeek.tsx`
- `src/store/playerStore.ts`
