### PR TITLE
feat(queue): persist header duration mode + rehydrate tests

### DIFF
--- a/src/components/QueuePanel.tsx
+++ b/src/components/QueuePanel.tsx
@@ -18,6 +18,7 @@ import { useCachedUrl } from './CachedImage';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../store/authStore';
+import type { QueueDurationDisplayMode } from '../store/authStoreTypes';
 import { encodeSharePayload } from '../utils/shareLink';
 import { copyTextToClipboard } from '../utils/serverMagicString';
 import { showToast } from '../utils/toast';
@@ -190,16 +191,14 @@ function LoadPlaylistModal({ onClose, onLoad }: { onClose: () => void, onLoad: (
   );
 }
 
-type DurationMode = 'total' | 'remaining' | 'eta';
-
 interface QueueHeaderProps {
   queue: Track[];
   queueIndex: number;
   activePlaylist: { id: string; name: string } | null;
   isNowPlayingCollapsed: boolean;
   setIsNowPlayingCollapsed: (v: boolean) => void;
-  durationMode: DurationMode;
-  setDurationMode: (m: DurationMode) => void;
+  durationMode: QueueDurationDisplayMode;
+  setDurationMode: (m: QueueDurationDisplayMode) => void;
   t: TFunction;
 }
 function QueueHeader({ queue, queueIndex, activePlaylist, isNowPlayingCollapsed, setIsNowPlayingCollapsed, durationMode, setDurationMode, t }: QueueHeaderProps) {
@@ -235,7 +234,7 @@ function QueueHeader({ queue, queueIndex, activePlaylist, isNowPlayingCollapsed,
     else dur = fmtEta(remainingSecs);
   }
 
-  const nextMode: DurationMode =
+  const nextMode: QueueDurationDisplayMode =
     durationMode === 'total' ? 'remaining' :
     durationMode === 'remaining' ? 'eta' : 'total';
   const nextTooltipKey =
@@ -385,8 +384,9 @@ function QueuePanelHostOrSolo() {
 
   const isNowPlayingCollapsed = useAuthStore(s => s.queueNowPlayingCollapsed);
   const setIsNowPlayingCollapsed = useAuthStore(s => s.setQueueNowPlayingCollapsed);
+  const durationMode = useAuthStore(s => s.queueDurationDisplayMode);
+  const setDurationMode = useAuthStore(s => s.setQueueDurationDisplayMode);
   const toolbarButtons = useQueueToolbarStore(s => s.buttons);
-  const [durationMode, setDurationMode] = useState<DurationMode>('total');
   const [showCrossfadePopover, setShowCrossfadePopover] = useState(false);
   const [lufsTgtOpen, setLufsTgtOpen] = useState(false);
   const [lufsTgtPopStyle, setLufsTgtPopStyle] = useState<React.CSSProperties>({});

--- a/src/store/authStore.settings.test.ts
+++ b/src/store/authStore.settings.test.ts
@@ -61,6 +61,7 @@ describe('trivial pass-through setters', () => {
     ['setLyricsStaticOnly', 'lyricsStaticOnly', true],
     ['setShowChangelogOnUpdate', 'showChangelogOnUpdate', false],
     ['setQueueNowPlayingCollapsed', 'queueNowPlayingCollapsed', true],
+    ['setQueueDurationDisplayMode', 'queueDurationDisplayMode', 'eta'],
     ['setEnableHiRes', 'enableHiRes', true],
     ['setHotCacheEnabled', 'hotCacheEnabled', true],
     ['setMixMinRatingFilterEnabled', 'mixMinRatingFilterEnabled', true],

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -86,6 +86,7 @@ export const useAuthStore = create<AuthState>()(
       lastSeenChangelogVersion: '',
       seekbarStyle: 'truewave',
       queueNowPlayingCollapsed: false,
+      queueDurationDisplayMode: 'total',
       enableHiRes: false,
       audioOutputDevice: null,
       hotCacheEnabled: false,
@@ -147,6 +148,10 @@ export const useAuthStore = create<AuthState>()(
       storage: createJSONStorage(() => localStorage),
       partialize: state => {
         const { musicFolders: _mf, musicLibraryFilterVersion: _fv, ...rest } = state;
+        // Denylist: everything else is persisted. New store fields therefore serialize by
+        // default. If this is ever refactored to an allowlist, each new persisted key must be
+        // listed explicitly — otherwise it would drop from localStorage with no failing test
+        // unless we add coverage for that field's round-trip.
         return rest;
       },
       onRehydrateStorage: () => (state, error) => {

--- a/src/store/authStoreRehydrate.test.ts
+++ b/src/store/authStoreRehydrate.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { computeAuthStoreRehydration } from './authStoreRehydrate';
+import { useAuthStore } from './authStore';
+import type { AuthState } from './authStoreTypes';
+import { resetAuthStore } from '@/test/helpers/storeReset';
+
+describe('computeAuthStoreRehydration', () => {
+  beforeEach(() => {
+    resetAuthStore();
+  });
+
+  describe('queueDurationDisplayMode', () => {
+    it.each(['invalid_mode', 123, null, undefined] as const)(
+      'maps corrupted value %j to total',
+      (corrupt) => {
+        const base = useAuthStore.getState();
+        const patch = computeAuthStoreRehydration({
+          ...base,
+          queueDurationDisplayMode: corrupt as never,
+        });
+        expect(patch.queueDurationDisplayMode).toBe('total');
+      },
+    );
+
+    it('maps a rehydrated object without the key to total', () => {
+      const base = useAuthStore.getState();
+      const { queueDurationDisplayMode: _drop, ...without } = base;
+      const patch = computeAuthStoreRehydration(without as AuthState);
+      expect(patch.queueDurationDisplayMode).toBe('total');
+    });
+
+    it.each(['total', 'remaining', 'eta'] as const)(
+      'does not overwrite valid mode %s',
+      (mode) => {
+        const base = useAuthStore.getState();
+        const patch = computeAuthStoreRehydration({
+          ...base,
+          queueDurationDisplayMode: mode,
+        });
+        expect(patch.queueDurationDisplayMode).toBeUndefined();
+      },
+    );
+  });
+});

--- a/src/store/authStoreRehydrate.ts
+++ b/src/store/authStoreRehydrate.ts
@@ -15,6 +15,7 @@ import type {
   AuthState,
   DiscordCoverSource,
   LyricsSourceConfig,
+  QueueDurationDisplayMode,
   SeekbarStyle,
 } from './authStoreTypes';
 
@@ -78,6 +79,13 @@ export function computeAuthStoreRehydration(state: AuthState): Partial<AuthState
     ? {}
     : { seekbarStyle: 'truewave' as SeekbarStyle };
 
+  const VALID_QUEUE_DURATION_MODES = new Set<string>(['total', 'remaining', 'eta']);
+  const queueDurationDisplayModeMigrated = VALID_QUEUE_DURATION_MODES.has(
+    (state as { queueDurationDisplayMode?: unknown }).queueDurationDisplayMode as string,
+  )
+    ? {}
+    : { queueDurationDisplayMode: 'total' as QueueDurationDisplayMode };
+
   // The `animationMode` 3-state setting was removed; users on `'reduced'`
   // or `'static'` collapse onto the former `'full'` path automatically as
   // soon as the field is gone from the store. Strip the persisted field
@@ -126,6 +134,7 @@ export function computeAuthStoreRehydration(state: AuthState): Partial<AuthState
     ...lyricsSourcesMigrated,
     ...wheelSmoothOneTime,
     ...seekbarStyleMigrated,
+    ...queueDurationDisplayModeMigrated,
     ...discordCoverSourceMigrated,
   };
 }

--- a/src/store/authStoreTypes.ts
+++ b/src/store/authStoreTypes.ts
@@ -13,6 +13,9 @@ export interface ServerProfile {
 }
 
 export type SeekbarStyle = 'truewave' | 'pseudowave' | 'linedot' | 'bar' | 'thick' | 'segmented' | 'neon' | 'pulsewave' | 'particletrail' | 'liquidfill' | 'retrotape';
+
+/** Queue header: cycle total duration / time left / ETA finish clock. */
+export type QueueDurationDisplayMode = 'total' | 'remaining' | 'eta';
 export type LoggingMode = 'off' | 'normal' | 'debug';
 export type NormalizationEngine = 'off' | 'replaygain' | 'loudness';
 export type DiscordCoverSource = 'none' | 'apple' | 'server';
@@ -129,6 +132,8 @@ export interface AuthState {
   seekbarStyle: SeekbarStyle;
   /** Persisted UI toggle: is the Now Playing section in queue panel collapsed */
   queueNowPlayingCollapsed: boolean;
+  /** Queue header duration chip: total vs remaining vs ETA */
+  queueDurationDisplayMode: QueueDurationDisplayMode;
 
   /** Alpha: native hi-res sample rate output (disabled = safe 44.1 kHz mode) */
   enableHiRes: boolean;
@@ -280,6 +285,7 @@ export interface AuthState {
   setLastSeenChangelogVersion: (v: string) => void;
   setSeekbarStyle: (v: SeekbarStyle) => void;
   setQueueNowPlayingCollapsed: (v: boolean) => void;
+  setQueueDurationDisplayMode: (v: QueueDurationDisplayMode) => void;
   setEnableHiRes: (v: boolean) => void;
   setAudioOutputDevice: (v: string | null) => void;
   setHotCacheEnabled: (v: boolean) => void;

--- a/src/store/authUiAppearanceActions.ts
+++ b/src/store/authUiAppearanceActions.ts
@@ -20,6 +20,7 @@ export function createUiAppearanceActions(set: SetState): Pick<
   | 'setLinuxWebkitKineticScroll'
   | 'setSeekbarStyle'
   | 'setQueueNowPlayingCollapsed'
+  | 'setQueueDurationDisplayMode'
   | 'setShowFullscreenLyrics'
   | 'setFsLyricsStyle'
   | 'setSidebarLyricsStyle'
@@ -38,6 +39,7 @@ export function createUiAppearanceActions(set: SetState): Pick<
     setLinuxWebkitKineticScroll: (v) => set({ linuxWebkitKineticScroll: v }),
     setSeekbarStyle: (v) => set({ seekbarStyle: v }),
     setQueueNowPlayingCollapsed: (v) => set({ queueNowPlayingCollapsed: v }),
+    setQueueDurationDisplayMode: (v) => set({ queueDurationDisplayMode: v }),
     setShowFullscreenLyrics: (v) => set({ showFullscreenLyrics: v }),
     setFsLyricsStyle: (v) => set({ fsLyricsStyle: v }),
     setSidebarLyricsStyle: (v) => set({ sidebarLyricsStyle: v }),


### PR DESCRIPTION
## Summary

- **Persist** the queue panel header duration display mode (`total` | `remaining` | `eta`) in the existing Zustand `authStore` (`localStorage` key `psysonic-auth`), instead of ephemeral `useState` in `QueuePanel`.
- **Sanitize** invalid or missing values on rehydration (same pattern as `seekbarStyle`).
- **Document** the latent risk if `partialize` is ever refactored from denylist to allowlist.
- **Tests**: trivial setter coverage + focused `computeAuthStoreRehydration` tests for the new field.

## Problem

Clicking the duration chip in the queue header cycled between total duration, time remaining, and clock ETA, but the choice lived only in component state. After a full app restart it always fell back to the default (`total`), which felt like a bug.

## Solution

- Introduce `QueueDurationDisplayMode` in `authStoreTypes` and store `queueDurationDisplayMode` with `setQueueDurationDisplayMode` (wired through `createUiAppearanceActions`, next to `setQueueNowPlayingCollapsed`).
- Default remains `'total'` for new installs and sane fallback.
- `QueuePanel` reads/writes via `useAuthStore` selectors instead of `useState`.

## Rehydration / safety

`computeAuthStoreRehydration` validates against `total` | `remaining` | `eta`. Garbage, `null`, `undefined`, or a missing key maps the patch to `'total'` so the UI never receives an unknown mode.

## Persistence note (`partialize`)

`persist` still uses a **denylist** (`musicFolders`, `musicLibraryFilterVersion` stripped); everything else is serialized. A short comment in `authStore.ts` warns that a future **allowlist** refactor must explicitly include each persisted key or values can disappear silently without a failing test unless we add round-trip coverage.

## Files touched

| File | Change |
|------|--------|
| `src/store/authStoreTypes.ts` | `QueueDurationDisplayMode` type; state + setter on `AuthState` |
| `src/store/authStore.ts` | Default `queueDurationDisplayMode: 'total'`; `partialize` comment |
| `src/store/authUiAppearanceActions.ts` | `setQueueDurationDisplayMode` |
| `src/store/authStoreRehydrate.ts` | Sanitize invalid `queueDurationDisplayMode` |
| `src/components/QueuePanel.tsx` | Replace local state with `useAuthStore` |
| `src/store/authStore.settings.test.ts` | Pin `setQueueDurationDisplayMode` |
| `src/store/authStoreRehydrate.test.ts` | **New** — corrupt / missing / valid rehydration cases |

## How to test

1. Open queue panel, click the duration chip until you land on e.g. **ETA** or **remaining**.
2. Fully quit and restart the app → same mode should still be selected.
3. (Optional) In DevTools, edit `localStorage['psysonic-auth']` and set `state.queueDurationDisplayMode` to a bogus string → reload → should reset to **`total`** without breaking the app.

```bash
npx vitest run src/store/authStore.settings.test.ts src/store/authStoreRehydrate.test.ts