### PR TITLE
perf(bundle): lazy-load rarely-visited pages + split vendor chunks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useState, useCallback, useRef, lazy, Suspense } from 'react';
 import { showToast } from './utils/toast';
 import { BrowserRouter, Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { listen } from '@tauri-apps/api/event';
@@ -14,6 +14,7 @@ import { useIsMobile } from './hooks/useIsMobile';
 import LiveSearch from './components/LiveSearch';
 import NowPlayingDropdown from './components/NowPlayingDropdown';
 import QueuePanel from './components/QueuePanel';
+// Eager — main browsing flow, loaded on first paint
 import Home from './pages/Home';
 import Albums from './pages/Albums';
 import Artists from './pages/Artists';
@@ -22,23 +23,27 @@ import NewReleases from './pages/NewReleases';
 import Favorites from './pages/Favorites';
 import RandomMix from './pages/RandomMix';
 import RandomLanding from './pages/RandomLanding';
-import Settings from './pages/Settings';
 import Login from './pages/Login';
 import AlbumDetail from './pages/AlbumDetail';
-import LabelAlbums from './pages/LabelAlbums';
-import Statistics from './pages/Statistics';
 import MostPlayed from './pages/MostPlayed';
-import Help from './pages/Help';
 import RandomAlbums from './pages/RandomAlbums';
 import SearchResults from './pages/SearchResults';
-import AdvancedSearch from './pages/AdvancedSearch';
 import Playlists from './pages/Playlists';
 import PlaylistDetail from './pages/PlaylistDetail';
-import InternetRadio from './pages/InternetRadio';
-import FolderBrowser from './pages/FolderBrowser';
-import DeviceSync from './pages/DeviceSync';
 import NowPlayingPage from './pages/NowPlaying';
-import WhatsNew from './pages/WhatsNew';
+
+// Lazy — visited rarely or on-demand. Each becomes its own chunk so the
+// initial bundle stays smaller and these pages don't block first paint.
+const Settings       = lazy(() => import('./pages/Settings'));
+const Statistics     = lazy(() => import('./pages/Statistics'));
+const Help           = lazy(() => import('./pages/Help'));
+const WhatsNew       = lazy(() => import('./pages/WhatsNew'));
+const DeviceSync     = lazy(() => import('./pages/DeviceSync'));
+const OfflineLibrary = lazy(() => import('./pages/OfflineLibrary'));
+const LabelAlbums    = lazy(() => import('./pages/LabelAlbums'));
+const AdvancedSearch = lazy(() => import('./pages/AdvancedSearch'));
+const FolderBrowser  = lazy(() => import('./pages/FolderBrowser'));
+const InternetRadio  = lazy(() => import('./pages/InternetRadio'));
 import MiniPlayer from './components/MiniPlayer';
 import { initMiniPlayerBridgeOnMain } from './utils/miniPlayerBridge';
 import FullscreenPlayer from './components/FullscreenPlayer';
@@ -50,7 +55,6 @@ import TooltipPortal from './components/TooltipPortal';
 import ConnectionIndicator from './components/ConnectionIndicator';
 import LastfmIndicator from './components/LastfmIndicator';
 import OfflineBanner from './components/OfflineBanner';
-import OfflineLibrary from './pages/OfflineLibrary';
 import Genres from './pages/Genres';
 import GenreDetail from './pages/GenreDetail';
 import ExportPickerModal from './components/ExportPickerModal';
@@ -401,35 +405,37 @@ function AppShell() {
           <OfflineBanner onRetry={connRetry} isChecking={connRetrying} showSettingsLink={!hasOfflineContent} serverName={serverName} />
         )}
         <div className="content-body" style={{ padding: 0, position: 'relative' }}>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/albums" element={<Albums />} />
