### PR TITLE
docs: add NOTICE, TRADEMARK, and README forking guidance

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,40 @@
+# Notice
+
+Psysonic is licensed under the GNU GPLv3.
+
+Psysonic, including features such as **Orbit** (synchronized shared
+listening sessions), was originally designed and implemented by the
+Psysonic project maintainers and contributors.
+
+Forks and modified versions are welcome under the GPLv3, but they
+must preserve copyright notices, license information, and clear
+attribution to the original Psysonic project.
+
+Modified versions must not imply that original Psysonic features were
+independently created by the fork, nor imply endorsement by the
+Psysonic project.
+
+## Required Attribution for Derivative Works
+
+The following attribution requirements apply to all derivative works
+under the additional terms permitted by **GPLv3 §7(b)**. Forks and
+redistributions must preserve these notices intact:
+
+1. The unmodified contents of this `NOTICE.md` file must be retained
+   in the source tree of any fork or derivative work.
+2. Derivative works that include or are based on the **Orbit**
+   feature — its design, protocol, or implementation — must clearly
+   state in their own documentation and release notes that the Orbit
+   feature was originally designed and implemented in Psysonic, and
+   must not present Orbit's design or implementation as independent
+   original work of the fork.
+3. The user-facing name "Orbit" is a Psysonic feature mark and may
+   not be reused by forks; see `TRADEMARK.md`. The attribution
+   requirement in (2) applies regardless of what the feature is
+   renamed to in a fork.
+4. The same applies to any other original Psysonic feature that a
+   fork chooses to retain.
+
+These terms do not restrict the freedoms granted by the GPLv3; they
+are attribution-preservation terms explicitly permitted by GPLv3
+§7(b) and must be carried forward in further redistribution.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ GNU GPL v3.0
 
 ---
 
+## Forks and Attribution
+
+Psysonic is GPLv3 software. You are free to fork, modify, and redistribute it under the terms of that license.
+
+If you distribute a modified or rebranded version, please clearly state that it is based on Psysonic and preserve attribution to the original project.
+
+Features such as Orbit were originally designed and implemented in Psysonic. Forks must not present original Psysonic work as their own independent creation.
+
+---
+
 <div align="center">
 
 ## Stop using boring music clients.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,66 @@
+# Trademark Notice
+
+The Psysonic source code is licensed under the GNU GPLv3.
+The **Psysonic name, logo, wordmark, visual brand identity, and the
+names of original Psysonic features are not** — they are excluded
+from the GPLv3 grant and remain the property of the Psysonic project
+maintainers.
+
+## Covered Marks
+
+- The name **"Psysonic"** (in any capitalization or stylization)
+- The Psysonic logo and icon (`public/psysonic-inapp-logo.svg`,
+  app icons, tray icons, installer artwork)
+- The Psysonic wordmark and any derivative branding
+- The names of original Psysonic features that function as feature
+  identity, in particular **"Orbit"**
+
+## What You May Do
+
+- Use the Psysonic name to factually refer to the upstream project
+  (e.g. *"based on Psysonic"*, *"a fork of Psysonic"*, *"compatible
+  with Psysonic"*).
+- Redistribute unmodified Psysonic builds under the Psysonic name,
+  in accordance with the GPLv3.
+- Link to the official Psysonic repository, website, and community
+  channels.
+
+## What You May Not Do
+
+- Use the Psysonic name, logo, or branding for a **modified or
+  rebranded fork**, distribution, or derivative product.
+- Name a fork in a way that suggests it *is* Psysonic, an official
+  release of Psysonic, or endorsed by the Psysonic project (e.g.
+  "Psysonic Pro", "Psysonic Plus", "Psysonic Next", "MyPsysonic").
+- Reuse the Psysonic logo, icon set, or installer artwork in a fork
+  or derivative product, even with modifications.
+- Continue to use the feature name **"Orbit"** in a fork or
+  derivative. If your fork ships the Orbit feature (or code derived
+  from it), you must rename the user-facing feature.
+- Present original Psysonic features (such as Orbit) as independent
+  creations of a fork. See `NOTICE.md` for the attribution
+  requirements that apply to derivative works under GPLv3 §7(b).
+- Imply sponsorship, endorsement, or affiliation with the Psysonic
+  project where none exists.
+
+## Forking Done Right
+
+You are warmly invited to fork the code under the GPLv3.
+If you publish a fork or derivative, please:
+
+1. Choose your own distinct project name and branding.
+2. Keep the GPLv3 license, copyright notices, and the `NOTICE.md`
+   file intact (this is required, not optional — see `NOTICE.md`).
+3. State clearly that your project is *based on Psysonic* and link
+   back to the upstream repository.
+4. Replace Psysonic-branded assets (logos, icons, installer art,
+   wordmarks) with your own.
+5. If you ship features that originated in Psysonic (such as Orbit),
+   rename the user-facing feature and credit Psysonic as the
+   original designer and implementer.
+
+## Questions
+
+If you are unsure whether a planned use of the Psysonic name or
+branding is acceptable, please open an issue or contact the
+maintainers before publishing.


### PR DESCRIPTION
## Summary

- New `NOTICE.md` with GPLv3 §7(b) attribution-preservation terms that derivative works must carry forward, with explicit language for original Psysonic features such as Orbit.
- New `TRADEMARK.md` clarifying that the Psysonic name, logo, brand identity, and the names of original Psysonic features (in particular **Orbit**) are not part of the GPLv3 grant. Forks may reuse the code, but must rename Psysonic-branded assets and feature names.
- New **Forks and Attribution** section in `README.md` summarising the above for first-time readers.

## Why

Psysonic is and remains GPLv3 — anyone is free to fork. These docs do not restrict that. They formalise two things that GPLv3 already allows but that benefit from being spelled out:

1. **Trademark scope** (Psysonic name + logo + feature names like Orbit are not licensed under GPLv3 — standard for GPL projects).
2. **Attribution preservation under GPLv3 §7(b)** (forks must keep the NOTICE intact and credit Psysonic as the original designer/implementer of features like Orbit, regardless of what they rename them to in the fork).

Together these establish a clear, GPL-compatible expectation: forks are welcome, rebranding is fine, but original Psysonic work must be credited and Psysonic-branded names must not be reused.

## Test plan

- [ ] `NOTICE.md` reads correctly on GitHub
- [ ] `TRADEMARK.md` reads correctly on GitHub
- [ ] README "Forks and Attribution" section renders in the right place (after License, before the closing centered block)