### PR TITLE
fix(windows): idle WebView2 when Tauri windows are hidden

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3039,8 +3039,13 @@ fn default_mini_position(app: &tauri::AppHandle) -> Option<tauri::PhysicalPositi
 /// or every `requestAnimationFrame` loop — it sets a flag the app reads, zeros
 /// `--psy-anim-speed` (for CSS that opts into it), and pauses **@keyframes**
 /// animations via `animation-play-state` (not CSS transitions).
+///
+/// Also sets `data-psy-native-hidden` on `<html>` so global CSS can pause every
+/// animation including `::before`/`::after` and portal content under `<body>`
+/// when `document.hidden` stays false on some WebView2 builds after `win.hide()`.
 const PAUSE_RENDERING_JS: &str = r#"
 window.__psyHidden = true;
+document.documentElement.setAttribute('data-psy-native-hidden', 'true');
 document.documentElement.style.setProperty('--psy-anim-speed', '0');
 (function () {
   const root = document.getElementById('root');
@@ -3054,6 +3059,7 @@ document.documentElement.style.setProperty('--psy-anim-speed', '0');
 /// JS snippet to resume rendering when the window becomes visible again.
 const RESUME_RENDERING_JS: &str = r#"
 window.__psyHidden = false;
+document.documentElement.removeAttribute('data-psy-native-hidden');
 document.documentElement.style.removeProperty('--psy-anim-speed');
 (function () {
   const root = document.getElementById('root');

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2748,7 +2748,9 @@ fn build_tray_icon(app: &tauri::AppHandle) -> tauri::Result<TrayIcon> {
                 if let Some(win) = app.get_webview_window("main") {
                     if win.is_visible().unwrap_or(false) {
                         let _ = win.hide();
+                        let _ = win.eval(PAUSE_RENDERING_JS);
                     } else {
+                        let _ = win.eval(RESUME_RENDERING_JS);
                         let _ = win.show();
                         let _ = win.set_focus();
                     }
@@ -2782,7 +2784,9 @@ fn build_tray_icon(app: &tauri::AppHandle) -> tauri::Result<TrayIcon> {
                 if let Some(win) = app.get_webview_window("main") {
                     if win.is_visible().unwrap_or(false) {
                         let _ = win.hide();
+                        let _ = win.eval(PAUSE_RENDERING_JS);
                     } else {
+                        let _ = win.eval(RESUME_RENDERING_JS);
                         let _ = win.show();
                         let _ = win.set_focus();
                     }
@@ -3027,6 +3031,28 @@ fn default_mini_position(app: &tauri::AppHandle) -> Option<tauri::PhysicalPositi
     ))
 }
 
+/// JS snippet to inject into a hidden webview to stop all rendering work.
+/// This is critical on Windows where WebView2 keeps the GPU context alive
+/// even when the window is hidden — without this the webview continues
+/// running rAF loops, CSS animations, and setInterval timers.
+const PAUSE_RENDERING_JS: &str = r#"
+window.__psyHidden = true;
+document.documentElement.style.setProperty('--psy-anim-speed', '0');
+// Pause all CSS animations
+document.querySelectorAll('*').forEach(el => {
+  el.style.animationPlayState = 'paused';
+});
+"#;
+
+/// JS snippet to resume rendering when the window becomes visible again.
+const RESUME_RENDERING_JS: &str = r#"
+window.__psyHidden = false;
+document.documentElement.style.removeProperty('--psy-anim-speed');
+document.querySelectorAll('*').forEach(el => {
+  el.style.animationPlayState = '';
+});
+"#;
+
 /// Build the mini player webview window. Caller decides `visible` so the
 /// same code path serves both pre-creation (Windows, hidden at app start)
 /// and lazy creation (other platforms, shown on demand).
@@ -3099,9 +3125,18 @@ fn build_mini_player_window(
     // fire stray Moved events with default coords during the first paint.
     mark_mini_pos_programmatic();
 
-    builder
+    let win = builder
         .build()
-        .map_err(|e| format!("failed to build mini player window: {e}"))
+        .map_err(|e| format!("failed to build mini player window: {e}"))?;
+
+    // Inject pause script immediately when the window is created hidden.
+    // On Windows WebView2 keeps the GPU context alive even with
+    // `SetIsVisible(false)` — this JS stops all rendering work.
+    if !visible {
+        let _ = win.eval(PAUSE_RENDERING_JS);
+    }
+
+    Ok(win)
 }
 
 /// Pre-build the mini player window hidden, so the first `open_mini_player`
@@ -3132,12 +3167,17 @@ fn open_mini_player(app: tauri::AppHandle) -> Result<(), String> {
     let visible = win.is_visible().unwrap_or(false);
     if visible {
         win.hide().map_err(|e| e.to_string())?;
+        // Stop rendering work on the now-hidden mini window.
+        let _ = win.eval(PAUSE_RENDERING_JS);
         if let Some(main) = app.get_webview_window("main") {
             let _ = main.unminimize();
             let _ = main.show();
             let _ = main.set_focus();
         }
     } else {
+        // Resume rendering before showing — the window needs to be ready
+        // to paint as soon as it becomes visible.
+        let _ = win.eval(RESUME_RENDERING_JS);
         // Re-applying the saved position after show() — many Linux WMs
         // (Mutter, KWin) re-centre hidden windows when they're shown
         // again, ignoring any earlier set_position. Mark the move as
@@ -3163,6 +3203,7 @@ fn open_mini_player(app: tauri::AppHandle) -> Result<(), String> {
 fn close_mini_player(app: tauri::AppHandle) -> Result<(), String> {
     if let Some(win) = app.get_webview_window("mini") {
         win.hide().map_err(|e| e.to_string())?;
+        let _ = win.eval(PAUSE_RENDERING_JS);
     }
     if let Some(main) = app.get_webview_window("main") {
         let _ = main.unminimize();
@@ -3180,13 +3221,30 @@ fn close_mini_player(app: tauri::AppHandle) -> Result<(), String> {
 fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
     if let Some(mini) = app.get_webview_window("mini") {
         let _ = mini.hide();
+        let _ = mini.eval(PAUSE_RENDERING_JS);
     }
     if let Some(main) = app.get_webview_window("main") {
+        let _ = main.eval(RESUME_RENDERING_JS);
         main.unminimize().map_err(|e| e.to_string())?;
         main.show().map_err(|e| e.to_string())?;
         main.set_focus().map_err(|e| e.to_string())?;
     }
     Ok(())
+}
+
+/// Pause all rendering work in the current webview. Called when the window
+/// is hidden on Windows to stop GPU usage — WebView2 keeps the compositor
+/// alive even with SetIsVisible(false), so we inject JS to halt animations.
+#[tauri::command]
+fn pause_rendering(window: tauri::WebviewWindow) -> Result<(), String> {
+    window.eval(PAUSE_RENDERING_JS).map_err(|e| e.to_string())
+}
+
+/// Resume rendering work in the current webview. Called when the window
+/// becomes visible again.
+#[tauri::command]
+fn resume_rendering(window: tauri::WebviewWindow) -> Result<(), String> {
+    window.eval(RESUME_RENDERING_JS).map_err(|e| e.to_string())
 }
 
 /// Toggle always-on-top on the mini player window.
@@ -3530,6 +3588,10 @@ pub fn run() {
 
                     #[cfg(not(target_os = "macos"))]
                     {
+                        // Pause rendering before JS decides whether to hide to tray or exit.
+                        if let Some(w) = window.app_handle().get_webview_window("main") {
+                            let _ = w.eval(PAUSE_RENDERING_JS);
+                        }
                         // Let JS decide: minimize to tray or exit, based on user setting.
                         let _ = window.emit("window:close-requested", ());
                     }
@@ -3538,6 +3600,9 @@ pub fn run() {
                     // state is preserved, and restore the main window.
                     api.prevent_close();
                     let _ = window.hide();
+                    if let Some(w) = window.app_handle().get_webview_window("mini") {
+                        let _ = w.eval(PAUSE_RENDERING_JS);
+                    }
                     if let Some(main) = window.app_handle().get_webview_window("main") {
                         let _ = main.unminimize();
                         let _ = main.show();
@@ -3567,6 +3632,8 @@ pub fn run() {
             set_mini_player_always_on_top,
             resize_mini_player,
             show_main_window,
+            pause_rendering,
+            resume_rendering,
             register_global_shortcut,
             unregister_global_shortcut,
             mpris_set_metadata,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2747,8 +2747,8 @@ fn build_tray_icon(app: &tauri::AppHandle) -> tauri::Result<TrayIcon> {
             "show_hide"  => {
                 if let Some(win) = app.get_webview_window("main") {
                     if win.is_visible().unwrap_or(false) {
-                        let _ = win.hide();
                         let _ = win.eval(PAUSE_RENDERING_JS);
+                        let _ = win.hide();
                     } else {
                         let _ = win.eval(RESUME_RENDERING_JS);
                         let _ = win.show();
@@ -2783,8 +2783,8 @@ fn build_tray_icon(app: &tauri::AppHandle) -> tauri::Result<TrayIcon> {
                 let app = tray.app_handle();
                 if let Some(win) = app.get_webview_window("main") {
                     if win.is_visible().unwrap_or(false) {
-                        let _ = win.hide();
                         let _ = win.eval(PAUSE_RENDERING_JS);
+                        let _ = win.hide();
                     } else {
                         let _ = win.eval(RESUME_RENDERING_JS);
                         let _ = win.show();
@@ -3031,26 +3031,37 @@ fn default_mini_position(app: &tauri::AppHandle) -> Option<tauri::PhysicalPositi
     ))
 }
 
-/// JS snippet to inject into a hidden webview to stop all rendering work.
-/// This is critical on Windows where WebView2 keeps the GPU context alive
-/// even when the window is hidden — without this the webview continues
-/// running rAF loops, CSS animations, and setInterval timers.
+/// JS snippet to inject into a hidden webview to reduce compositor work while
+/// the host window is invisible.
+///
+/// WebView2 on Windows can keep a GPU-backed compositor active even when the
+/// native window is hidden. This script does **not** stop arbitrary JS timers
+/// or every `requestAnimationFrame` loop — it sets a flag the app reads, zeros
+/// `--psy-anim-speed` (for CSS that opts into it), and pauses **@keyframes**
+/// animations via `animation-play-state` (not CSS transitions).
 const PAUSE_RENDERING_JS: &str = r#"
 window.__psyHidden = true;
 document.documentElement.style.setProperty('--psy-anim-speed', '0');
-// Pause all CSS animations
-document.querySelectorAll('*').forEach(el => {
-  el.style.animationPlayState = 'paused';
-});
+(function () {
+  const root = document.getElementById('root');
+  if (!root) return;
+  root.querySelectorAll('*').forEach(function (el) {
+    el.style.animationPlayState = 'paused';
+  });
+})();
 "#;
 
 /// JS snippet to resume rendering when the window becomes visible again.
 const RESUME_RENDERING_JS: &str = r#"
 window.__psyHidden = false;
 document.documentElement.style.removeProperty('--psy-anim-speed');
-document.querySelectorAll('*').forEach(el => {
-  el.style.animationPlayState = '';
-});
+(function () {
+  const root = document.getElementById('root');
+  if (!root) return;
+  root.querySelectorAll('*').forEach(function (el) {
+    el.style.animationPlayState = '';
+  });
+})();
 "#;
 
 /// Build the mini player webview window. Caller decides `visible` so the
@@ -3166,9 +3177,10 @@ fn open_mini_player(app: tauri::AppHandle) -> Result<(), String> {
 
     let visible = win.is_visible().unwrap_or(false);
     if visible {
-        win.hide().map_err(|e| e.to_string())?;
-        // Stop rendering work on the now-hidden mini window.
+        // Pause before hide so `__psyHidden` is set while the webview is still
+        // guaranteed schedulable (mirrors tray / main close ordering).
         let _ = win.eval(PAUSE_RENDERING_JS);
+        win.hide().map_err(|e| e.to_string())?;
         if let Some(main) = app.get_webview_window("main") {
             let _ = main.unminimize();
             let _ = main.show();
@@ -3202,8 +3214,8 @@ fn open_mini_player(app: tauri::AppHandle) -> Result<(), String> {
 #[tauri::command]
 fn close_mini_player(app: tauri::AppHandle) -> Result<(), String> {
     if let Some(win) = app.get_webview_window("mini") {
-        win.hide().map_err(|e| e.to_string())?;
         let _ = win.eval(PAUSE_RENDERING_JS);
+        win.hide().map_err(|e| e.to_string())?;
     }
     if let Some(main) = app.get_webview_window("main") {
         let _ = main.unminimize();
@@ -3220,8 +3232,8 @@ fn close_mini_player(app: tauri::AppHandle) -> Result<(), String> {
 #[tauri::command]
 fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
     if let Some(mini) = app.get_webview_window("mini") {
-        let _ = mini.hide();
         let _ = mini.eval(PAUSE_RENDERING_JS);
+        let _ = mini.hide();
     }
     if let Some(main) = app.get_webview_window("main") {
         let _ = main.eval(RESUME_RENDERING_JS);
@@ -3232,9 +3244,7 @@ fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Pause all rendering work in the current webview. Called when the window
-/// is hidden on Windows to stop GPU usage — WebView2 keeps the compositor
-/// alive even with SetIsVisible(false), so we inject JS to halt animations.
+/// Inject the pause script into this webview (CSS @keyframes pause + `__psyHidden`).
 #[tauri::command]
 fn pause_rendering(window: tauri::WebviewWindow) -> Result<(), String> {
     window.eval(PAUSE_RENDERING_JS).map_err(|e| e.to_string())
@@ -3599,10 +3609,10 @@ pub fn run() {
                     // Native close on the mini: hide instead of destroying so
                     // state is preserved, and restore the main window.
                     api.prevent_close();
-                    let _ = window.hide();
                     if let Some(w) = window.app_handle().get_webview_window("mini") {
                         let _ = w.eval(PAUSE_RENDERING_JS);
                     }
+                    let _ = window.hide();
                     if let Some(main) = window.app_handle().get_webview_window("main") {
                         let _ = main.unminimize();
                         let _ = main.show();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -378,11 +378,9 @@ function AppShell() {
     };
   }, []);
 
-  // Pause CSS animations when the window is minimized / hidden.
-  // WebView2 on Windows keeps compositing infinite-loop animations (mesh-aura,
-  // portrait-drift, eq-bounce, …) even when the app is minimized, which shows
-  // up as steady GPU usage. The CSS rule `html[data-app-hidden="true"]` in
-  // components.css pauses all running animations while this flag is set.
+  // Pause CSS animations when the browser tab is hidden (`document.hidden`).
+  // Tauri `win.hide()` is mirrored separately via `data-psy-native-hidden` from
+  // Rust (see components.css). WebView2 can keep compositing without the former.
   useEffect(() => {
     const update = () => {
       document.documentElement.dataset.appHidden = document.hidden ? 'true' : 'false';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import PlayerBar from './components/PlayerBar';
 import BottomNav from './components/BottomNav';
 import MobilePlayerView from './components/MobilePlayerView';
 import { useIsMobile } from './hooks/useIsMobile';
+import { WindowVisibilityProvider } from './hooks/useWindowVisibility';
 import LiveSearch from './components/LiveSearch';
 import NowPlayingDropdown from './components/NowPlayingDropdown';
 import QueuePanel from './components/QueuePanel';
@@ -932,10 +933,11 @@ function TauriEventBridge() {
         unlisten.push(u);
       }
 
-      // window:close-requested is emitted by Rust (prevent_close + emit).
+     // window:close-requested is emitted by Rust (prevent_close + emit).
       // JS decides: minimize to tray or exit, based on user setting.
       const u = await listen('window:close-requested', async () => {
         if (useAuthStore.getState().minimizeToTray) {
+          await invoke('pause_rendering').catch(() => {});
           await getCurrentWindow().hide();
         } else {
           await invoke('exit_app');
@@ -1134,24 +1136,26 @@ export default function App() {
   }, []);
 
   return (
-    <BrowserRouter>
-      <PasteClipboardHandler />
-      <TauriEventBridge />
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route
-          path="/*"
-          element={
-            <RequireAuth>
-              <DragDropProvider>
-                <AppShell />
-              </DragDropProvider>
-            </RequireAuth>
-          }
-        />
-      </Routes>
-      {exportPickerOpen && <ExportPickerModal onConfirm={handleExport} onClose={() => setExportPickerOpen(false)} />}
-      <ZipDownloadOverlay />
-    </BrowserRouter>
+    <WindowVisibilityProvider>
+      <BrowserRouter>
+        <PasteClipboardHandler />
+        <TauriEventBridge />
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route
+            path="/*"
+            element={
+              <RequireAuth>
+                <DragDropProvider>
+                  <AppShell />
+                </DragDropProvider>
+              </RequireAuth>
+            }
+          />
+        </Routes>
+        {exportPickerOpen && <ExportPickerModal onConfirm={handleExport} onClose={() => setExportPickerOpen(false)} />}
+        <ZipDownloadOverlay />
+      </BrowserRouter>
+    </WindowVisibilityProvider>
   );
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,6 +7,7 @@ import { usePlayerStore, songToTrack } from '../store/playerStore';
 import { useTranslation } from 'react-i18next';
 import { playAlbum } from '../utils/playAlbum';
 import { useIsMobile } from '../hooks/useIsMobile';
+import { useWindowVisibility } from '../hooks/useWindowVisibility';
 import { useAuthStore } from '../store/authStore';
 import { useThemeStore } from '../store/themeStore';
 import { filterAlbumsByMixRatings, getMixMinRatingsConfigFromAuth } from '../utils/mixRatingFilter';
@@ -65,6 +66,7 @@ export default function Hero({ albums: albumsProp }: HeroProps = {}) {
   const [albums, setAlbums] = useState<SubsonicAlbum[]>([]);
   const [activeIdx, setActiveIdx] = useState(0);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const windowHidden = useWindowVisibility();
 
   useEffect(() => {
     if (albumsProp?.length) { setAlbums(albumsProp); return; }
@@ -87,18 +89,23 @@ export default function Hero({ albums: albumsProp }: HeroProps = {}) {
     mixMinRatingArtist,
   ]);
 
-  // Start / restart auto-advance timer
+  // Start / restart auto-advance timer (paused while the Tauri window is hidden).
   const startTimer = useCallback((len: number) => {
     if (timerRef.current) clearInterval(timerRef.current);
-    if (len <= 1) return;
+    timerRef.current = null;
+    if (len <= 1 || windowHidden) return;
     timerRef.current = setInterval(() => {
+      if (document.hidden || (window as any).__psyHidden) return;
       setActiveIdx(prev => (prev + 1) % len);
     }, INTERVAL_MS);
-  }, []);
+  }, [windowHidden]);
 
   useEffect(() => {
     startTimer(albums.length);
-    return () => { if (timerRef.current) clearInterval(timerRef.current); };
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+      timerRef.current = null;
+    };
   }, [albums.length, startTimer]);
 
   const goTo = useCallback((idx: number) => {

--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -9,6 +9,7 @@ import { usePlayerStore } from '../store/playerStore';
 import { useAuthStore } from '../store/authStore';
 import { useKeybindingsStore, matchInAppBinding } from '../store/keybindingsStore';
 import { useDragDrop } from '../contexts/DragDropContext';
+import { useWindowVisibility } from '../hooks/useWindowVisibility';
 import { IS_LINUX } from '../utils/platform';
 import MiniContextMenu from './MiniContextMenu';
 import OverlayScrollArea from './OverlayScrollArea';
@@ -114,6 +115,9 @@ export default function MiniPlayer() {
   const ticker = useRef<number | null>(null);
   const queueScrollRef = useRef<HTMLDivElement>(null);
   const volumeWrapRef = useRef<HTMLDivElement>(null);
+  const hiddenRef = useRef(false);
+  const isHidden = useWindowVisibility();
+  useEffect(() => { hiddenRef.current = isHidden; }, [isHidden]);
 
   // ── PsyDnD reorder ──
   // Mirrors QueuePanel's pattern: mousedown threshold → startDrag, mousemove
@@ -235,6 +239,7 @@ export default function MiniPlayer() {
       if (typeof e.payload.volume === 'number') setVolumeState(e.payload.volume);
     });
     const unProgress = listen<ProgressPayload>('audio:progress', (e) => {
+      if (hiddenRef.current || (window as any).__psyHidden) return;
       setCurrentTime(e.payload.current_time);
       if (e.payload.duration > 0) setDuration(e.payload.duration);
     });

--- a/src/components/PlaybackScheduleBadge.tsx
+++ b/src/components/PlaybackScheduleBadge.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { usePlayerStore } from '../store/playerStore';
 import { useShallow } from 'zustand/react/shallow';
 import { formatPlaybackScheduleRemaining } from '../utils/playbackScheduleFormat';
+import { useWindowVisibility } from '../hooks/useWindowVisibility';
 
 export interface PlaybackScheduleBadgeProps {
   /** Anchor element (usually the play/pause button wrapper) — the ring centres on it. */
@@ -46,15 +47,19 @@ export default function PlaybackScheduleBadge({ layoutAnchorRef, className }: Pl
 
   const [nowMs, setNowMs] = useState(() => Date.now());
   const [anchorRect, setAnchorRect] = useState<{ left: number; top: number; size: number } | null>(null);
+  const windowHidden = useWindowVisibility();
 
   useEffect(() => {
-    if (deadlineMs == null) return;
-    const id = window.setInterval(() => setNowMs(Date.now()), 500);
+    if (deadlineMs == null || windowHidden) return;
+    const id = window.setInterval(() => {
+      if (document.hidden || (window as any).__psyHidden) return;
+      setNowMs(Date.now());
+    }, 500);
     return () => window.clearInterval(id);
-  }, [deadlineMs]);
+  }, [deadlineMs, windowHidden]);
 
   useLayoutEffect(() => {
-    if (deadlineMs == null) return;
+    if (deadlineMs == null || windowHidden) return;
     const el = layoutAnchorRef.current;
     if (!el) return;
     const sync = () => {
@@ -74,7 +79,7 @@ export default function PlaybackScheduleBadge({ layoutAnchorRef, className }: Pl
       window.removeEventListener('scroll', sync, true);
       window.clearInterval(iv);
     };
-  }, [deadlineMs, layoutAnchorRef]);
+  }, [deadlineMs, layoutAnchorRef, windowHidden]);
 
   if (deadlineMs == null || startMs == null || !anchorRect) return null;
 

--- a/src/components/WaveformSeek.tsx
+++ b/src/components/WaveformSeek.tsx
@@ -739,6 +739,10 @@ export function SeekbarPreview({
     const animState = makeAnimState();
     let t = 0;
     const tick = () => {
+      if (document.hidden || (window as any).__psyHidden) {
+        rafRef.current = requestAnimationFrame(tick);
+        return;
+      }
       t += 0.016;
       animState.time = t;
       const progress = 0.15 + 0.65 * (0.5 + 0.5 * Math.sin(t));
@@ -871,6 +875,10 @@ export default function WaveformSeek({ trackId }: Props) {
     animStateRef.current = makeAnimState();
     let rafId: number;
     const tick = () => {
+      if (document.hidden || (window as any).__psyHidden) {
+        rafId = requestAnimationFrame(tick);
+        return;
+      }
       animStateRef.current.time += 0.016;
       drawSeekbar(canvas, seekbarStyle, heightsRef.current, progressRef.current, bufferedRef.current, animStateRef.current);
       rafId = requestAnimationFrame(tick);

--- a/src/components/WaveformSeek.tsx
+++ b/src/components/WaveformSeek.tsx
@@ -727,7 +727,6 @@ export function SeekbarPreview({
   onClick: () => void;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const rafRef    = useRef<number | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -738,9 +737,24 @@ export function SeekbarPreview({
     }
     const animState = makeAnimState();
     let t = 0;
+    let rafId: number | null = null;
+    let pollId: number | null = null;
+    const stop = () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      if (pollId !== null) {
+        window.clearTimeout(pollId);
+        pollId = null;
+      }
+    };
     const tick = () => {
       if (document.hidden || (window as any).__psyHidden) {
-        rafRef.current = requestAnimationFrame(tick);
+        pollId = window.setTimeout(() => {
+          pollId = null;
+          tick();
+        }, 400);
         return;
       }
       t += 0.016;
@@ -748,10 +762,10 @@ export function SeekbarPreview({
       const progress = 0.15 + 0.65 * (0.5 + 0.5 * Math.sin(t));
       const buffered  = Math.min(1, progress + 0.18);
       drawSeekbar(canvas, style, heights, progress, buffered, animState);
-      rafRef.current = requestAnimationFrame(tick);
+      rafId = requestAnimationFrame(tick);
     };
-    rafRef.current = requestAnimationFrame(tick);
-    return () => { if (rafRef.current !== null) cancelAnimationFrame(rafRef.current); };
+    tick();
+    return () => stop();
   }, [style]);
 
   return (
@@ -873,18 +887,32 @@ export default function WaveformSeek({ trackId }: Props) {
     const canvas = canvasRef.current;
     if (!canvas) return;
     animStateRef.current = makeAnimState();
-    let rafId: number;
+    let rafId: number | null = null;
+    let pollId: number | null = null;
+    const stop = () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      if (pollId !== null) {
+        window.clearTimeout(pollId);
+        pollId = null;
+      }
+    };
     const tick = () => {
       if (document.hidden || (window as any).__psyHidden) {
-        rafId = requestAnimationFrame(tick);
+        pollId = window.setTimeout(() => {
+          pollId = null;
+          tick();
+        }, 400);
         return;
       }
       animStateRef.current.time += 0.016;
       drawSeekbar(canvas, seekbarStyle, heightsRef.current, progressRef.current, bufferedRef.current, animStateRef.current);
       rafId = requestAnimationFrame(tick);
     };
-    rafId = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(rafId);
+    tick();
+    return () => stop();
   }, [seekbarStyle]);
 
   // Resize observer.

--- a/src/hooks/useWindowVisibility.tsx
+++ b/src/hooks/useWindowVisibility.tsx
@@ -1,0 +1,56 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  type ReactNode,
+} from 'react';
+
+const WindowVisibilityContext = createContext(false);
+
+/**
+ * Tracks whether the Tauri window is hidden.
+ *
+ * On Windows WebView2, `visibilitychange` and `blur`/`focus` events do not
+ * fire when `win.hide()` is called. We fall back to polling `document.hidden`
+ * with an adaptive interval: fast checks while visible (to catch show quickly),
+ * slow checks while hidden (to minimize CPU wakeups).
+ */
+export function WindowVisibilityProvider({ children }: { children: ReactNode }) {
+  const [hidden, setHidden] = useState(document.hidden);
+  const hiddenRef = useRef(hidden);
+
+  const scheduleCheck = useCallback(() => {
+    const interval = hiddenRef.current ? 1000 : 200;
+    const id = setTimeout(() => {
+      const current = document.hidden;
+      if (current !== hiddenRef.current) {
+        hiddenRef.current = current;
+        setHidden(current);
+      }
+      scheduleCheck();
+    }, interval);
+    return id;
+  }, []);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    timerRef.current = scheduleCheck();
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, [scheduleCheck]);
+
+  return (
+    <WindowVisibilityContext.Provider value={hidden}>
+      {children}
+    </WindowVisibilityContext.Provider>
+  );
+}
+
+export function useWindowVisibility() {
+  return useContext(WindowVisibilityContext);
+}

--- a/src/hooks/useWindowVisibility.tsx
+++ b/src/hooks/useWindowVisibility.tsx
@@ -2,7 +2,6 @@ import {
   createContext,
   useContext,
   useState,
-  useCallback,
   useRef,
   useEffect,
   type ReactNode,
@@ -22,27 +21,32 @@ export function WindowVisibilityProvider({ children }: { children: ReactNode }) 
   const [hidden, setHidden] = useState(document.hidden);
   const hiddenRef = useRef(hidden);
 
-  const scheduleCheck = useCallback(() => {
-    const interval = hiddenRef.current ? 1000 : 200;
-    const id = setTimeout(() => {
-      const current = document.hidden;
-      if (current !== hiddenRef.current) {
-        hiddenRef.current = current;
-        setHidden(current);
-      }
-      scheduleCheck();
-    }, interval);
-    return id;
-  }, []);
-
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   useEffect(() => {
-    timerRef.current = scheduleCheck();
-    return () => {
-      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    hiddenRef.current = document.hidden;
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const schedule = () => {
+      if (cancelled) return;
+      const interval = hiddenRef.current ? 1000 : 200;
+      timeoutId = setTimeout(() => {
+        timeoutId = null;
+        if (cancelled) return;
+        const current = document.hidden;
+        if (current !== hiddenRef.current) {
+          hiddenRef.current = current;
+          setHidden(current);
+        }
+        schedule();
+      }, interval);
     };
-  }, [scheduleCheck]);
+
+    schedule();
+    return () => {
+      cancelled = true;
+      if (timeoutId !== null) clearTimeout(timeoutId);
+    };
+  }, []);
 
   return (
     <WindowVisibilityContext.Provider value={hidden}>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -9626,11 +9626,11 @@ html.no-compositing .fs-seekbar-played {
 .device-sync-row-meta { font-size: 0.75rem; color: var(--text-secondary); flex-shrink: 0; }
 
 /* ── Pause CSS animations when the window is hidden / minimized ────────────
-   Set via App.tsx on `visibilitychange`. WebView2 on Windows keeps compositing
-   infinite CSS animations (mesh-aura, portrait-drift, eq-bounce, track-pulse,
-   led-pulse, …) even when the app is minimized, causing constant GPU use.
-   Pausing them cuts that to near zero while hidden without touching the
-   running Rust/audio threads. */
+   - `data-app-hidden`: App.tsx `visibilitychange` → `document.hidden` (all platforms).
+   - `data-psy-native-hidden`: Rust inject on Tauri `win.hide()` / show (WebView2
+     often keeps `document.hidden === false` when the native window is hidden).
+   Either flag pauses infinite animations including portaled nodes and ::pseudo,
+   without touching Rust/audio threads. */
 /* ─ What's New — banner + page ────────────────────────────────────────────
    Fixed neutral palette so it reads identically on every theme (light and
    dark). The banner sits in the sidebar just above Now Playing; the page
@@ -10268,7 +10268,10 @@ html.no-compositing .fs-seekbar-played {
 
 html[data-app-hidden="true"] *,
 html[data-app-hidden="true"] *::before,
-html[data-app-hidden="true"] *::after {
+html[data-app-hidden="true"] *::after,
+html[data-psy-native-hidden="true"] *,
+html[data-psy-native-hidden="true"] *::before,
+html[data-psy-native-hidden="true"] *::after {
   animation-play-state: paused !important;
 }
 

--- a/src/utils/playbackScheduleFormat.ts
+++ b/src/utils/playbackScheduleFormat.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { usePlayerStore } from '../store/playerStore';
+import { useWindowVisibility } from '../hooks/useWindowVisibility';
 
 /** Remaining time until wall-clock `deadlineMs` (m:ss or h:mm:ss). */
 export function formatPlaybackScheduleRemaining(deadlineMs: number | null, nowMs: number): string {
@@ -43,11 +44,15 @@ export function usePlaybackScheduleRemaining(): PlaybackScheduleInfo | null {
     : null;
   const deadlineMs = mode === 'pause' ? scheduledPauseAtMs : mode === 'start' ? scheduledResumeAtMs : null;
   const [nowMs, setNowMs] = useState(() => Date.now());
+  const windowHidden = useWindowVisibility();
   useEffect(() => {
-    if (deadlineMs == null) return;
-    const id = window.setInterval(() => setNowMs(Date.now()), 500);
+    if (deadlineMs == null || windowHidden) return;
+    const id = window.setInterval(() => {
+      if (document.hidden || (window as any).__psyHidden) return;
+      setNowMs(Date.now());
+    }, 500);
     return () => window.clearInterval(id);
-  }, [deadlineMs]);
+  }, [deadlineMs, windowHidden]);
   if (mode == null || deadlineMs == null) return null;
   return { remaining: formatPlaybackScheduleRemaining(deadlineMs, nowMs), mode };
 }


### PR DESCRIPTION
### Problem

On **Windows (WebView2)**, hiding a window with Tauri’s `win.hide()` does not always behave like a normal browser tab hide: the native window disappears, but the engine can keep **compositor and main-thread work** going (CSS `@keyframes`, decorative canvas loops, periodic JS timers, etc.). Often **`document.hidden` / `visibilitychange` do not line up** with “the native window is already hidden”, so Page Visibility alone is not enough to pause visual work.

### Scope

Mitigation is **best-effort reduction of visual/compositor and periodic JS wakeups**, not a full “freeze the JS runtime”.

- **`window.__psyHidden`** — set from injected JS when we pause or hide a webview; the UI reads it where `document.hidden` is not enough.
- **Rust → `eval` pause/resume** — sets/clears `__psyHidden`, optional `--psy-anim-speed`, walks **`#root`** descendants to set/clear inline **`animation-play-state`** for **`@keyframes`** (not CSS `transition`, not arbitrary timers / all rAF). **`eval(PAUSE)` runs before `hide()`** on tray, mini, native mini close, and related paths.
- **`data-psy-native-hidden`** on `<html>` from the same inject — drives the same global **`animation-play-state: paused !important`** CSS as **`data-app-hidden`**, so **portaled UI and pseudo-elements** still pause when WebView2 keeps `document.hidden === false` after `win.hide()`.
- **Commands** `pause_rendering` / `resume_rendering` — used from JS on close-to-tray.
- **`WindowVisibilityProvider`** — adaptive polling of `document.hidden` with reliable timer cleanup.
- **`MiniPlayer`** — skips `audio:progress` updates when hidden / `__psyHidden`.
- **`WaveformSeek`** — while hidden, a **~400 ms poll** instead of a tight rAF loop; teardown cancels both.
- **`Hero`** — no 10 s carousel interval while the window is hidden.
- **`PlaybackScheduleBadge`** / **`usePlaybackScheduleRemaining`** — no 400/500 ms intervals while hidden; ticks respect `document.hidden` and `__psyHidden`.

### Limitations

- Does **not** stop **all** timers, **all** rAF, or **all** GPU use — WebView2 can still hold a GPU context; we reduce **content-driven** churn.
- Inline inject still targets **`@keyframes`** under **`#root`** only; global pause for portaled content relies on the **`html[data-psy-native-hidden]`** / **`data-app-hidden`** CSS rules.

### Files

- `src-tauri/src/lib.rs`
- `src/App.tsx`
- `src/components/MiniPlayer.tsx`
- `src/components/WaveformSeek.tsx`
- `src/components/Hero.tsx`
- `src/components/PlaybackScheduleBadge.tsx`
- `src/utils/playbackScheduleFormat.ts`
- `src/hooks/useWindowVisibility.tsx`
- `src/styles/components.css`

### Verification

- **Windows:** tray hide/show, mini toggle, pre-created hidden mini, sleep-timer / delayed-start when armed — GPU and periodic spikes should improve; no regression when windows are visible.
- **Linux / macOS:** same flows — behaviour unchanged or safer; relevant paths are not `#[cfg(windows)]`-gated away.
