### PR TITLE
fix(album): hide Artist Bio button on Various-Artists compilations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -559,6 +559,12 @@ Foundational work: faster reviews, narrower diffs, and a safety net under the pa
 
 * The Info tab rendered one frame on each track switch with the previous track's artist image URL paired with the new track's cache key — **`CachedImage`**'s IndexedDB then persisted that mismatched blob, so every subsequent track stayed stuck on the previous artist's image. Artist info and song detail are now held as **`{ id, info }`** tuples and the image render is gated on id-match, so source and cache key always come from the same track.
 
+### Album header — Artist Bio button hidden on Various-Artists compilations
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#733](https://github.com/Psychotoxical/psysonic/pull/733)**
+
+* The Album header showed an **Artist Bio** button on every album, but when the album-artist label is **"Various Artists"**, **"Various"**, **"VA"** or a language equivalent there is no single artist to fetch a bio for and the button opened an empty modal. Both the mobile icon and the desktop button are now hidden when the album-artist label matches that compilation heuristic.
+
 ## [1.45.0] - 2026-05-04
 
 ## Added

--- a/src/components/AlbumHeader.tsx
+++ b/src/components/AlbumHeader.tsx
@@ -17,6 +17,22 @@ import { formatMb } from '../utils/format/formatBytes';
 import { sanitizeHtml } from '../utils/sanitizeHtml';
 import { OpenArtistRefInline } from './OpenArtistRefInline';
 
+/** True when the album artist label means "no single artist" — `getArtistInfo`
+ *  has nothing meaningful to return for these, so the Artist Bio entry is hidden.
+ */
+function isVariousArtistsLabel(name: string | undefined | null): boolean {
+  if (!name) return false;
+  const trimmed = name.trim().toLowerCase();
+  return (
+    trimmed === 'various artists' ||
+    trimmed === 'various' ||
+    trimmed === 'va' ||
+    trimmed === 'multiple artists' ||
+    trimmed === 'verschiedene interpreten' ||
+    trimmed === 'verschiedene'
+  );
+}
+
 function BioModal({ bio, onClose }: { bio: string; onClose: () => void }) {
   const { t } = useTranslation();
   return (
@@ -108,6 +124,7 @@ export default function AlbumHeader({
   const totalSize = songs.reduce((acc, s) => acc + (s.size ?? 0), 0);
   const formatLabel = [...new Set(songs.map(s => s.suffix).filter((f): f is string => !!f))].map(f => f.toUpperCase()).join(' / ');
   const isNewAlbum = isAlbumRecentlyAdded(info.created);
+  const showBioButton = !isVariousArtistsLabel(info.artist);
 
   const lightboxCoverSrc = useMemo(
     () => (info.coverArt ? buildCoverArtUrl(info.coverArt, 2000) : ''),
@@ -248,14 +265,16 @@ export default function AlbumHeader({
                       <Share2 size={16} />
                     </button>
 
-                    <button
-                      className="album-icon-btn album-icon-btn--sm"
-                      onClick={onBio}
-                      aria-label={t('albumDetail.artistBio')}
-                      data-tooltip={t('albumDetail.artistBio')}
-                    >
-                      <Highlighter size={16} />
-                    </button>
+                    {showBioButton && (
+                      <button
+                        className="album-icon-btn album-icon-btn--sm"
+                        onClick={onBio}
+                        aria-label={t('albumDetail.artistBio')}
+                        data-tooltip={t('albumDetail.artistBio')}
+                      >
+                        <Highlighter size={16} />
+                      </button>
+                    )}
 
                     {downloadProgress !== null ? (
                       <div className="album-icon-btn album-icon-btn--sm album-icon-btn--progress">
@@ -338,9 +357,11 @@ export default function AlbumHeader({
                     </button>
                   </div>
 
-                  <button className="btn btn-ghost" id="album-bio-btn" onClick={onBio}>
-                    <Highlighter size={16} /> {t('albumDetail.artistBio')}
-                  </button>
+                  {showBioButton && (
+                    <button className="btn btn-ghost" id="album-bio-btn" onClick={onBio}>
+                      <Highlighter size={16} /> {t('albumDetail.artistBio')}
+                    </button>
+                  )}
 
                   {downloadProgress !== null ? (
                     <div className="download-progress-wrap">


### PR DESCRIPTION
## Summary
- The Album header showed an Artist Bio button on every album. When the album-artist label is "Various Artists" / "Various" / "VA" or a language equivalent, there is no single artist to fetch a bio for — the button opened an empty modal.
- Hide both the mobile icon and the desktop button when the label matches a compilation heuristic.

## Test plan
- Open a compilation album (e.g. one where `album.artist === "Various Artists"`): Bio button absent in both mobile and desktop layouts.
- Open a normal album: Bio button still present and works.
- `./dev.sh check` green locally (frontend tests + tsc + coverage + build, backend tests + clippy + coverage).