### PR TITLE
fix: floating-player-scroll-padding

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1068,6 +1068,13 @@
   contain: paint;
 }
 
+/* When floating player is active, add extra bottom padding so content doesn't
+   get hidden behind the fixed floating bar (player height + bottom offset + minimal spacing).
+   !important needed to override inline padding:0 on App.tsx content-body */
+.app-shell.floating-player .content-body {
+  padding-bottom: calc(var(--player-height) + 12px) !important;
+}
+
 /* Every page re-uses .content-body as its outer wrapper, but App.tsx already
    renders one around <Routes /> as the scroll container. The inner one must
    not establish its own scroll ancestor — otherwise `position: sticky`


### PR DESCRIPTION
## Prevent content from being hidden behind floating player bar

### Problem
When the "Floating Player Bar" setting is enabled (Settings → Appearance), the player bar becomes `position: fixed` and floats 12px above the window bottom. However, the main scroll container (`.content-body`) did not account for this floating element.

**Result:** Users could not see the last items when scrolling to the bottom of any page — they remained hidden behind the floating bar.

### Root Cause
1. The `.content-body` in `App.tsx` has an inline style `padding: 0` which overrides any CSS padding
2. The grid layout changes when `floating-player` class is applied (removes the player row), but no compensation was added for the fixed-position bar
3. Individual pages don't add bottom padding because they rely on the parent container

### Solution
Added a CSS rule that detects when the floating player is active and applies the necessary bottom padding to the scroll container:

```css
.app-shell.floating-player .content-body {
  padding-bottom: calc(var(--player-height) + 12px) !important;
}