### PR TITLE
fix(tray): resume rendering on second-launch restore (#497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The currently-playing track in any tracklist (**AlbumDetail**, **ArtistDetail**, **PlaylistDetail**, **Favorites**, **RandomMix**) ran an **`opacity` pulse** on the entire row plus three **`transform` keyframe** EQ-bar siblings — both compositor properties, but on **WebKitGTK without compositing** (Linux + NVIDIA proprietary + `WEBKIT_DISABLE_COMPOSITING_MODE=1`) every animated row falls back to a full **software repaint** of the subtree per frame. On AlbumDetail the combined cost held the WebProcess at **~80 % CPU** for the duration of playback; CPU dropped immediately on pause/stop.
 * `.track-row.active` keeps the **accent-tinted background** but no longer pulses. The "now playing" indicator becomes a single Lucide **`AudioLines` icon** (one SVG per active row instead of three animated spans). Cleanup: dead `track-pulse` + `eq-bounce` keyframes and a duplicate, shadowed `.eq-bar` block in `theme.css`.
 
+### Tray — broken navigation after restoring via desktop / start-menu shortcut
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), reported by netherguy4, PR [#501](https://github.com/Psychotoxical/psysonic/pull/501)**
+
+* When the main window was closed to the tray and then re-opened via the **desktop / start-menu shortcut** (instead of the tray icon), the window came back but the **next navigation rendered a blank page**. Restoring via the **tray icon** worked correctly.
+* Root cause: closing to the tray injects a "pause rendering" snippet that sets `data-psy-native-hidden="true"` on `<html>` and pauses every CSS animation. The tray-icon restore path injects the matching "resume rendering" snippet before showing the window — the second-launch restore path (handled by the **single-instance plugin**) was **missing that step**, so route wrappers using `.animate-fade-in` (`animation: fadeIn … both`, starts at `opacity: 0`) stayed frozen invisible.
+* Fix: mirror the tray-icon restore path and resume rendering before `show()` in the single-instance callback. Both restore paths are now consistent.
+
 ## [1.45.0] - 2026-05-04
 
 ## Added

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -649,6 +649,13 @@ pub fn run() {
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             if !crate::cli::handle_cli_on_primary_instance(app, &argv) {
                 let window = app.get_webview_window("main").expect("no main window");
+                // The window may have been hidden via the close-to-tray path,
+                // which injects PAUSE_RENDERING_JS (sets `__psyHidden=true`,
+                // pauses CSS animations). Tray-icon restore mirrors this with
+                // RESUME_RENDERING_JS — second-launch restore must do the same,
+                // otherwise the webview comes back with rendering still paused
+                // and navigation looks blank (issue #497).
+                let _ = window.eval(RESUME_RENDERING_JS);
                 let _ = window.show();
                 let _ = window.unminimize();
                 let _ = window.set_focus();


### PR DESCRIPTION
## Summary

Fixes [#497](https://github.com/Psychotoxical/psysonic/issues/497) — restoring Psysonic via desktop / start-menu shortcut while the window is hidden in the tray brought up the window with rendering still paused, so the next navigation rendered a blank page.

## Why

When the user closes the main window to the tray, `PAUSE_RENDERING_JS` is injected (`window:close-requested` path in `lib.rs`):

- `window.__psyHidden = true`
- `<html data-psy-native-hidden="true">`
- `--psy-anim-speed: 0`
- Per-element `animation-play-state: paused` on every node under `#root`

A global CSS rule then keeps every animation paused while the attribute is set:

```css
html[data-psy-native-hidden="true"] *,
html[data-psy-native-hidden="true"] *::before,
html[data-psy-native-hidden="true"] *::after {
  animation-play-state: paused !important;
}
```

Page wrappers across the app use `.animate-fade-in` (= `animation: fadeIn … both`) which starts at `opacity: 0`. With animations paused the wrapper of a freshly mounted route stays stuck at `opacity: 0` → the new page looks blank, even though the DOM is there.

The tray-icon restore path (`tray.rs:109` / `:145`) already calls `RESUME_RENDERING_JS` before `show()`. The single-instance plugin callback (which fires when the user re-launches via desktop / start-menu shortcut while the primary instance is alive) only did `show()` + `unminimize()` + `set_focus()` — never resumed rendering. So the second-launch restore left the webview paused and broke the next navigation.

## Fix

Inject `RESUME_RENDERING_JS` in the single-instance callback before `show()`, mirroring the tray-icon restore path. One-line behavioural change; no other plumbing affected.

## Test plan

- [x] Repro confirmed locally: close to tray (X) → relaunch via shortcut → navigate to another page → page blank ✅ (before)
- [x] After fix: same flow → navigation works normally ✅
- [x] Tray-icon restore still works (regression check)
- [ ] CLI forwarding via single-instance (`--player …` on Windows / macOS) still works — same callback path; CLI branch returns early before the new eval, so unaffected