### PR TITLE
chore: fix stale doc references

### DIFF
--- a/src/test/README.md
+++ b/src/test/README.md
@@ -15,7 +15,7 @@ src/test/
   helpers/
     factories.ts                # makeTrack / makeTracks fixtures
     renderWithProviders.tsx     # render() wrapped with MemoryRouter + i18n
-  CLAUDE.md                     # this file
+  README.md                     # this file
 ```
 
 ## Running tests

--- a/src/utils/miniPlayerBridge.ts
+++ b/src/utils/miniPlayerBridge.ts
@@ -206,8 +206,8 @@ export function initMiniPlayerBridgeOnMain(): () => void {
     usePlayerStore.getState().redoLastQueueEdit();
   });
 
-  // Gapless ↔ Crossfade are mutually exclusive (see CLAUDE.md). Bridge handles
-  // the exclusion so the mini doesn't need to know about both states to act.
+  // Gapless ↔ Crossfade are mutually exclusive. Bridge handles the exclusion
+  // so the mini doesn't need to know about both states to act.
   const gaplessUnlisten = listen<{ value: boolean }>('mini:set-gapless', (e) => {
     const v = !!e.payload?.value;
     const a = useAuthStore.getState();


### PR DESCRIPTION
## Summary

Two stale references pointed at a doc filename that no longer matches the actual file on disk:

- `src/test/README.md` listed the wrong filename for the readme itself in the layout block.
- `src/utils/miniPlayerBridge.ts:209` had a comment referencing a doc that lives outside the repo. The constraint it documents (Gapless ↔ Crossfade exclusivity) is still accurate, only the doc pointer was stale.

No behaviour change. No CHANGELOG entry (internal docs/comments only).

## Test plan

- [x] `git diff` review — both edits are textual, no code paths touched