-            <Route path="/random" element={<RandomLanding />} />
-            <Route path="/random/albums" element={<RandomAlbums />} />
-            <Route path="/album/:id" element={<AlbumDetail />} />
-            <Route path="/artists" element={<Artists />} />
-            <Route path="/artist/:id" element={<ArtistDetail />} />
-            <Route path="/new-releases" element={<NewReleases />} />
-            <Route path="/favorites" element={<Favorites />} />
-            <Route path="/random/mix" element={<RandomMix />} />
-            <Route path="/label/:name" element={<LabelAlbums />} />
-            <Route path="/search" element={<SearchResults />} />
-            <Route path="/search/advanced" element={<AdvancedSearch />} />
-            <Route path="/statistics" element={<Statistics />} />
-            <Route path="/most-played" element={<MostPlayed />} />
-            <Route path="/now-playing" element={isMobile ? <MobilePlayerView /> : <NowPlayingPage />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="/whats-new" element={<WhatsNew />} />
-            <Route path="/help" element={<Help />} />
-            <Route path="/offline" element={<OfflineLibrary />} />
-            <Route path="/genres" element={<Genres />} />
-            <Route path="/genres/:name" element={<GenreDetail />} />
-            <Route path="/playlists" element={<Playlists />} />
-            <Route path="/playlists/:id" element={<PlaylistDetail />} />
-            <Route path="/radio" element={<InternetRadio />} />
-            <Route path="/folders" element={<FolderBrowser />} />
-            <Route path="/device-sync" element={<DeviceSync />} />
-          </Routes>
+          <Suspense fallback={null}>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/albums" element={<Albums />} />
+              <Route path="/random" element={<RandomLanding />} />
+              <Route path="/random/albums" element={<RandomAlbums />} />
+              <Route path="/album/:id" element={<AlbumDetail />} />
+              <Route path="/artists" element={<Artists />} />
+              <Route path="/artist/:id" element={<ArtistDetail />} />
+              <Route path="/new-releases" element={<NewReleases />} />
+              <Route path="/favorites" element={<Favorites />} />
+              <Route path="/random/mix" element={<RandomMix />} />
+              <Route path="/label/:name" element={<LabelAlbums />} />
+              <Route path="/search" element={<SearchResults />} />
+              <Route path="/search/advanced" element={<AdvancedSearch />} />
+              <Route path="/statistics" element={<Statistics />} />
+              <Route path="/most-played" element={<MostPlayed />} />
+              <Route path="/now-playing" element={isMobile ? <MobilePlayerView /> : <NowPlayingPage />} />
+              <Route path="/settings" element={<Settings />} />
+              <Route path="/whats-new" element={<WhatsNew />} />
+              <Route path="/help" element={<Help />} />
+              <Route path="/offline" element={<OfflineLibrary />} />
+              <Route path="/genres" element={<Genres />} />
+              <Route path="/genres/:name" element={<GenreDetail />} />
+              <Route path="/playlists" element={<Playlists />} />
+              <Route path="/playlists/:id" element={<PlaylistDetail />} />
+              <Route path="/radio" element={<InternetRadio />} />
+              <Route path="/folders" element={<FolderBrowser />} />
+              <Route path="/device-sync" element={<DeviceSync />} />
+            </Routes>
+          </Suspense>
         </div>
         </div>
       </main>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,5 +27,25 @@ export default defineConfig({
     target: process.env.TAURI_ENV_PLATFORM === "windows" ? "chrome105" : "safari13",
     minify: !process.env.TAURI_ENV_DEBUG ? "esbuild" : false,
     sourcemap: !!process.env.TAURI_ENV_DEBUG,
+    rollupOptions: {
+      output: {
+        // Vendor chunks isolate dependencies that change rarely from app code,
+        // so a normal app update doesn't invalidate the cached vendor bundles
+        // (helps especially with the Tauri updater pulling deltas).
+        manualChunks: {
+          react: ["react", "react-dom", "react-router-dom"],
+          tauri: [
+            "@tauri-apps/api",
+            "@tauri-apps/plugin-shell",
+            "@tauri-apps/plugin-dialog",
+            "@tauri-apps/plugin-fs",
+            "@tauri-apps/plugin-process",
+            "@tauri-apps/plugin-store",
+            "@tauri-apps/plugin-updater",
+          ],
+          i18n: ["i18next", "react-i18next"],
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
Cold-start bundle was a single **1.88 MB / 577 KB-gzipped** chunk that parsed every page in the app before first paint, including pages a typical session never opens.

Two-part fix:

### 1. Route-level lazy loading
10 rarely-visited pages now use \`React.lazy()\` — each becomes its own chunk that only downloads when the route is actually hit:

- Settings, Statistics, Help, WhatsNew
- DeviceSync, OfflineLibrary, LabelAlbums
- AdvancedSearch, FolderBrowser, InternetRadio

The whole \`<Routes>\` tree is wrapped in \`<Suspense fallback={null}>\` — no visible loading state, browser cache hits on subsequent visits.

### 2. Vendor chunks
\`vite.config.ts\` now uses \`rollupOptions.output.manualChunks\` to split dependencies that change rarely from app code:

- \`react\`: react, react-dom, react-router-dom
- \`tauri\`: all @tauri-apps/* plugins
- \`i18n\`: i18next, react-i18next

Tauri auto-updater pulls smaller deltas when only app code changed (vendor chunks stay byte-identical and cached).

## Build output

**Before:** 1.88 MB / 577 KB gz monolithic.

**After cold start:** \`~450 KB gz\` (index 370 + react 54 + tauri 6 + i18n 20) — **22% smaller initial download**.

Plus 11 lazy chunks. Notably WhatsNew's bundled CHANGELOG (215 KB / 76 KB gz) is now off the cold-start path entirely.

\`\`\`
dist/assets/OfflineLibrary-*.js                    3.95 kB │ gzip:  1.47 kB
dist/assets/Help-*.js                              5.41 kB │ gzip:  1.71 kB
dist/assets/AdvancedSearch-*.js                    8.38 kB │ gzip:  2.87 kB
dist/assets/Statistics-*.js                       11.10 kB │ gzip:  3.11 kB
dist/assets/FolderBrowser-*.js                    14.22 kB │ gzip:  5.16 kB
dist/assets/InternetRadio-*.js                    16.72 kB │ gzip:  5.87 kB
dist/assets/tauri-*.js                            20.30 kB │ gzip:  5.65 kB
dist/assets/DeviceSync-*.js                       29.47 kB │ gzip:  8.87 kB
dist/assets/i18n-*.js                             60.35 kB │ gzip: 20.54 kB
dist/assets/Settings-*.js                        124.05 kB │ gzip: 28.43 kB
dist/assets/react-*.js                           165.76 kB │ gzip: 54.88 kB
dist/assets/CHANGELOG-*.js                       215.46 kB │ gzip: 76.48 kB
dist/assets/index-*.js                          1211.13 kB │ gzip: 370.86 kB
\`\`\`

## Test plan
- [x] Build succeeds, all chunks emit
- [x] Local: app feels noticeably faster on cold start (subjective)
- [ ] Verify Settings, Help, WhatsNew, DeviceSync, etc. open correctly on first navigation (each downloads its chunk)
- [ ] Verify subsequent visits are instant (browser cache hit)
- [ ] Confirm no flash of empty content from \`<Suspense fallback={null}>\` on slow networks

🤖 Generated with [Claude Code](https://claude.com/claude-code)