### PR TITLE
style(credits): bullet markers on contributor cards

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3247,6 +3247,20 @@
   font-size: 12px;
   color: var(--text-secondary);
   line-height: 1.7;
+  list-style: none;
+}
+.contributor-card-list li {
+  position: relative;
+  padding-left: 14px;
+}
+.contributor-card-list li::before {
+  content: '•';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--accent);
+  font-weight: 700;
+  line-height: 1.7;
 }
 
 /* ── Datenschutz-Hinweis-Banner (z.B. oben im Integrations-Tab) ──────────── */


### PR DESCRIPTION
## Summary
- Accent-colored \`•\` in front of each contribution line in the Settings contributors cards.
- CSS-only; no markup or data changes.

## Test plan
- [ ] Settings → System → Contributors → expand any card → each contribution line is prefixed with a bullet.
- [ ] Bullet colour tracks the active theme's accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)