### PR TITLE
fix(settings): server row actions wrap inside the card at narrow widths

### DIFF
--- a/src/components/settings/ServersTab.tsx
+++ b/src/components/settings/ServersTab.tsx
@@ -213,7 +213,7 @@ export function ServersTab({
                 >
                   <div style={{ display: 'flex', alignItems: 'stretch', gap: '0.75rem' }}>
                     <ServerGripHandle idx={srvIdx} label={serverListDisplayLabel(srv, auth.servers)} />
-                    <div style={{ flex: 1, display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '1rem' }}>
+                    <div style={{ flex: 1, display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
                     <div style={{ minWidth: 0 }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '2px' }}>
                         <span style={{ fontWeight: 600 }}>{serverListDisplayLabel(srv, auth.servers)}</span>
@@ -236,7 +236,7 @@ export function ServersTab({
                         {srv.username}
                       </div>
                     </div>
-                    <div style={{ display: 'flex', gap: '6px', flexShrink: 0, alignItems: 'center' }}>
+                    <div style={{ display: 'flex', gap: '6px', flexShrink: 0, alignItems: 'center', marginLeft: 'auto' }}>
                       {status === 'ok' && <CheckCircle2 size={16} style={{ color: 'var(--positive)' }} />}
                       {status === 'error' && <WifiOff size={16} style={{ color: 'var(--danger)' }} />}
                       {status === 'testing' && <div className="spinner" style={{ width: 16, height: 16 }} />}


### PR DESCRIPTION
At narrower Settings pane widths the Test Connection / Use / Delete cluster on each server card spilled past the card's right edge.

* The action cluster had `flex-shrink: 0` and the parent flex row had no `flex-wrap`, so the buttons couldn't move onto a new line when the available width shrunk.
* Enable `flex-wrap: wrap` on the parent flex row and pin the action cluster with `margin-left: auto` so it stays right-aligned once it wraps under the server info.

## Test plan
- [ ] Settings → Servers at a wide pane width: server card looks unchanged (actions inline on the right of the info column).
- [ ] Narrow the Settings pane until the actions no longer fit: cluster wraps onto its own line under the info, still right-aligned, no overflow past the card edge.
- [ ] The status icon, spinner, "Active" badge and AudioMuse toggle below all still render correctly.