### PR TITLE
fix(title): play glyph in OS window title stays centred with the text

### DIFF
--- a/src/hooks/useNowPlayingTrayTitle.ts
+++ b/src/hooks/useNowPlayingTrayTitle.ts
@@ -14,7 +14,11 @@ export function useNowPlayingTrayTitle(currentTrack: Track | null, isPlaying: bo
       try {
         const appWindow = getCurrentWindow();
         if (currentTrack) {
-          const state = isPlaying ? '▶' : '⏸';
+          // `⏵` (U+23F5) instead of `▶` (U+25B6): the Geometric-Shapes triangle
+          // renders well below the baseline in most OS title-bar fonts (Segoe UI,
+          // GNOME Cantarell, etc.), while the Miscellaneous-Technical pair
+          // `⏵`/`⏸` shares metrics and stays centred next to the text.
+          const state = isPlaying ? '⏵' : '⏸';
           const title = `${state} ${currentTrack.artist} - ${currentTrack.title} | Psysonic`;
           document.title = title;
           await appWindow.setTitle(title);


### PR DESCRIPTION
Reported by zunoz on the Psysonic Discord: the play triangle in the OS window title (and the matching Windows taskbar entry) sits noticeably below the baseline while the pause glyph looks correctly centred.

* The title used `▶` (U+25B6) from the Geometric-Shapes block; most OS title-bar fonts (Segoe UI on Windows, GNOME Cantarell, etc.) render that triangle well below the baseline.
* Switched the play glyph to `⏵` (U+23F5), the designated `⏸` pair from the Miscellaneous-Technical block — both glyphs share metrics and stay aligned with the surrounding text in those fonts.
* In-app custom title bar already renders `▶`/`⏸` correctly (zunoz confirmed) and is left untouched, so the cosmetic change is scoped to `useNowPlayingTrayTitle`.

## Test plan
- [ ] Start playback: OS window title and Windows taskbar entry show the play glyph centred on the text baseline.
- [ ] Pause playback: pause glyph stays centred (regression check).
- [ ] In-app custom title bar still uses the previous glyphs and looks the same.