### PR TITLE
fix(equalizer): bail out when canvas has no laid-out dimensions

### DIFF
--- a/src/components/Equalizer.tsx
+++ b/src/components/Equalizer.tsx
@@ -38,16 +38,22 @@ function drawCurve(canvas: HTMLCanvasElement, gains: number[], accentColor: stri
   const dpr = window.devicePixelRatio || 1;
   const W = canvas.offsetWidth;
   const H = canvas.offsetHeight;
-  canvas.width = W * dpr;
-  canvas.height = H * dpr;
-  const ctx = canvas.getContext('2d')!;
-  ctx.scale(dpr, dpr);
 
   const fMin = 20, fMax = 20000;
   const dbMin = -13, dbMax = 13;
   const padL = 36, padR = 8, padT = 8, padB = 1;
   const innerW = W - padL - padR;
   const innerH = H - padT - padB;
+
+  // Canvas hidden or not laid out yet (e.g. inside a collapsed <details> on macOS WebKit).
+  // Bail before allocating an invalid back-buffer; ResizeObserver redraws when the canvas
+  // gets real dimensions.
+  if (innerW <= 0 || innerH <= 0) return;
+
+  canvas.width = W * dpr;
+  canvas.height = H * dpr;
+  const ctx = canvas.getContext('2d')!;
+  ctx.scale(dpr, dpr);
 
   const freqToX = (f: number) =>
     padL + (Math.log10(f / fMin) / Math.log10(fMax / fMin)) * innerW;


### PR DESCRIPTION
## Summary

- Equalizer's `drawCurve` read `offsetWidth`/`offsetHeight` unconditionally; when the canvas sits inside a collapsed `<details>` (SettingsSubSection) on first paint, both are 0, `innerW` becomes negative, the points loop never runs, and `points[0][0]` throws.
- Linux WebKitGTK happens to lay out `<details>` expanded on first render; macOS WebKit does not — same code path crashed the entire React tree because there is no ErrorBoundary above Settings.
- Fix: bail early when `innerW` or `innerH` is non-positive. The existing ResizeObserver already redraws once the canvas gets real dimensions, so the curve appears the moment the section is expanded.

Closes #382.

## Test plan
- [x] Reproduce on macOS (dev build) before fix → entire app blanks on Settings → Audio
- [x] Apply fix, reload via Vite HMR → no crash, Settings → Audio renders normally
- [x] Verify Equalizer curve still draws correctly once the SubSection is expanded
- [x] Linux regression check (no behavioural change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)