### PR TITLE
fix(server-switch): keep cached playback alive + Settings tab-id typo

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1441,10 +1441,10 @@ export default function Settings() {
     if (inv) {
       setPastedServerInvite(inv);
       setShowAddForm(true);
-      setActiveTab('server');
+      setActiveTab('servers');
       navigate(
         { pathname: location.pathname, search: location.search, hash: location.hash },
-        { replace: true, state: { tab: 'server' as Tab } },
+        { replace: true, state: { tab: 'servers' as Tab } },
       );
       return;
     }

--- a/src/utils/switchActiveServer.ts
+++ b/src/utils/switchActiveServer.ts
@@ -1,12 +1,7 @@
 import { pingWithCredentials, scheduleInstantMixProbeForServer } from '../api/subsonic';
 import type { ServerProfile } from '../store/authStore';
 import { useAuthStore } from '../store/authStore';
-import { usePlayerStore } from '../store/playerStore';
 
-/**
- * Ping, update server identity / Instant Mix probe, set active server, clear local playback
- * and pull the new server's saved play queue.
- */
 export async function switchActiveServer(server: ServerProfile): Promise<boolean> {
   try {
     const ping = await pingWithCredentials(server.url, server.username, server.password);
@@ -21,8 +16,6 @@ export async function switchActiveServer(server: ServerProfile): Promise<boolean
     scheduleInstantMixProbeForServer(server.id, server.url, server.username, server.password, identity);
     auth.setActiveServer(server.id);
     auth.setLoggedIn(true);
-    usePlayerStore.getState().clearQueue();
-    await usePlayerStore.getState().initializeFromServerQueue();
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

Two small fixes around server switching.

## 1. Queue no longer wipes on server switch

`switchActiveServer` was calling `clearQueue()` + `initializeFromServerQueue()` right after `setActiveServer`. `clearQueue()` invokes `audio_stop`, so the currently-playing (cached) track was cut off the moment the user clicked a different server in the header — even if the new server hadn't produced anything yet.

Restores the pre-c75297fc behaviour: just swap `activeServerId`, let the Rust engine keep streaming the already-resolved URL, and let the app-boot hook (`App.tsx:258`) or the next user action pick up the new server's saved queue.

Caveat (pre-existing, not introduced by this change): if the running track ends and `next()` tries to resolve an old-server track ID against the new server, playback stops with a 404. Same end-state as before, just not *immediately* on click.

## 2. Settings paste-invite tab id typo

`#261` landed on top of `#259`, which had renamed the Settings tab id from `'server'` to `'servers'`. The `openAddServerInvite` route-state handler in `Settings.tsx` still used the old literal — tripped a TS error and meant pasting a `psysonic1-` invite did not actually switch tabs.

## Test plan

- [ ] Play a track from Server A → switch to Server B in the header → current track keeps playing, no audio interruption
- [ ] On Server A, then switch to Server B where a saved queue exists → current track keeps playing; on next user action (e.g. `Next`) the new server's content takes over
- [ ] Paste a `psysonic1-` invite anywhere → Settings opens on the Servers tab (plural) with the form prefilled
- [ ] `tsc --noEmit` is clean