### PR TITLE
fix(refactor): cfg-gate two items so macOS build is warning-clean

### DIFF
--- a/src-tauri/crates/psysonic-audio/src/lib.rs
+++ b/src-tauri/crates/psysonic-audio/src/lib.rs
@@ -20,6 +20,7 @@ pub mod radio_commands;
 pub mod transport_commands;
 mod device_watcher;
 mod engine;
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 mod power_resume;
 #[cfg(target_os = "windows")]
 mod power_notify_win;

--- a/src-tauri/src/lib_commands/ui/mod.rs
+++ b/src-tauri/src/lib_commands/ui/mod.rs
@@ -1,8 +1,14 @@
 mod mini;
 
 pub(crate) use mini::{
-    build_mini_player_window, close_mini_player, open_mini_player, pause_rendering,
-    persist_mini_pos_throttled, preload_mini_player, resize_mini_player, resume_rendering,
-    set_mini_player_always_on_top, show_main_window, PAUSE_RENDERING_JS, RESUME_RENDERING_JS,
+    close_mini_player, open_mini_player, pause_rendering, persist_mini_pos_throttled,
+    preload_mini_player, resize_mini_player, resume_rendering, set_mini_player_always_on_top,
+    show_main_window, PAUSE_RENDERING_JS, RESUME_RENDERING_JS,
 };
+// Pre-create-on-startup is a Windows-only path (see `lib.rs:setup`); other
+// platforms create the mini-player webview lazily on first invoke. The
+// re-export is gated to match so non-Windows builds don't warn on an
+// unused import.
+#[cfg(target_os = "windows")]
+pub(crate) use mini::build_mini_player_window;
 // Bandsintown moved to psysonic-integration; lib.rs uses the full path.


### PR DESCRIPTION
## Summary

Mac smoke build (Frank, 2026-05-09) surfaced 5 warnings, all cfg-leaks of items that are conditionally compiled on Windows + Linux:

\`\`\`
warning: static \`RESUME_REOPEN_DEBOUNCE\` is never used
warning: constant \`DEBOUNCE\` is never used
warning: function \`debounce_allow_resume_reopen\` is never used
warning: function \`reopen_audio_after_system_resume\` is never used
warning: \`psysonic-audio\` (lib) generated 4 warnings

warning: unused import: \`build_mini_player_window\`
warning: \`psysonic\` (lib) generated 1 warning
\`\`\`

### Fix

- \`psysonic-audio::power_resume\` is consumed only by \`power_notify_win\` and \`power_notify_linux\` — \`register_post_sleep_audio_recovery\` intentionally falls through to a no-op on macOS (the generic device watcher covers the resume case there). Gate the module declaration to \`#[cfg(any(target_os = "windows", target_os = "linux"))]\`.
- \`lib_commands::ui::build_mini_player_window\` is re-exported for the Windows-only pre-create path in \`lib.rs:setup\` (other platforms create the mini-player webview lazily on first invoke). Gate the re-export to \`#[cfg(target_os = "windows")]\`.

Both are non-functional — the items themselves are already correctly scoped via cfg in their consumers; only the declarations / re-exports were missing the matching gate.

## Test plan

- [ ] \`cargo check --workspace\` on macOS — warning-free.
- [ ] \`cargo check --workspace\` on Linux — still clean (no regression on the gated paths).
- [ ] \`cargo check --workspace\` on Windows — still clean, mini-player Windows pre-create still resolves.