### PR TITLE
fix(ci): drop --auto from nix-lock PR merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,4 +314,4 @@ jobs:
             --head "$BRANCH" \
             --title "chore(nix): refresh lock + npmDepsHash for v${VERSION}" \
             --body "Auto-generated after the v${VERSION} release: refreshes \`flake.lock\` and \`nix/upstream-sources.json\` so the Cachix substituter resolves the latest pin."
-          gh pr merge "$BRANCH" --squash --auto --delete-branch
+          gh pr merge "$BRANCH" --squash --delete-branch


### PR DESCRIPTION
The v1.43.0 release exposed a second issue in the new lock-refresh PR flow: \`gh pr merge --auto\` is rejected by GitHub when the PR has no required status checks and no required reviews — it considers the PR \"in clean status\" and refuses to schedule the auto-merge.

Our ruleset has neither (0 required reviews, 0 required status checks), so there's nothing for auto-merge to wait for. Switching to a direct \`gh pr merge --squash --delete-branch\` does the right thing immediately.

If the project ever adds required checks (CI tests on every PR, etc.), \`--auto\` becomes the right answer again.

## Verification
- v1.43.0's verify-nix step opened PR #226 successfully (after enabling the repo "Allow GitHub Actions to create and approve pull requests" setting).
- The auto-merge call failed with: \`GraphQL: Pull request Pull request is in clean status (enablePullRequestAutoMerge)\`.
- Merged #226 manually with \`gh pr merge --squash --delete-branch\` — succeeded instantly. That's the form this PR commits to the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)