### PR TITLE
perf(albums): bump infinite-scroll prefetch margin from 200px to 1500px

### DIFF
--- a/src/pages/Albums.tsx
+++ b/src/pages/Albums.tsx
@@ -186,7 +186,9 @@ export default function Albums() {
   useEffect(() => {
     const observer = new IntersectionObserver(
       entries => { if (entries[0].isIntersecting) loadMore(); },
-      { rootMargin: '200px' }
+      // Prefetch ~1.5 screens ahead so the user never visibly waits at the
+      // bottom of the grid. 200px caught the user at the very edge.
+      { rootMargin: '1500px' }
     );
     if (observerTarget.current) observer.observe(observerTarget.current);
     return () => observer.disconnect();


### PR DESCRIPTION
## Summary
\`Albums.tsx\` already paginates via \`IntersectionObserver\` on a sentinel at the bottom of the grid, but the trigger \`rootMargin\` was \`200px\` — by the time the user had scrolled there, they were already at the edge waiting for the request to land.

Bumping to \`1500px\` (~1.5 screens at typical heights) prefetches ahead of the scroll instead of behind it. The next batch is visibly already in place when the user reaches it; for shorter screen sessions there's no perceived "loading more" state at all.

## Files
- \`src/pages/Albums.tsx:186-193\`

## Test plan
- [x] Local: scrolled through the alphabetical Albums grid — next page is loaded before reaching the bottom
- [ ] Verify with very tall screens (1500px is ~1.5 screens at default heights, may be more for 4K)
- [ ] Verify on slow network the spinner still appears if user scrolls faster than fetch completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)