### PR TITLE
feat(nix): psysonic-gdk-session, devShell target dir, nixos-install refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,7 @@ result-*
 # Local incremental cargo (nix develop; not used by flake — see nix/psysonic.nix cleanSource)
 .build-local/
 
-# Local helper (not in repo); same contents can be recovered from branch history if needed
+# Local Nix helpers (not in repo — optional; use `nix develop` / flake without them)
+dev.sh
+shell.nix
 prod.sh

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ research/
 # Nix build output symlink
 result
 result-*
+
+# Local incremental cargo (nix develop; not used by flake — see nix/psysonic.nix cleanSource)
+.build-local/
+
+# Local helper (not in repo); same contents can be recovered from branch history if needed
+prod.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,7 @@ Multi-album and multi-artist **context menus** now include a shared star-rating 
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#447](https://github.com/Psychotoxical/psysonic/pull/447)**
 
-The flake exposes two Linux installables: **`psysonic`** / **`default`** pins **`GDK_BACKEND=x11`** for a stable GTK/WebKit stack on mixed Wayland setups; **`psysonic-gdk-session`** drops that override so GDK follows the session (native Wayland where the stack supports it). **[nixos-install.md](nixos-install.md)** and the README spell out trade-offs and include **zsh-safe** quoting for `nix run 'github:…#…'` URLs.
+The flake exposes two Linux installables: **`psysonic`** / **`default`** pins **`GDK_BACKEND=x11`** for a stable GTK/WebKit stack on mixed Wayland setups; **`psysonic-gdk-session`** drops that override so GDK follows the session (native Wayland where the stack supports it). **[nixos-install.md](nixos-install.md)** documents trade-offs and **zsh-safe** quoting for `nix run 'github:…#…'` URLs.
 
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,20 @@ The filter panel layout was tightened up at the same time: two sub-headings (**M
 Under the hood, `fetchRandomMixSongsUntilFull` now scales batch size, max-batch ceiling and dup-streak budget with the requested target — so a 150-track mix can finish in a single round-trip on most libraries instead of stalling out at ~120.
 
 
+### UI — Bulk Entity Ratings, Random Albums Multi-Select, Album New Badge
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#446](https://github.com/Psychotoxical/psysonic/pull/446)**
+
+Multi-album and multi-artist **context menus** now include a shared star-rating row for the current selection (mixed ratings show empty until you set a value; keyboard navigation supported), with new aria-label strings across locales. **Random Albums** passes the active selection into each **AlbumCard** so the same bulk context menu works from the roll grid. The album **New** badge moves to the **top-right** of the cover and **stacks** with the offline badge so the two no longer overlap.
+
+
+### NixOS — Flake: X11-wrapped default vs session GDK
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#447](https://github.com/Psychotoxical/psysonic/pull/447)**
+
+The flake exposes two Linux installables: **`psysonic`** / **`default`** pins **`GDK_BACKEND=x11`** for a stable GTK/WebKit stack on mixed Wayland setups; **`psysonic-gdk-session`** drops that override so GDK follows the session (native Wayland where the stack supports it). **[nixos-install.md](nixos-install.md)** and the README spell out trade-offs and include **zsh-safe** quoting for `nix run 'github:…#…'` URLs.
+
+
 ## Fixed
 
 - **Settings → Audio no longer blanks the app on macOS** *(Issue [#382](https://github.com/Psychotoxical/psysonic/issues/382), PR [#384](https://github.com/Psychotoxical/psysonic/pull/384), by [@Psychotoxical](https://github.com/Psychotoxical))*: Fixed a macOS-only crash where opening Settings → Audio could turn the whole app into a blank window. The Equalizer canvas now waits until it has valid layout dimensions before drawing, and redraws automatically once the section is visible.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ Supports **8 languages** and growing.
 curl -fsSL https://raw.githubusercontent.com/Psychotoxical/psysonic/main/scripts/install.sh | sudo bash
 ```
 
+## NixOS (flake)
+
+Full guide: **[nixos-install.md](nixos-install.md)** (Cachix, `configuration.nix`, **`psysonic`** vs **`psysonic-gdk-session`**).
+
+**zsh:** `?` and `#` in a flake URL are treated as glob / history syntax. **Quote** the whole installable (everything before any `--` that separates app args):
+
+```bash
+nix run 'github:Psychotoxical/psysonic?ref=main#default' -- --help
+nix run 'github:Psychotoxical/psysonic?ref=main#psysonic-gdk-session' -- --help
+```
+
+Bash often accepts the same URL unquoted; when in doubt, use quotes there too.
+
 ## Windows
 
 Download the latest installer from Releases.

--- a/README.md
+++ b/README.md
@@ -137,19 +137,6 @@ Supports **8 languages** and growing.
 curl -fsSL https://raw.githubusercontent.com/Psychotoxical/psysonic/main/scripts/install.sh | sudo bash
 ```
 
-## NixOS (flake)
-
-Full guide: **[nixos-install.md](nixos-install.md)** (Cachix, `configuration.nix`, **`psysonic`** vs **`psysonic-gdk-session`**).
-
-**zsh:** `?` and `#` in a flake URL are treated as glob / history syntax. **Quote** the whole installable (everything before any `--` that separates app args):
-
-```bash
-nix run 'github:Psychotoxical/psysonic?ref=main#default' -- --help
-nix run 'github:Psychotoxical/psysonic?ref=main#psysonic-gdk-session' -- --help
-```
-
-Bash often accepts the same URL unquoted; when in doubt, use quotes there too.
-
 ## Windows
 
 Download the latest installer from Releases.

--- a/flake.nix
+++ b/flake.nix
@@ -4,15 +4,18 @@
 
     Packages:
       nix build .#psysonic          # or .#default — desktop app (.desktop + icon)
+      nix build .#psysonic-gdk-session   # same, but no forced GDK_BACKEND=x11 (session Wayland/X11)
       nix profile install .#psysonic
 
     Run (after build, or from any clone with flake):
       nix run .#psysonic
+      nix run .#psysonic-gdk-session
       nix run github:Psychotoxical/psysonic
 
     Development:
       nix develop                   # mkShell (Rust/Node/WebKit deps + hooks)
       nix shell .#devShells.default # same environment without entering subshell semantics
+      Local cargo output: .build-local/ (gitignored; not copied into flake source tarball)
 
     Release pipeline updates `flake.lock` (nixpkgs pin refresh) and
     `nix/upstream-sources.json` (npmDepsHash) on every `v*` tag push —
@@ -71,6 +74,10 @@
           ++ gstPlugins;
 
           shellHook = ''
+            _repo="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+            if [ -n "$_repo" ] && [ -f "$_repo/flake.nix" ]; then
+              export CARGO_TARGET_DIR="''${CARGO_TARGET_DIR:-$_repo/.build-local/cargo-target}"
+            fi
             export LD_LIBRARY_PATH="${pkgs.libayatana-appindicator}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
             export GST_PLUGIN_PATH="${gstPluginPath}''${GST_PLUGIN_PATH:+:$GST_PLUGIN_PATH}"
             export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules''${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}"
@@ -92,12 +99,21 @@
           src = self;
           inherit upstreamMeta;
         };
+
+      psysonicGdkSessionFor =
+        system:
+        nixpkgs.legacyPackages.${system}.callPackage ./nix/psysonic.nix {
+          src = self;
+          inherit upstreamMeta;
+          forceGdkX11 = false;
+        };
     in
     {
       devShells = forSystem (system: { default = mkShellFor system; });
 
       packages = forSystem (system: {
         psysonic = psysonicFor system;
+        psysonic-gdk-session = psysonicGdkSessionFor system;
         default = psysonicFor system;
       });
 
@@ -105,6 +121,7 @@
         system:
         let
           p = psysonicFor system;
+          pGdk = psysonicGdkSessionFor system;
         in
         {
           default = {
@@ -112,6 +129,14 @@
             program = lib.getExe p;
             meta = {
               inherit (p.meta) description homepage license;
+              mainProgram = "psysonic";
+            };
+          };
+          psysonic-gdk-session = {
+            type = "app";
+            program = lib.getExe pGdk;
+            meta = {
+              inherit (pGdk.meta) description homepage license;
               mainProgram = "psysonic";
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,8 @@
     Psysonic for NixOS / nixpkgs: installable app + dev shell.
 
     Packages:
-      nix build .#psysonic          # or .#default — desktop app (.desktop + icon)
-      nix build .#psysonic-gdk-session   # same, but no forced GDK_BACKEND=x11 (session Wayland/X11)
+      nix build .#psysonic          # or .#default — desktop app (.desktop + icon); GDK_BACKEND=x11 (default, fewer WebKit surprises)
+      nix build .#psysonic-gdk-session   # same app, no forced GDK x11 — optional; can misbehave on some stacks (see nixos-install.md)
       nix profile install .#psysonic
 
     Run (after build, or from any clone with flake):

--- a/nix/psysonic.nix
+++ b/nix/psysonic.nix
@@ -35,6 +35,9 @@
   gst_all_1,
   src,
   upstreamMeta,
+  # When true (default), wrapProgram sets GDK_BACKEND=x11 for WebKit stability on many setups.
+  # When false, GDK follows the session (e.g. native Wayland) — often better HiDPI sizing.
+  forceGdkX11 ? true,
 }:
 
 let
@@ -59,7 +62,8 @@ let
       && !(lib.hasInfix "/target/" f)
       && !(lib.hasInfix "/.git/" f)
       && !(lib.hasInfix "/result/" f)
-      && !(lib.hasInfix "/.flatpak-builder/" f);
+      && !(lib.hasInfix "/.flatpak-builder/" f)
+      && !(lib.hasInfix "/.build-local/" f);
   };
   npmDeps = fetchNpmDeps {
     src = srcClean;
@@ -156,15 +160,20 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  postFixup = ''
-    wrapProgram $out/bin/psysonic \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libayatana-appindicator ]}" \
-      --prefix GST_PLUGIN_PATH : "${gstPluginPath}" \
-      --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules" \
-      --set GDK_BACKEND x11 \
-      --set WEBKIT_DISABLE_COMPOSITING_MODE 1 \
-      --set WEBKIT_DISABLE_DMABUF_RENDERER 1
-  '';
+  postFixup =
+    let
+      gdkX11Wrap = lib.optionalString forceGdkX11 ''
+        --set GDK_BACKEND x11 \
+      '';
+    in
+    ''
+      wrapProgram $out/bin/psysonic \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libayatana-appindicator ]}" \
+        --prefix GST_PLUGIN_PATH : "${gstPluginPath}" \
+        --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules" \
+        ${gdkX11Wrap}--set WEBKIT_DISABLE_COMPOSITING_MODE 1 \
+        --set WEBKIT_DISABLE_DMABUF_RENDERER 1
+    '';
 
   meta = {
     description = "Desktop music player for Subsonic-compatible servers";

--- a/nixos-install.md
+++ b/nixos-install.md
@@ -158,6 +158,8 @@ From a **flake-enabled** clone of the repo:
 
 The flake **`devShell`** uses the same **`nixpkgs`** input as **`packages.psysonic`** (see **`flake.nix`**).
 
+Optional **local-only** helpers (`dev.sh`, `shell.nix`, `prod.sh`) are **gitignored** — not part of the upstream tree; keep your own copies if you use them (e.g. a small `dev.sh` that runs `nix develop` and `npm run tauri:dev`).
+
 ## Desktop entry
 
 The flake package installs a **`.desktop`** file and icon via `copyDesktopItems`; after `nixos-rebuild switch` (or a Home Manager activation that includes the package), Psysonic should appear in your application launcher like any other desktop app.

--- a/nixos-install.md
+++ b/nixos-install.md
@@ -100,7 +100,11 @@ Use the alternate package when you understand that trade-off:
 inputs.psysonic.packages.${system}.psysonic-gdk-session
 ```
 
-Or one-shot: `nix run github:Psychotoxical/psysonic#psysonic-gdk-session`.
+Or one-shot (quote the URL in **zsh** — `?` / `#` are special):
+
+```bash
+nix run 'github:Psychotoxical/psysonic#psysonic-gdk-session' -- --help
+```
 
 ### Pinning a revision, branch, or tag
 
@@ -135,10 +139,10 @@ End users who pin **`main`** should run `nix flake update psysonic` (or equivale
 From any machine with flakes:
 
 ```bash
-nix run github:Psychotoxical/psysonic
+nix run 'github:Psychotoxical/psysonic'
 ```
 
-Same as `nix build` / `packages.<system>.default` (the **x11-wrapped** binary); uses the flake `apps` output. For the session-GDK variant, use `#psysonic-gdk-session` (see [Linux wrapper](#linux-wrapper-default-vs-gdk-session) above).
+Same as `nix build` / `packages.<system>.default` (the **x11-wrapped** binary); uses the flake `apps` output. For the session-GDK variant, use `'github:Psychotoxical/psysonic#psysonic-gdk-session'` (see [Linux wrapper](#linux-wrapper-default-vs-gdk-session) above). With a branch pin, keep the **whole** `github:…?ref=…#…` string in **single quotes** under **zsh**.
 
 ### Apply configuration
 

--- a/nixos-install.md
+++ b/nixos-install.md
@@ -85,6 +85,23 @@ environment.systemPackages = with pkgs; [
 ];
 ```
 
+### Linux wrapper: default vs gdk-session
+
+The flake exposes **two** installable packages on Linux. They are the same build; only the **wrapped runtime environment** differs:
+
+| Flake attribute | Wrapper behaviour |
+|----------------|-------------------|
+| **`psysonic`** (and **`default`**) | Sets **`GDK_BACKEND=x11`** together with the usual WebKit / GStreamer / AppIndicator paths. This is the **recommended default**: it matches the dev shell assumptions and avoids many WebKitGTK + Wayland edge cases. |
+| **`psysonic-gdk-session`** | **Does not** set `GDK_BACKEND`; GTK follows the session (e.g. native Wayland when available). Can improve **HiDPI sizing** on some desktops, but may cause **black window, broken scrolling, or tray quirks** on other GPU/compositor stacks—the same class of issues described under Linux / WebKit in the in-app Help. **Not default** on purpose. |
+
+Use the alternate package when you understand that trade-off:
+
+```nix
+inputs.psysonic.packages.${system}.psysonic-gdk-session
+```
+
+Or one-shot: `nix run github:Psychotoxical/psysonic#psysonic-gdk-session`.
+
 ### Pinning a revision, branch, or tag
 
 - **`main`** (default in the examples above) follows upstream development.
@@ -121,7 +138,7 @@ From any machine with flakes:
 nix run github:Psychotoxical/psysonic
 ```
 
-Same package as `nix build` / `packages.<system>.default`; uses the flake `apps` output.
+Same as `nix build` / `packages.<system>.default` (the **x11-wrapped** binary); uses the flake `apps` output. For the session-GDK variant, use `#psysonic-gdk-session` (see [Linux wrapper](#linux-wrapper-default-vs-gdk-session) above).
 
 ### Apply configuration
 

--- a/nixos-install.md
+++ b/nixos-install.md
@@ -158,8 +158,6 @@ From a **flake-enabled** clone of the repo:
 
 The flake **`devShell`** uses the same **`nixpkgs`** input as **`packages.psysonic`** (see **`flake.nix`**).
 
-If you prefer **classic `nix-shell`** without evaluating the flake, the repo also provides **`shell.nix`**: it pulls **`nixos-unstable`** via `fetchTarball`, so the nixpkgs pin may **differ** from **`flake.lock`**; use it only when you understand that tradeoff (comments at the top of `shell.nix` describe local Tauri build commands).
-
 ## Desktop entry
 
 The flake package installs a **`.desktop`** file and icon via `copyDesktopItems`; after `nixos-rebuild switch` (or a Home Manager activation that includes the package), Psysonic should appear in your application launcher like any other desktop app.


### PR DESCRIPTION
Adds a second flake output, psysonic-gdk-session, that does not force GDK_BACKEND=x11, so GTK follows the compositor (native Wayland where supported). The existing psysonic / default package keeps the X11 GDK override for a predictable WebKitGTK stack on mixed sessions.

Updates nixos-install.md with when to use which package, nix run examples, and zsh-safe quoting for flake refs (? / #). devShell sets CARGO_TARGET_DIR under .build-local/ (excluded from Nix source via cleanSource); .gitignore covers local prod.sh, dev.sh, shell.nix.

