### PR TITLE
refactor(playlist): G.69 — extract runPlaylistLoad + usePlaylistPreview + usePlaylistBulkPlayCallbacks + usePlaylistDerived (cluster)

### DIFF
--- a/src/hooks/usePlaylistBulkPlayCallbacks.ts
+++ b/src/hooks/usePlaylistBulkPlayCallbacks.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+import type { Track } from '../store/playerStoreTypes';
+import { enqueuePlaylistAll, playPlaylistAll, shufflePlaylistAll } from '../utils/playlistBulkPlayActions';
+
+export interface PlaylistBulkPlayCallbacksDeps {
+  songsLength: number;
+  id: string | undefined;
+  tracks: Track[];
+  touchPlaylist: (id: string) => void;
+  playTrack: (track: Track, queue: Track[]) => void;
+  enqueue: (tracks: Track[]) => void;
+}
+
+export interface PlaylistBulkPlayCallbacks {
+  handlePlayAll: () => void;
+  handleShuffleAll: () => void;
+  handleEnqueueAll: () => void;
+}
+
+export function usePlaylistBulkPlayCallbacks(deps: PlaylistBulkPlayCallbacksDeps): PlaylistBulkPlayCallbacks {
+  const { songsLength, id, tracks, touchPlaylist, playTrack, enqueue } = deps;
+
+  const handlePlayAll = useCallback(
+    () => playPlaylistAll({ songsLength, id, tracks, touchPlaylist, playTrack, enqueue }),
+    [songsLength, id, tracks, touchPlaylist, playTrack, enqueue],
+  );
+
+  const handleShuffleAll = useCallback(
+    () => shufflePlaylistAll({ songsLength, id, tracks, touchPlaylist, playTrack, enqueue }),
+    [songsLength, id, tracks, touchPlaylist, playTrack, enqueue],
+  );
+
+  const handleEnqueueAll = useCallback(
+    () => enqueuePlaylistAll({ songsLength, id, tracks, touchPlaylist, playTrack, enqueue }),
+    [songsLength, id, tracks, touchPlaylist, playTrack, enqueue],
+  );
+
+  return { handlePlayAll, handleShuffleAll, handleEnqueueAll };
+}

--- a/src/hooks/usePlaylistDerived.ts
+++ b/src/hooks/usePlaylistDerived.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+import type { SubsonicSong } from '../api/subsonicTypes';
+import type { Track } from '../store/playerStoreTypes';
+import { usePlayerStore } from '../store/playerStore';
+import { songToTrack } from '../utils/songToTrack';
+import { getDisplayedSongs, type PlaylistSortDir, type PlaylistSortKey } from '../utils/playlistDisplayedSongs';
+
+export interface PlaylistDerivedOptions {
+  filterText: string;
+  sortKey: PlaylistSortKey;
+  sortDir: PlaylistSortDir;
+  ratings: Record<string, number>;
+  starredSongs: Set<string>;
+}
+
+export interface PlaylistDerived {
+  existingIds: Set<string>;
+  tracks: Track[];
+  displayedSongs: SubsonicSong[];
+  displayedTracks: Track[];
+  isFiltered: boolean;
+}
+
+export function usePlaylistDerived(songs: SubsonicSong[], opts: PlaylistDerivedOptions): PlaylistDerived {
+  const userRatingOverrides = usePlayerStore(s => s.userRatingOverrides);
+  const starredOverrides = usePlayerStore(s => s.starredOverrides);
+  const { filterText, sortKey, sortDir, ratings, starredSongs } = opts;
+
+  const existingIds = useMemo(() => new Set(songs.map(s => s.id)), [songs]);
+  const tracks = useMemo(() => songs.map(songToTrack), [songs]);
+
+  const displayedSongs = useMemo(
+    () => getDisplayedSongs(songs, {
+      filterText, sortKey, sortDir,
+      ratings, userRatingOverrides, starredOverrides, starredSongs,
+    }),
+    [songs, filterText, sortKey, sortDir, ratings, userRatingOverrides, starredOverrides, starredSongs],
+  );
+  const displayedTracks = useMemo(
+    () => displayedSongs === songs ? tracks : displayedSongs.map(songToTrack),
+    [displayedSongs, songs, tracks],
+  );
+  const isFiltered = displayedSongs !== songs;
+
+  return { existingIds, tracks, displayedSongs, displayedTracks, isFiltered };
+}

