### PR TITLE
fix(context-menu): drop inline z-index that hid menus under floating player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+### Context menu — render above the floating player bar
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), reported by Prymz, PR [#522](https://github.com/Psychotoxical/psysonic/pull/522)**
+
+* The main context menu wrapper carried an inline `zIndex: 999` that overrode the stylesheet's `z-index: 10000`, and the floating player bar sits at `z-index: 1000`. Right-clicking a track near the bottom of the screen with the floating bar enabled cut off the bottom of the menu (issue [#521](https://github.com/Psychotoxical/psysonic/issues/521)).
+* Inline override removed; the stylesheet rule wins so the menu always paints above the floating bar. Submenus inherit the parent menu's stacking context and follow.
+
 ### Home — Because-you-listened rail compact in narrow layouts
 
 **By [@Psychotoxical](https://github.com/Psychotoxical), PR [#520](https://github.com/Psychotoxical/psysonic/pull/520)**

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1519,7 +1519,7 @@ export default function ContextMenu() {
       <div
         ref={menuRef}
         className="context-menu animate-fade-in"
-        style={{ left: coords.x, top: coords.y, zIndex: 999 }}
+        style={{ left: coords.x, top: coords.y }}
         tabIndex={-1}
         onKeyDown={onMenuKeyDown}
       >


### PR DESCRIPTION
## Summary

- The main context menu wrapper carried an inline `style={{ ..., zIndex: 999 }}` that overrode the `.context-menu { z-index: 10000 }` stylesheet rule.
- The floating player bar sits at `z-index: 1000` (`layout.css:1353`), so when a context menu opened near the bottom of the screen — long enough or anchored low — the player bar painted on top and hid the bottom of the menu (issue #521).
- Removing the inline override lets the stylesheet's 10000 win. Submenus have no inline z-index and inherit the parent menu's stacking context, so they follow.

Suggested by Prymz, reported on issue #521.

Closes #521.

## Test plan

- [ ] Enable Settings → Appearance → Visual Options → Floating Player Bar.
- [ ] Right-click a track in `Tracks` near the bottom of the screen — context menu paints fully above the floating player bar.
- [ ] Hover a submenu trigger (e.g. *Add to playlist*) — submenu also stays above the player bar.
- [ ] Disable the floating player bar and re-test — docked layout unaffected.