### PR TITLE
fix(queue): preserve scroll context on manual queue click

### DIFF
--- a/src/components/QueuePanel.tsx
+++ b/src/components/QueuePanel.tsx
@@ -297,6 +297,12 @@ function QueuePanelHostOrSolo() {
   const enqueueAt = usePlayerStore(s => s.enqueueAt);
   const contextMenu = usePlayerStore(s => s.contextMenu);
 
+  // When the user picks a track *from* the queue list, suppress the
+  // upcoming auto-scroll so their click target stays in view instead of
+  // the list rebasing onto the next track. Auto-advance (natural playback)
+  // never sets this flag, so it keeps its original "show what's next" behavior.
+  const suppressNextAutoScrollRef = useRef(false);
+
   const playbackSource = usePlayerStore(s => s.currentPlaybackSource);
 
   const crossfadeEnabled = useAuthStore(s => s.crossfadeEnabled);
@@ -407,6 +413,10 @@ function QueuePanelHostOrSolo() {
   }, [enqueueAt]);
 
   useEffect(function queueAutoScroll() {
+    if (suppressNextAutoScrollRef.current) {
+      suppressNextAutoScrollRef.current = false;
+      return;
+    }
     if (!queueListRef.current || queueIndex < 0) return;
     if (activeTab !== 'queue') return;
     const songs = queueListRef.current!.querySelectorAll<HTMLElement>('[data-queue-idx]');
@@ -741,7 +751,10 @@ function QueuePanelHostOrSolo() {
               <div
                 data-queue-idx={idx}
                 className={`queue-item ${isPlaying ? 'active' : ''} ${contextMenu.isOpen && contextMenu.type === 'queue-item' && contextMenu.queueIndex === idx ? 'context-active' : ''}`}
-                onClick={() => playTrack(track, queue)}
+                onClick={() => {
+                  suppressNextAutoScrollRef.current = true;
+                  playTrack(track, queue);
+                }}
                 onContextMenu={(e) => {
                   e.preventDefault();
                   usePlayerStore.getState().openContextMenu(e.clientX, e.clientY, track, 'queue-item', idx);


### PR DESCRIPTION
## Summary

The queue panel auto-scrolls to the upcoming track on every \`currentTrack\` change. That's the right behavior for natural advance (track ends, next/prev buttons), but when the user *clicks a track inside the queue list itself*, the same scroll fires and slides their click target off screen as the list rebases onto the new "next track". Disorienting — the user just acted on something specific and expects to keep seeing it.

Fix: a one-shot suppression flag set from the queue-item \`onClick\` handler. The immediately following auto-scroll effect sees the flag, resets it, and skips the \`scrollIntoView\` call. Natural advance from any other source leaves the flag untouched and behaves exactly as before.

No store changes, no new state, just a \`useRef\` inside \`QueuePanel\`.

## Test plan

- [ ] Open queue, scroll down, click a track further down the list → clicked track stays visible in place; header shows it as current
- [ ] Let a track play out naturally → queue auto-scrolls to the new next track as before
- [ ] Use PlayerBar Next / Prev → queue auto-scrolls to next track as before (these don't go through the queue panel)
- [ ] Switching between Queue and Lyrics tabs while playing → no regression