### PR TITLE
fix(home): refresh Mainstage when active server changes

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,6 +16,7 @@ const HOME_DISCOVER_SLICE = 20;
 
 export default function Home() {
   const homeSections = useHomeStore(s => s.sections);
+  const activeServerId = useAuthStore(s => s.activeServerId);
   const musicLibraryFilterVersion = useAuthStore(s => s.musicLibraryFilterVersion);
   const mixMinRatingFilterEnabled = useAuthStore(s => s.mixMinRatingFilterEnabled);
   const mixMinRatingAlbum = useAuthStore(s => s.mixMinRatingAlbum);
@@ -70,6 +71,7 @@ export default function Home() {
     })();
     return () => { cancelled = true; };
   }, [
+    activeServerId,
     musicLibraryFilterVersion,
     homeSections,
     mixMinRatingFilterEnabled,


### PR DESCRIPTION
## Summary
- `Home` useEffect was missing `activeServerId` in its dependency array, so switching servers while already on the Mainstage left the previous server's albums/artists on screen (with broken covers against the new server).
- Now reads `activeServerId` from `authStore` and includes it in the deps, so the fetch re-runs on switch.

## Test plan
- [x] Type-check clean (`tsc --noEmit`)
- [ ] Be on Mainstage, switch to another server via sidebar → albums + artists repopulate from the new server, no stale broken covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)