### PR TITLE
ci(release): run channel publish after promote when GITHUB_TOKEN push skips push rules

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -1,16 +1,23 @@
 name: Next Channel
 
+# Pushes made with the default GITHUB_TOKEN from another workflow (e.g. Promote main to next)
+# do not trigger push workflows — GitHub blocks recursive runs. Use workflow_run below.
 on:
   push:
     branches: [next]
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Promote main to next"]
+    types: [completed]
 
 jobs:
   publish-next:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/reusable-channel-publish.yml
     with:
       channel: next
-      source_ref: ${{ github.ref_name }}
+      # workflow_run uses default-branch context; ref_name would be wrong — always build `next`
+      source_ref: ${{ github.event_name == 'workflow_run' && 'next' || github.ref_name }}
       target_branch: next
       prerelease: true
       draft_release: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,21 @@
 name: Release Channel
 
+# Same GITHUB_TOKEN push limitation as Next Channel (see next.yml).
 on:
   push:
     branches: [release]
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Promote next to release"]
+    types: [completed]
 
 jobs:
   publish-release:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/reusable-channel-publish.yml
     with:
       channel: release
-      source_ref: ${{ github.ref_name }}
+      source_ref: ${{ github.event_name == 'workflow_run' && 'release' || github.ref_name }}
       target_branch: release
       prerelease: false
       draft_release: true


### PR DESCRIPTION
GitHub does not fire push workflows for commits pushed with the default actions token. Chain Next/Release channel workflows from the matching promote workflow_run on success.

Made-with: Cursor