### PR TITLE
fix(queue): keep EQ bars animating when window loses focus

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -11112,8 +11112,10 @@ html[data-psy-native-hidden="true"] *::after {
 /* Window visible but unfocused (alt-tab, click into another app): only
    pause the heaviest known infinite animations to save GPU. The previous
    `*`-selector variant fired a repaint over every node and triggered a
-   stale-blur HMR rendering bug on WebKitGTK + no-compositing. */
-html[data-app-blurred="true"] .eq-bars .eq-bar,
+   stale-blur HMR rendering bug on WebKitGTK + no-compositing.
+   Note: queue `.eq-bars` are intentionally NOT in this list — three small
+   `scaleY` transforms cost nothing GPU-wise, but pausing them looked like
+   a "frozen UI" bug to users on WMs that drop window focus on hover. */
 html[data-app-blurred="true"] .player-marquee,
 html[data-app-blurred="true"] .marquee-text,
 html[data-app-blurred="true"] .np-dot-pulse,


### PR DESCRIPTION
## Summary
- The blur-pause selector added in #434 included `.eq-bars .eq-bar`, causing the now-playing equalizer indicator in the queue to freeze whenever the window lost OS focus (alt-tab, hover-focus WMs like Niri/Hyprland, DevTools window stealing focus on WebKitGTK).
- Drops `.eq-bars .eq-bar` from the `data-app-blurred="true"` pause list. Three small `scaleY` transforms cost effectively nothing GPU-wise, so dropping them from the pause list trades negligible idle GPU for a much less broken-looking UI.
- The other entries (`.player-marquee`, `.marquee-text`, `.np-dot-pulse`, `.fs-mesh-blob`, `.fs-portrait-wrap`, `.spin`) stay — those are the heavy ones #426/#434 actually targeted.
- The `data-app-hidden="true"` `*`-pause for fully hidden windows/tabs is unchanged.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Play a track, open the queue, alt-tab away → EQ bars keep animating
- [x] Pause playback → bars freeze (still driven by `.paused` class on `.eq-bars`)
- [ ] Hide window via tray → bars freeze (driven by `data-app-hidden`)