--- a/src/hooks/usePlaylistPreview.ts
+++ b/src/hooks/usePlaylistPreview.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect } from 'react';
+import { usePreviewStore } from '../store/previewStore';
+import type { SubsonicSong } from '../api/subsonicTypes';
+
+export function usePlaylistPreview(): {
+  startPreview: (song: SubsonicSong) => void;
+} {
+  // Pause/resume of the main player + timer + cancel-on-supersede are all
+  // handled in `audio_preview_play` / `audio_preview_stop`. The store mirrors
+  // engine events so we just dispatch here and read `previewingId` for UI.
+  const startPreview = useCallback((song: SubsonicSong) => {
+    usePreviewStore.getState().startPreview({
+      id: song.id,
+      title: song.title,
+      artist: song.artist,
+      coverArt: song.coverArt,
+      duration: song.duration,
+    }, 'suggestions').catch(() => { /* engine errored — store already rolled back */ });
+  }, []);
+
+  // Cancel any in-flight preview when the user navigates away.
+  useEffect(() => () => {
+    if (usePreviewStore.getState().previewingId) {
+      usePreviewStore.getState().stopPreview();
+    }
+  }, []);
+
+  return { startPreview };
+}

--- a/src/pages/PlaylistDetail.tsx
+++ b/src/pages/PlaylistDetail.tsx
@@ -1,8 +1,6 @@
-import { getPlaylist, updatePlaylist } from '../api/subsonicPlaylists';
-import { filterSongsToActiveLibrary } from '../api/subsonicLibrary';
+import { updatePlaylist } from '../api/subsonicPlaylists';
 import type { SubsonicPlaylist, SubsonicSong } from '../api/subsonicTypes';
-import { songToTrack } from '../utils/songToTrack';
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { ChevronDown, ChevronLeft, ChevronRight, Play, ListPlus, Trash2, Search, X, Loader2, Plus, GripVertical, Star, RefreshCw, Shuffle, Heart, HardDriveDownload, Check, Pencil, Globe, Lock, Camera, Download, FileUp, RotateCcw, Sparkles, Square, AudioLines } from 'lucide-react';
 import { useTracklistColumns, type ColDef } from '../utils/useTracklistColumns';
@@ -38,10 +36,10 @@ import PlaylistSuggestions from '../components/playlist/PlaylistSuggestions';
 import PlaylistHero from '../components/playlist/PlaylistHero';
 import PlaylistTracklist from '../components/playlist/PlaylistTracklist';
 import PlaylistFilterToolbar from '../components/playlist/PlaylistFilterToolbar';
-import { getDisplayedSongs, type PlaylistSortKey, type PlaylistSortDir } from '../utils/playlistDisplayedSongs';
+import type { PlaylistSortKey, PlaylistSortDir } from '../utils/playlistDisplayedSongs';
 import { runPlaylistZipDownload } from '../utils/runPlaylistZipDownload';
 import { runPlaylistSaveMeta } from '../utils/runPlaylistSaveMeta';
-import { playPlaylistAll, shufflePlaylistAll, enqueuePlaylistAll } from '../utils/playlistBulkPlayActions';
+import { runPlaylistLoad } from '../utils/runPlaylistLoad';
 import { startPlaylistRowDrag } from '../utils/startPlaylistRowDrag';
 import { runPlaylistReorderDrop } from '../utils/runPlaylistReorderDrop';
 import { usePlaylistCovers } from '../hooks/usePlaylistCovers';
@@ -50,6 +48,9 @@ import { usePlaylistSuggestions } from '../hooks/usePlaylistSuggestions';
 import { usePlaylistSongSearch } from '../hooks/usePlaylistSongSearch';
 import { usePlaylistSongMutations } from '../hooks/usePlaylistSongMutations';
 import { usePlaylistStarRating } from '../hooks/usePlaylistStarRating';
