### PR TITLE
fix(release): rebind untagged draft releases to expected app-v tag

### DIFF
--- a/.github/workflows/reusable-channel-publish.yml
+++ b/.github/workflows/reusable-channel-publish.yml
@@ -207,6 +207,30 @@ jobs:
               core.info(`Created release id=${releaseId} tag=${tag} target_commitish=${targetCommitish}`);
             }
 
+            // Self-heal: GitHub can occasionally produce a draft release with an untagged
+            // placeholder even when tag_name was requested. Force the expected tag binding.
+            const { data: createdOrUpdated } = await github.rest.repos.getRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: releaseId,
+            });
+            if ((createdOrUpdated.tag_name || "") !== tag) {
+              core.warning(
+                `Release id=${releaseId} has tag '${createdOrUpdated.tag_name ?? ""}', expected '${tag}'. Re-binding release tag.`
+              );
+              await github.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: releaseId,
+                tag_name: tag,
+                target_commitish: targetCommitish,
+                name,
+                body,
+                draft,
+                prerelease,
+              });
+            }
+
             core.setOutput("release_id", String(releaseId));
       - name: validate release id output
         env:


### PR DESCRIPTION
After create/update, fetch release by id and force tag_name/target_commitish when GitHub returns an unexpected tag (including untagged placeholders). This self-heals release metadata before downstream upload steps consume release_id.