### PR TITLE
ci(release): skip channel publish on Nix-only pushes

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -8,6 +8,11 @@ name: Next Channel
 on:
   push:
     branches: [next]
+    # Merging auto PR "chore(nix): refresh lock …" only touches these paths — do not
+    # re-run the full channel (would loop: publish → verify-nix PR → merge → push → publish).
+    paths-ignore:
+      - "flake.lock"
+      - "nix/**"
   workflow_dispatch:
   workflow_run:
     workflows: ["Promote main to next"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ name: Release Channel
 on:
   push:
     branches: [release]
+    # Same nix-refresh loop as next.yml — ignore lock-only merges from verify-nix PRs.
+    paths-ignore:
+      - "flake.lock"
+      - "nix/**"
   workflow_dispatch:
   workflow_run:
     workflows: ["Promote next to release"]


### PR DESCRIPTION
Avoid feedback loop when merging verify-nix refresh PRs (flake.lock + nix/) back into next/release.