### PR TITLE
fix(ui): selectstart blocker handles Text node event targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -488,6 +488,12 @@ Foundational work: faster reviews, narrower diffs, and a safety net under the pa
 * Album detail **header** shows **multiple album artists** when the server sends OpenSubsonic **`albumArtists`** on the album or on child songs — each name links to its artist page instead of only the first id (issue [#552](https://github.com/Psychotoxical/psysonic/issues/552)).
 * **Player bar**, **mobile now playing**, and **mini player** copy **`artists`** through **`songToTrack`** so multi-performer tracks get **per-artist** links like the album tracklist column.
 
+### UI — selectstart blocker no longer throws on Text node targets
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#718](https://github.com/Psychotoxical/psysonic/pull/718)**
+
+* The global **`selectstart`** handler assumed `event.target` was always an **`Element`**. Starting selection inside text (e.g. Now Playing **`[data-selectable]`** copy) could pass a **Text** node and crash with **`target.closest is not a function`**. The handler now resolves Text nodes to their parent element before applying allow/deny rules.
+
 ## [1.45.0] - 2026-05-04
 
 ## Added

--- a/src/hooks/useGlobalDndAndSelectionBlockers.ts
+++ b/src/hooks/useGlobalDndAndSelectionBlockers.ts
@@ -5,7 +5,9 @@ function eventTargetElement(e: Event): Element | null {
   const t = e.target;
   if (!t) return null;
   if (t instanceof Element) return t;
-  return t.parentElement;
+  if (!(t instanceof Node)) return null;
+  const parent = t.parentNode;
+  return parent instanceof Element ? parent : null;
 }
 
 function isTextInputElement(el: Element): boolean {

--- a/src/hooks/useGlobalDndAndSelectionBlockers.ts
+++ b/src/hooks/useGlobalDndAndSelectionBlockers.ts
@@ -1,5 +1,18 @@
 import { useEffect } from 'react';
 
+/** `Event.target` may be a Text node — only Elements expose `closest` / `tagName`. */
+function eventTargetElement(e: Event): Element | null {
+  const t = e.target;
+  if (!t) return null;
+  if (t instanceof Element) return t;
+  return t.parentElement;
+}
+
+function isTextInputElement(el: Element): boolean {
+  const tag = el.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || (el as HTMLElement).isContentEditable;
+}
+
 /**
  * Globally tame Linux/WebKitGTK + Wayland behaviour that the page-level
  * CSS / Tauri config can't reach:
@@ -29,16 +42,20 @@ export function useGlobalDndAndSelectionBlockers(): void {
 
     const blockSelectAll = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
-        const target = e.target as HTMLElement;
-        if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
+        const el = eventTargetElement(e);
+        if (el && isTextInputElement(el)) return;
         e.preventDefault();
       }
     };
 
     const blockSelectStart = (e: Event) => {
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
-      if ((target as HTMLElement).closest('[data-selectable]')) return;
+      const el = eventTargetElement(e);
+      if (!el) {
+        e.preventDefault();
+        return;
+      }
+      if (isTextInputElement(el)) return;
+      if (el.closest('[data-selectable]')) return;
       e.preventDefault();
     };
 


### PR DESCRIPTION
## Summary

- `selectstart` can fire with a **Text** node as `event.target`, which has no `closest()`.
- Resolve the target to an `Element` (or its parent) before checking inputs and `[data-selectable]` regions.

## Test plan

- [ ] Select text inside a `[data-selectable]` region (e.g. Now Playing bio) — no console error, selection works.
- [ ] Mouse-drag selection outside selectable regions is still blocked on Linux/WebKit.
- [ ] Input/textarea/contentEditable selection unchanged.