### PR TITLE
fix(equalizer): redraw curve when <details> reopens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -645,6 +645,12 @@ Foundational work: faster reviews, narrower diffs, and a safety net under the pa
 * Clicking the **artist** in the Favorites songs table opened the artist page _and_ started the song — the cell was missing the click guard the album cell already had. Now matches every other tracklist in the app.
 * Selecting a song no longer pushes the column header and every row down by one line. The "X selected / Add to playlist / Clear" cluster moved out of the full-width bar into the existing action-buttons row (right-aligned), matching the album toolbar, so the next item stays under the same cursor position.
 
+### Equalizer — frequency-response curve no longer disappears on re-expand
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), thanks to zunoz for the report on the Psysonic Discord, PR [#747](https://github.com/Psychotoxical/psysonic/pull/747)**
+
+* Collapsing and re-expanding **Settings → Audio → Equalizer** sometimes left the curve area blank: `ResizeObserver` does not reliably fire for the `display: none → block` transition the surrounding `<details>` triggers, so the redraw that depends on it never ran on the second open. A `toggle` listener on the parent `<details>` now redraws explicitly on open.
+
 ## [1.45.0] - 2026-05-04
 
 ## Added

--- a/src/components/Equalizer.tsx
+++ b/src/components/Equalizer.tsx
@@ -41,6 +41,20 @@ export default function Equalizer() {
     return () => ro.disconnect();
   }, [redraw]);
 
+  // ResizeObserver does not always fire for the `display: none → block`
+  // transition the surrounding <details> causes when toggled, leaving the
+  // canvas blank on the second open. Redraw explicitly when the parent
+  // <details> opens; rAF waits one frame for the canvas to take its size.
+  useEffect(() => {
+    const details = canvasRef.current?.closest('details');
+    if (!details) return;
+    const onToggle = () => {
+      if (details.open) requestAnimationFrame(redraw);
+    };
+    details.addEventListener('toggle', onToggle);
+    return () => details.removeEventListener('toggle', onToggle);
+  }, [redraw]);
+
   const isCustomSaved = activePreset && !BUILTIN_PRESETS.some(p => p.name === activePreset);
   const selectValue = activePreset ?? '__custom__';
 


### PR DESCRIPTION
Reported by zunoz on the Psysonic Discord: the Equalizer's frequency-response canvas appears blank after expanding the section a second time. Repro: Settings → Audio → expand EQ → collapse EQ → expand EQ.

* `Equalizer` redraws the canvas from `useEffect([redraw])` on mount and from a `ResizeObserver` on size changes. `drawCurve` early-returns when the canvas is zero-sized (existing macOS-WebKit `<details>` guard).
* In some WebKit / Chromium configurations, `ResizeObserver` does not fire for the `display: none → display: block` transition the surrounding `<details>` causes when toggled, so the second open never triggers a redraw and the canvas stays blank.
* Add a `toggle` listener on the closest `<details>` ancestor; on open, redraw inside `requestAnimationFrame` so the canvas has its laid-out size first. Additive — leaves the working ResizeObserver path untouched.

## Test plan
- [ ] Settings → Audio → expand Equalizer: curve renders.
- [ ] Collapse Equalizer, expand again: curve renders (was blank before).
- [ ] Switch to Appearance, change theme, return to Audio, expand Equalizer: curve renders with new accent colour.
- [ ] Resize the Settings window while EQ is open: curve still rescales (ResizeObserver path).