### PR TITLE
chore(release): bump to 1.43.2 (flatpak test retry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 >
 > **📦 Version jump 1.34.x → 1.40.0:** The 1.34.x patch series was bumped a lot as each small feature landed. 1.40.0 consolidates the last few weeks of work — macOS signing + auto-updater, the Device-Sync overhaul, theme work and contrast audits — into a single coherent release. The next major bump (2.0.0) is planned once Windows code-signing + Windows auto-updater are active as well.
 
-## [1.43.1]
+## [1.43.2]
 
 test
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psysonic",
-  "version": "1.43.1",
+  "version": "1.43.2",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "psysonic"
-version = "1.43.1"
+version = "1.43.2"
 dependencies = [
  "biquad",
  "discord-rich-presence",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psysonic"
-version = "1.43.1"
+version = "1.43.2"
 description = "Psysonic Desktop Music Player"
 authors = []
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Psysonic",
-  "version": "1.43.1",
+  "version": "1.43.2",
   "identifier": "dev.psysonic.player",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
1.43.1 hat wegen der immutable-Tag-Rule auf den falschen Commit gezeigt. Neuer Tag auf dem aktuellen main mit dem gated release.yml.