### PR TITLE
fix(loudness): break feedback loop that froze Windows UI when LUFS active

### DIFF
--- a/src-tauri/src/analysis_cache.rs
+++ b/src-tauri/src/analysis_cache.rs
@@ -1,6 +1,7 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::io::Cursor;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use ebur128::{EbuR128, Mode as Ebur128Mode};
@@ -324,6 +325,39 @@ pub enum SeedFromBytesOutcome {
     SkippedWaveformCacheHit,
     /// `AnalysisCache` was not registered on the app handle.
     SkippedNoAnalysisCache,
+    /// Another seed for the same `track_id` is already running on a different
+    /// thread; this caller bails out so the winner's result is used.
+    SkippedConcurrent,
+}
+
+/// Track-ids whose `seed_from_bytes` is currently running. There are six
+/// independent producers (legacy stream capture, ranged stream completion,
+/// audio_preload, psysonic-local file read, in-memory play paths, and the
+/// frontend-triggered `analysis_enqueue_seed_from_url` backfill) that can
+/// fire for the same id concurrently when LUFS is on. Without this guard
+/// the same MP3 gets fully decoded by Symphonia + EBU R128 twice — ~30 s
+/// of wasted CPU per cache-miss track. First caller wins; the rest return
+/// `SkippedConcurrent` immediately.
+static SEEDS_IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn seeds_in_flight() -> &'static Mutex<HashSet<String>> {
+    SEEDS_IN_FLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// RAII helper: removes the in-flight marker on drop. Survives panics and
+/// any early `?`-returns inside `seed_from_bytes`.
+struct SeedInFlightGuard {
+    track_id: String,
+}
+
+impl Drop for SeedInFlightGuard {
+    fn drop(&mut self) {
+        if let Some(set) = SEEDS_IN_FLIGHT.get() {
+            if let Ok(mut g) = set.lock() {
+                g.remove(&self.track_id);
+            }
+        }
+    }
 }
 
 pub fn seed_from_bytes(
@@ -331,6 +365,23 @@ pub fn seed_from_bytes(
     track_id: &str,
     bytes: &[u8],
 ) -> Result<SeedFromBytesOutcome, String> {
+    // Reserve the slot for this track_id. Atomic under the mutex: insert()
+    // returns false if the id was already present.
+    let track_key = track_id.to_string();
+    let claimed = {
+        let mut guard = seeds_in_flight().lock().map_err(|_| "seeds-in-flight lock poisoned".to_string())?;
+        guard.insert(track_key.clone())
+    };
+    if !claimed {
+        crate::app_deprintln!(
+            "[analysis] full-track analysis skip track_id={} reason=concurrent_seed_in_flight bytes={}",
+            track_id,
+            bytes.len()
+        );
+        return Ok(SeedFromBytesOutcome::SkippedConcurrent);
+    }
+    let _flight_guard = SeedInFlightGuard { track_id: track_key };
+
     let started = Instant::now();
     let Some(cache) = app.try_state::<AnalysisCache>() else {
         crate::app_deprintln!(

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -46,6 +46,61 @@ struct NormalizationStatePayload {
     target_lufs: f32,
 }
 
+/// Last `audio:normalization-state` emit, kept so we can suppress duplicate
+/// payloads. The frontend already debounces this event, but on Windows
+/// (WebView2) the IPC pipe is the bottleneck — every echo we skip here is
+/// renderer-thread time we don't pay.
+static LAST_NORM_STATE_EMIT: OnceLock<Mutex<Option<NormalizationStatePayload>>> = OnceLock::new();
+
+fn norm_state_lock() -> &'static Mutex<Option<NormalizationStatePayload>> {
+    LAST_NORM_STATE_EMIT.get_or_init(|| Mutex::new(None))
+}
+
+fn norm_state_changed(prev: &NormalizationStatePayload, next: &NormalizationStatePayload) -> bool {
+    if prev.engine != next.engine { return true; }
+    if (prev.target_lufs - next.target_lufs).abs() >= 0.02 { return true; }
+    match (prev.current_gain_db, next.current_gain_db) {
+        (None, None) => false,
+        (Some(a), Some(b)) => (a - b).abs() >= 0.05,
+        _ => true, // None ↔ Some transition is significant
+    }
+}
+
+fn maybe_emit_normalization_state(app: &AppHandle, payload: NormalizationStatePayload) {
+    let mut guard = norm_state_lock().lock().unwrap();
+    let should_emit = match guard.as_ref() {
+        Some(prev) => norm_state_changed(prev, &payload),
+        None => true,
+    };
+    if !should_emit { return; }
+    *guard = Some(payload.clone());
+    drop(guard);
+    let _ = app.emit("audio:normalization-state", payload);
+}
+
+/// Last `analysis:loudness-partial` gain emitted per track-identity, used to
+/// suppress emits whose gain hasn't moved meaningfully (≥ 0.1 dB). The partial
+/// heuristic in `emit_partial_loudness_from_bytes` and the ranged-progress curve
+/// both produce values that drift by hundredths of a dB even on identical input,
+/// so the time-based throttle alone is not enough to keep the loop quiet.
+static LAST_PARTIAL_LOUDNESS_EMIT: OnceLock<Mutex<std::collections::HashMap<String, f32>>> = OnceLock::new();
+const PARTIAL_LOUDNESS_DELTA_THRESHOLD_DB: f32 = 0.1;
+
+fn partial_loudness_should_emit(track_key: &str, gain_db: f32) -> bool {
+    let mut guard = LAST_PARTIAL_LOUDNESS_EMIT
+        .get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+        .lock()
+        .unwrap();
+    let prev = guard.get(track_key).copied();
+    if let Some(p) = prev {
+        if (p - gain_db).abs() < PARTIAL_LOUDNESS_DELTA_THRESHOLD_DB {
+            return false;
+        }
+    }
+    guard.insert(track_key.to_string(), gain_db);
+    true
+}
+
 
 // ─── 10-Band Graphic Equalizer ────────────────────────────────────────────────
 
@@ -1313,15 +1368,18 @@ async fn ranged_download_task(
                     if let Some(provisional_db) =
                         provisional_loudness_gain_from_progress(downloaded, total_size, target_lufs, start_db)
                     {
-                        let _ = app.emit(
-                            "analysis:loudness-partial",
-                            PartialLoudnessPayload {
-                                track_id: playback_identity(&url),
-                                gain_db: provisional_db,
-                                target_lufs,
-                                is_partial: true,
-                            },
-                        );
+                        let track_key = playback_identity(&url).unwrap_or_else(|| url.clone());
+                        if partial_loudness_should_emit(&track_key, provisional_db) {
+                            let _ = app.emit(
+                                "analysis:loudness-partial",
+                                PartialLoudnessPayload {
+                                    track_id: playback_identity(&url),
+                                    gain_db: provisional_db,
+                                    target_lufs,
+                                    is_partial: true,
+                                },
+                            );
+                        }
                     }
                 }
             }
@@ -1420,6 +1478,16 @@ fn emit_partial_loudness_from_bytes(
         pre_floor.max(heuristic_floor)
     };
     let gain_db = (-(mb * 0.7)).max(floor_db).min(0.0);
+    let track_key = playback_identity(url).unwrap_or_else(|| url.to_string());
+    if !partial_loudness_should_emit(&track_key, gain_db as f32) {
+        crate::app_deprintln!(
+            "[normalization] partial-loudness skip reason=delta-below-threshold gain_db={:.2} threshold_db={:.2} track_id={:?}",
+            gain_db,
+            PARTIAL_LOUDNESS_DELTA_THRESHOLD_DB,
+            playback_identity(url)
+        );
+        return;
+    }
     crate::app_deprintln!(
         "[normalization] partial-loudness emit bytes={} gain_db={:.2} target_lufs={:.2} track_id={:?}",
         bytes.len(),
@@ -3324,8 +3392,8 @@ pub async fn audio_play(
         volume,
         effective_volume
     );
-    let _ = app.emit(
-        "audio:normalization-state",
+    maybe_emit_normalization_state(
+        &app,
         NormalizationStatePayload {
             engine: normalization_engine_name(norm_mode).to_string(),
             current_gain_db,
@@ -3820,20 +3888,19 @@ fn spawn_progress_task(
     gapless_switch_at: Arc<AtomicU64>,
     current_playback_url: Arc<Mutex<Option<String>>>,
 ) {
+    // Keep progress aligned with audible output (ALSA/PipeWire/Pulse queue) on
+    // Linux; mirrors the quantum policy used for stream open/reopen plus a small
+    // scheduler/mixer cushion so the UI doesn't run ahead. Other platforms have
+    // their own latency reporting paths and don't need the compensation here.
+    #[cfg(target_os = "linux")]
     fn estimated_output_latency_secs(sample_rate_hz: f64) -> f64 {
-        #[cfg(target_os = "linux")]
-        {
-            // Keep progress aligned with audible output (ALSA/PipeWire/Pulse
-            // queue). We mirror the quantum policy used for stream open/reopen.
-            let rate = sample_rate_hz.max(1.0);
-            let frames = if rate > 48_000.0 { 8192.0 } else { 4096.0 };
-            // Add a small scheduler/mixer cushion so UI doesn't run ahead.
-            return (frames / rate) + 0.012;
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            0.0
-        }
+        let rate = sample_rate_hz.max(1.0);
+        let frames = if rate > 48_000.0 { 8192.0 } else { 4096.0 };
+        (frames / rate) + 0.012
+    }
+    #[cfg(not(target_os = "linux"))]
+    fn estimated_output_latency_secs(_sample_rate_hz: f64) -> f64 {
+        0.0
     }
 
     tokio::spawn(async move {
@@ -4273,8 +4340,9 @@ pub fn audio_update_replay_gain(
     if let Some(sink) = &cur.sink {
         ramp_sink_volume(Arc::clone(sink), prev_effective, effective);
     }
-    let _ = app.emit(
-        "audio:normalization-state",
+    drop(cur);
+    maybe_emit_normalization_state(
+        &app,
         NormalizationStatePayload {
             engine: normalization_engine_name(norm_mode).to_string(),
             current_gain_db,
@@ -4771,8 +4839,8 @@ pub fn audio_set_normalization(
         target,
         pre
     );
-    let _ = app.emit(
-        "audio:normalization-state",
+    maybe_emit_normalization_state(
+        &app,
         NormalizationStatePayload {
             engine: normalization_engine_name(mode).to_string(),
             // At mode-switch time the effective track gain may not be recalculated yet.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1406,12 +1406,24 @@ fn enqueue_analysis_seed(app: &tauri::AppHandle, track_id: &str, bytes: &[u8]) -
         .try_state::<analysis_cache::AnalysisCache>()
         .and_then(|cache| cache.get_latest_loudness_for_track(track_id).ok().flatten())
         .is_some();
-    crate::app_deprintln!(
-        "[analysis] seed result track_id={} bytes={} has_loudness={}",
-        track_id,
-        bytes.len(),
-        has_loudness
-    );
+    // SkippedConcurrent gets logged with the actual outcome so the line doesn't
+    // read "seed result has_loudness=false" when in fact another path is mid-seed
+    // and will publish the row in seconds.
+    if outcome == analysis_cache::SeedFromBytesOutcome::SkippedConcurrent {
+        crate::app_deprintln!(
+            "[analysis] seed deferred to in-flight peer track_id={} bytes={} has_loudness_now={}",
+            track_id,
+            bytes.len(),
+            has_loudness
+        );
+    } else {
+        crate::app_deprintln!(
+            "[analysis] seed result track_id={} bytes={} has_loudness={}",
+            track_id,
+            bytes.len(),
+            has_loudness
+        );
+    }
     Ok(has_loudness)
 }
 

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -611,6 +611,12 @@ function touchHotCacheOnPlayback(trackId: string, serverId: string) {
 /** Coalesce concurrent `analysis_get_waveform_for_track` for one id (StrictMode double mount, init + queue restore). */
 const waveformRefreshInflight = new Map<string, Promise<void>>();
 
+/** Coalesce concurrent `analysis_get_loudness_for_track` for one id+mode pair. The
+ *  analysis:waveform-updated listener fires refreshWaveform + refreshLoudness in
+ *  parallel for every full-track analysis completion; without coalescing, gapless
+ *  preload + current-track completion can stack two SQLite reads + two state writes. */
+const loudnessRefreshInflight = new Map<string, Promise<void>>();
+
 /** Skip redundant `audio_set_normalization` IPC when the same payload is sent twice within a short window (e.g. StrictMode). */
 let lastNormAudioInvokeKey = '';
 let lastNormAudioInvokeAtMs = 0;
@@ -628,6 +634,42 @@ function invokeAudioSetNormalizationDeduped(payload: {
   lastNormAudioInvokeKey = key;
   lastNormAudioInvokeAtMs = now;
   void invoke('audio_set_normalization', payload).catch(() => {});
+}
+
+/**
+ * Skip redundant `audio_update_replay_gain` IPC when the same payload was sent
+ * recently. updateReplayGainForCurrentTrack runs from the analysis:loudness-partial
+ * listener (~every 900 ms while LUFS is on); without dedupe each tick triggers a
+ * full IPC roundtrip + backend audio:normalization-state echo + frontend setState,
+ * which saturates the WebView2 renderer thread on Windows after a few minutes.
+ */
+let lastRgInvokeKey = '';
+let lastRgInvokeAtMs = 0;
+
+function invokeAudioUpdateReplayGainDeduped(payload: {
+  volume: number;
+  replayGainDb: number | null;
+  replayGainPeak: number | null;
+  loudnessGainDb: number | null;
+  preGainDb: number;
+  fallbackDb: number;
+}) {
+  const fmt = (v: number | null) => (v == null || !Number.isFinite(v) ? 'null' : v.toFixed(3));
+  const key = [
+    payload.volume.toFixed(4),
+    fmt(payload.replayGainDb),
+    fmt(payload.replayGainPeak),
+    fmt(payload.loudnessGainDb),
+    payload.preGainDb.toFixed(2),
+    payload.fallbackDb.toFixed(2),
+  ].join('|');
+  const now = Date.now();
+  if (key === lastRgInvokeKey && now - lastRgInvokeAtMs < 250) {
+    return;
+  }
+  lastRgInvokeKey = key;
+  lastRgInvokeAtMs = now;
+  invoke('audio_update_replay_gain', payload).catch(console.error);
 }
 
 function isReplayGainActive() {
@@ -731,9 +773,19 @@ async function refreshWaveformForTrack(trackId: string) {
 async function refreshLoudnessForTrack(
   trackId: string,
   opts?: { syncPlayingEngine?: boolean },
-) {
+): Promise<void> {
   if (!trackId) return;
   const syncEngine = opts?.syncPlayingEngine !== false;
+  const inflightKey = `${trackId}|${syncEngine ? 'sync' : 'no-sync'}`;
+  const existing = loudnessRefreshInflight.get(inflightKey);
+  if (existing) return existing;
+  const job = (async () => { await runRefreshLoudnessForTrack(trackId, syncEngine); })()
+    .finally(() => { loudnessRefreshInflight.delete(inflightKey); });
+  loudnessRefreshInflight.set(inflightKey, job);
+  return job;
+}
+
+async function runRefreshLoudnessForTrack(trackId: string, syncEngine: boolean): Promise<void> {
   emitNormalizationDebug('refresh:start', { trackId });
   usePlayerStore.setState({ normalizationDbgSource: 'refresh:start', normalizationDbgTrackId: trackId });
   try {
@@ -1227,6 +1279,12 @@ export function initAudioListeners(): () => void {
       if (payloadTrackId && payloadTrackId !== current.id) return;
       if (!Number.isFinite(payload.gainDb)) return;
       if (stableLoudnessGainByTrackId[current.id]) return;
+      // Skip when the cached gain is already within ~0.05 dB of the new payload —
+      // float jitter from the partial-loudness heuristic would otherwise re-trigger
+      // updateReplayGainForCurrentTrack → audio_update_replay_gain → backend echo
+      // every PARTIAL_LOUDNESS_EMIT_INTERVAL_MS even when nothing audibly changed.
+      const existing = cachedLoudnessGainByTrackId[current.id];
+      if (Number.isFinite(existing) && Math.abs(existing - payload.gainDb) < 0.05) return;
       cachedLoudnessGainByTrackId[current.id] = payload.gainDb;
       emitNormalizationDebug('partial-loudness:apply', {
         trackId: current.id,
@@ -2620,14 +2678,14 @@ export const usePlayerStore = create<PlayerState>()(
           normalizationTargetLufs: normalization.normalizationTargetLufs,
           normalizationEngineLive: normalization.normalizationEngineLive,
         }));
-        invoke('audio_update_replay_gain', {
-           volume,
-           replayGainDb,
-           replayGainPeak,
-           loudnessGainDb: currentTrack ? (cachedLoudnessGainByTrackId[currentTrack.id] ?? null) : null,
-           preGainDb: authState.replayGainPreGainDb,
-           fallbackDb: authState.replayGainFallbackDb,
-         }).catch(console.error);
+        invokeAudioUpdateReplayGainDeduped({
+          volume,
+          replayGainDb,
+          replayGainPeak,
+          loudnessGainDb: currentTrack ? (cachedLoudnessGainByTrackId[currentTrack.id] ?? null) : null,
+          preGainDb: authState.replayGainPreGainDb,
+          fallbackDb: authState.replayGainFallbackDb,
+        });
        },
     }),
     {


### PR DESCRIPTION
## Summary

Fixes a hard renderer-thread freeze on Windows (Tauri WebView2) that triggered after a few minutes of playback **only when loudness normalization is active**. Linux WebKitGTK was unaffected. Backend tasks kept running, only the UI stalled.

This branch carries **two commits** that are independent and can be tested separately:

1. `fix(loudness): break feedback loop …` — the actual freeze fix.
2. `fix(analysis): dedupe concurrent seed_from_bytes …` — drive-by, surfaced while testing the first commit. Cucadmuh requested it land on the same branch.

---

## Commit 1 — feedback loop (the freeze)

While LUFS is on, the backend emits `analysis:loudness-partial` every `PARTIAL_LOUDNESS_EMIT_INTERVAL_MS` (900 ms, per active stream task). The frontend listener wrote `cachedLoudnessGainByTrackId` and unconditionally called `updateReplayGainForCurrentTrack`, which `invoke`'d `audio_update_replay_gain`, which emitted `audio:normalization-state` back, which the renderer had to drain → loop. WebKitGTK absorbs the cadence; WebView2 cannot, and saturates.

**5 gates close the loop, smallest first:**

**Frontend — `src/store/playerStore.ts`**
1. `analysis:loudness-partial` listener short-circuits when the new `gainDb` is within 0.05 dB of the cached value.
2. New `invokeAudioUpdateReplayGainDeduped` helper (mirrors the `audio_set_normalization` dedupe from #320): 250 ms key-based dedupe by full payload tuple. `updateReplayGainForCurrentTrack` now goes through it.
3. New `loudnessRefreshInflight` map coalesces concurrent `refreshLoudnessForTrack` calls per `(trackId, syncMode)`, mirroring `waveformRefreshInflight`.

**Backend — `src-tauri/src/audio.rs`**
4. `maybe_emit_normalization_state` helper holds the last emitted `NormalizationStatePayload` behind a `Mutex` and skips emits when `engine` matches and `current_gain_db` (±0.05 dB) / `target_lufs` (±0.02) are unchanged. Applied at all three emit sites: `audio_play`, `audio_update_replay_gain`, `audio_set_normalization`.
5. `partial_loudness_should_emit` gate with a per-track-identity last-emitted-gain map. Suppresses `analysis:loudness-partial` emits within `PARTIAL_LOUDNESS_DELTA_THRESHOLD_DB = 0.1 dB` of the previous emit. Applied to both `emit_partial_loudness_from_bytes` (legacy capture path) and the inline `ranged_download_task` progress emit.

**Drive-by:** split `estimated_output_latency_secs` (added in c6fc3ec) into two `#[cfg]`-gated definitions so `sample_rate_hz` is no longer flagged as unused on Windows / macOS builds.

**Net effect:** when loudness is steady (the common case), zero IPC traffic on the loudness-partial → update-replay-gain → normalization-state echo path. Renderer stays drainable on Windows.

---

## Commit 2 — concurrent seed_from_bytes dedupe

Surfaced in two consecutive cache-miss recordings while testing commit 1. Six independent paths reach `analysis_cache::seed_from_bytes` for the same `track_id`:

- `track_download_task` legacy capture
- `ranged_download_task` HTTP buffer full
- `audio_preload` bytes-ready
- `psysonic-local` file-read complete
- `spawn_analysis_seed_from_in_memory_bytes` (gapless reuse / preloaded / stream cache)
- `analysis_enqueue_seed_from_url` (frontend backfill triggered by `refresh:miss` while a playback path is mid-seed)

When LUFS is on and a track is streamed for the first time, **two** of these fire in parallel and Symphonia + EBU R128 decode the same buffer twice — ~30 s of duplicate CPU per track, plus a redundant SQLite write of an identical row.

**Fix:** new `SeedFromBytesOutcome::SkippedConcurrent` + a `SEEDS_IN_FLIGHT: Mutex<HashSet<String>>` static. First caller into `seed_from_bytes` wins the slot via `HashSet::insert`; later callers return `SkippedConcurrent` immediately. RAII `SeedInFlightGuard` releases the slot on every exit path (including panics). Existing `Ok(_) => {}` match arms in `audio.rs` already swallow non-`Upserted` outcomes, so no changes needed there. `enqueue_analysis_seed` in `lib.rs` distinguishes the deferred-to-peer log from a genuine seed result.

## Test plan

- [x] Windows / WebView2: no freeze with LUFS on (confirmed by reporter)
- [x] Windows / WebView2: no `sample_rate_hz` warning during cargo build
- [ ] Linux / WebKitGTK: spot-check no regression (loudness still applies, partial gain still updates "Now dB" readout)
- [ ] LUFS toggle ON ↔ OFF mid-playback still produces correct gain changes
- [ ] Cover replay-gain-only mode (LUFS off, ReplayGain on) still works as before
- [ ] Cold-start with LUFS already on: first track's partial-loudness still drives the readout
- [ ] First-listen of a cache-miss track under LUFS: only **one** `full-track analysis start/done` pair in logs (not two), `seed deferred to in-flight peer` appears for the loser
- [ ] Compare commit 1 only (revert commit 2) vs both commits — both must keep the freeze gone; only with both should the duplicate analysis disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)