### PR TITLE
ci(release): always checkout next/release for channel publish

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -2,6 +2,9 @@ name: Next Channel
 
 # Pushes made with the default GITHUB_TOKEN from another workflow (e.g. Promote main to next)
 # do not trigger push workflows — GitHub blocks recursive runs. Use workflow_run below.
+#
+# workflow_dispatch: set "Use workflow from branch" to `main` so reusable-channel-publish.yml
+# is the latest (tag guards, etc.). The tree built for artifacts is always ref `next` below.
 on:
   push:
     branches: [next]
@@ -16,8 +19,8 @@ jobs:
     uses: ./.github/workflows/reusable-channel-publish.yml
     with:
       channel: next
-      # workflow_run uses default-branch context; ref_name would be wrong — always build `next`
-      source_ref: ${{ github.event_name == 'workflow_run' && 'next' || github.ref_name }}
+      # Always build from channel branch; do not tie checkout to workflow_dispatch UI branch.
+      source_ref: next
       target_branch: next
       prerelease: true
       draft_release: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release Channel
 
 # Same GITHUB_TOKEN push limitation as Next Channel (see next.yml).
+#
+# workflow_dispatch: use workflow from `main` for latest publish logic; checkout ref is always `release`.
 on:
   push:
     branches: [release]
@@ -15,7 +17,7 @@ jobs:
     uses: ./.github/workflows/reusable-channel-publish.yml
     with:
       channel: release
-      source_ref: ${{ github.event_name == 'workflow_run' && 'release' || github.ref_name }}
+      source_ref: release
       target_branch: release
       prerelease: false
       draft_release: true


### PR DESCRIPTION
workflow_dispatch previously used github.ref_name for source_ref, so running Next Channel from branch `next` loaded stale reusable workflows and could recreate the invalid `app-v` tag. Pin source_ref to the channel branch; document running manual workflows from `main` for latest publish YAML.