### PR TITLE
fix(favorites): show artist name in filter label, not Subsonic ID

### DIFF
--- a/src/components/favorites/FavoritesSongsSectionHeader.tsx
+++ b/src/components/favorites/FavoritesSongsSectionHeader.tsx
@@ -10,6 +10,7 @@ interface Props {
   visibleSongs: SubsonicSong[];
   songs: SubsonicSong[];
   selectedArtist: string | null;
+  selectedArtistName: string | null;
   setSelectedArtist: React.Dispatch<React.SetStateAction<string | null>>;
   selectedGenres: string[];
   setSelectedGenres: React.Dispatch<React.SetStateAction<string[]>>;
@@ -27,7 +28,7 @@ interface Props {
 }
 
 export default function FavoritesSongsSectionHeader({
-  visibleSongs, songs, selectedArtist, setSelectedArtist,
+  visibleSongs, songs, selectedArtist, selectedArtistName, setSelectedArtist,
   selectedGenres, setSelectedGenres, yearRange, setYearRange,
   showFilters, setShowFilters, setSortKey, setSortClickCount,
   playTrack, enqueue, starredOverrides, minYear, currentYear,
@@ -42,7 +43,7 @@ export default function FavoritesSongsSectionHeader({
         {(selectedArtist || selectedGenres.length > 0 || yearRange[0] !== minYear || yearRange[1] !== currentYear) && (
           <span style={{ fontSize: '0.8rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>
             {selectedArtist
-              ? t('favorites.showingFiltered', { filtered: visibleSongs.length, total: songs.filter(s => starredOverrides[s.id] !== false).length, artist: selectedArtist })
+              ? t('favorites.showingFiltered', { filtered: visibleSongs.length, total: songs.filter(s => starredOverrides[s.id] !== false).length, artist: selectedArtistName ?? selectedArtist })
               : t('favorites.showingCount', { filtered: visibleSongs.length, total: songs.filter(s => starredOverrides[s.id] !== false).length })}
           </span>
         )}

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -114,6 +114,11 @@ export default function Favorites() {
     selectedArtist, selectedGenres, yearRange, ratings,
   });
 
+  const selectedArtistName = useMemo(
+    () => selectedArtist ? topFavoriteArtists.find(a => a.id === selectedArtist)?.name ?? null : null,
+    [selectedArtist, topFavoriteArtists],
+  );
+
   const { toggleSelect } = useFavoritesSelection(songs, inSelectMode, tracklistRef);
 
 
@@ -174,6 +179,7 @@ export default function Favorites() {
                 visibleSongs={visibleSongs}
                 songs={songs}
                 selectedArtist={selectedArtist}
+                selectedArtistName={selectedArtistName}
                 setSelectedArtist={setSelectedArtist}
                 selectedGenres={selectedGenres}
                 setSelectedGenres={setSelectedGenres}


### PR DESCRIPTION
## Summary

Clicking a card under **Top Artists by Favorites** set the filter to the artist's Subsonic ID, and the *Showing X of Y* label interpolated that ID into the `{{artist}}` placeholder — so users saw a GUID like `OjdsOiMQ6ve5rZWPj2ePFc` instead of `Toto`. Reported by zunoz on Discord.

- Resolve `selectedArtistName` from `topFavoriteArtists` (each entry already carries `{id, name}`) and pass it to `FavoritesSongsSectionHeader`.
- Header uses the name in the `showingFiltered` translation; falls back to the ID if the lookup is empty, but that path is not reachable under normal use since the top-artists row is the only thing that sets the filter.
- The artist-filter matching itself is unchanged — `useFavoritesSongFiltering` still compares against `artistId` / `artist` / `albumArtist`.

## Test plan

- [ ] Favorites → click a card under *Top Artists by Favorites*
- [ ] *Showing X of Y* label now reads `(<Artist Name>)`, not a GUID
- [ ] Click again to clear → label disappears, song list returns to unfiltered
- [ ] *Clear all* / *Clear artist filter* buttons still clear the filter