### PR TITLE
chore(tauri): don't auto-open devtools on launch

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3621,14 +3621,6 @@ pub fn run() {
                 }
             }
 
-            #[cfg(debug_assertions)]
-            {
-                use tauri::Manager;
-                if let Some(win) = app.get_webview_window("main") {
-                    win.open_devtools();
-                }
-            }
-
             // ── System tray ───────────────────────────────────────────────
             // Always build on startup when possible; the frontend calls toggle_tray_icon(false)
             // immediately after load if the user has disabled the tray icon.


### PR DESCRIPTION
## Summary
- Drop the `#[cfg(debug_assertions)] open_devtools()` block from `setup()`.
- DevTools remain accessible in dev builds via **Ctrl+Shift+I** and right-click → Inspect — they just don't pop up automatically anymore.

Production behaviour unchanged: DevTools stay hard-stripped from release builds via Tauri's `windows[].devtools=false` default.

## Test plan
- [x] `cargo check` passes
- [ ] `npm run tauri:dev` — main window opens without DevTools popping up
- [ ] Ctrl+Shift+I still toggles DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)