### PR TITLE
fix(queue): restore pre-#419 Play-icon prefix on the active row

### DIFF
--- a/src/components/QueuePanel.tsx
+++ b/src/components/QueuePanel.tsx
@@ -395,7 +395,6 @@ function QueuePanelHostOrSolo() {
   const crossfadeBtnRef = useRef<HTMLButtonElement>(null);
   const crossfadePopoverRef = useRef<HTMLDivElement>(null);
   const reanalyzeLoudnessForTrack = usePlayerStore(s => s.reanalyzeLoudnessForTrack);
-  const isStorePlaying = usePlayerStore(s => s.isPlaying);
   const authLoudnessTargetLufs = useAuthStore(s => s.loudnessTargetLufs);
   const setLoudnessTargetLufs = useAuthStore(s => s.setLoudnessTargetLufs);
   const loudnessPreAnalysisAttenuationDb = useAuthStore(s => s.loudnessPreAnalysisAttenuationDb);
@@ -1092,15 +1091,9 @@ function QueuePanelHostOrSolo() {
                 }}
                 style={dragStyle}
               >
-                {isPlaying && (
-                  <div className={`eq-bars${isStorePlaying ? '' : ' paused'}`} style={{ marginRight: '8px', flexShrink: 0 }}>
-                    <div className="eq-bar" />
-                    <div className="eq-bar" />
-                    <div className="eq-bar" />
-                  </div>
-                )}
                 <div className="queue-item-info">
                   <div className="queue-item-title truncate" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    {isPlaying && <Play size={10} fill="currentColor" style={{ flexShrink: 0 }} />}
                     <span className="truncate">{track.title}</span>
                   </div>
                   <div className="queue-item-artist truncate">{track.artist}</div>


### PR DESCRIPTION
## Summary

Reverts the queue-row "now playing" indicator from the animated 3-bar `eq-bars` block (introduced in [#419](https://github.com/Psychotoxical/psysonic/pull/419)) back to the small inline **Play** icon (10px) that lived next to the active title before #419.

The `eq-bars` prefix was wrapped *outside* the title and pushed the song name to the right; the original Play icon sits *inside* the title flex with `gap: 6px` and doesn't shift the row layout.

## Why

User feedback: the eq-bars prefix in the queue felt out of place — they expected the small Play icon they remembered from before #419. The other tracklist surfaces (AlbumDetail, Favorites, RandomMix, ArtistDetail, PlaylistDetail) still use eq-bars-as-track-number-replacement, which is the established pattern there and is unchanged by this PR.

The currently-playing row keeps its `.queue-item.active` CSS treatment (accent-dim background + accent text colour) — only the prefix changes back.

## Diff

- `QueuePanel.tsx`: replace the `{isPlaying && <div className="eq-bars">…</div>}` block with the original `{isPlaying && <Play size={10} fill="currentColor" />}` inside `.queue-item-title`.
- Drop the now-unused `isStorePlaying = usePlayerStore(s => s.isPlaying)` selector.

## Test plan

- [ ] Currently-playing track in QueuePanel shows the small filled Play icon to the left of its title (no eq-bars block).
- [ ] Active row still has the accent-dim background + accent text colour.
- [ ] AlbumDetail, Favorites, RandomMix, ArtistDetail, PlaylistDetail tracklists still show eq-bars in place of the track number for the currently-playing row (unchanged).