### PR TITLE
fix(home): align mainstage row title with "New Releases"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -618,6 +618,12 @@ Foundational work: faster reviews, narrower diffs, and a safety net under the pa
 * The **Square** preview was clipped at the bottom — the preview frame capped only `maxHeight: 52vh` while letting the 1:1 canvas span the full modal width, so the canvas overflowed the cap and `overflow: hidden` removed the last grid row with nothing to scroll into. Both dimensions are now capped per format (Square → **`maxWidth: 52vh`**, Story → **`min(320px, calc(52vh * 9 / 16))`**, Twitter remains modal-width-bound), so the preview always fits without clipping.
 * The preview also looked **blurry** — the canvas was rendered at **540 px** wide and CSS upscaled it back to ~676 px in the 720 px modal, while cover thumbnails were decoded at only **256 px** and stretched into ~300 px tiles. The preview canvas now renders at the **full export width (1080)** and decodes covers at the **export tile size (600)**, so text is crisp and album thumbnails downsample cleanly.
 
+### Home — Mainstage row title matches the sidebar and page label
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), thanks to zunoz for the report on the Psysonic Discord, PR [#741](https://github.com/Psychotoxical/psysonic/pull/741)**
+
+* The Mainstage row whose title chevron jumps to **`/new-releases`** was labelled **Recently Added** while the sidebar entry and the page itself read **New Releases** — three different names for the same destination. The row title and the matching **Home Customizer** entry now reuse **`sidebar.newReleases`** so the wording lives in exactly one place; the orphan **`home.recent`** key is dropped from all nine locale files.
+
 ## [1.45.0] - 2026-05-04
 
 ## Added

--- a/src/components/settings/HomeCustomizer.tsx
+++ b/src/components/settings/HomeCustomizer.tsx
@@ -7,7 +7,7 @@ export function HomeCustomizer() {
 
   const SECTION_LABELS: Record<HomeSectionId, string> = {
     hero:            t('home.hero'),
-    recent:          t('home.recent'),
+    recent:          t('sidebar.newReleases'),
     discover:        t('home.discover'),
     becauseYouLike:  t('home.becauseYouLike'),
     discoverSongs:   t('home.discoverSongs'),

--- a/src/locales/de/home.ts
+++ b/src/locales/de/home.ts
@@ -1,7 +1,6 @@
 export const home = {
   hero: 'Featured',
   starred: 'Persönliche Favoriten',
-  recent: 'Zuletzt hinzugefügt',
   mostPlayed: 'Meistgehört',
   recentlyPlayed: 'Kürzlich gespielt',
   losslessAlbums: 'Lossless-Alben',

--- a/src/locales/en/home.ts
+++ b/src/locales/en/home.ts
@@ -1,7 +1,6 @@
 export const home = {
   hero: 'Featured',
   starred: 'Personal Favorites',
-  recent: 'Recently Added',
   mostPlayed: 'Most Played',
   recentlyPlayed: 'Recently Played',
   losslessAlbums: 'Lossless Albums',

--- a/src/locales/es/home.ts
+++ b/src/locales/es/home.ts
@@ -1,7 +1,6 @@
 export const home = {
   hero: 'Destacado',
   starred: 'Favoritos Personales',
-  recent: 'Agregados Recientemente',
   mostPlayed: 'Más Reproducidos',
   recentlyPlayed: 'Reproducidos Recientemente',
   losslessAlbums: 'Álbumes sin Pérdidas',

--- a/src/locales/fr/home.ts
+++ b/src/locales/fr/home.ts
@@ -1,7 +1,6 @@
 export const home = {
   hero: 'En vedette',
   starred: 'Favoris personnels',
-  recent: 'Ajoutés récemment',
   mostPlayed: 'Les plus écoutés',
   recentlyPlayed: 'Récemment écoutés',
   losslessAlbums: 'Albums lossless',

--- a/src/locales/nb/home.ts
+++ b/src/locales/nb/home.ts
@@ -1,7 +1,6 @@
 export const home = {
   hero: 'Utvalgt',
   starred: 'Personlige favoritter',
-  recent: 'Nylig lagt til',
   mostPlayed: 'Mest spilt',
   recentlyPlayed: 'Nylig spilt',
   losslessAlbums: 'Lossless-album',

--- a/src/locales/nl/home.ts
+++ b/src/locales/nl/home.ts
@@ -1,7 +1,6 @@
 export const home = {
   hero: 'Uitgelicht',
   starred: 'Persoonlijke favorieten',
-  recent: 'Recent toegevoegd',
   mostPlayed: 'Meest gespeeld',
   recentlyPlayed: 'Recent afgespeeld',
   losslessAlbums: 'Lossless-albums',

--- a/src/locales/ro/home.ts
+++ b/src/locales/ro/home.ts
@@ -1,7 +1,6 @@
 export const home = {
   hero: 'Promovat',
   starred: 'Evaluate',
-  recent: 'Adăugate Recent',
   mostPlayed: 'Cele mai Redate',
   recentlyPlayed: 'Redate Recent',
   losslessAlbums: 'Albume Lossless',

--- a/src/locales/ru/home.ts
+++ b/src/locales/ru/home.ts
@@ -1,7 +1,6 @@
 export const home = {
   hero: 'Подборка',
   starred: 'Личное избранное',
-  recent: 'Недавно добавлено',
   mostPlayed: 'Популярное',
   recentlyPlayed: 'Недавно проиграно',
   losslessAlbums: 'Lossless-альбомы',

--- a/src/locales/zh/home.ts
+++ b/src/locales/zh/home.ts
@@ -1,7 +1,6 @@
 export const home = {
   hero: '精选',
   starred: '个人收藏',
-  recent: '最近添加',
   mostPlayed: '最常播放',
   recentlyPlayed: '最近播放',
   losslessAlbums: '无损专辑',

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -196,7 +196,7 @@ export default function Home() {
           <>
             {!homeAlbumRowsDisabled && isVisible('recent') && (
               <AlbumRow
-                title={t('home.recent')}
+                title={t('sidebar.newReleases')}
                 titleLink="/new-releases"
                 albums={recent}
                 onLoadMore={() => loadMore('newest', recent, setRecent)}


### PR DESCRIPTION
## Summary
- The Mainstage row whose title chevron links to `/new-releases` was labelled **Recently Added** (`home.recent`), while the sidebar entry and the page itself are **New Releases** (`sidebar.newReleases`) — three names for the same destination.
- Reuse `sidebar.newReleases` in both consumers (the row title in `Home.tsx` and the matching section label in `HomeCustomizer.tsx`), so the string lives in exactly one place.
- The orphan `home.recent` key is dropped from all nine locale files.
- Reported on the Psysonic Discord by zunoz.

## Test plan
- [x] `npx vitest run` — 953/953 green, `npx tsc --noEmit`, `npm run build`
- [ ] Manual: Home → first row above the fold reads **New Releases** in EN and matches the sidebar / page wording across all locales
- [ ] Manual: Settings → Personalisation → Home Customizer entry for that section reads **New Releases**