### PR TITLE
chore(aur): bump pkgver to 1.44.0

### DIFF
--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Psychotoxic <psychotoxic@gmx.de>
 pkgname=psysonic
-pkgver=1.43.0
+pkgver=1.44.0
 pkgrel=1
 pkgdesc="Desktop music player for Subsonic API-compatible servers (Navidrome, Gonic, etc.)"
 arch=('x86_64')


### PR DESCRIPTION
## Summary
- Bump AUR PKGBUILD to track v1.44.0 release.
- AUR remote already published (commit ae018e3 on `aur.archlinux.org/psysonic`).

## Test plan
- [ ] CI green