### PR TITLE
perf(search): use CachedImage for result thumbs to stop re-render download storms

### DIFF
--- a/src/components/LiveSearch.tsx
+++ b/src/components/LiveSearch.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Search, Disc3, Users, Music, SlidersVertical, TextSearch } from 'lucide-react';
-import { search, SearchResults, buildCoverArtUrl } from '../api/subsonic';
+import { search, SearchResults, buildCoverArtUrl, coverArtCacheKey } from '../api/subsonic';
 import { usePlayerStore, songToTrack } from '../store/playerStore';
 import { useAuthStore } from '../store/authStore';
 import { useTranslation } from 'react-i18next';
+import CachedImage from './CachedImage';
 
 function debounce(fn: (q: string) => void, ms: number): (q: string) => void {
   let timer: ReturnType<typeof setTimeout>;
@@ -166,7 +167,12 @@ export default function LiveSearch() {
                         onClick={() => { navigate(`/album/${a.id}`); setOpen(false); setQuery(''); }}
                         role="option" aria-selected={activeIndex === i}>
                         {a.coverArt ? (
-                          <img className="search-result-thumb" src={buildCoverArtUrl(a.coverArt, 40)} alt="" loading="lazy" />
+                          <CachedImage
+                            className="search-result-thumb"
+                            src={buildCoverArtUrl(a.coverArt, 40)}
+                            cacheKey={coverArtCacheKey(a.coverArt, 40)}
+                            alt=""
+                          />
                         ) : (
                           <div className="search-result-icon"><Disc3 size={14} /></div>
                         )}

--- a/src/components/MobileSearchOverlay.tsx
+++ b/src/components/MobileSearchOverlay.tsx
@@ -2,10 +2,11 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 import { X, Search, Disc3, Users, Music, Music2, Clock, ChevronRight } from 'lucide-react';
-import { search, SearchResults, buildCoverArtUrl } from '../api/subsonic';
+import { search, SearchResults, buildCoverArtUrl, coverArtCacheKey } from '../api/subsonic';
 import { usePlayerStore, songToTrack } from '../store/playerStore';
 import { useAuthStore } from '../store/authStore';
 import { useTranslation } from 'react-i18next';
+import CachedImage from './CachedImage';
 
 const STORAGE_KEY = 'psysonic_recent_searches';
 const MAX_RECENT = 6;
@@ -203,7 +204,12 @@ export default function MobileSearchOverlay({ onClose }: { onClose: () => void }
                 {results!.albums.map(a => (
                   <button key={a.id} className="mobile-search-item" onClick={() => goTo(`/album/${a.id}`)}>
                     {a.coverArt ? (
-                      <img className="mobile-search-thumb" src={buildCoverArtUrl(a.coverArt, 80)} alt="" loading="lazy" />
+                      <CachedImage
+                        className="mobile-search-thumb"
+                        src={buildCoverArtUrl(a.coverArt, 80)}
+                        cacheKey={coverArtCacheKey(a.coverArt, 80)}
+                        alt=""
+                      />
                     ) : (
                       <div className="mobile-search-avatar">
                         <Disc3 size={20} />
@@ -225,7 +231,12 @@ export default function MobileSearchOverlay({ onClose }: { onClose: () => void }
                 {results!.songs.map(s => (
                   <button key={s.id} className="mobile-search-item" onClick={() => playSong(s)}>
                     {s.coverArt ? (
-                      <img className="mobile-search-thumb" src={buildCoverArtUrl(s.coverArt, 80)} alt="" loading="lazy" />
+                      <CachedImage
+                        className="mobile-search-thumb"
+                        src={buildCoverArtUrl(s.coverArt, 80)}
+                        cacheKey={coverArtCacheKey(s.coverArt, 80)}
+                        alt=""
+                      />
                     ) : (
                       <div className="mobile-search-avatar">
                         <Music size={20} />


### PR DESCRIPTION
## Summary
Search dropdowns (sidebar LiveSearch + mobile overlay) rendered cover thumbs via raw \`<img src={buildCoverArtUrl(...)}>\` instead of the IndexedDB-backed \`CachedImage\` path used everywhere else.

\`buildCoverArtUrl()\` mints a fresh URL on every call (new random salt + MD5 token per Subsonic spec), so the browser cache was permanently defeated — every re-render produced new URLs and the browser dispatched HTTP requests for every "new" image.

While typing in the search field this multiplied: each keystroke triggered a re-render with fresh URLs for every visible cover, and after the 300 ms debounce a fresh \`search()\` result triggered another wave. Five visible album thumbs × five keystrokes ≈ 50 redundant cover fetches in 1.5 s — exactly the periodic typing delays cucadmuh reported.

Switching all three call sites to \`CachedImage\` + the stable \`coverArtCacheKey()\` 

> \`buildCoverArtUrl()\` generates a new ephemeral URL every call — browser cache is useless. Use \`coverArtCacheKey(id, size)\` + \`CachedImage\` for \`<img>\` tags.

## Files
- \`src/components/LiveSearch.tsx:169\` — sidebar live-search album thumbs
- \`src/components/MobileSearchOverlay.tsx:206\` — mobile search album thumbs
- \`src/components/MobileSearchOverlay.tsx:228\` — mobile search song thumbs

## Test plan
- [x] Local: typing in the sidebar search field — confirmed noticeably smoother (no per-keystroke download storm)
- [ ] Mobile search overlay smoke test
- [ ] Verify same album searched twice in a session resolves from cache (instant thumbs second time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)