### PR TITLE
fix(i18n): OpenDyslexic font supports Cyrillic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Next step on the accessibility track after the colour-side work (WCAG contrast audits across every theme, dedicated colour-vision-deficiency theme variants for protanopia / deuteranopia / tritanopia): a dyslexia-friendly **OpenDyslexic** font option in the existing font picker.
 * OpenDyslexic uses a heavier weighted baseline and asymmetric glyph shapes — `b`/`d`, `p`/`q` never mirror, italics are differentiated forms rather than slanted regulars — which many dyslexic readers find easier to track than a typical sans.
 * Bundled locally via `@fontsource/opendyslexic` (SIL OFL, freely redistributable). No CDN dependency. The Settings picker grew an optional **subtitle** field on font entries so the OpenDyslexic row carries a "dyslexia-friendly · no RU/ZH support" hint without cluttering the other 14 fonts.
-* **Latin + Latin-extended only.** Cyrillic and CJK locales (RU, ZH) fall back to the system font when OpenDyslexic is selected; the subtitle calls that out upfront. Subtitle text is translated in all 8 locales.
+* **Latin, Latin-extended and Cyrillic.** Chinese (ZH) falls back to the system font when OpenDyslexic is selected; the subtitle calls that out upfront. Subtitle text is translated in all 8 locales.
 
 ### Lossless Albums — rail on Home + dedicated page + sidebar entry
 

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -587,7 +587,7 @@ export const deTranslation = {
     languageNb: 'Norwegisch',
     languageRu: 'Russisch',
     font: 'Schriftart',
-    fontHintOpenDyslexic: 'Legasthenie-freundlich · keine RU/ZH-Unterstützung',
+    fontHintOpenDyslexic: 'Legasthenie-freundlich · keine Chinesisch-Unterstützung',
     theme: 'Design',
     appearance: 'Darstellung',
     servers: 'Server',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -590,7 +590,7 @@ export const enTranslation = {
     languageRu: 'Russian',
     languageEs: 'Spanish',
     font: 'Font',
-    fontHintOpenDyslexic: 'Dyslexia-friendly · no RU/ZH support',
+    fontHintOpenDyslexic: 'Dyslexia-friendly · no Chinese support',
     theme: 'Theme',
     appearance: 'Appearance',
     servers: 'Servers',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -580,7 +580,7 @@ export const esTranslation = {
     languageRu: 'Ruso',
     languageEs: 'Español',
     font: 'Fuente',
-    fontHintOpenDyslexic: 'Compatible con dislexia · sin soporte RU/ZH',
+    fontHintOpenDyslexic: 'Compatible con dislexia · sin soporte para chino',
     theme: 'Tema',
     appearance: 'Apariencia',
     servers: 'Servidores',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -577,7 +577,7 @@ export const frTranslation = {
     languageNb: 'Norvégien',
     languageRu: 'Russe',
     font: 'Police',
-    fontHintOpenDyslexic: 'Adapté à la dyslexie · sans prise en charge RU/ZH',
+    fontHintOpenDyslexic: 'Adapté à la dyslexie · sans prise en charge du chinois',
     theme: 'Thème',
     appearance: 'Apparence',
     servers: 'Serveurs',

--- a/src/locales/nb.ts
+++ b/src/locales/nb.ts
@@ -577,7 +577,7 @@ export const nbTranslation = {
     languageNb: 'Norsk',
     languageRu: 'Russisk',
     font: 'Skrifttype',
-    fontHintOpenDyslexic: 'Dyslexivennlig · ingen RU/ZH-støtte',
+    fontHintOpenDyslexic: 'Dyslexivennlig · ingen kinesisk støtte',
     theme: 'Tema',
     appearance: 'Utseende',
     servers: 'Tjenere',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -576,7 +576,7 @@ export const nlTranslation = {
     languageNb: 'Noors',
     languageRu: 'Russisch',
     font: 'Lettertype',
-    fontHintOpenDyslexic: 'Dyslexie-vriendelijk · geen RU/ZH-ondersteuning',
+    fontHintOpenDyslexic: 'Dyslexie-vriendelijk · geen Chinese ondersteuning',
     theme: 'Thema',
     appearance: 'Weergave',
     servers: 'Servers',

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -611,7 +611,7 @@ export const ruTranslation = {
     languageRu: 'Русский',
     languageRu2: 'Русский 2',
     font: 'Шрифт',
-    fontHintOpenDyslexic: 'Подходит для дислексии · без поддержки RU/ZH',
+    fontHintOpenDyslexic: 'Подходит для дислексии · без поддержки китайского',
     theme: 'Тема',
     appearance: 'Оформление',
     servers: 'Серверы',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -571,7 +571,7 @@ export const zhTranslation = {
     languageNb: '挪威',
     languageRu: '俄语',
     font: '字体',
-    fontHintOpenDyslexic: '阅读障碍友好 · 不支持俄文/中文',
+    fontHintOpenDyslexic: '阅读障碍友好 · 不支持中文',
     theme: '主题',
     appearance: '外观',
     servers: '服务器',


### PR DESCRIPTION
## Summary

The OpenDyslexic subtitle hint in the font picker (introduced in #507) stated `no RU/ZH support`. That's only half right — `@fontsource/opendyslexic` 5.x ships **Latin, Latin-extended _and_ Cyrillic** glyphs, so Russian renders correctly. Only **Chinese (CJK)** actually falls back to the system font.

Empirically verified by cucadmuh on a Russian-locale install: the OpenDyslexic font is applied to Cyrillic strings end-to-end, no fallback to system font.

## What changed

Updated `fontHintOpenDyslexic` in all 8 locale files to drop the false `RU` claim:

| Locale | New |
|---|---|
| en | `Dyslexia-friendly · no Chinese support` |
| de | `Legasthenie-freundlich · keine Chinesisch-Unterstützung` |
| fr | `Adapté à la dyslexie · sans prise en charge du chinois` |
| nl | `Dyslexie-vriendelijk · geen Chinese ondersteuning` |
| nb | `Dyslexivennlig · ingen kinesisk støtte` |
| es | `Compatible con dislexia · sin soporte para chino` |
| ru | `Подходит для дислексии · без поддержки китайского` |
| zh | `阅读障碍友好 · 不支持中文` |

The `ru.ts` file is the funniest one — it used to claim its own locale was unsupported.

## Notes

- Lands post v1.46.0-rc.1; rides along to the v1.46.0 final tag, no RC2 needed.
- CHANGELOG fix follows in a second commit on this branch (the false claim also lives inside the v1.46.0 #507 entry, will be corrected in place).
- Solo PR → squash on merge.

## Test plan

- [ ] Switch to RU locale, set font to OpenDyslexic, confirm Russian renders in OpenDyslexic glyphs (not system fallback).
- [ ] Switch to ZH locale, set font to OpenDyslexic, confirm Chinese still falls back to system font (expected).
- [ ] Verify subtitle text reads correctly in each of the 8 locales.