### PR TITLE
fix(theme): migrate persisted state from removed theme ids

### DIFF
--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -44,6 +44,23 @@ export function getScheduledTheme(state: Pick<ThemeState, 'enableThemeScheduler'
   return isDay ? state.themeDay : state.themeNight;
 }
 
+/** Themes removed in PR #490 (community theme redesign). Each key maps to the
+ *  closest surviving palette so persisted state from older builds doesn't land
+ *  on a non-existent `data-theme` attribute and silently fall back to :root. */
+const REMOVED_THEME_REMAP: Record<string, string> = {
+  'amber-night':    'obsidian-gold',   // warm gold/amber dark family
+  'ice-blue':       'carbon-grey',     // cool neutral dark (no surviving cyan)
+  'monochrome':     'carbon-grey',     // neutral grey dark
+  'phosphor-green': 'deep-forest',     // green dark family
+  'rose-dark':      'sakura-night',    // pink/rose dark family
+};
+
+function remapTheme(value: unknown): unknown {
+  return typeof value === 'string' && value in REMOVED_THEME_REMAP
+    ? REMOVED_THEME_REMAP[value]
+    : value;
+}
+
 export const useThemeStore = create<ThemeState>()(
   persist(
     (set) => ({
@@ -74,6 +91,17 @@ export const useThemeStore = create<ThemeState>()(
     }),
     {
       name: 'psysonic_theme',
+      version: 1,
+      migrate: (persistedState, _version) => {
+        if (!persistedState || typeof persistedState !== 'object') return persistedState;
+        const s = persistedState as Record<string, unknown>;
+        return {
+          ...s,
+          theme:      remapTheme(s.theme),
+          themeDay:   remapTheme(s.themeDay),
+          themeNight: remapTheme(s.themeNight),
+        };
+      },
     }
   )
 );


### PR DESCRIPTION
## Summary

Follow-up to PR [#490](https://github.com/Psychotoxical/psysonic/pull/490) which dropped five community themes (`amber-night`, `ice-blue`, `monochrome`, `phosphor-green`, `rose-dark`).

Existing users who had any of those selected land on a `data-theme` attribute that no longer matches any CSS block — the browser silently falls back to `:root` defaults, and the theme picker shows the old id as inactive (no checkmark on any tile).

## Fix

Add a Zustand persist `migrate` hook (`version: 1`) that remaps the removed ids to the closest surviving palette per colour family:

| Removed | Replacement | Why |
|---|---|---|
| `amber-night` | `obsidian-gold` | warm gold/amber dark family |
| `ice-blue` | `carbon-grey` | cool neutral dark (no surviving cyan) |
| `monochrome` | `carbon-grey` | neutral grey dark |
| `phosphor-green` | `deep-forest` | green dark family |
| `rose-dark` | `sakura-night` | pink/rose dark family |

Applies to `theme`, `themeDay` and `themeNight` — so a scheduled night theme set to a removed id is also remapped.

New installs are unaffected (`migrate` only runs against persisted state).

## Test plan

- [ ] Manually set `localStorage.psysonic_theme` to `{"state":{"theme":"amber-night",...},"version":0}` (or any of the five removed ids), reload — picker should now show `obsidian-gold` as active and `<html data-theme="obsidian-gold">`.
- [ ] Same with `themeDay: 'ice-blue'` and theme scheduler enabled — should remap to `carbon-grey` and pick the right one based on time-of-day.
- [ ] Fresh install (clear localStorage) — default `mocha` greift, no migrate noise.