### PR TITLE
fix(mini-player): drop saved position when its monitor is gone

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3012,6 +3012,27 @@ fn persist_mini_pos_throttled(app: &tauri::AppHandle, x: i32, y: i32) {
     write_mini_pos(app, MiniPlayerPosition { x, y });
 }
 
+/// Returns true when the saved top-left lands inside an available monitor
+/// with enough room (≥ 80 px in each axis) to leave a draggable corner of
+/// the window on-screen. Used to drop persisted positions that point at a
+/// monitor that is no longer enumerated (unplugged, hot-plug detection
+/// race during early boot, resolution change, monitor reorder).
+fn mini_position_visible(app: &tauri::AppHandle, x: i32, y: i32) -> bool {
+    const MIN_VISIBLE: i32 = 80;
+    let monitors = match app.available_monitors() {
+        Ok(m) if !m.is_empty() => m,
+        _ => return false,
+    };
+    monitors.iter().any(|m| {
+        let mp = m.position();
+        let ms = m.size();
+        x >= mp.x
+            && y >= mp.y
+            && x + MIN_VISIBLE <= mp.x + ms.width as i32
+            && y + MIN_VISIBLE <= mp.y + ms.height as i32
+    })
+}
+
 /// Default position when nothing is persisted: bottom-right of the monitor
 /// the main window sits on (falls back to primary). A 24 px logical margin
 /// keeps it off the screen edge; +56 px on the bottom margin avoids most
@@ -3103,7 +3124,11 @@ fn build_mini_player_window(
     // Resolve target position BEFORE building so the WM places the window
     // correctly from creation. Calling `set_position` after `build()` is
     // unreliable on several Linux WMs which re-centre hidden windows.
+    // Drop the persisted position if it would land on a monitor that is
+    // no longer enumerated (unplugged second monitor, hot-plug race during
+    // early boot, resolution change) — fall back to the default placement.
     let target_physical = read_mini_pos(app)
+        .filter(|p| mini_position_visible(app, p.x, p.y))
         .map(|p| tauri::PhysicalPosition::new(p.x, p.y))
         .or_else(|| default_mini_position(app));
     let scale = app
@@ -3207,12 +3232,17 @@ fn open_mini_player(app: tauri::AppHandle) -> Result<(), String> {
         // again, ignoring any earlier set_position. Mark the move as
         // programmatic so the Moved-event handler doesn't echo the
         // intermediate centre coords back to disk.
-        let target = read_mini_pos(&app);
+        // Drop the persisted position if its monitor is gone and fall
+        // back to the default placement so we don't open off-screen.
+        let target = read_mini_pos(&app)
+            .filter(|p| mini_position_visible(&app, p.x, p.y))
+            .map(|p| tauri::PhysicalPosition::new(p.x, p.y))
+            .or_else(|| default_mini_position(&app));
         mark_mini_pos_programmatic();
         win.show().map_err(|e| e.to_string())?;
         let _ = win.set_focus();
         if let Some(p) = target {
-            let _ = win.set_position(tauri::PhysicalPosition::new(p.x, p.y));
+            let _ = win.set_position(p);
         }
         if let Some(main) = app.get_webview_window("main") {
             let _ = main.minimize();


### PR DESCRIPTION
### Problem

Reported by @Psychotoxical (Linux + 2 monitors) and observed by another user on Windows + 2 monitors: the mini player sometimes opens off-screen the first time it's launched for the day.

### Root cause

The mini player persists its top-left position to \`mini_player_pos.json\` (physical pixels) and re-applies it on every open. With multiple monitors that breaks in three failure modes:

- Second monitor not yet enumerated when the window first opens (hot-plug detection race during early boot — common on Windows).
- Monitor reorder / resolution change since the last save.
- Monitor unplugged.

In all three the saved coordinates point at a region that no current monitor covers, and the window opens in the void.

### Fix

Validate the persisted position against \`app.available_monitors()\` before applying it: require the saved top-left plus an 80 px corner to fit inside any currently-enumerated monitor. If not, fall back to \`default_mini_position\` (bottom-right of the main window's monitor). The persisted file is left untouched so the position comes back the next time the missing monitor is present again.

Validation runs in both:
- \`build_mini_player_window\` — initial creation (covers the Windows pre-creation race in \`.setup()\` and lazy creation on Linux/macOS).
- \`open_mini_player\` — re-show path, where Linux WMs (Mutter, KWin) may re-centre hidden windows on show, so we re-apply position.

### Side effects

- If the saved monitor is *temporarily* gone (display sleep, hot-plug race, monitor in standby during boot), the mini opens on the main monitor instead of off-screen. User can drag it back, which writes a new saved position; or, if the file is left as-is and the monitor returns later, the next open uses the saved position again.
- No-op when only one monitor is enumerated AND the saved position fits — preserves the current single-monitor behaviour exactly.

### Verification

- \`cargo check\` clean.
- Manual test plan: with two monitors connected, place mini on monitor 2, close. Disconnect monitor 2 (or simulate by changing monitor order). Reopen mini → should land on monitor 1's bottom-right instead of off-screen. Reconnect monitor 2 and reopen → should restore to the saved monitor-2 position.