### PR TITLE
fix(build): static subsonicRatings import + Vite 1 MB chunk warning limit

### DIFF
--- a/src/api/subsonicStarRating.ts
+++ b/src/api/subsonicStarRating.ts
@@ -1,4 +1,5 @@
 import { api, libraryFilterParams } from './subsonicClient';
+import { invalidateEntityUserRatingCaches } from './subsonicRatings';
 import type {
   EntityRatingSupportLevel,
   StarredResults,
@@ -38,11 +39,12 @@ export async function unstar(id: string, type: 'song' | 'album' | 'artist' = 'al
 export async function setRating(id: string, rating: number): Promise<void> {
   await api('setRating.view', { id, rating });
   // Cached song lists keyed by rating (e.g. Tracks → Highly Rated rail) become
-  // stale immediately. Lazy-import to keep the module dep direction
-  // subsonic ← navidromeBrowse and avoid pulling Tauri internals into shared
-  // type-only consumers.
+  // stale immediately. `invalidateEntityUserRatingCaches` is static-imported:
+  // mix paths already pull `subsonicRatings` (e.g. mixRatingFilter), so a
+  // dynamic import would not split chunks and only triggered INEFFECTIVE_DYNAMIC_IMPORT.
+  // Navidrome browse stays lazy to keep this module free of that dependency when unused.
   void import('./navidromeBrowse').then(m => m.ndInvalidateSongsCache()).catch(() => {});
-  void import('./subsonicRatings').then(m => m.invalidateEntityUserRatingCaches(id)).catch(() => {});
+  invalidateEntityUserRatingCaches(id);
 }
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,8 @@ export default defineConfig({
   },
   envPrefix: ["VITE_", "TAURI_ENV_*"],
   build: {
+    // Default 500 kB warns on every build; desktop bundles are often larger without being a problem.
+    chunkSizeWarningLimit: 1000,
     target: process.env.TAURI_ENV_PLATFORM === "windows" ? "chrome109" : "safari16",
     minify: !process.env.TAURI_ENV_DEBUG ? "esbuild" : false,
     sourcemap: !!process.env.TAURI_ENV_DEBUG,


### PR DESCRIPTION
## Summary
- Remove the ineffective `import('./subsonicRatings')` after `setRating` and call `invalidateEntityUserRatingCaches` via a normal static import. `mixRatingFilter` already pulls `subsonicRatings` on hot paths, so the dynamic import could not split the bundle and produced `INEFFECTIVE_DYNAMIC_IMPORT`.
- Raise `build.chunkSizeWarningLimit` to **1000** kB (~1 MB) so production builds avoid noisy oversized-chunk warnings that are acceptable for desktop Tauri bundles.

## Test plan
- [x] `npm test` — all Vitest suites pass (`928` tests locally).
- [x] `cargo test --workspace --all-targets` in `src-tauri` — green.
- [ ] Optional: `npm run build` / Tauri bundle — verify no `INEFFECTIVE_DYNAMIC_IMPORT` and fewer chunk warnings.