### PR TITLE
fix(settings): stabilize header height, raise search affordance

### DIFF
--- a/src/styles/components/settings.css
+++ b/src/styles/components/settings.css
@@ -197,6 +197,9 @@
   justify-content: space-between;
   gap: var(--space-3);
   margin-bottom: 1.5rem;
+  /* Fixiert die Zeilenhöhe so dass Lupen-Button vs. offenes Suchfeld
+     die Zeile nicht 1–2 px nach unten verschieben können. */
+  min-height: 40px;
 }
 
 .settings-header .page-title {
@@ -207,12 +210,30 @@
 .settings-search {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   flex-shrink: 0;
   /* h1.page-title hat im Display-Font einen visuellen Glyph-Mittelpunkt
      unterhalb der Box-Mitte. align-items: center wirkt deshalb so, als hänge
      die Lupe zu hoch. Wir verschieben sie auf die Glyph-Baseline runter. */
   align-self: end;
-  padding-bottom: 4px;
+  padding-bottom: 6px;
+}
+
+.settings-search > .icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  color: var(--text-muted);
+  border-radius: var(--radius-md);
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.settings-search > .icon-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
 }
 
 .settings-search-wrap {
@@ -220,6 +241,7 @@
   display: flex;
   align-items: center;
   width: 240px;
+  height: 32px;
 }
 
 .settings-search-icon {


### PR DESCRIPTION
## Summary
- Lock `.settings-header` to `min-height: 40px` so toggling the search between the icon button and the open input no longer shifts the row 1–2 px down.
- Give the lupe button a real 28×28 hit area with `border-radius` + hover state, plus a fixed `height: 32px` on `.settings-search-wrap` so the open and closed states reserve the same vertical space.
- Bumps `padding-bottom` on `.settings-search` from 4 → 6 px to better hug the display-font baseline of the title.

Reported by zunoz on Discord.

## Test plan
- [x] Open Settings → toggle the search icon → content below the header does not jump.
- [x] Hover the lupe button → shows hover background, click target feels comfortable.
- [x] Switch tabs / open search again → no layout regression.