### PR TITLE
fix(library): empty-state on Mainstage, Albums, New Releases, Random Albums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -651,6 +651,12 @@ Foundational work: faster reviews, narrower diffs, and a safety net under the pa
 
 * Collapsing and re-expanding **Settings → Audio → Equalizer** sometimes left the curve area blank: `ResizeObserver` does not reliably fire for the `display: none → block` transition the surrounding `<details>` triggers, so the redraw that depends on it never ran on the second open. A `toggle` listener on the parent `<details>` now redraws explicitly on open.
 
+### Library — empty-state on Mainstage, Albums, New Releases and Random Albums
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), thanks to zunoz for the report on the Psysonic Discord, PR [#750](https://github.com/Psychotoxical/psysonic/pull/750)**
+
+* Selecting an empty library no longer leaves these pages as a fully blank canvas. A shared `common.libraryEmpty` message ("Your library is empty.") added across all nine locales is shown in place of the empty rails/grids. Pages that already had a dedicated empty-state (Artists, Genres, Composers, Playlists, Favorites, Most Played, Lossless Albums, Label Albums, Internet Radio) keep their per-page wording. On Albums and New Releases, an active genre / year / starred / compilation filter still shows the regular filtered-results behaviour rather than the library-empty message.
+
 ## [1.45.0] - 2026-05-04
 
 ## Added

--- a/src/locales/de/common.ts
+++ b/src/locales/de/common.ts
@@ -63,4 +63,5 @@ export const common = {
   more: 'mehr',
   yearRange: 'Jahresbereich',
   clearAll: 'Alles zurücksetzen',
+  libraryEmpty: 'Deine Bibliothek ist leer.',
 };

--- a/src/locales/en/common.ts
+++ b/src/locales/en/common.ts
@@ -63,4 +63,5 @@ export const common = {
   more: 'more',
   yearRange: 'Year Range',
   clearAll: 'Clear all',
+  libraryEmpty: 'Your library is empty.',
 };

--- a/src/locales/es/common.ts
+++ b/src/locales/es/common.ts
@@ -53,4 +53,5 @@ export const common = {
   more: 'más',
   yearRange: 'Rango de años',
   clearAll: 'Limpiar todo',
+  libraryEmpty: 'Tu biblioteca está vacía.',
 };

--- a/src/locales/fr/common.ts
+++ b/src/locales/fr/common.ts
@@ -53,4 +53,5 @@ export const common = {
   more: 'plus',
   yearRange: 'Plage d\'années',
   clearAll: 'Tout effacer',
+  libraryEmpty: 'Votre bibliothèque est vide.',
 };

--- a/src/locales/nb/common.ts
+++ b/src/locales/nb/common.ts
@@ -53,4 +53,5 @@ export const common = {
   more: 'mer',
   yearRange: 'Årsspenn',
   clearAll: 'Tøm alt',
+  libraryEmpty: 'Biblioteket ditt er tomt.',
 };

--- a/src/locales/nl/common.ts
+++ b/src/locales/nl/common.ts
@@ -53,4 +53,5 @@ export const common = {
   more: 'meer',
   yearRange: 'Jaarbereik',
   clearAll: 'Alles wissen',
+  libraryEmpty: 'Je bibliotheek is leeg.',
 };

--- a/src/locales/ro/common.ts
+++ b/src/locales/ro/common.ts
@@ -63,4 +63,5 @@ export const common = {
   more: 'mai mult',
   yearRange: 'Interval de an',
   clearAll: 'Golește tot',
+  libraryEmpty: 'Biblioteca ta este goală.',
 };

--- a/src/locales/ru/common.ts
+++ b/src/locales/ru/common.ts
@@ -53,4 +53,5 @@ export const common = {
   more: 'еще',
   yearRange: 'Диапазон лет',
   clearAll: 'Очистить всё',
+  libraryEmpty: 'Ваша библиотека пуста.',
 };

--- a/src/locales/zh/common.ts
+++ b/src/locales/zh/common.ts
@@ -53,4 +53,5 @@ export const common = {
   more: '更多',
   yearRange: '年份范围',
   clearAll: '清除全部',
+  libraryEmpty: '你的音乐库是空的。',
 };

--- a/src/pages/Albums.tsx
+++ b/src/pages/Albums.tsx
@@ -310,6 +310,10 @@ export default function Albums() {
         <div style={{ display: 'flex', justifyContent: 'center', padding: '3rem' }}>
           <div className="spinner" />
         </div>
+      ) : !loading && albums.length === 0 && !genreFiltered && !yearActive && !starredOnly && compFilter === 'all' ? (
+        <div className="empty-state" style={{ padding: '3rem 1rem', textAlign: 'center' }}>
+          {t('common.libraryEmpty')}
+        </div>
       ) : (
         <>
           {!perfFlags.disableMainstageGridCards && (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -183,6 +183,16 @@ export default function Home() {
 
   const homeLiteArtworkFx = perfFlags.disableHomeArtworkFx;
   const homeFlatArtworkClip = perfFlags.disableHomeArtworkClip;
+  // Treat the library as empty when every album endpoint returned zero. The
+  // song/artist rails can be empty for non-empty libraries (rare server quirks),
+  // so they don't count toward this signal.
+  const libraryEmpty =
+    !loading &&
+    recent.length === 0 &&
+    random.length === 0 &&
+    mostPlayed.length === 0 &&
+    recentlyPlayed.length === 0 &&
+    starred.length === 0;
   return (
     <div className={`animate-fade-in${homeLiteArtworkFx ? ' home-lite-artwork' : ''}${homeFlatArtworkClip ? ' home-flat-artwork-clip' : ''}`}>
       {!perfFlags.disableMainstageHero && isVisible('hero') && <Hero albums={heroAlbums} />}
@@ -191,6 +201,10 @@ export default function Home() {
         {loading ? (
           <div style={{ display: 'flex', justifyContent: 'center', padding: '4rem' }}>
             <div className="spinner" />
+          </div>
+        ) : libraryEmpty ? (
+          <div className="empty-state" style={{ padding: '4rem 1rem', textAlign: 'center' }}>
+            {t('common.libraryEmpty')}
           </div>
         ) : (
           <>

--- a/src/pages/NewReleases.tsx
+++ b/src/pages/NewReleases.tsx
@@ -178,6 +178,10 @@ export default function NewReleases() {
         <div style={{ display: 'flex', justifyContent: 'center', padding: '3rem' }}>
           <div className="spinner" />
         </div>
+      ) : !loading && albums.length === 0 && !filtered ? (
+        <div className="empty-state" style={{ padding: '3rem 1rem', textAlign: 'center' }}>
+          {t('common.libraryEmpty')}
+        </div>
       ) : (
         <>
           <VirtualCardGrid

--- a/src/pages/RandomAlbums.tsx
+++ b/src/pages/RandomAlbums.tsx
@@ -180,6 +180,10 @@ export default function RandomAlbums() {
         <div style={{ display: 'flex', justifyContent: 'center', padding: '4rem' }}>
           <div className="spinner" />
         </div>
+      ) : !loading && albums.length === 0 ? (
+        <div className="empty-state" style={{ padding: '3rem 1rem', textAlign: 'center' }}>
+          {t('common.libraryEmpty')}
+        </div>
       ) : (
         <VirtualCardGrid
           items={albums}


### PR DESCRIPTION
Reported by zunoz on the Psysonic Discord: selecting an empty library leaves Mainstage and the album list pages fully blank. Other pages like Artists already show a friendly "No artists found." — match that pattern across the album pages.

* New shared message `common.libraryEmpty` ("Your library is empty.") added to all 9 locales.
* Mainstage shows it when every album rail returns zero items after loading; song/artist rails alone don't count (rare server quirks).
* Albums and New Releases show it only when no filter is active (genre, year, starred, compilation) so filtered "no matches" stays a separate state.
* Random Albums shows it after loading. Pages that already had a dedicated empty-state (Artists, Genres, Composers, Playlists, Favorites, MostPlayed, LosslessAlbums, LabelAlbums, InternetRadio) are left alone.

## Test plan
- [ ] Switch to an empty library (or temporarily filter to one with no content): Mainstage, Albums, New Releases, Random Albums each show "Your library is empty." instead of a blank page.
- [ ] Switch back to a populated library: all four pages render their rails / grids as before.
- [ ] On Albums with content, apply a genre / year / starred / compilation filter that matches nothing: existing filtered-empty behaviour stays unchanged (no `libraryEmpty` message).
- [ ] Spot-check that DE / FR / RU / ZH render the localised message in the same spot.