### PR TITLE
fix(player): persist queue panel visibility + drop dead loudness binding

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -4422,7 +4422,6 @@ pub fn audio_update_replay_gain(
             },
         )
     });
-    let resolved_loudness_gain_db = cache_loudness.or(loudness_gain_db);
     let effective_loudness_db = if norm_mode == 2 {
         match url_for_loudness.as_deref() {
             Some(_u) => loudness_gain_db_after_resolve(

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -3121,6 +3121,7 @@ export const usePlayerStore = create<PlayerState>()(
         currentTrack: state.currentTrack,
         queue: state.queue,
         queueIndex: state.queueIndex,
+        isQueueVisible: state.isQueueVisible,
         // currentTime is intentionally NOT persisted here.
         // handleAudioProgress fires every 100ms and each setState with a
         // persisted field triggers a full JSON serialisation of the queue to


### PR DESCRIPTION
## Summary
- **`feat(player)`**: Add `isQueueVisible` to the `psysonic-player` persist `partialize` so the right-hand queue panel remembers open/closed across restarts. Counterpart to `psysonic_sidebar_collapsed` for the left sidebar (which already persisted).
- **`chore(audio)`**: Drop the unused `resolved_loudness_gain_db` binding in `audio_update_replay_gain` (build warning leftover from #333 — the live use is in the `audio_play` path on line 3485).

## Test plan
- [x] `cargo check --lib` clean (warning gone)
- [x] `tsc --noEmit` clean
- [x] Verified via WebKitGTK localStorage: `isQueueVisible` now serialized into `psysonic-player` state on toggle, value survives restart after a couple of restarts (initial cache miss expected, since the field was absent in old persisted JSON until the next `set()` rewrites partialize)

🤖 Generated with [Claude Code](https://claude.com/claude-code)