### PR TITLE
feat(http): enable gzip + brotli decompression for reqwest clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ Foundational work: faster reviews, narrower diffs, and a safety net under the pa
 
 ## Added
 
+### HTTP — gzip + brotli decompression for the Rust-side clients
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#704](https://github.com/Psychotoxical/psysonic/pull/704)**
+
+* Every HTTP client on the Rust side now advertises `Accept-Encoding` and transparently decodes compressed responses. The JSON-heavy endpoints — Navidrome native `/api`, Bandsintown, Radio-Browser, Last.fm — were the gap: the WebView's `axios` calls were already compressed, the Rust clients were not. Earlier curl measurements put the wire savings on those payloads at roughly **76–93 %**.
+* Implementation is a dependency-feature change only (`gzip` + `brotli` on `reqwest`) — no behaviour change beyond smaller transfers, and no extra cost on the clients that fetch already-compressed audio.
+
 ### Queue Toolbar — customizable button order + per-button visibility
 
 **By [@kveld9](https://github.com/kveld9), PR [#534](https://github.com/Psychotoxical/psysonic/pull/534)**

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -129,6 +129,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +682,24 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -5950,13 +5980,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,7 +52,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rodio = { version = "0.22", default-features = false, features = ["playback", "symphonia-all"] }
 symphonia = { version = "0.5", default-features = false, features = ["flac", "mp3", "pcm", "aac", "alac", "isomp4", "vorbis", "ogg", "wav", "adpcm"] }
-reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "multipart", "query", "form", "rustls", "blocking"] }
+reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "multipart", "query", "form", "rustls", "blocking", "gzip", "brotli"] }
 futures-util = "0.3"
 md5 = "0.8"
 tokio = { version = "1", features = ["rt", "time", "sync"] }

--- a/src-tauri/crates/psysonic-analysis/Cargo.toml
+++ b/src-tauri/crates/psysonic-analysis/Cargo.toml
@@ -12,7 +12,7 @@ tauri = { version = "2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "time", "sync"] }
-reqwest = { version = "0.13", default-features = false, features = ["stream", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["stream", "rustls", "gzip", "brotli"] }
 futures-util = "0.3"
 ebur128 = "0.1"
 md5 = "0.8"

--- a/src-tauri/crates/psysonic-audio/Cargo.toml
+++ b/src-tauri/crates/psysonic-audio/Cargo.toml
@@ -13,7 +13,7 @@ tauri = { version = "2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "time", "sync"] }
-reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "rustls", "blocking"] }
+reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "rustls", "blocking", "gzip", "brotli"] }
 futures-util = "0.3"
 rodio = { version = "0.22", default-features = false, features = ["playback", "symphonia-all"] }
 symphonia = { version = "0.5", default-features = false, features = ["flac", "mp3", "pcm", "aac", "alac", "isomp4", "vorbis", "ogg", "wav", "adpcm"] }

--- a/src-tauri/crates/psysonic-integration/Cargo.toml
+++ b/src-tauri/crates/psysonic-integration/Cargo.toml
@@ -12,7 +12,7 @@ tauri = { version = "2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "time", "sync"] }
-reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "rustls", "blocking"] }
+reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "rustls", "blocking", "gzip", "brotli"] }
 futures-util = "0.3"
 discord-rich-presence = "1.1"
 url = "2"

--- a/src-tauri/crates/psysonic-syncfs/Cargo.toml
+++ b/src-tauri/crates/psysonic-syncfs/Cargo.toml
@@ -16,7 +16,7 @@ tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "time", "sync"] }
-reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "rustls", "blocking"] }
+reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "rustls", "blocking", "gzip", "brotli"] }
 futures-util = "0.3"
 sysinfo = { version = "0.38", default-features = false, features = ["disk"] }
 url = "2"


### PR DESCRIPTION
## Summary
- Adds `gzip` + `brotli` to all five `reqwest` declarations across the Cargo workspace (top `psysonic` crate + `psysonic-audio` / `-analysis` / `-integration` / `-syncfs`).
- reqwest auto-decompresses by default once these features are enabled — pure dependency-feature change, no call-site edits.
- Real wire savings land on the JSON clients (Navidrome native `/api`, Bandsintown, Radio-Browser, Last.fm) — roughly -76% to -93% on earlier curl measurements. Audio-only crates get the features for consistency; reqwest just advertises `Accept-Encoding` there, so no runtime cost when the server returns already-compressed bytes as-is.
- `Cargo.lock` grows additively (`async-compression` + compression codecs, +35 lines, 0 removed); no other crates moved.

This is a fresh re-implementation of the stale `feat/http-compression` branch, which predated the backend Cargo-workspace split by 219 commits. The Network Stats overlay from that branch is intentionally left out — it needs its own rewrite against the new crate / component structure.

## Test plan
- `./dev.sh check` — green (full frontend + backend sweep, including `cargo test --workspace` and `cargo clippy --workspace`)