### PR TITLE
chore(aur): bump pkgver to 1.45.0

### DIFF
--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Psychotoxic <psychotoxic@gmx.de>
 pkgname=psysonic
-pkgver=1.44.0
+pkgver=1.45.0
 pkgrel=1
 pkgdesc="Desktop music player for Subsonic API-compatible servers (Navidrome, Gonic, etc.)"
 arch=('x86_64')


### PR DESCRIPTION
## Summary
- Bumps `packages/aur/PKGBUILD` pkgver from 1.44.0 to 1.45.0 to match the v1.45.0 release.

## Test plan
- [x] `app-v1.45.0` tag verified upstream
- [x] AUR push (`~/aur-psysonic`) follows after merge