### PR TITLE
fix(playlists): add bulk-delete button to header in selection mode

### DIFF
--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1279,6 +1279,7 @@ export const deTranslation = {
     deleteSuccess: '{{count}} Playlists gelöscht',
     deleteFailed: 'Fehler beim Löschen von {{name}}',
     deleteSelected: 'Ausgewählte löschen',
+    deleteSelectedPartial: 'Nur {{n}} von {{total}} ausgewählten Playlists können gelöscht werden (die anderen gehören jemand anderem).',
     mergeSuccess: '{{count}} Songs in {{playlist}} zusammengeführt',
     mergeNoNewSongs: 'Keine neuen Songs zum Hinzufügen',
     mergeError: 'Fehler beim Zusammenführen von Playlists',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1282,6 +1282,7 @@ export const enTranslation = {
     deleteSuccess: '{{count}} playlists deleted',
     deleteFailed: 'Error deleting {{name}}',
     deleteSelected: 'Delete selected',
+    deleteSelectedPartial: 'Only {{n}} of {{total}} selected playlists can be deleted (the others belong to someone else).',
     mergeSuccess: '{{count}} songs merged into {{playlist}}',
     mergeNoNewSongs: 'No new songs to add',
     mergeError: 'Error merging playlists',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1272,6 +1272,7 @@ export const esTranslation = {
     deleteSuccess: '{{count}} listas eliminadas',
     deleteFailed: 'Error al eliminar {{name}}',
     deleteSelected: 'Eliminar seleccionadas',
+    deleteSelectedPartial: 'Solo {{n}} de {{total}} listas seleccionadas pueden eliminarse (las demás pertenecen a otro usuario).',
     mergeSuccess: '{{count}} canciones unificadas en {{playlist}}',
     mergeNoNewSongs: 'No hay canciones nuevas para agregar',
     mergeError: 'Error al unificar listas',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -1267,6 +1267,7 @@ export const frTranslation = {
     deleteSuccess: '{{count}} playlists supprimées',
     deleteFailed: 'Erreur lors de la suppression de {{name}}',
     deleteSelected: 'Supprimer la sélection',
+    deleteSelectedPartial: 'Seulement {{n}} des {{total}} playlists sélectionnées peuvent être supprimées (les autres appartiennent à quelqu\'un d\'autre).',
     mergeSuccess: '{{count}} morceaux fusionnés dans {{playlist}}',
     mergeNoNewSongs: 'Aucun nouveau morceau à ajouter',
     mergeError: 'Erreur lors de la fusion des playlists',

--- a/src/locales/nb.ts
+++ b/src/locales/nb.ts
@@ -1266,6 +1266,7 @@ export const nbTranslation = {
     deleteSuccess: '{{count}} spillelister slettet',
     deleteFailed: 'Feil ved sletting av {{name}}',
     deleteSelected: 'Slett valgte',
+    deleteSelectedPartial: 'Bare {{n}} av {{total}} valgte spillelister kan slettes (de andre tilhører noen andre).',
     mergeSuccess: '{{count}} sanger slått sammen i {{playlist}}',
     mergeNoNewSongs: 'Ingen nye sanger å legge til',
     mergeError: 'Feil ved sammenslåing av spillelister',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -1266,6 +1266,7 @@ export const nlTranslation = {
     deleteSuccess: '{{count}} playlists verwijderd',
     deleteFailed: 'Fout bij verwijderen van {{name}}',
     deleteSelected: 'Geselecteerde verwijderen',
+    deleteSelectedPartial: 'Slechts {{n}} van de {{total}} geselecteerde playlists kunnen worden verwijderd (de andere zijn van iemand anders).',
     mergeSuccess: '{{count}} nummers samengevoegd in {{playlist}}',
     mergeNoNewSongs: 'Geen nieuwe nummers om toe te voegen',
     mergeError: 'Fout bij samenvoegen van playlists',

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -1346,6 +1346,7 @@ export const ruTranslation = {
     deleteSuccess: '{{count}} плейлистов удалено',
     deleteFailed: 'Ошибка при удалении {{name}}',
     deleteSelected: 'Удалить выбранные',
+    deleteSelectedPartial: 'Можно удалить только {{n}} из {{total}} выбранных плейлистов (остальные принадлежат другим пользователям).',
     mergeSuccess: '{{count}} треков объединено в {{playlist}}',
     mergeNoNewSongs: 'Нет новых треков для добавления',
     mergeError: 'Ошибка при объединении плейлистов',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -1261,6 +1261,7 @@ export const zhTranslation = {
     deleteSuccess: '{{count}} 个播放列表已删除',
     deleteFailed: '删除 {{name}} 时出错',
     deleteSelected: '删除所选',
+    deleteSelectedPartial: '所选 {{total}} 个播放列表中只有 {{n}} 个可删除（其余属于他人）。',
     mergeSuccess: '{{count}} 首歌曲已合并到 {{playlist}}',
     mergeNoNewSongs: '没有新歌曲可添加',
     mergeError: '合并播放列表时出错',

--- a/src/pages/Playlists.tsx
+++ b/src/pages/Playlists.tsx
@@ -734,6 +734,23 @@ export default function Playlists() {
               )}
             </>
           )}
+          {selectionMode && selectedIds.size > 0 && (() => {
+            const deletableCount = selectedPlaylists.filter(isPlaylistDeletable).length;
+            return (
+              <button
+                className="btn btn-danger"
+                onClick={handleDeleteSelected}
+                disabled={deletableCount === 0}
+                data-tooltip={deletableCount === selectedIds.size
+                  ? undefined
+                  : t('playlists.deleteSelectedPartial', { n: deletableCount, total: selectedIds.size })}
+                data-tooltip-pos="bottom"
+              >
+                <Trash2 size={15} />
+                {t('playlists.deleteSelected')}
+              </button>
+            );
+          })()}
           <button
             className={`btn btn-surface${selectionMode ? ' btn-sort-active' : ''}`}
             onClick={toggleSelectionMode}


### PR DESCRIPTION
## Summary
- Selection mode exposes the delete action only through the context menu today, which is easy to miss. Add a visible \`Delete selected\` button next to the Cancel toggle in the Playlists header.
- Reuses the existing \`handleDeleteSelected\` flow — no behavioural change to the deletion itself.
- Button disables itself when none of the selected playlists are owned by the current user; shows a tooltip if only some of them are deletable.

## Test plan
- [ ] Enter selection mode, pick one own playlist → Delete-selected button appears, click it → playlist is deleted.
- [ ] Select multiple own playlists → button shows, deletes all of them.
- [ ] Select a foreign (read-only) playlist → button is disabled.
- [ ] Select a mix (one own + one foreign) → button is active with tooltip "Only 1 of 2 ...".

🤖 Generated with [Claude Code](https://claude.com/claude-code)