### PR TITLE
chore(test): activate aggregate vitest coverage thresholds

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,13 +38,17 @@ export default defineConfig({
         'src/main.tsx',
         'src/vite-env.d.ts',
       ],
-      // Soft thresholds — Phase 0 is infra, not coverage push. Real numbers
-      // land in Phase 1 once cucadmuh and Frank lock the gate.
+      // Aggregate ratchet — prevents regressions across the whole tree.
+      // Set ~1pp under the current measured floor (lines 13.3, statements
+      // 12.5, functions 11.3, branches 9.9 as of 2026-05-12). Real per-file
+      // coverage on critical paths is enforced by the hot-path gate
+      // (.github/frontend-hot-path-files.txt + scripts/check-frontend-coverage.cjs).
+      // Bump these numbers up as refactor PRs add coverage; never down.
       thresholds: {
-        lines: 0,
-        functions: 0,
-        branches: 0,
-        statements: 0,
+        lines: 12,
+        functions: 10,
+        branches: 9,
+        statements: 11,
       },
     },
   },


### PR DESCRIPTION
## Summary
Phase 0 of the frontend refactor (per the external-team plan): activate the numeric coverage thresholds that Phase A of the testing plan called for. Sets the aggregate floor 1pp under the currently measured state so it acts as a regression ratchet, not an immediate blocker.

## What changed
- `vitest.config.ts` thresholds: `0 / 0 / 0 / 0` → `lines 12 / functions 10 / branches 9 / statements 11`
- Comment in the config explains the policy: aggregate is a regression ratchet, per-file enforcement stays in the hot-path gate (`.github/frontend-hot-path-files.txt` + `scripts/check-frontend-coverage.cjs`)

## Why these numbers
Measured baseline on `main` as of 2026-05-12:
- Statements 12.47% — gate at **11**
- Branches 9.85% — gate at **9**
- Functions 11.25% — gate at **10**
- Lines 13.32% — gate at **12**

The aggregate is low because 200+ untouched files (pages, settings components, niche utils) sit at 0% — the test rollout (#536, #539–#550) targeted hot paths. Once refactor PRs cover more code, these numbers ratchet up; never down.

## Verification
\`./dev.sh check\` — full pre-PR sweep, all 10 steps PASS (frontend + backend).