### PR TITLE
fix: artist top songs continue playback

### DIFF
--- a/src/pages/ArtistDetail.tsx
+++ b/src/pages/ArtistDetail.tsx
@@ -344,6 +344,33 @@ export default function ArtistDetail() {
     }
   };
 
+  const playTopSongWithContinuation = async (startIndex: number) => {
+    if (!artist || albums.length === 0) return;
+    setPlayAllLoading(true);
+    try {
+      // Obtener todas las canciones del artista
+      const allTracks = await fetchAllTracks();
+      
+      // Top songs desde el índico clickeado en adelante
+      const topTracksFromIndex = topSongs.slice(startIndex).map(songToTrack);
+      
+      // IDs de top songs para evitar duplicados
+      const topSongIds = new Set(topSongs.map(s => s.id));
+      
+      // Filtrar canciones del artista para excluir top songs
+      const remainingTracks = allTracks.filter(t => !topSongIds.has(t.id));
+      
+      // Combinar: top songs restantes + resto del catálogo del artista
+      const queue = [...topTracksFromIndex, ...remainingTracks];
+      
+      if (queue.length > 0) {
+        playTrack(queue[0], queue);
+      }
+    } finally {
+      setPlayAllLoading(false);
+    }
+  };
+
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     e.target.value = '';
@@ -597,14 +624,14 @@ export default function ArtistDetail() {
                        style={{ gridTemplateColumns: '60px minmax(150px, 1fr) minmax(100px, 1fr) 65px' }}
                        onClick={e => {
                          if ((e.target as HTMLElement).closest('button, a, input')) return;
-                         playTrack(track, topSongs.map(songToTrack));
+                         playTopSongWithContinuation(idx);
                        }}
                        onContextMenu={(e) => {
                          e.preventDefault();
                          openContextMenu(e.clientX, e.clientY, track, 'song');
                        }}
                      >
-                <div className={`track-num${currentTrack?.id === song.id ? ' track-num-active' : ''}`} style={{ cursor: 'pointer' }} onClick={e => { e.stopPropagation(); playTrack(track, topSongs.map(songToTrack)); }}>
+                <div className={`track-num${currentTrack?.id === song.id ? ' track-num-active' : ''}`} style={{ cursor: 'pointer' }} onClick={e => { e.stopPropagation(); playTopSongWithContinuation(idx); }}>
                   {currentTrack?.id === song.id && isPlaying && <span className="track-num-eq"><div className="eq-bars"><span className="eq-bar" /><span className="eq-bar" /><span className="eq-bar" /></div></span>}
                   <span className="track-num-play"><Play size={13} fill="currentColor" /></span>
                   <span className="track-num-number">{idx + 1}</span>

--- a/src/pages/ArtistDetail.tsx
+++ b/src/pages/ArtistDetail.tsx
@@ -348,19 +348,19 @@ export default function ArtistDetail() {
     if (!artist || albums.length === 0) return;
     setPlayAllLoading(true);
     try {
-      // Obtener todas las canciones del artista
+      // Get all artist tracks ordered by album and track number
       const allTracks = await fetchAllTracks();
-      
-      // Top songs desde el índico clickeado en adelante
+
+      // Top songs from clicked index onward
       const topTracksFromIndex = topSongs.slice(startIndex).map(songToTrack);
-      
-      // IDs de top songs para evitar duplicados
+
+      // Track IDs for deduplication
       const topSongIds = new Set(topSongs.map(s => s.id));
-      
-      // Filtrar canciones del artista para excluir top songs
+
+      // Filter remaining tracks to exclude top songs (prevent duplicates)
       const remainingTracks = allTracks.filter(t => !topSongIds.has(t.id));
-      
-      // Combinar: top songs restantes + resto del catálogo del artista
+
+      // Build queue: remaining top songs + rest of artist catalog
       const queue = [...topTracksFromIndex, ...remainingTracks];
       
       if (queue.length > 0) {


### PR DESCRIPTION
## Fix: Continue playback after top songs finish on artist page

### Problem
When clicking a top song on the artist detail page, playback would stop after the 5 top songs finished. Users expected the music to continue with the rest of the artist's catalog.

### Solution
Added [playTopSongWithContinuation()](cci:1://file:///home/kveld/Documentos/psysonic/src/pages/ArtistDetail.tsx:346:2-371:4) function that builds a seamless queue:
1. **Top songs** from the clicked index onward
2. **All remaining artist tracks** ordered by album (year) + track number
3. **No duplicates** — top songs already in albums are filtered out

### Changes
- [src/pages/ArtistDetail.tsx](cci:7://file:///home/kveld/Documentos/psysonic/src/pages/ArtistDetail.tsx:0:0-0:0): New [playTopSongWithContinuation()](cci:1://file:///home/kveld/Documentos/psysonic/src/pages/ArtistDetail.tsx:346:2-371:4) function
- Updated click handlers on top song rows to use the new function

### Behavior
- User clicks top song # 3 → Queue: `[# 3, # 4, # 5] + [all other artist tracks by album]`
- Playback continues uninterrupted until entire artist catalog is finished
- Matches Spotify/Apple Music behavior when playing from artist "Popular" section