### PR TITLE
fix(tray): gate playback_state cfg for Windows and Linux only

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3690,6 +3690,7 @@ fn build_tray_icon(app: &tauri::AppHandle) -> tauri::Result<TrayIcon> {
             if g.is_empty() { None } else { Some(g.clone()) }
         })
         .unwrap_or_else(|| "Psysonic".to_string());
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     let playback_state = app
         .try_state::<TrayPlaybackState>()
         .map(|s| s.0.lock().unwrap().clone())


### PR DESCRIPTION
playback_state is only used for the Windows tray tooltip icon and the Linux now-playing menu row; compiling it on macOS triggered an unused_variables warning in CI.