### PR TITLE
chore(credits): catch up Settings contributors list

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -143,6 +143,13 @@ const CONTRIBUTORS = [
       'WebKitGTK wheel scroll mode: smooth (kinetic) default with optional linear toggle (PR #207)',
       'ArtistCardLocal i18n: use plural-aware artists.albumCount key instead of hardcoded German',
       'NixOS / flake install guide with Cachix setup (PR #209)',
+      'Subsonic: align Rust HTTP UA with main WebView UA (PR #235)',
+      'UI: overlay scrollbars, resizer hit-test, and Linux mini-wheel (PR #255)',
+      'Server invites: magic-string paste, Navidrome admin share, add-user validation (PR #258)',
+      'Linux: stop Wayland GTK drag proxy and PsyDnD ghost (PR #268)',
+      'Sidebar: long-press drag to reorder and hide nav items (PR #269)',
+      'Sleep timer and delayed start via long-press on play/pause (PR #270)',
+      'Lucky Mix — instant queue from listening history, ratings, and AudioMuse similar tracks (PR #278)',
     ],
   },
   {
@@ -184,6 +191,8 @@ const CONTRIBUTORS = [
       'Click-to-toggle duration / remaining time in player bar with persisted preference (PR #212)',
       'Opt-in floating player bar with themed background, accent-colored border, rounded album art, and centered volume section (PR #216)',
       'Linux GPU-vendor auto-detection to configure the WebKitGTK DMA-BUF renderer (disabled on NVIDIA proprietary) (PR #217)',
+      'Artist page: continue playback when starting top songs (PR #220)',
+      'Floating player bar: scroll-padding fix (PR #221)',
     ],
   },
   {
@@ -193,6 +202,13 @@ const CONTRIBUTORS = [
       'Nightfox.nvim theme group in Open Source Classics (PR #114)',
       'Switch reqwest to rustls-tls for cross-platform TLS (PR #112)',
       'ICY stream metadata & AzuraCast Now Playing support (PR #146)',
+    ],
+  },
+  {
+    github: 'peri4ko',
+    since: '1.43.0',
+    contributions: [
+      'WebView2 idle hooks when Tauri windows are hidden — Windows GPU and compositor mitigation (PR #273)',
     ],
   },
 ] as const;


### PR DESCRIPTION
Brings the Settings → System → About contributors panel back in sync with merged PRs since v1.43.0.

### Added entries

**cucadmuh** (existing entry, 7 new lines):
- #235 — Subsonic UA sync with main WebView UA
- #255 — Overlay scrollbars, resizer hit-test, Linux mini-wheel
- #258 — Magic-string server invites + Navidrome admin share + add-user validation
- #268 — Linux: stop Wayland GTK drag proxy and PsyDnD ghost
- #269 — Sidebar long-press drag to reorder and hide nav items
- #270 — Sleep timer and delayed start via long-press
- #278 — Lucky Mix instant queue

**kveld9** (existing entry, 2 new lines):
- #220 — Artist top songs: continue playback
- #221 — Floating player bar scroll-padding fix

**peri4ko** (new contributor, since 1.43.0):
- #273 — WebView2 idle hooks when Tauri windows are hidden (Windows GPU/compositor mitigation)

### Verification

- \`npm run build\` clean.
- Display order in the panel is unchanged (sorted by contribution count at render time).