### PR TITLE
chore(deps): bump rustls-webpki + postcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psysonic",
-  "version": "1.42.1",
+  "version": "1.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "psysonic",
-      "version": "1.42.1",
+      "version": "1.43.0",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "@fontsource-variable/figtree": "^5.2.10",
@@ -2671,9 +2671,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4236,9 +4236,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- `rustls-webpki` 0.103.12 → 0.103.13 — fixes Dependabot alert #2 (high: DoS via panic on malformed CRL BIT STRING)
- `postcss` 8.5.8 → 8.5.10 — fixes Dependabot alert #3 (medium: XSS via unescaped `</style>` in stringify output)

Both are semver patch bumps via lock file only — no manifest changes.

The third open alert (glib 0.18 → 0.20, medium soundness) is blocked on tauri/wry pinning the gtk-rs 0.18 stack and will need to wait for upstream.

## Test plan
- [x] `cargo check` (debug) passes
- [x] `cargo check --release` passes
- [x] `npm run build` passes
- [ ] `npm run tauri:dev` — connect to a Navidrome server (validates rustls path), navigate themes (validates postcss output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)