### PR TITLE
fix(ci): upgrade github-script action to v9

### DIFF
--- a/.github/workflows/reusable-channel-publish.yml
+++ b/.github/workflows/reusable-channel-publish.yml
@@ -127,7 +127,7 @@ jobs:
           echo "$EOF_MARKER" >> "$GITHUB_OUTPUT"
       - name: create or update release
         id: create-release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PACKAGE_VERSION: ${{ steps.get-version.outputs.version }}
           RELEASE_TAG: ${{ steps.tag.outputs.value }}


### PR DESCRIPTION
Move reusable channel publish release step from actions/github-script v7 to v9 to stay compatible with Node 24 on GitHub runners.