### PR TITLE
fix(sidebar): centre Playlists icon and unify hover hitbox in collapsed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Limited loudness backfill warmup to the current track plus the next 5 tracks, reducing runaway analysis scheduling from large bulk queue updates.
 * Added debug counters for prune results to make queue-pressure behavior visible during diagnostics.
 
+### Sidebar — Playlists icon and hover hitbox in collapsed mode
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#481](https://github.com/Psychotoxical/psysonic/pull/481)**
+
+* The **Playlists** icon in the collapsed sidebar was **off-centre** and had a **wider hover background** than every other item, because it still rendered through the expanded-mode wrapper (with `padding-right` and a `flex: 1` main link to fit the expand-toggle). Collapsed mode now reuses the **standard nav-link path** — same hitbox, same alignment as Artists, Albums, Favorites, etc.
+
 ## [1.45.0] - 2026-05-04
 
 ## Added

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -861,7 +861,7 @@ export default function Sidebar({
               }
             : {};
 
-          return item.to === '/playlists' ? (
+          return item.to === '/playlists' && !isCollapsed ? (
             <div
               key={item.to}
               className={`sidebar-playlists-wrapper${rowClass ? ` ${rowClass}` : ''}`}
@@ -872,25 +872,21 @@ export default function Sidebar({
                 <NavLink
                   to={item.to}
                   className={({ isActive }) => `nav-link sidebar-playlists-main-link ${isActive ? 'active' : ''}`}
-                  data-tooltip={isCollapsed ? t(item.labelKey) : undefined}
-                  data-tooltip-pos="bottom"
                 >
-                  <item.icon size={isCollapsed ? 22 : 18} />
-                  {!isCollapsed && <span>{t(item.labelKey)}</span>}
+                  <item.icon size={18} />
+                  <span>{t(item.labelKey)}</span>
                 </NavLink>
-                {!isCollapsed && (
-                  <button
-                    className={`sidebar-playlists-toggle ${playlistsExpanded ? 'expanded' : ''}`}
-                    onClick={() => setPlaylistsExpanded(!playlistsExpanded)}
-                    aria-expanded={playlistsExpanded}
-                    aria-label={playlistsExpanded ? t('sidebar.collapsePlaylists') : t('sidebar.expandPlaylists')}
-                    data-tooltip={playlistsExpanded ? t('sidebar.collapsePlaylists') : t('sidebar.expandPlaylists')}
-                  >
-                    <ChevronRight size={14} />
-                  </button>
-                )}
+                <button
+                  className={`sidebar-playlists-toggle ${playlistsExpanded ? 'expanded' : ''}`}
+                  onClick={() => setPlaylistsExpanded(!playlistsExpanded)}
+                  aria-expanded={playlistsExpanded}
+                  aria-label={playlistsExpanded ? t('sidebar.collapsePlaylists') : t('sidebar.expandPlaylists')}
+                  data-tooltip={playlistsExpanded ? t('sidebar.collapsePlaylists') : t('sidebar.expandPlaylists')}
+                >
+                  <ChevronRight size={14} />
+                </button>
               </div>
-              {!isCollapsed && playlistsExpanded && (
+              {playlistsExpanded && (
                 <div className="sidebar-playlists-list">
                   {playlistsLoading ? (
                     <div className="sidebar-playlists-loading">
@@ -904,8 +900,6 @@ export default function Sidebar({
                         key={pl.id}
                         to={`/playlists/${pl.id}`}
                         className={({ isActive }) => `nav-link sidebar-playlist-item ${isActive ? 'active' : ''}`}
-                        data-tooltip={isCollapsed ? displayPlaylistName(pl.name) : undefined}
-                        data-tooltip-pos="bottom"
                       >
                         {isSmartPlaylistName(pl.name) ? <Sparkles size={12} /> : <PlayCircle size={12} />}
                         <span>{displayPlaylistName(pl.name)}</span>


### PR DESCRIPTION
## Summary

In the collapsed sidebar, the **Playlists** entry rendered with an off-centre icon and a noticeably wider hover background than every other item (Artists, Albums, Favorites, …). This PR makes Playlists collapse-render identically to the rest.

## Why

The Playlists nav row has a custom render path with a wrapper, a header-row and a `flex: 1` main link to fit the expand-toggle button next to the label. Those elements were also active in collapsed mode, where:

- `.sidebar-playlists-header-row` keeps `padding-right: var(--space-2)` → asymmetric padding pushes the icon left
- `.sidebar-playlists-main-link` has `flex: 1` → the link stretches across the available width, growing the hover hitbox

Both effects were silent in expanded mode (because the toggle button is rendered there) but ugly in collapsed mode (no toggle, no label, just a misaligned icon and a wide hover background).

## Fix

Hoist the `isCollapsed` check above the playlists special-case in the render switch, so collapsed mode reuses the standard `<NavLink class="nav-link">` branch — identical to Artists, Albums, Favorites, etc. Expanded-mode treatment (wrapper, header-row, expand-toggle, nested playlist list) is unchanged.

While there: removed a handful of now-redundant `isCollapsed ?` ternaries inside the expanded-only branch (they were always taking the expanded value).

## Footprint

- 1 file: `src/components/Sidebar.tsx` (+13 / −19)
- No CSS changes
- No workflow / lock-file touches

## Test plan

- [ ] Collapse the sidebar — Playlists icon is now centred like every other icon, hover background matches Favorites / Artists / Albums.
- [ ] Expand the sidebar — Playlists row still has its expand chevron and reveals the playlist list when toggled.
- [ ] Click Playlists in collapsed mode → routes to `/playlists` as before.
- [ ] Hover tooltip on the collapsed Playlists icon still shows "Playlists".