### PR TITLE
fix(linux): prefer pipewire/pulse aliases over raw ALSA default

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -2076,10 +2076,28 @@ fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32)
 
     let host = rodio::cpal::default_host();
 
-    // Resolve the target device: named device first, fall back to system default.
-    let device = device_name.and_then(|name| {
+    // Resolve the target device: explicit name first, then (on Linux) prefer
+    // a "pipewire" or "pulse" ALSA alias before falling back to cpal's system
+    // default. On PipeWire-based distros the raw ALSA `default` alias can
+    // route to a null sink at app-start (issue #234 on Debian 13): the stream
+    // opens cleanly, progress ticks run, no audio reaches the user. The
+    // named-alias path goes through pipewire-alsa's real sink and just works.
+    // On systems where neither alias exists (pure ALSA, macOS, Windows),
+    // `find_by_name` returns None and we drop through to `default_output_device`
+    // unchanged — no regression.
+    let find_by_name = |name: &str| -> Option<_> {
         host.output_devices().ok()?.find(|d| d.name().ok().as_deref() == Some(name))
-    }).or_else(|| host.default_output_device());
+    };
+
+    let device = device_name
+        .and_then(find_by_name)
+        .or_else(|| {
+            #[cfg(target_os = "linux")]
+            { find_by_name("pipewire").or_else(|| find_by_name("pulse")) }
+            #[cfg(not(target_os = "linux"))]
+            { None }
+        })
+        .or_else(|| host.default_output_device());
 
     if let Some(device) = device {
         if desired_rate > 0 {


### PR DESCRIPTION
## Summary
- On Linux, explicitly try the \`pipewire\` then \`pulse\` ALSA aliases before falling back to \`cpal::host.default_output_device()\`.
- No explicit user choice in Settings is still honoured — this only changes the implicit fallback.
- macOS / Windows code paths unchanged.

## Motivation
Closes #234. On PipeWire-based distros (Debian 13, Ubuntu 22+, and many Gnome setups), cpal's default-device resolution returns the raw ALSA \`default\` alias. During app-start that alias sometimes routes to a null sink — the stream opens cleanly, progress ticks fire, but no audio reaches the user. Choosing a device in Settings is the known workaround because it forces the explicit find-by-name path, which goes through a real pipewire/pulse sink.

## Test plan
- [ ] Arch/CachyOS (baseline): regression check — no audible change, stream still opens.
- [ ] Debian 13 / Ubuntu (PipeWire): first-launch audio works without the Settings-tweak workaround.
- [ ] Pure ALSA system (no pipewire/pulse aliases present): falls through unchanged.
- [ ] macOS / Windows: no code path affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)