### PR TITLE
fix(internet-radio): restore delete button styling on station cards

### DIFF
--- a/src/components/internetRadio/RadioCard.tsx
+++ b/src/components/internetRadio/RadioCard.tsx
@@ -109,14 +109,16 @@ export default function RadioCard({
           </button>
         </div>
 
-        <button
-          className={`playlist-card-delete ${deleteConfirmId === s.id ? 'playlist-card-delete--confirm' : ''}`}
-          onClick={onDelete}
-          data-tooltip={deleteConfirmId === s.id ? t('radio.confirmDelete') : t('radio.deleteStation')}
-          data-tooltip-pos="bottom"
-        >
-          {deleteConfirmId === s.id ? <Trash2 size={12} /> : <X size={12} />}
-        </button>
+        <div className="playlist-card-actions">
+          <button
+            className={`playlist-card-action playlist-card-action--delete ${deleteConfirmId === s.id ? 'playlist-card-action--delete-confirm' : ''}`}
+            onClick={onDelete}
+            data-tooltip={deleteConfirmId === s.id ? t('radio.confirmDelete') : t('radio.deleteStation')}
+            data-tooltip-pos="bottom"
+          >
+            {deleteConfirmId === s.id ? <Trash2 size={12} /> : <X size={12} />}
+          </button>
+        </div>
       </div>
 
       {/* Info */}


### PR DESCRIPTION
## Summary
- The delete button on Internet Radio station cards referenced the CSS classes `playlist-card-delete` / `playlist-card-delete--confirm`, which were renamed to `playlist-card-action--delete` / `--delete-confirm` when PlaylistCard was reworked. InternetRadio was never updated, so the button rendered unstyled and effectively invisible.
- Wrap the button in `.playlist-card-actions` and use the current classes, matching PlaylistCard. No new CSS needed — the existing rules already cover positioning, hover-reveal and the confirm-pulse state.

## Test plan
- `./dev.sh check` — green
- Manual: Internet Radio page → hover a station card → red delete button appears top-right → first click arms the confirm state (pulsing) → second click deletes