### PR TITLE
feat(settings): keep current active server when adding a new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **`downscaleCoverBlob`** respects **AbortSignal** through **`canvas.toBlob`**.
 * **`CachedImage`:** **`fetchQueueBias`** gives **artist** search thumbs **higher network-slot priority** than **album** thumbs when the pool is saturated; **`observeRootMargin`** defaults **wider** so **priority** updates **earlier** ahead of the scroll viewport.
 
+### Settings — adding a server no longer switches to it
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#475](https://github.com/Psychotoxical/psysonic/pull/475)**
+
+* When you add a new server from **Settings → Servers**, the new entry now appears in the server picker but **your current active server stays active** — playback, queue and library view are no longer interrupted.
+* The login screen on `/login` is unchanged: signing in there still selects the chosen server.
+
 ## Fixed
 
 ### Hot cache, HTTP streaming replay, and queue source indicator

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -2067,8 +2067,6 @@ export default function Settings() {
         };
         auth.setSubsonicServerIdentity(id, identity);
         scheduleInstantMixProbeForServer(id, data.url, data.username, data.password, identity);
-        auth.setActiveServer(id);
-        auth.setLoggedIn(true);
         setConnStatus(s => ({ ...s, [id]: 'ok' }));
       } else {
         setConnStatus(s => ({ ...s, [tempId]: 'error' }));

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -362,6 +362,7 @@ const CONTRIBUTORS = [
       'Random Mix: playlist-size picker (50/75/100/125/150) and filter-panel layout cleanup (PR #445)',
       'Queue: optional "Preserve Play Next order" toggle — multiple Play Next inserts queue up behind each other instead of latest-on-top (PR #464)',
       'Library: "favorites only" filter on Albums, Artists and Advanced Search — toolbar toggle reading star overrides live (PR #466)',
+      'Settings: keep current active server when adding a new one — no more auto-switch interrupting playback or library context (PR #475)',
     ],
   },
 ] as const;


### PR DESCRIPTION
## Summary

- Adding a new server from Settings no longer auto-switches the active server.
- The new entry appears in the server list and is immediately usable from the server picker, but playback context, queue, and library view stay on the server the user is already on.
- The previously-issued `setLoggedIn(true)` call was redundant in this path (Settings is behind `RequireAuth`, so `isLoggedIn` is already true) and has been removed alongside.

## Why

Auto-switching the active server on add was disruptive — adding a second server (e.g. a friend's library, a test instance, a backup server) yanked the user out of their current playback session and library view. The expected behaviour is that managing servers is a config action, not a navigation action.

## Out of scope

The login flow on `/login` is unchanged: signing in there still sets the active server, which is the explicit intent of that screen.

## Test plan

- [ ] On a session with an existing active server, open Settings → Servers → Add Server and complete a successful add.
- [ ] Verify the new server appears in the list with status `ok`.
- [ ] Verify the active server (header indicator, library, queue) is unchanged.
- [ ] Verify the new server can be selected manually via the server picker and switching works as before.
- [ ] Verify the login flow on `/login` still selects the chosen server (regression check).