### PR TITLE
fix(search): right-click context menu on artist + album rows

### DIFF
--- a/src/components/LiveSearch.tsx
+++ b/src/components/LiveSearch.tsx
@@ -157,9 +157,14 @@ export default function LiveSearch() {
                   <div className="search-section-label"><Users size={12} /> {t('search.artists')}</div>
                   {results.artists.map(a => {
                     const i = idx++;
+                    const isCtxActive = ctxIsOpen && ctxType === 'artist' && ctxItemId === a.id;
                     return (
-                      <button key={a.id} className={`search-result-item${activeIndex === i ? ' active' : ''}`}
+                      <button key={a.id} className={`search-result-item${activeIndex === i ? ' active' : ''}${isCtxActive ? ' context-active' : ''}`}
                         onClick={() => { navigate(`/artist/${a.id}`); setOpen(false); setQuery(''); }}
+                        onContextMenu={(e) => {
+                          e.preventDefault();
+                          openContextMenu(e.clientX, e.clientY, a, 'artist');
+                        }}
                         role="option" aria-selected={activeIndex === i}>
                         <div className="search-result-icon"><Users size={14} /></div>
                         <span>{a.name}</span>
@@ -174,9 +179,14 @@ export default function LiveSearch() {
                   <div className="search-section-label"><Disc3 size={12} /> {t('search.albums')}</div>
                   {results.albums.map(a => {
                     const i = idx++;
+                    const isCtxActive = ctxIsOpen && ctxType === 'album' && ctxItemId === a.id;
                     return (
-                      <button key={a.id} className={`search-result-item${activeIndex === i ? ' active' : ''}`}
+                      <button key={a.id} className={`search-result-item${activeIndex === i ? ' active' : ''}${isCtxActive ? ' context-active' : ''}`}
                         onClick={() => { navigate(`/album/${a.id}`); setOpen(false); setQuery(''); }}
+                        onContextMenu={(e) => {
+                          e.preventDefault();
+                          openContextMenu(e.clientX, e.clientY, a, 'album');
+                        }}
                         role="option" aria-selected={activeIndex === i}>
                         {a.coverArt ? (
                           <CachedImage


### PR DESCRIPTION
## Summary

Continuation of PR #298. The right-click context menu was added to **song** rows in the live-search dropdown but artist and album rows were left out. This patch applies the same treatment to both:

- Right-click an artist or album row → matching context menu opens (`type: 'artist'` / `type: 'album'`)
- Row gets the `.context-active` highlight while its menu is open
- Click behaviour (navigate to detail page) is unchanged
- Dropdown stays open during the menu interaction (same backdrop-removal fix from #298)

## Test plan

- [ ] Header live search → right-click an artist row → CM opens, row highlighted
- [ ] Header live search → right-click an album row → CM opens, row highlighted
- [ ] Right-click moves cleanly between artist / album / song rows
- [ ] Single click on artist / album still navigates to its detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)