### PR TITLE
ci(release): route nix lock refresh through PR + auto-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -291,7 +292,9 @@ jobs:
           # cachix dedupes against anything already in the cache.
           nix path-info --recursive .#psysonic | cachix push psysonic
 
-      - name: commit + push refreshed lock and hash (if changed)
+      - name: open + auto-merge PR with refreshed lock and hash (if changed)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -302,5 +305,13 @@ jobs:
             exit 0
           fi
           VERSION="${{ needs.create-release.outputs.package_version }}"
+          BRANCH="chore/nix-lock-refresh-v${VERSION}"
+          git checkout -b "$BRANCH"
           git commit -m "chore(nix): refresh lock + npmDepsHash for v${VERSION}"
-          git push origin HEAD:main
+          git push origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(nix): refresh lock + npmDepsHash for v${VERSION}" \
+            --body "Auto-generated after the v${VERSION} release: refreshes \`flake.lock\` and \`nix/upstream-sources.json\` so the Cachix substituter resolves the latest pin."
+          gh pr merge "$BRANCH" --squash --auto --delete-branch


### PR DESCRIPTION
## Summary
After locking \`main\` with the new branch ruleset, the existing direct push from the \`verify-nix\` job fails with \`GH013: Repository rule violations\`. This rewires that step to:

1. Create a per-release branch \`chore/nix-lock-refresh-v<VERSION>\`
2. Commit the refreshed \`flake.lock\` + \`nix/upstream-sources.json\` there
3. Push the branch
4. Open a PR
5. \`gh pr merge --squash --auto --delete-branch\` — auto-merge fires immediately since the ruleset has 0 required reviews + 0 required status checks

Repo settings already adjusted out-of-band:
- \`allow_auto_merge: true\`
- \`delete_branch_on_merge: true\`

Workflow gains \`pull-requests: write\` permission so \`GITHUB_TOKEN\` can create + merge.

## Failure mode
If auto-merge ever fails (token permission lost, repo setting flipped), the release artifacts and tag are already published — only the lock-refresh PR sits open and needs a manual merge. No data corruption, no blocked release.

## Test plan
- [ ] Next \`v*\` tag push: verify-nix job runs, creates a branch, opens a PR, auto-merges within seconds, leaves no leftover branch
- [ ] If lock files unchanged that release: step exits early without opening a PR (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)