### PR TITLE
fix(dev): support local Rust coverage checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dist-ssr
 # Tauri
 src-tauri/target/
 src-tauri/gen/
+src-tauri/lcov.info
 
 # Documentation
 CLAUDE.md

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,10 @@
             nodejs_22
             rustc
             cargo
+            clippy
+            cargo-llvm-cov
+            llvmPackages.llvm
+            jq
             cmake
             pkg-config
             openssl
@@ -81,6 +85,8 @@
             export LD_LIBRARY_PATH="${pkgs.libayatana-appindicator}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
             export GST_PLUGIN_PATH="${gstPluginPath}''${GST_PLUGIN_PATH:+:$GST_PLUGIN_PATH}"
             export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules''${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}"
+            export LLVM_COV="${pkgs.llvmPackages.llvm}/bin/llvm-cov"
+            export LLVM_PROFDATA="${pkgs.llvmPackages.llvm}/bin/llvm-profdata"
             export GDK_BACKEND=x11
             export WEBKIT_DISABLE_COMPOSITING_MODE=1
             export WEBKIT_DISABLE_DMABUF_RENDERER=1

--- a/scripts/check-hot-path-coverage.sh
+++ b/scripts/check-hot-path-coverage.sh
@@ -24,6 +24,7 @@
 #               `winget install jqlang.jq` or `choco install jq`).
 
 set -euo pipefail
+export LC_ALL=C
 
 JSON="${1:-src-tauri/target/llvm-cov/cov.json}"
 HOT_PATH_LIST="${2:-.github/hot-path-files.txt}"


### PR DESCRIPTION
Add the coverage and lint tools to the Nix dev shell so local pre-PR checks can match CI, and make the hot-path coverage gate locale-stable.