### PR TITLE
fix(css): scope data-app-blurred animation pause away from `*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,8 @@ The currently playing row in the queue list is now indicated by **animated equal
 
 - **Windows playback stutter under GPU load** *(Issue [#334](https://github.com/Psychotoxical/psysonic/issues/334), PR [#426](https://github.com/Psychotoxical/psysonic/pull/426), by [@Psychotoxical](https://github.com/Psychotoxical))*: Audio could stutter and crackle on Windows whenever another app put GPU/CPU pressure on the system (browser, 3D apps, games). The WASAPI render thread is now promoted to MMCSS "Pro Audio" via `AvSetMmThreadCharacteristicsW`, so it survives priority contention from competing graphics work. Reproed and validated under a Half-Life parallel-load stresstest. Companion mitigations for high-GPU situations: cosmetic UI animations now pause when the window loses OS focus, and a new **Reduce animations** toggle in **Settings → Appearance** caps animated seekbar styles (pulsewave, particletrail, liquidfill, retrotape) to 30 fps for users on GPU-constrained machines (off by default).
 
+- **Linux dev — sidebar and main content invisible after HMR** *(PR [#434](https://github.com/Psychotoxical/psysonic/pull/434), by [@Psychotoxical](https://github.com/Psychotoxical))*: The `data-app-blurred="true"` CSS rule introduced in #426 used a `*` selector to pause every animation while the window was unfocused. On WebKitGTK + no-compositing this triggered a stale rendering bug after Vite hot-reloads — the sidebar and main content stayed unpainted until any user interaction nudged a re-render. The rule now targets only the concrete heaviest infinite animations (eq bars, marquees, now-playing dot pulse, fullscreen mesh blob / portrait, `.spin`); release builds are unchanged in behaviour.
+
 
 
 ## [1.44.0] - 2026-04-29

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -11097,15 +11097,29 @@ html.no-compositing .fs-seekbar-played {
   background: var(--accent);
 }
 
+/* Window completely invisible (tab hidden via Visibility API, or Tauri
+   `win.hide()`): pausing every animation is safe because the user is not
+   looking. */
 html[data-app-hidden="true"] *,
 html[data-app-hidden="true"] *::before,
 html[data-app-hidden="true"] *::after,
 html[data-psy-native-hidden="true"] *,
 html[data-psy-native-hidden="true"] *::before,
-html[data-psy-native-hidden="true"] *::after,
-html[data-app-blurred="true"] *,
-html[data-app-blurred="true"] *::before,
-html[data-app-blurred="true"] *::after {
+html[data-psy-native-hidden="true"] *::after {
+  animation-play-state: paused !important;
+}
+
+/* Window visible but unfocused (alt-tab, click into another app): only
+   pause the heaviest known infinite animations to save GPU. The previous
+   `*`-selector variant fired a repaint over every node and triggered a
+   stale-blur HMR rendering bug on WebKitGTK + no-compositing. */
+html[data-app-blurred="true"] .eq-bars .eq-bar,
+html[data-app-blurred="true"] .player-marquee,
+html[data-app-blurred="true"] .marquee-text,
+html[data-app-blurred="true"] .np-dot-pulse,
+html[data-app-blurred="true"] .fs-mesh-blob,
+html[data-app-blurred="true"] .fs-portrait-wrap,
+html[data-app-blurred="true"] .spin {
   animation-play-state: paused !important;
 }
 


### PR DESCRIPTION
## Summary

Since the \`data-app-blurred\` mechanism from PR #426 landed on \`main\`, dev sessions on Linux (WebKitGTK + no-compositing) have shown a stale rendering bug after Vite HMR reloads: the sidebar and main content go invisible and only reappear when any user input nudges a re-render. Frank reproed it visually and Console showed no React errors — the DOM was rendered, just not painted, with \`html[data-app-blurred="true"]\` clinging to the root.

Strong suspect: the \`*\`-selector in the blurred-state CSS rule fires a recompute over every node, and on WebKitGTK + no-compositing during HMR something goes south.

## Fix

Split the original combined rule:

* \`data-app-hidden\` (Visibility API) and \`data-psy-native-hidden\` (Tauri \`win.hide()\`) keep the \`*\` selector — the window is genuinely invisible there, repaint cost is irrelevant and pausing everything is the safe behaviour.
* \`data-app-blurred\` (window visible but unfocused) drops \`*\` and only targets the **concrete heaviest infinite animations**: eq bars, marquee scroll, now-playing dot pulse, fullscreen mesh blobs, fullscreen portrait drift, generic \`.spin\`. Smaller ambient animations (orbit live badges, folder browser playing-icon, etc.) keep running while blurred — minor GPU cost relative to the broken HMR experience.

JS-side \`window.__psyBlurred\` flag in \`WaveformSeek.tsx\` is unchanged, so the seekbar's own polling fallback continues to work.

## Test plan
- [x] \`npm run build\` clean
- [ ] Linux dev: trigger HMR several times in a row and confirm the sidebar + main content stay rendered
- [ ] Production build still pauses the listed heavy animations on alt-tab / focus loss