### PR TITLE
fix(ci): mark checkout as safe.directory for flatpak build container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Container runs as root but the checkout is owned by the runner user;
+      # without this, any later `git` (including gh release upload's internal
+      # git probe) aborts with "dubious ownership".
+      - name: mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: install source-generation tools
         run: |
           dnf install -y python3-pip python3-aiohttp


### PR DESCRIPTION
Flatpak build lief durch (Bundle existiert), aber der finale `gh release upload` failte mit `fatal: detected dubious ownership` — die gnome-47 Container-Prozesse laufen als root, checkout ist als runner-UID gemountet, und `gh` probed intern git.

Fix: dedizierter Step direkt nach checkout der `safe.directory` global setzt.