### PR TITLE
chore: add GitHub issue forms (bug + feature + config)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,138 @@
+name: Bug report
+description: Something is broken or behaves incorrectly
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much as you can — the more
+        precise the report, the faster it can be reproduced and fixed.
+
+        **Before opening an issue:** if you're not sure whether the problem is on the Psysonic side
+        or on your Subsonic-compatible server, please ask in the [Discord](https://discord.gg/AMnDRErm4u)
+        or [Telegram](https://t.me/+GLBx1_xeH28xYTJi) community first.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What's wrong?
+      description: A short description of the problem (one or two sentences).
+      placeholder: e.g. The volume slider jumps back to 100 % every time I switch tracks.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered, minimal steps that lead to the problem.
+      placeholder: |
+        1. Open Psysonic and connect to my Navidrome server.
+        2. Start playback of any track.
+        3. Drag the volume slider to ~30 %.
+        4. Press the next button.
+        5. Volume slider has snapped back to 100 %.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happens?
+      description: Include any error toast or popup text exactly as shown.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Psysonic version
+      description: |
+        Exact version string from `Settings → About` (e.g. `1.45.2` or `1.46.0-dev`).
+      placeholder: 1.45.2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other (please describe in "Anything else")
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_source
+    attributes:
+      label: Install source
+      description: How did you install Psysonic?
+      options:
+        - AUR — psysonic
+        - AUR — psysonic-bin
+        - .deb (Linux)
+        - .rpm (Linux)
+        - Cachix / Nix
+        - .dmg (macOS)
+        - .msi installer (Windows)
+        - Built from source
+        - Other (please describe in "Anything else")
+
+  - type: dropdown
+    id: server
+    attributes:
+      label: Subsonic-compatible server
+      options:
+        - Navidrome
+        - Gonic
+        - Airsonic
+        - LMS
+        - Other Subsonic-compatible server
+        - Not sure / not relevant
+
+  - type: input
+    id: server_version
+    attributes:
+      label: Server version
+      description: If your server has a version string, paste it here. Skip if the bug is clearly UI-side.
+      placeholder: e.g. Navidrome 0.55.0
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        How to grab logs:
+          1. `Settings → Logging → Debug` (enables verbose logging)
+          2. Reproduce the bug
+          3. `Settings → Logging → Export logs` and attach the resulting file or paste the relevant section below.
+
+        Logs help a lot, especially for playback / streaming / sync bugs.
+      render: shell
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / video
+      description: Drag-and-drop is supported. Optional but appreciated for UI bugs.
+
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else
+      description: Distro / WM / GPU driver, Tauri-specific quirks, theme, anything that might be relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Usage questions / general help
+    url: https://discord.gg/AMnDRErm4u
+    about: |
+      Have a question, need help connecting to your server, or not sure if a behaviour is
+      a bug? Please ask in the Discord community first — the issue tracker is reserved for
+      confirmed bugs and feature requests.
+  - name: Telegram community
+    url: https://t.me/+GLBx1_xeH28xYTJi
+    about: Alternative chat channel for usage questions and general discussion.
+  - name: AUR packaging issues
+    url: https://aur.archlinux.org/packages/psysonic
+    about: |
+      For problems specific to the AUR `psysonic` or `psysonic-bin` packages (build failures,
+      dependency mismatches, AUR metadata), please comment on the AUR page first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. A short description of the use case is more
+        valuable than a fully-specified solution — the implementation usually shifts during
+        review, but the underlying need stays the same.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the use case?
+      description: |
+        What are you trying to do that's currently hard or impossible? Describe the workflow
+        or situation, not the proposed solution.
+      placeholder: |
+        e.g. When I'm on a long flight I want to keep listening to my offline-cached tracks,
+        but if I open Psysonic without an internet connection it shows the connection
+        screen instead of letting me into the player.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How do you imagine this working? Sketches, UI ideas, command names — anything goes.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or other approaches that didn't fit.
+
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else
+      description: Links to related issues, similar requests, screenshots, etc.


### PR DESCRIPTION
## Summary

Adds three GitHub issue forms under `.github/ISSUE_TEMPLATE/`:

- **Bug report** — required fields for summary, repro steps, expected/actual, version, OS. Optional dropdowns for install source (AUR / .deb / .rpm / Cachix / .dmg / .msi / from-source) and Subsonic server type. Logs textarea with inline how-to. Auto-labels: `bug`, `triage`.
- **Feature request** — required use case (phrased as workflow, not solution); optional proposed solution + alternatives. Auto-labels: `enhancement`, `triage`.
- **config.yml** — `blank_issues_enabled: false`; redirects general questions to Discord, Telegram for chat, and the AUR page for packaging issues.

Net effect: new issues arrive with the info needed for triage, casual support traffic is routed off the issue tracker.

## How to preview each form

GitHub renders YAML form templates with a live preview when viewing the file:

- [bug_report.yml](https://github.com/Psychotoxical/psysonic/blob/chore/issue-templates/.github/ISSUE_TEMPLATE/bug_report.yml) → click the **Preview** tab
- [feature_request.yml](https://github.com/Psychotoxical/psysonic/blob/chore/issue-templates/.github/ISSUE_TEMPLATE/feature_request.yml) → click the **Preview** tab
- config.yml has no rendered form (just controls the chooser screen)

## Test plan

- [ ] Preview bug report form, sanity-check field labels + dropdown options
- [ ] Preview feature request form
- [ ] Confirm dropdown options reflect current install/distribution channels
- [ ] After merge: open a test issue (any template) and verify the form lands with the configured labels