### PR TITLE
fix(aur): use app-v prefixed source dir in build/package

### DIFF
--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -24,7 +24,7 @@ source=("$pkgname-$pkgver.tar.gz::https://github.com/Psychotoxical/psysonic/arch
 sha256sums=('SKIP')
 
 build() {
-  cd "psysonic-$pkgver"
+  cd "psysonic-app-v$pkgver"
 
   export CARGO_HOME="$srcdir/cargo-home"
   export npm_config_cache="$srcdir/npm-cache"
@@ -48,7 +48,7 @@ build() {
 }
 
 package() {
-  cd "psysonic-$pkgver"
+  cd "psysonic-app-v$pkgver"
 
   # Binary (in /usr/lib to make room for the wrapper)
   install -Dm755 "src-tauri/target/release/psysonic" "$pkgdir/usr/lib/psysonic/psysonic"


### PR DESCRIPTION
## Summary
- GitHub tag archives named after `app-v*` produce `psysonic-app-v$pkgver/`, not `psysonic-$pkgver/`.
- Previous `cd "psysonic-$pkgver"` failed once the tag scheme switched (PR #346).
- Hotfixed live on AUR as `1.44.0-2`; this PR mirrors the fix in the in-repo PKGBUILD so the next version bump doesn't regress.

## Test plan
- [x] Verified locally: `tar -tzf` of the GitHub archive shows `psysonic-app-v1.44.0/` as top-level dir.
- [x] AUR `1.44.0-2` builds with the new `cd`.
- [ ] CI green