### PR TITLE
fix(audio): defer chained-track volume to gapless transition

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -3064,7 +3064,12 @@ pub async fn audio_chain_preload(
 
     let raw_bytes = Arc::new(data);
 
-    let (gain_linear, effective_volume) = compute_gain(replay_gain_db, replay_gain_peak, pre_gain_db, fallback_db, volume);
+    // Only `gain_linear` is needed — `effective_volume` is intentionally NOT
+    // applied to the Sink here. `audio_chain_preload` runs ~30 s before the
+    // current track ends, and `Sink::set_volume` affects the WHOLE Sink (incl.
+    // the still-playing current source). Volume for the chained track is
+    // applied at the gapless transition in `spawn_progress_task`, not here.
+    let (gain_linear, _effective_volume) = compute_gain(replay_gain_db, replay_gain_peak, pre_gain_db, fallback_db, volume);
 
     let done_next = Arc::new(AtomicBool::new(false));
     // Use a dedicated counter for the chained source — it will be swapped into
@@ -3116,11 +3121,11 @@ pub async fn audio_chain_preload(
     }
 
     // Append to the existing Sink. The audio hardware stream never stalls.
+    // Note: `set_volume` is deliberately NOT called here (see comment above).
     {
         let cur = state.current.lock().unwrap();
         match &cur.sink {
             Some(sink) => {
-                sink.set_volume(effective_volume);
                 sink.append(source);
             }
             None => return Ok(()), // playback stopped — bail
@@ -3208,7 +3213,12 @@ fn spawn_progress_task(
                     // a one-time value copy would go stale immediately.
                     samples_played = info.sample_counter;
 
-                    // Update tracking state.
+                    // Update tracking state and apply the chained track's
+                    // effective volume. Deferred from `audio_chain_preload`
+                    // (which runs ~30 s before the current track ends) to
+                    // avoid changing loudness of the still-playing current
+                    // track. `Sink::set_volume` affects the whole Sink, so it
+                    // must only be called at the boundary, not at preload.
                     {
                         let mut cur = current_arc.lock().unwrap();
                         cur.replay_gain_linear = info.replay_gain_linear;
@@ -3216,6 +3226,10 @@ fn spawn_progress_task(
                         cur.duration_secs = info.duration_secs;
                         cur.seek_offset = 0.0;
                         cur.play_started = Some(Instant::now());
+                        if let Some(sink) = &cur.sink {
+                            let effective = (cur.base_volume * cur.replay_gain_linear * MASTER_HEADROOM).clamp(0.0, 1.0);
+                            sink.set_volume(effective);
+                        }
                     }
 
                     // Record the gapless switch timestamp for ghost-command guard.


### PR DESCRIPTION
### Problem

Closes #275 — playback loudness audibly shifts exactly 30 s before a track ends, toward the next track's level. Reported by @thenktor with two clean repros at known ReplayGain deltas; @Psychotoxical confirmed independently.

### Root cause

\`audio_chain_preload\` runs ~30 s before the current track ends to queue the next source for sample-accurate gapless playback. It was also calling:

\`\`\`rust
sink.set_volume(effective_volume);  // ← effective_volume is for the NEXT track
sink.append(source);
\`\`\`

But \`Sink::set_volume\` affects the **whole** Sink — including the still-playing current source. So 30 s before track A ends, A's loudness was being clamped to B's RG-adjusted level. This bug is older than #242 (the Auto mode); \`git log -L\` traces it back to v1.8.0. Auto mode just makes the deltas between adjacent tracks larger more often (album↔track gain at album boundaries in mixed queues), which is why it became noticeable now.

### Fix

Move the \`set_volume\` to the gapless transition in \`spawn_progress_task\`, where \`cur.replay_gain_linear\` / \`cur.base_volume\` are already being swapped to the chained track's values. The sample-accurate source boundary is unchanged; only the Sink-volume update is deferred until the chained source is actually live.

### Side effects audited

- Hi-res rate-mismatch fallback returns before the sink block — unaffected.
- Manual skip during chain pending: \`audio_play\` creates a fresh Sink — unaffected.
- \`audio_set_volume\` / \`audio_update_replay_gain\` before transition operate on the current track's \`replay_gain_linear\` — still correct.
- After transition, \`cur.replay_gain_linear\` holds the chained track's gain **before** the new \`set_volume\` runs, so user volume changes remain correct.
- Crossfade is mutually exclusive with gapless — separate code path, untouched.

### Known tradeoff

Up to ~100 ms volume-update lag at the track boundary (one progress-tick interval), since the Sink keeps A's volume until the transition tick fires. Inaudible at typical RG deltas (1–3 dB) — rodio's mixer ramps \`set_volume\` smoothly. At large deltas (>5 dB) a brief loudness slope may be perceptible at the *start* of B, but that's musically much less intrusive than a 30 s pre-end shift in A.

If the slope turns out to be audible, two follow-up options:
1. Drop the transition-detection tick from 100 ms to ~25 ms — cheap.
2. Source-baked gain via \`amplify()\` — clean but bigger refactor (collides with \`audio_set_volume\` / \`audio_update_replay_gain\` paths that operate on Sink-volume).

### Verification

- \`cargo check\` clean.
- Manual: requires gapless enabled + a queue with two tracks at noticeably different ReplayGain values. Loudness should now stay constant during track A and only shift at the track boundary.