### PR TITLE
fix(fullscreen): no broken-image glyph when artist has no portrait

### DIFF
--- a/src/hooks/useFsArtistPortrait.ts
+++ b/src/hooks/useFsArtistPortrait.ts
@@ -3,17 +3,32 @@ import { getArtistInfo } from '../api/subsonicArtists';
 
 /** Fetches the large artist image for the given artist id, returning '' until
  *  the request resolves (or when there is no artist id). Falls through silently
- *  on network failures — the caller should layer a cover-art fallback on top. */
+ *  on network failures — the caller should layer a cover-art fallback on top.
+ *
+ *  Navidrome / Subsonic backends often return a `largeImageUrl` that 404s when
+ *  the artist has no scraped image (Last.fm placeholder), so the URL is
+ *  preflighted via an Image() probe and only exposed when it actually loads.
+ *  Otherwise the caller would render a broken-img glyph (`?`) on top of the
+ *  fullscreen background — see zunoz report on the Psysonic Discord. */
 export function useFsArtistPortrait(artistId: string | undefined): string {
   const [artistBgUrl, setArtistBgUrl] = useState<string>('');
   useEffect(() => {
     setArtistBgUrl('');
     if (!artistId) return;
     let cancelled = false;
+    let probe: HTMLImageElement | null = null;
     getArtistInfo(artistId).then(info => {
-      if (!cancelled && info.largeImageUrl) setArtistBgUrl(info.largeImageUrl);
+      if (cancelled || !info.largeImageUrl) return;
+      const url = info.largeImageUrl;
+      probe = new Image();
+      probe.onload = () => { if (!cancelled) setArtistBgUrl(url); };
+      probe.onerror = () => { /* leave empty so caller falls back to cover */ };
+      probe.src = url;
     }).catch(() => {});
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      if (probe) probe.onload = probe.onerror = null;
+    };
   }, [artistId]);
   return artistBgUrl;
 }


### PR DESCRIPTION
Reported by zunoz on the Psysonic Discord: the Fullscreen Player shows a stray broken-image glyph in the middle of the screen for artists without a scraped photo.

* Navidrome / Subsonic `getArtistInfo2` often returns a `largeImageUrl` that 404s when the artist has no scraped image (Last.fm placeholder).
* `useFsArtistPortrait` returned that URL as-is, so the `artistBgUrl || coverUrl` fallback in `FullscreenPlayer` saw a non-empty string and skipped the cover-art fallback; `FsPortrait` then rendered an `<img>` whose `src` failed and the browser painted its default broken-image glyph on top of the background.
* The hook now preflights the URL via an `Image()` probe and only exposes it once it actually loads; on error it leaves state empty so the cover-art fallback takes effect.

## Test plan
- [ ] Play a track whose artist has a valid portrait: Fullscreen still shows the artist image as before.
- [ ] Play a track whose artist has no portrait (or whose backend returns a broken URL): Fullscreen falls back to the album cover; no glyph.
- [ ] Skip back and forth between an artist with and without portrait: crossfade still works, no flicker of the broken glyph.