### PR TITLE
chore: align Tauri package version with package.json on main

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psysonic"
-version = "1.44.0-rc1"
+version = "1.44.0-dev"
 description = "Psysonic Desktop Music Player"
 authors = []
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Psysonic",
-  "version": "1.44.0-rc1",
+  "version": "1.44.0-dev",
   "identifier": "dev.psysonic.player",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Cargo.toml and tauri.conf.json had stale RC-style semver; match root package.json (1.44.0-dev) so local builds and artifact names stay consistent.
