### PR TITLE
chore(ci): gate non-flatpak release jobs off for 1.43.1 test tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
 
   build-macos-windows:
     needs: create-release
+    if: false # TEMP: flatpak-only test run
     permissions:
       contents: write
     strategy:
@@ -163,6 +164,7 @@ jobs:
 
   generate-manifest:
     needs: [create-release, build-macos-windows]
+    if: false # TEMP: flatpak-only test run
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -182,6 +184,7 @@ jobs:
 
   build-linux:
     needs: create-release
+    if: false # TEMP: flatpak-only test run
     permissions:
       contents: write
     runs-on: ubuntu-24.04
@@ -309,6 +312,7 @@ jobs:
   # The refreshed lock/hash files are committed back to `main` when they change.
   verify-nix:
     needs: create-release
+    if: false # TEMP: flatpak-only test run
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
Temporaer `if: false` auf `build-macos-windows`, `generate-manifest`, `build-linux`, `verify-nix` — damit der 1.43.1-Test-Tag nur den neuen `build-flatpak` Job ausloest und der Nix-Store / Cachix nicht schon die 1.43.1 kriegt.

Wird nach dem Flatpak-Test wieder revertet (separate PR).