### PR TITLE
chore(release): prepare 1.44.0 dev version and aur tag source

### DIFF
--- a/nix/upstream-sources.json
+++ b/nix/upstream-sources.json
@@ -1,3 +1,3 @@
 {
-  "npmDepsHash": "sha256-1Rc3boJ0jvwIS6eKm985bLK9upQ32H6ICQgQR7FYKUI="
+  "npmDepsHash": "sha256-PYqvngGz/yreDiQxAEIhD5nuEPezAELj/zaEpJ7c1f4="
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psysonic",
-  "version": "1.43.0",
+  "version": "1.44.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "psysonic",
-      "version": "1.43.0",
+      "version": "1.44.0-dev",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "@fontsource-variable/figtree": "^5.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psysonic",
-  "version": "1.44.0-rc1",
+  "version": "1.44.0-dev",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -20,7 +20,7 @@ makedepends=(
   'nasm'
   'cmake'
 )
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Psychotoxical/psysonic/archive/refs/tags/v$pkgver.tar.gz")
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Psychotoxical/psysonic/archive/refs/tags/app-v$pkgver.tar.gz")
 sha256sums=('SKIP')
 
 build() {


### PR DESCRIPTION
Set the app version to 1.44.0-dev in package manifests and update the AUR source tag template to app-v$pkgver while keeping pkgver on the current stable release.