### PR TITLE
fix(windows): tighten WebView2 idle hooks from #273 review

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -931,7 +931,7 @@ function TauriEventBridge() {
         unlisten.push(u);
       }
 
-     // window:close-requested is emitted by Rust (prevent_close + emit).
+      // window:close-requested is emitted by Rust (prevent_close + emit).
       // JS decides: minimize to tray or exit, based on user setting.
       const u = await listen('window:close-requested', async () => {
         if (useAuthStore.getState().minimizeToTray) {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -95,7 +95,7 @@ export default function Hero({ albums: albumsProp }: HeroProps = {}) {
     timerRef.current = null;
     if (len <= 1 || windowHidden) return;
     timerRef.current = setInterval(() => {
-      if (document.hidden || (window as any).__psyHidden) return;
+      if (document.hidden || window.__psyHidden) return;
       setActiveIdx(prev => (prev + 1) % len);
     }, INTERVAL_MS);
   }, [windowHidden]);

--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -239,7 +239,7 @@ export default function MiniPlayer() {
       if (typeof e.payload.volume === 'number') setVolumeState(e.payload.volume);
     });
     const unProgress = listen<ProgressPayload>('audio:progress', (e) => {
-      if (hiddenRef.current || (window as any).__psyHidden) return;
+      if (hiddenRef.current || window.__psyHidden) return;
       setCurrentTime(e.payload.current_time);
       if (e.payload.duration > 0) setDuration(e.payload.duration);
     });

--- a/src/components/PlaybackScheduleBadge.tsx
+++ b/src/components/PlaybackScheduleBadge.tsx
@@ -52,7 +52,7 @@ export default function PlaybackScheduleBadge({ layoutAnchorRef, className }: Pl
   useEffect(() => {
     if (deadlineMs == null || windowHidden) return;
     const id = window.setInterval(() => {
-      if (document.hidden || (window as any).__psyHidden) return;
+      if (document.hidden || window.__psyHidden) return;
       setNowMs(Date.now());
     }, 500);
     return () => window.clearInterval(id);

--- a/src/components/WaveformSeek.tsx
+++ b/src/components/WaveformSeek.tsx
@@ -750,7 +750,7 @@ export function SeekbarPreview({
       }
     };
     const tick = () => {
-      if (document.hidden || (window as any).__psyHidden) {
+      if (document.hidden || window.__psyHidden) {
         pollId = window.setTimeout(() => {
           pollId = null;
           tick();
@@ -900,7 +900,7 @@ export default function WaveformSeek({ trackId }: Props) {
       }
     };
     const tick = () => {
-      if (document.hidden || (window as any).__psyHidden) {
+      if (document.hidden || window.__psyHidden) {
         pollId = window.setTimeout(() => {
           pollId = null;
           tick();

--- a/src/hooks/useWindowVisibility.tsx
+++ b/src/hooks/useWindowVisibility.tsx
@@ -14,25 +14,31 @@ const WindowVisibilityContext = createContext(false);
  *
  * On Windows WebView2, `visibilitychange` and `blur`/`focus` events do not
  * fire when `win.hide()` is called. We fall back to polling `document.hidden`
- * with an adaptive interval: fast checks while visible (to catch show quickly),
- * slow checks while hidden (to minimize CPU wakeups).
+ * OR-ed with `window.__psyHidden` (set from Rust before/after `win.hide()` /
+ * `show()`) — the latter is the reliable signal on WebView2 where
+ * `document.hidden` may stay false. Adaptive interval: slow while hidden
+ * (minimize wakeups), 500 ms while visible (catch show without burning CPU).
  */
+function isWindowHidden() {
+  return document.hidden || !!window.__psyHidden;
+}
+
 export function WindowVisibilityProvider({ children }: { children: ReactNode }) {
-  const [hidden, setHidden] = useState(document.hidden);
+  const [hidden, setHidden] = useState(isWindowHidden);
   const hiddenRef = useRef(hidden);
 
   useEffect(() => {
-    hiddenRef.current = document.hidden;
+    hiddenRef.current = isWindowHidden();
     let cancelled = false;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const schedule = () => {
       if (cancelled) return;
-      const interval = hiddenRef.current ? 1000 : 200;
+      const interval = hiddenRef.current ? 1000 : 500;
       timeoutId = setTimeout(() => {
         timeoutId = null;
         if (cancelled) return;
-        const current = document.hidden;
+        const current = isWindowHidden();
         if (current !== hiddenRef.current) {
           hiddenRef.current = current;
           setHidden(current);

--- a/src/utils/playbackScheduleFormat.ts
+++ b/src/utils/playbackScheduleFormat.ts
@@ -48,7 +48,7 @@ export function usePlaybackScheduleRemaining(): PlaybackScheduleInfo | null {
   useEffect(() => {
     if (deadlineMs == null || windowHidden) return;
     const id = window.setInterval(() => {
-      if (document.hidden || (window as any).__psyHidden) return;
+      if (document.hidden || window.__psyHidden) return;
       setNowMs(Date.now());
     }, 500);
     return () => window.clearInterval(id);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+declare global {
+  interface Window {
+    __psyHidden?: boolean;
+  }
+}
+
+export {};


### PR DESCRIPTION
Follow-up to #273 — addresses the non-blocking notes from the macOS review.

### Changes

- **Type `window.__psyHidden` once** via `declare global { interface Window { __psyHidden?: boolean } }` in `vite-env.d.ts`. Drops the six `(window as any).__psyHidden` casts in Hero, MiniPlayer, PlaybackScheduleBadge, WaveformSeek (×2), and `playbackScheduleFormat`.
- **`WindowVisibilityProvider` now ORs `window.__psyHidden`** into the hidden state (and the initial state, via a small `isWindowHidden()` helper). On WebView2 `document.hidden` does not always flip when `win.hide()` is called, so effects gated by `useWindowVisibility()` (Hero carousel, PlaybackScheduleBadge, MiniPlayer audio:progress, etc.) can now actually skip creating intervals/rAF instead of relying solely on the per-tick fallback check.
- **Slow visible-poll from 200 ms → 500 ms.** 5 wakeups/s just to detect a hide → show transition was overkill; 500 ms is plenty responsive and halves the idle wakeup rate.
- **Fix stray leading-space indent** on the `// window:close-requested` comment in `App.tsx`.

### Verification

- `npm run build` clean (tsc + bundle).
- macOS: tray hide/show, mini toggle, Cmd+W, minimize/restore — all flows still behave as in #273.
- Windows: should benefit from the `__psyHidden` OR — intervals are now skipped at the `useEffect` level when the window is Tauri-hidden but `document.hidden` lies.