### PR TITLE
fix(ui): swap Gapless / Infinite Queue toolbar icons (closes #274)

### DIFF
--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { emit, listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { useTranslation } from 'react-i18next';
-import { Play, Pause, SkipBack, SkipForward, Pin, PinOff, Maximize2, X, ListMusic, Volume2, VolumeX, Shuffle, Infinity as InfinityIcon, Waves, ArrowUpToLine } from 'lucide-react';
+import { Play, Pause, SkipBack, SkipForward, Pin, PinOff, Maximize2, X, ListMusic, Volume2, VolumeX, Shuffle, Infinity as InfinityIcon, Waves, MoveRight } from 'lucide-react';
 import CachedImage from './CachedImage';
 import { buildCoverArtUrl, coverArtCacheKey } from '../api/subsonic';
 import { usePlayerStore } from '../store/playerStore';
@@ -582,7 +582,7 @@ export default function MiniPlayer() {
             data-tooltip={t('queue.gapless')}
             aria-label={t('queue.gapless')}
           >
-            <InfinityIcon size={13} />
+            <MoveRight size={13} />
           </button>
 
           <button
@@ -604,7 +604,7 @@ export default function MiniPlayer() {
             data-tooltip={t('queue.infiniteQueue')}
             aria-label={t('queue.infiniteQueue')}
           >
-            <ArrowUpToLine size={13} />
+            <InfinityIcon size={13} />
           </button>
 
           <span className="mini-player__toolbar-sep" aria-hidden />

--- a/src/components/QueuePanel.tsx
+++ b/src/components/QueuePanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useMemo, useEffect } from 'react';
 import { Track, usePlayerStore, songToTrack } from '../store/playerStore';
-import { Play, Music, Star, X, Trash2, Save, FolderOpen, Shuffle, Infinity, Waves, MicVocal, ListMusic, Check, ListPlus, ArrowUpToLine, Radio, HardDrive, ChevronDown, Info, Share2 } from 'lucide-react';
+import { Play, Music, Star, X, Trash2, Save, FolderOpen, Shuffle, Infinity, Waves, MicVocal, ListMusic, Check, ListPlus, MoveRight, Radio, HardDrive, ChevronDown, Info, Share2 } from 'lucide-react';
 import { buildCoverArtUrl, coverArtCacheKey, getAlbum, getPlaylists, getPlaylist, updatePlaylist, deletePlaylist, SubsonicPlaylist } from '../api/subsonic';
 import { usePlaylistStore } from '../store/playlistStore';
 import { useCachedUrl } from './CachedImage';
@@ -588,7 +588,7 @@ export default function QueuePanel() {
           data-tooltip={t('queue.gapless')}
           aria-label={t('queue.gapless')}
         >
-          <Infinity size={13} />
+          <MoveRight size={13} />
         </button>
         <div style={{ position: 'relative' }}>
           <button
@@ -640,7 +640,7 @@ export default function QueuePanel() {
           data-tooltip={t('queue.infiniteQueue')}
           aria-label={t('queue.infiniteQueue')}
         >
-          <ArrowUpToLine size={13} />
+          <Infinity size={13} />
         </button>
       </div>
 


### PR DESCRIPTION
Closes #274.

The infinity symbol was on the Gapless toggle and an arrow-up-to-line on Infinite Queue. The mapping was wrong both ways round — infinity reads much more naturally on a queue that never ends, and the arrow-up icon had no obvious meaning for either toggle.

### Change

- **Infinite Queue** → \`Infinity\` (was \`ArrowUpToLine\`).
- **Gapless** → \`MoveRight\` (was \`Infinity\`). A right-pointing arrow visualises 'flows straight through to the next track without stopping' and stays visually distinct from the chain/link family at 13 px.

Applied in both the QueuePanel toolbar and the Mini Player toolbar.

### Verification

- \`npm run build\` clean.
- Spot-checked locally — the two icons no longer look similar at toolbar size.