### PR TITLE
docs(issue-template): label Nix install option as "flakes"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -87,7 +87,7 @@ body:
         - AUR — psysonic-bin
         - .deb (Linux)
         - .rpm (Linux)
-        - Cachix / Nix
+        - flakes
         - .dmg (macOS)
         - .msi installer (Windows)
         - Built from source


### PR DESCRIPTION
## Summary

- The install-source dropdown in `bug_report.yml` (added in #517) listed `Cachix / Nix`. Cachix is just a binary cache for derivations; users actually install via the Nix flake. Relabel the option to `flakes` so the dropdown describes the mechanism people pick.

Suggested by cucadmuh.

## Test plan

- [ ] Open a draft bug report on GitHub and confirm the new dropdown label renders as `flakes`.