### PR TITLE
refactor(player): E.36 — extract schedule-pause/resume factory

### DIFF
--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -45,10 +45,6 @@ import {
 } from './loudnessGainCache';
 import {
   clearAllPlaybackScheduleTimers,
-  clearScheduledPauseTimers,
-  clearScheduledResumeTimers,
-  schedulePauseTimer,
-  scheduleResumeTimer,
 } from './scheduleTimers';
 import { invokeAudioUpdateReplayGainDeduped } from './normalizationIpcDedupe';
 import { touchHotCacheOnPlayback } from './hotCacheTouch';
@@ -154,6 +150,7 @@ export type { PlayerState, Track };
 import { createLastfmActions } from './lastfmActions';
 import { createMiscActions } from './miscActions';
 import { createQueueMutationActions } from './queueMutationActions';
+import { createScheduleActions } from './scheduleActions';
 import { createTransportLightActions } from './transportLightActions';
 import { createUiStateActions } from './uiStateActions';
 import { createUndoRedoActions } from './undoRedoActions';
@@ -211,6 +208,7 @@ export const usePlayerStore = create<PlayerState>()(
       ...createTransportLightActions(set, get),
       ...createUndoRedoActions(set, get),
       ...createMiscActions(set, get),
+      ...createScheduleActions(set, get),
 
       // ── playTrack ────────────────────────────────────────────────────────────
       playTrack: (track, queue, manual = true, _orbitConfirmed = false, targetQueueIndex) => {
@@ -656,43 +654,6 @@ export const usePlayerStore = create<PlayerState>()(
            });
           })();
         }
-      },
-
-      clearScheduledPause: () => {
-        clearScheduledPauseTimers();
-        set({ scheduledPauseAtMs: null, scheduledPauseStartMs: null });
-      },
-
-      clearScheduledResume: () => {
-        clearScheduledResumeTimers();
-        set({ scheduledResumeAtMs: null, scheduledResumeStartMs: null });
-      },
-
-      schedulePauseIn: (seconds) => {
-        const s = get();
-        if (!s.isPlaying) return;
-        const delayMs = Math.max(500, Math.round(Number(seconds) * 1000));
-        const startedAt = Date.now();
-        const at = startedAt + delayMs;
-        set({ scheduledPauseAtMs: at, scheduledPauseStartMs: startedAt });
-        schedulePauseTimer(delayMs, () => {
-          set({ scheduledPauseAtMs: null, scheduledPauseStartMs: null });
-          get().pause();
-        });
-      },
-
-      scheduleResumeIn: (seconds) => {
-        const s = get();
-        if (s.isPlaying) return;
-        if (!s.currentTrack && !s.currentRadio) return;
-        const delayMs = Math.max(500, Math.round(Number(seconds) * 1000));
-        const startedAt = Date.now();
-        const at = startedAt + delayMs;
-        set({ scheduledResumeAtMs: at, scheduledResumeStartMs: startedAt });
-        scheduleResumeTimer(delayMs, () => {
-          set({ scheduledResumeAtMs: null, scheduledResumeStartMs: null });
-          get().resume();
-        });
       },
 
       // ── next / previous ──────────────────────────────────────────────────────

--- a/src/store/scheduleActions.ts
+++ b/src/store/scheduleActions.ts
@@ -1,0 +1,63 @@
+import type { PlayerState } from './playerStoreTypes';
+import {
+  clearScheduledPauseTimers,
+  clearScheduledResumeTimers,
+  schedulePauseTimer,
+  scheduleResumeTimer,
+} from './scheduleTimers';
+
+type SetState = (
+  partial: Partial<PlayerState> | ((state: PlayerState) => Partial<PlayerState>),
+) => void;
+type GetState = () => PlayerState;
+
+/**
+ * User-facing scheduled-pause / scheduled-resume actions. Each setter
+ * clamps the delay to ≥ 500 ms, stores the absolute target + start
+ * timestamps in the store (so countdown UI can render a progress arc),
+ * and arms a single-shot timer in `scheduleTimers.ts`. The matching
+ * `clearScheduled*` actions cancel the timer and blank the timestamps.
+ */
+export function createScheduleActions(set: SetState, get: GetState): Pick<
+  PlayerState,
+  'clearScheduledPause' | 'clearScheduledResume' | 'schedulePauseIn' | 'scheduleResumeIn'
+> {
+  return {
+    clearScheduledPause: () => {
+      clearScheduledPauseTimers();
+      set({ scheduledPauseAtMs: null, scheduledPauseStartMs: null });
+    },
+
+    clearScheduledResume: () => {
+      clearScheduledResumeTimers();
+      set({ scheduledResumeAtMs: null, scheduledResumeStartMs: null });
+    },
+
+    schedulePauseIn: (seconds) => {
+      const s = get();
+      if (!s.isPlaying) return;
+      const delayMs = Math.max(500, Math.round(Number(seconds) * 1000));
+      const startedAt = Date.now();
+      const at = startedAt + delayMs;
+      set({ scheduledPauseAtMs: at, scheduledPauseStartMs: startedAt });
+      schedulePauseTimer(delayMs, () => {
+        set({ scheduledPauseAtMs: null, scheduledPauseStartMs: null });
+        get().pause();
+      });
+    },
+
+    scheduleResumeIn: (seconds) => {
+      const s = get();
+      if (s.isPlaying) return;
+      if (!s.currentTrack && !s.currentRadio) return;
+      const delayMs = Math.max(500, Math.round(Number(seconds) * 1000));
+      const startedAt = Date.now();
+      const at = startedAt + delayMs;
+      set({ scheduledResumeAtMs: at, scheduledResumeStartMs: startedAt });
+      scheduleResumeTimer(delayMs, () => {
+        set({ scheduledResumeAtMs: null, scheduledResumeStartMs: null });
+        get().resume();
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Four scheduled-timer actions (`schedulePauseIn`, `scheduleResumeIn`, `clearScheduledPause`, `clearScheduledResume`) extracted into `createScheduleActions` (`src/store/scheduleActions.ts`), following the same pattern as E.31–E.35.
- Pure code-move. `playerStore.ts`: 1030 → 991 LOC (−39, first sub-1000 state since Phase E began).

## Test plan

- [x] `./dev.sh check` green (frontend tests, typecheck, coverage gates, hot-path gates, backend tests + clippy + coverage)
- [x] Existing playerStore characterization tests continue to exercise the actions through the full store flow