### PR TITLE
feat: make Now Playing toggleable, dim disabled toggles, improve Clear queue label

### DIFF
--- a/src/components/QueuePanel.test.tsx
+++ b/src/components/QueuePanel.test.tsx
@@ -112,7 +112,7 @@ describe('QueuePanel — toolbar', () => {
     expect(getByLabelText('Save Playlist')).toBeInTheDocument();
     expect(getByLabelText('Load Playlist')).toBeInTheDocument();
     expect(getByLabelText('Copy queue share link')).toBeInTheDocument();
-    expect(getByLabelText('Clear')).toBeInTheDocument();
+    expect(getByLabelText('Clear queue')).toBeInTheDocument();
   });
 
   it('Shuffle button is disabled when the queue has fewer than 2 tracks', () => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -156,8 +156,12 @@ export default function Sidebar({
     [libraryItemsForReorder, luckyMixAvailable],
   );
   const visibleSystemConfigs = useMemo(
-    () => systemItemsForReorder.filter(c => c.visible),
+    () => systemItemsForReorder.filter(c => c.visible && c.id !== 'nowPlaying'),
     [systemItemsForReorder],
+  );
+  const nowPlayingVisible = useMemo(
+    () => sidebarItems.find(i => i.id === 'nowPlaying')?.visible ?? true,
+    [sidebarItems],
   );
 
   const [navDnd, setNavDnd] = useState<{
@@ -958,19 +962,21 @@ export default function Sidebar({
         {/* What's New banner — only visible while the current release hasn't been seen. */}
         <WhatsNewBanner collapsed={isCollapsed} />
 
-        {/* Now Playing — fixed, always visible */}
-        <NavLink
-          to="/now-playing"
-          className={({ isActive }) => `nav-link nav-link-nowplaying ${isActive ? 'active' : ''}`}
-          data-tooltip={isCollapsed ? t('sidebar.nowPlaying') : undefined}
-          data-tooltip-pos="bottom"
-        >
-          <span className="nav-np-icon-wrap">
-            <AudioLines size={isCollapsed ? 22 : 18} />
-            {isPlaying && currentTrack && <span className="nav-np-dot" />}
-          </span>
-          {!isCollapsed && <span>{t('sidebar.nowPlaying')}</span>}
-        </NavLink>
+        {/* Now Playing — toggleable via sidebar customizer */}
+        {nowPlayingVisible && (
+          <NavLink
+            to="/now-playing"
+            className={({ isActive }) => `nav-link nav-link-nowplaying ${isActive ? 'active' : ''}`}
+            data-tooltip={isCollapsed ? t('sidebar.nowPlaying') : undefined}
+            data-tooltip-pos="bottom"
+          >
+            <span className="nav-np-icon-wrap">
+              <AudioLines size={isCollapsed ? 22 : 18} />
+              {isPlaying && currentTrack && <span className="nav-np-dot" />}
+            </span>
+            {!isCollapsed && <span>{t('sidebar.nowPlaying')}</span>}
+          </NavLink>
+        )}
 
         {hasOfflineContent && (
           <NavLink

--- a/src/config/navItems.ts
+++ b/src/config/navItems.ts
@@ -35,4 +35,5 @@ export const ALL_NAV_ITEMS: Record<string, NavItemMeta> = {
   deviceSync:   { icon: HardDriveUpload,labelKey: 'sidebar.deviceSync',   to: '/device-sync',   section: 'library' },
   statistics:   { icon: BarChart3,      labelKey: 'sidebar.statistics',   to: '/statistics',    section: 'system'  },
   help:         { icon: HelpCircle,     labelKey: 'sidebar.help',         to: '/help',          section: 'system'  },
+  nowPlaying:   { icon: AudioLines,     labelKey: 'sidebar.nowPlaying',  to: '/now-playing',   section: 'system'  },
 };

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1160,7 +1160,7 @@ export const deTranslation = {
     appendToQueue: 'An Warteschlange anhängen',
     delete: 'Löschen',
     deleteConfirm: 'Playlist "{{name}}" löschen?',
-    clear: 'Leeren',
+    clear: 'Warteschlange leeren',
     shuffle: 'Warteschlange mischen',
     gapless: 'Nahtlos',
     crossfade: 'Crossfade',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1165,7 +1165,7 @@ export const enTranslation = {
     appendToQueue: 'Append to queue',
     delete: 'Delete',
     deleteConfirm: 'Delete playlist "{{name}}"?',
-    clear: 'Clear',
+    clear: 'Clear queue',
     shuffle: 'Shuffle queue',
     gapless: 'Gapless',
     crossfade: 'Crossfade',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1142,7 +1142,7 @@ export const esTranslation = {
     appendToQueue: 'Agregar a cola',
     delete: 'Eliminar',
     deleteConfirm: '¿Eliminar lista "{{name}}"?',
-    clear: 'Limpiar',
+    clear: 'Limpiar cola',
     shuffle: 'Mezclar cola',
     gapless: 'Gapless',
     crossfade: 'Crossfade',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -1138,7 +1138,7 @@ export const frTranslation = {
     appendToQueue: 'Ajouter à la file',
     delete: 'Supprimer',
     deleteConfirm: 'Supprimer la liste « {{name}} » ?',
-    clear: 'Vider',
+    clear: 'Vider la file',
     shuffle: 'Mélanger la file',
     gapless: 'Sans blanc',
     crossfade: 'Fondu',

--- a/src/locales/nb.ts
+++ b/src/locales/nb.ts
@@ -1137,7 +1137,7 @@ export const nbTranslation = {
     appendToQueue: 'Legg til i kø',
     delete: 'Slett',
     deleteConfirm: 'Slett spillelisten "{{name}}"?',
-    clear: 'Fjern',
+    clear: 'Tøm kø',
     shuffle: 'Bland kø',
     gapless: 'Uten mellomrom',
     crossfade: 'Crossfade',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -1137,7 +1137,7 @@ export const nlTranslation = {
     appendToQueue: 'Toevoegen aan wachtrij',
     delete: 'Verwijderen',
     deleteConfirm: 'Afspeellijst "{{name}}" verwijderen?',
-    clear: 'Leegmaken',
+    clear: 'Wachtrij leegmaken',
     shuffle: 'Wachtrij shufflen',
     gapless: 'Naadloos',
     crossfade: 'Overgang',

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -1190,7 +1190,7 @@ export const ruTranslation = {
     appendToQueue: 'Добавить в очередь',
     delete: 'Удалить',
     deleteConfirm: 'Удалить плейлист «{{name}}»?',
-    clear: 'Очистить',
+    clear: 'Очистить очередь',
     shuffle: 'Перемешать',
     gapless: 'Без пауз',
     crossfade: 'Кроссфейд',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -1132,7 +1132,7 @@ export const zhTranslation = {
     appendToQueue: '追加到队列',
     delete: '删除',
     deleteConfirm: '删除播放列表 "{{name}}"？',
-    clear: '清空',
+    clear: '清空队列',
     shuffle: '随机打乱队列',
     gapless: '无缝播放',
     crossfade: '交叉淡入淡出',

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -4594,7 +4594,7 @@ function HomeCustomizer() {
     <div className="settings-card" style={{ padding: '4px 0' }}>
       {sections.map(sec => (
         <div key={sec.id} className="sidebar-customizer-row">
-          <span style={{ flex: 1, fontSize: 14 }}>{SECTION_LABELS[sec.id]}</span>
+          <span style={{ flex: 1, fontSize: 14, opacity: sec.visible ? 1 : 0.4 }}>{SECTION_LABELS[sec.id]}</span>
           <label className="toggle-switch" aria-label={SECTION_LABELS[sec.id]}>
             <input type="checkbox" checked={sec.visible} onChange={() => toggleSection(sec.id)} />
             <span className="toggle-track" />
@@ -4729,7 +4729,7 @@ function QueueToolbarCustomizer() {
             ) : (
               <div style={{ width: 1, height: 16, background: 'var(--border-subtle)', flexShrink: 0 }} />
             )}
-            <span style={{ flex: 1, fontSize: 14 }}>{label}</span>
+            <span style={{ flex: 1, fontSize: 14, opacity: btn.visible ? 1 : 0.4 }}>{label}</span>
             <label className="toggle-switch" aria-label={label}>
               <input type="checkbox" checked={btn.visible} onChange={() => toggleButton(btn.id)} />
               <span className="toggle-track" />
@@ -5055,7 +5055,7 @@ function SidebarCustomizer() {
       >
         <SidebarGripHandle idx={localIdx} section={section} label={t(meta.labelKey)} />
         <Icon size={16} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
-        <span style={{ flex: 1, fontSize: 14 }}>{t(meta.labelKey)}</span>
+        <span style={{ flex: 1, fontSize: 14, opacity: cfg.visible ? 1 : 0.4 }}>{t(meta.labelKey)}</span>
         <label className="toggle-switch" aria-label={t(meta.labelKey)}>
           <input type="checkbox" checked={cfg.visible} onChange={() => toggleItem(cfg.id)} />
           <span className="toggle-track" />
@@ -5067,7 +5067,7 @@ function SidebarCustomizer() {
   return (
     <>
       <div className="settings-card" style={{ marginBottom: '1rem' }}>
-        <div className="settings-toggle-row">
+        <div className="settings-toggle-row" style={{ opacity: randomNavMode === 'separate' ? 1 : 0.4 }}>
           <div>
             <div style={{ fontWeight: 500 }}>{t('settings.randomNavSplitTitle')}</div>
             <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('settings.randomNavSplitDesc')}</div>
@@ -5093,7 +5093,7 @@ function SidebarCustomizer() {
           <div className="sidebar-customizer-block-label">{t('sidebar.system')}</div>
           {systemItems.map((cfg, i) => renderRow(cfg, i, 'system'))}
           <div className="sidebar-customizer-fixed-hint">
-            <span>{t('settings.sidebarFixed')}: {t('sidebar.nowPlaying')}, {t('sidebar.settings')}</span>
+            <span>{t('settings.sidebarFixed')}: {t('sidebar.settings')}</span>
           </div>
         </div>
       </div>

--- a/src/store/sidebarStore.ts
+++ b/src/store/sidebarStore.ts
@@ -7,7 +7,7 @@ export interface SidebarItemConfig {
 }
 
 // All configurable nav items in their default order.
-// Fixed items (nowPlaying, settings, offline) are not listed here.
+// Fixed items (settings, offline) are not listed here.
 export const DEFAULT_SIDEBAR_ITEMS: SidebarItemConfig[] = [
   { id: 'mainstage',     visible: true },
   { id: 'newReleases',   visible: true },
@@ -29,6 +29,7 @@ export const DEFAULT_SIDEBAR_ITEMS: SidebarItemConfig[] = [
   { id: 'deviceSync',    visible: false },
   { id: 'statistics',    visible: true },
   { id: 'help',          visible: true },
+  { id: 'nowPlaying',   visible: true },
 ];
 
 interface SidebarStore {


### PR DESCRIPTION
## Summary

Three UI polish changes to the sidebar and settings personalisation:

### 1. Now Playing toggleable in Sidebar Customizer
- Added `nowPlaying` to `ALL_NAV_ITEMS` (`src/config/navItems.ts`) so it appears in the sidebar settings as a toggleable row
- Added to `DEFAULT_SIDEBAR_ITEMS` (`src/store/sidebarStore.ts`) with `visible: true` by default
- Filtered it out of `visibleSystemConfigs` in `Sidebar.tsx` to avoid duplicate rendering — the existing special rendering (playing dot, `nav-link-nowplaying` class) is kept but now gated by store visibility
- Removed `nowPlaying` from the "Always visible" hint in Settings — it's no longer fixed

### 2. Dim disabled toggle labels
Applied `opacity: 0.4` to toggle text labels when disabled across all three customizers:
- **Home Customizer** — `Settings.tsx:4597`
- **Queue Toolbar Customizer** — `Settings.tsx:4732`
- **Sidebar Customizer** — `Settings.tsx:5058` (both item rows and the Split Mix Navigation toggle)

### 3. Clear → Clear queue
Renamed the queue toolbar button label from a generic verb to a more descriptive action in all 8 locale files (`src/locales/*.ts`).

## Testing checklist

- [ ] **Sidebar** — Go to Settings → Personalisation → Sidebar. Verify "Now Playing" appears as a toggleable row in the System section with the AudioLines icon
- [ ] **Sidebar** — Toggle Now Playing off. Verify it disappears from the sidebar. Toggle it back on — it reappears with the playing dot when a track is active
- [ ] **Sidebar** — Verify the "Always visible" hint now only shows "Settings" (not "Now Playing")
- [ ] **Sidebar** — Verify Split Mix Navigation toggle text dims when off
- [ ] **Dimming** — In all three customizers (Home, Queue Toolbar, Sidebar), verify toggle row text is at full opacity when enabled and dimmed (`opacity: 0.4`) when disabled
- [ ] **Queue** — Verify the Clear button in the queue toolbar now reads "Clear queue" in the tooltip and in settings
- [ ] **Drag-out hide** — Verify dragging Now Playing outside the sidebar hides it (via `isSidebarNavItemUserHideable` which checks `ALL_NAV_ITEMS`)
- [ ] **Persistence** — Toggle items, reload the page, verify the state is restored from localStorage
- [ ] **Reset** — Click the reset button in sidebar settings and verify all items return to defaults including Now Playing visible