### PR TITLE
fix(fullscreen): remove WebKitGTK halo ring on mesh blobs

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3190,13 +3190,16 @@
   height: 130%;
   left: -35%;
   bottom: -35%;
+  /* opacity on the element avoids color-mix(…, transparent) WebKit artifacts —
+     interpolating to the CSS keyword 'transparent' (rgba(0,0,0,0)) produces a
+     visible halo ring at the gradient boundary on WebKitGTK. */
   background: radial-gradient(ellipse,
-    color-mix(in srgb, var(--dynamic-fs-accent, var(--accent)), transparent 86%) 0%,
-    color-mix(in srgb, var(--dynamic-fs-accent, var(--accent)), transparent 96%) 45%,
+    var(--dynamic-fs-accent, var(--accent)) 0%,
     transparent 70%);
+  opacity: 0.14;
   animation: mesh-aura-a 26s ease-in-out infinite;
   animation-delay: 350ms;
-  transition: background 400ms ease-in-out;
+  transition: opacity 400ms ease-in-out;
 }
 
 .fs-mesh-blob-b {
@@ -3205,12 +3208,12 @@
   right: -25%;
   top: -25%;
   background: radial-gradient(ellipse,
-    color-mix(in srgb, var(--dynamic-fs-accent, var(--accent)), transparent 92%) 0%,
-    color-mix(in srgb, var(--dynamic-fs-accent, var(--accent)), transparent 98%) 45%,
+    var(--dynamic-fs-accent, var(--accent)) 0%,
     transparent 70%);
+  opacity: 0.08;
   animation: mesh-aura-b 20s ease-in-out infinite;
   animation-delay: 350ms;
-  transition: background 400ms ease-in-out;
+  transition: opacity 400ms ease-in-out;
 }
 
 /* ── Artist portrait — right half, object-fit: contain ── */


### PR DESCRIPTION
Cherry-picked from @kilyabin's #231 — the fork branch was behind \`main\` so this isolates the actual CSS fix.

## Summary
\`color-mix(in srgb, accent, transparent N%)\` interpolates to the CSS keyword \`transparent\` (= \`rgba(0,0,0,0)\`), which WebKitGTK renders with a visible halo ring at the gradient boundary. Replace the color-mix stops with a straight \`accent → transparent 70%\` radial gradient and move the blob opacity onto the element (\`opacity: 0.14\` / \`0.08\`). Animation target switches from \`background\` to \`opacity\`.

## Test plan
- [x] Verified on Linux (WebKitGTK, NVIDIA proprietary): halo ring gone from \`.fs-mesh-blob-a\` / \`.fs-mesh-blob-b\`, aura animation unchanged
- [x] \`npm run build\` green

Credit: commit authored by @kilyabin.