### PR TITLE
chore(subsonic): log pingWithCredentials failures

### DIFF
--- a/src/api/subsonic.ts
+++ b/src/api/subsonic.ts
@@ -309,7 +309,8 @@ export async function pingWithCredentials(
       serverVersion: typeof data?.serverVersion === 'string' ? data.serverVersion : undefined,
       openSubsonic: data?.openSubsonic === true,
     };
-  } catch {
+  } catch (err) {
+    console.warn('[psysonic] pingWithCredentials failed:', serverUrl, err);
     return { ok: false };
   }
 }


### PR DESCRIPTION
## Summary

- \`pingWithCredentials\` swallows every upstream error and returns \`{ ok: false }\`, so server-switch fails silently and we never see why (timeout, network, CORS, 401, …).
- Add a single \`console.warn\` in the catch with the URL and the underlying error so the next time the issue reproduces we have something to work with in DevTools.
- Behaviour unchanged — purely diagnostic.

## Test plan

- [ ] Trigger a failing ping (wrong port / offline server) and confirm \`[psysonic] pingWithCredentials failed: …\` appears in the console
- [ ] Successful pings produce no log