### PR TITLE
fix(seekbar): blank canvas after update from legacy build

### DIFF
--- a/src/components/WaveformSeek.tsx
+++ b/src/components/WaveformSeek.tsx
@@ -785,6 +785,10 @@ export function drawSeekbar(
     case 'particletrail': drawParticleTrail(canvas, progress, buffered, anim); break;
     case 'liquidfill':    drawLiquidFill(canvas, progress, buffered, anim); break;
     case 'retrotape':     drawRetroTape(canvas, progress, buffered, anim); break;
+    // Safety net: if a legacy or tampered persisted style sneaks past the
+    // authStore migration, fall back to the truewave renderer instead of
+    // leaving a blank canvas.
+    default:              drawWaveform(canvas, heights, progress, buffered); break;
   }
 }
 

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -800,12 +800,18 @@ export const useAuthStore = create<AuthState>()(
           } catch { /* ignore */ }
         }
 
-        // One-time: 'waveform' style was renamed to 'truewave' (with 'pseudowave'
-        // added as the deterministic legacy variant). Existing persisted value
-        // 'waveform' should land on the new bins-based default.
-        const seekbarStyleMigrated = (state.seekbarStyle as string) === 'waveform'
-          ? { seekbarStyle: 'truewave' as SeekbarStyle }
-          : {};
+        // 'waveform' style was renamed to 'truewave' (with 'pseudowave' added
+        // as the deterministic legacy variant). Any persisted value that is
+        // not a valid SeekbarStyle (legacy 'waveform', undefined, tampered
+        // strings) lands on the new bins-based default — otherwise the
+        // dispatcher's switch finds no match and the seekbar renders blank.
+        const VALID_SEEKBAR_STYLES = new Set<string>([
+          'truewave', 'pseudowave', 'linedot', 'bar', 'thick',
+          'segmented', 'neon', 'pulsewave', 'particletrail', 'liquidfill', 'retrotape',
+        ]);
+        const seekbarStyleMigrated = VALID_SEEKBAR_STYLES.has(state.seekbarStyle as string)
+          ? {}
+          : { seekbarStyle: 'truewave' as SeekbarStyle };
 
         const st = state as {
           loudnessTargetLufs?: unknown;


### PR DESCRIPTION
## Summary

Users who updated from a build that pre-dated PR #316 (the \`'waveform'\` → \`'truewave' / 'pseudowave'\` split) sometimes ended up with **no seekbar at all** in the player bar. Clicking any style in **Settings → Appearance → Seekbar Style** brought the seekbar back; that was the workaround.

## Root cause

Two issues compounded:

1. The rehydrate migration in \`authStore.ts\` matched **only** the literal string \`'waveform'\` and left every other unrecognised persisted value untouched (legacy values from earlier intermediate builds, \`undefined\`, anything tampered with in localStorage).
2. \`drawSeekbar\` in \`WaveformSeek.tsx\` had **no \`default:\` branch** in its style switch — so any value that was not in the current \`SeekbarStyle\` union resulted in zero draw calls and a blank canvas.

Once the user clicked a valid style in Settings, the persisted value became valid and the seekbar rendered fine.

## Fix

Two-layer defence:

1. **Store-side**: the migration now whitelists the valid \`SeekbarStyle\` values and resets *anything else* (legacy, undefined, tampered) to \`'truewave'\` on rehydrate.
2. **Render-side**: \`drawSeekbar\` gains a \`default:\` branch that falls back to the \`truewave\` renderer, so even if a future style mismatch slips past the store guard the user still sees a usable seekbar instead of a blank one.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`vite build\` clean
- [ ] Manual: install previous release, set seekbar style to a value that was valid then but isn't now, update, verify seekbar appears with the truewave fallback
- [ ] Manual: with a valid current style persisted (e.g. \`'pseudowave'\`), confirm the migration leaves it alone