### PR TITLE
fix(build): enable zbus async-io feature on linux

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -77,7 +77,7 @@ dasp_sample = "0.11.0"
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-zbus = { version = "5.15", default-features = false, features = ["blocking-api"] }
+zbus = { version = "5.15", default-features = false, features = ["blocking-api", "async-io"] }
 # Match wry/tauri’s WebKitGTK stack — used only to turn off kinetic wheel scrolling.
 webkit2gtk = { version = "2.0", default-features = false, features = ["v2_40"] }
 

--- a/src-tauri/crates/psysonic-audio/Cargo.toml
+++ b/src-tauri/crates/psysonic-audio/Cargo.toml
@@ -31,7 +31,7 @@ id3 = "1.16.4"
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-zbus = { version = "5.15", default-features = false, features = ["blocking-api"] }
+zbus = { version = "5.15", default-features = false, features = ["blocking-api", "async-io"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = [


### PR DESCRIPTION
## Summary

Narrow fix: clean rebuilds of `main` failed on linux with

```
error: Either "async-io" (default) or "tokio" must be enabled.
```

inside `zbus 5.15`. Both `src-tauri/Cargo.toml` and `crates/psysonic-audio/Cargo.toml` already pinned `zbus` with `default-features = false` and only `blocking-api`, but that feature set is not buildable on its own — the crate panics at compile time without an executor backend.

The workspace `--workspace` build path (CI, normal local `./dev.sh`) silently worked because cargo unified features through other dependents, so this only surfaced after a `cargo clean` or a fresh CI cache.

Adding `async-io` (zbus's default) restores the missing executor backend without changing runtime behavior.

## Test plan

- [x] `cd src-tauri && cargo clean && cargo build -p psysonic` (linux, NixOS dev shell)
- [ ] `cargo test --workspace --all-targets`
- [ ] `./dev.sh` → Tauri dev starts on Linux