+import { usePlaylistPreview } from '../hooks/usePlaylistPreview';
+import { usePlaylistBulkPlayCallbacks } from '../hooks/usePlaylistBulkPlayCallbacks';
+import { usePlaylistDerived } from '../hooks/usePlaylistDerived';
 
 // ── Column configuration ──────────────────────────────────────────────────────
 const PL_COLUMNS: readonly ColDef[] = [
@@ -209,24 +210,9 @@ export default function PlaylistDetail() {
 
   useEffect(() => {
     if (!id) return;
-    setLoading(true);
-    getPlaylist(id)
-      .then(async ({ playlist, songs }) => {
-        const filteredSongs = await filterSongsToActiveLibrary(songs);
-        setPlaylist(playlist);
-        setSongs(filteredSongs);
-        if (playlist.coverArt) setCustomCoverId(playlist.coverArt);
-        const init: Record<string, number> = {};
-        const starred = new Set<string>();
-        filteredSongs.forEach(s => {
-          if (s.userRating) init[s.id] = s.userRating;
-          if (s.starred) starred.add(s.id);
-        });
-        setRatings(init);
-        setStarredSongs(starred);
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
+    runPlaylistLoad({
+      id, setLoading, setPlaylist, setSongs, setCustomCoverId, setRatings, setStarredSongs,
+    });
   }, [id, lastModified]);
 
   // ── Meta edit ─────────────────────────────────────────────────
@@ -264,25 +250,7 @@ export default function PlaylistDetail() {
   });
 
   // ── Preview (30s mid-song sample via Rust audio engine) ────────
-  // Pause/resume of the main player + timer + cancel-on-supersede are all
-  // handled in `audio_preview_play` / `audio_preview_stop`. The store mirrors
-  // engine events so we just dispatch here and read `previewingId` for UI.
-  const startPreview = useCallback((song: SubsonicSong) => {
-    usePreviewStore.getState().startPreview({
-      id: song.id,
-      title: song.title,
-      artist: song.artist,
-      coverArt: song.coverArt,
-      duration: song.duration,
-    }, 'suggestions').catch(() => { /* engine errored — store already rolled back */ });
-  }, []);
-
-  // Cancel any in-flight preview when the user navigates away.
-  useEffect(() => () => {
-    if (usePreviewStore.getState().previewingId) {
-      usePreviewStore.getState().stopPreview();
-    }
-  }, []);
+  const { startPreview } = usePlaylistPreview();
 
   // ── Rating / Star ─────────────────────────────────────────────
   const { handleRate, handleToggleStar } = usePlaylistStarRating({
@@ -308,21 +276,9 @@ export default function PlaylistDetail() {
   };
 
   // ── Memoized derivations ──────────────────────────────────────
-  const existingIds = useMemo(() => new Set(songs.map(s => s.id)), [songs]);
-  const tracks = useMemo(() => songs.map(songToTrack), [songs]);
-
-  const displayedSongs = useMemo(
-    () => getDisplayedSongs(songs, {
-      filterText, sortKey, sortDir,
-      ratings, userRatingOverrides, starredOverrides, starredSongs,
-    }),
-    [songs, filterText, sortKey, sortDir, ratings, userRatingOverrides, starredOverrides, starredSongs],
-  );
-  const displayedTracks = useMemo(
-    () => displayedSongs === songs ? tracks : displayedSongs.map(songToTrack),
-    [displayedSongs, songs, tracks],
-  );
-  const isFiltered = displayedSongs !== songs;
+  const { existingIds, tracks, displayedSongs, displayedTracks, isFiltered } = usePlaylistDerived(songs, {
+    filterText, sortKey, sortDir, ratings, starredSongs,
+  });
 
   // ── Drag-over visual feedback ─────────────────────────────────
   const handleRowMouseEnter = (idx: number, e: React.MouseEvent) => {
@@ -333,20 +289,9 @@ export default function PlaylistDetail() {
   };
 
   // ── Playback actions (encapsulated like AlbumHeader) ─────────
-  const handlePlayAll = useCallback(
-    () => playPlaylistAll({ songsLength: songs.length, id, tracks, touchPlaylist, playTrack, enqueue }),
-    [songs.length, id, tracks, touchPlaylist, playTrack, enqueue],
-  );
-
-  const handleShuffleAll = useCallback(
-    () => shufflePlaylistAll({ songsLength: songs.length, id, tracks, touchPlaylist, playTrack, enqueue }),
-    [songs.length, id, tracks, touchPlaylist, playTrack, enqueue],
-  );
-
-  const handleEnqueueAll = useCallback(
-    () => enqueuePlaylistAll({ songsLength: songs.length, id, tracks, touchPlaylist, playTrack, enqueue }),
-    [songs.length, id, tracks, touchPlaylist, playTrack, enqueue],
-  );
+  const { handlePlayAll, handleShuffleAll, handleEnqueueAll } = usePlaylistBulkPlayCallbacks({
+    songsLength: songs.length, id, tracks, touchPlaylist, playTrack, enqueue,
+  });
 
   // ── Render ────────────────────────────────────────────────────
   if (loading) {

--- a/src/utils/runPlaylistLoad.ts
+++ b/src/utils/runPlaylistLoad.ts
@@ -1,0 +1,38 @@
+import type React from 'react';
+import { getPlaylist } from '../api/subsonicPlaylists';
+import { filterSongsToActiveLibrary } from '../api/subsonicLibrary';
+import type { SubsonicPlaylist, SubsonicSong } from '../api/subsonicTypes';
+
+export interface RunPlaylistLoadDeps {
+  id: string;
+  setLoading: (v: boolean) => void;
+  setPlaylist: React.Dispatch<React.SetStateAction<SubsonicPlaylist | null>>;
+  setSongs: React.Dispatch<React.SetStateAction<SubsonicSong[]>>;
+  setCustomCoverId: React.Dispatch<React.SetStateAction<string | null>>;
+  setRatings: React.Dispatch<React.SetStateAction<Record<string, number>>>;
+  setStarredSongs: React.Dispatch<React.SetStateAction<Set<string>>>;
+}
+
+export async function runPlaylistLoad(deps: RunPlaylistLoadDeps): Promise<void> {
+  const { id, setLoading, setPlaylist, setSongs, setCustomCoverId, setRatings, setStarredSongs } = deps;
+  setLoading(true);
+  try {
+    const { playlist, songs } = await getPlaylist(id);
+    const filteredSongs = await filterSongsToActiveLibrary(songs);
+    setPlaylist(playlist);
+    setSongs(filteredSongs);
+    if (playlist.coverArt) setCustomCoverId(playlist.coverArt);
+    const init: Record<string, number> = {};
+    const starred = new Set<string>();
+    filteredSongs.forEach(s => {
+      if (s.userRating) init[s.id] = s.userRating;
+      if (s.starred) starred.add(s.id);
+    });
+    setRatings(init);
+    setStarredSongs(starred);
+  } catch {
+    // intentional swallow; load failure leaves loading false + playlist null
+  } finally {
+    setLoading(false);
+  }
+}


### PR DESCRIPTION
## Summary

- **`src/utils/runPlaylistLoad.ts`** — async fetch + populate flow for the load `useEffect`.
- **`src/hooks/usePlaylistPreview.ts`** — `startPreview` dispatch + unmount cleanup.
- **`src/hooks/usePlaylistBulkPlayCallbacks.ts`** — three `useCallback` wrappers for play / shuffle / enqueue.
- **`src/hooks/usePlaylistDerived.ts`** — existingIds, tracks, sort/filter `displayedSongs` + aliased `displayedTracks` + `isFiltered`.

`pages/PlaylistDetail.tsx` 507 → 437 LOC. Pure code move otherwise.

## Test plan

- [x] `./dev.sh check` passes.
- [ ] Smoke: open a playlist (load populates header + tracklist + suggestions), preview a suggestion + navigate away (preview stops), play/shuffle/enqueue all buttons fire, change filter + sort and verify tracklist updates.