### PR TITLE
fix(playerbar): mute / unmute tooltip on the speaker icon

### DIFF
--- a/src/components/playerBar/PlayerVolume.tsx
+++ b/src/components/playerBar/PlayerVolume.tsx
@@ -40,7 +40,8 @@ export function PlayerVolume({
             setVolume(0);
           }
         }}
-        aria-label={t('player.volume')}
+        aria-label={volume === 0 ? t('player.unmute') : t('player.mute')}
+        data-tooltip={volume === 0 ? t('player.unmute') : t('player.mute')}
         style={{ color: 'var(--text-muted)', flexShrink: 0 }}
       >
         {volume === 0 ? <VolumeX size={16} /> : <Volume2 size={16} />}

--- a/src/locales/de/player.ts
+++ b/src/locales/de/player.ts
@@ -39,6 +39,8 @@ export const player = {
   repeatOne: 'Einen',
   progress: 'Songfortschritt',
   volume: 'Lautstärke',
+  mute: 'Stummschalten',
+  unmute: 'Stumm aufheben',
   toggleQueue: 'Warteschlange umschalten',
   collapseQueueResize: 'Warteschlange einklappen, Breite ändern',
   moreOptions: 'Weitere Optionen',

--- a/src/locales/en/player.ts
+++ b/src/locales/en/player.ts
@@ -39,6 +39,8 @@ export const player = {
   repeatOne: 'One',
   progress: 'Song Progress',
   volume: 'Volume',
+  mute: 'Mute',
+  unmute: 'Unmute',
   toggleQueue: 'Toggle Queue',
   collapseQueueResize: 'Collapse queue, resize',
   moreOptions: 'More options',

--- a/src/locales/es/player.ts
+++ b/src/locales/es/player.ts
@@ -39,6 +39,8 @@ export const player = {
   repeatOne: 'Una',
   progress: 'Progreso de Canción',
   volume: 'Volumen',
+  mute: 'Silenciar',
+  unmute: 'Quitar silencio',
   toggleQueue: 'Alternar Cola',
   collapseQueueResize: 'Contraer cola, cambiar ancho',
   moreOptions: 'Más opciones',

--- a/src/locales/fr/player.ts
+++ b/src/locales/fr/player.ts
@@ -39,6 +39,8 @@ export const player = {
   repeatOne: 'Un',
   progress: 'Progression',
   volume: 'Volume',
+  mute: 'Couper le son',
+  unmute: 'Activer le son',
   toggleQueue: 'Afficher/masquer la file',
   collapseQueueResize: 'Réduire la file, redimensionner',
   moreOptions: 'Plus d’options',

--- a/src/locales/nb/player.ts
+++ b/src/locales/nb/player.ts
@@ -39,6 +39,8 @@ export const player = {
   repeatOne: 'Én',
   progress: 'Sangfremdrift',
   volume: 'Volum',
+  mute: 'Demp',
+  unmute: 'Slå på lyden',
   toggleQueue: 'Veksle kø',
   collapseQueueResize: 'Skjul kø, endre bredde',
   moreOptions: 'Flere alternativer',

--- a/src/locales/nl/player.ts
+++ b/src/locales/nl/player.ts
@@ -39,6 +39,8 @@ export const player = {
   repeatOne: 'Één',
   progress: 'Nummervoortgang',
   volume: 'Volume',
+  mute: 'Dempen',
+  unmute: 'Dempen opheffen',
   toggleQueue: 'Wachtrij in-/uitschakelen',
   collapseQueueResize: 'Wachtrij inklappen, breedte wijzigen',
   moreOptions: 'Meer opties',

--- a/src/locales/ro/player.ts
+++ b/src/locales/ro/player.ts
@@ -39,6 +39,8 @@ export const player = {
   repeatOne: 'Unul',
   progress: 'Progresul Piesei',
   volume: 'Volum',
+  mute: 'Oprește sunetul',
+  unmute: 'Pornește sunetul',
   toggleQueue: 'Comutați Coada',
   collapseQueueResize: 'Strânge coada, redimensionează',
   moreOptions: 'Mai multe opțiuni',

--- a/src/locales/ru/player.ts
+++ b/src/locales/ru/player.ts
@@ -39,6 +39,8 @@ export const player = {
   repeatOne: 'Один',
   progress: 'Прогресс',
   volume: 'Громкость',
+  mute: 'Отключить звук',
+  unmute: 'Включить звук',
   toggleQueue: 'Очередь',
   collapseQueueResize: 'Свернуть очередь, изменить ширину',
   moreOptions: 'Дополнительно',

--- a/src/locales/zh/player.ts
+++ b/src/locales/zh/player.ts
@@ -39,6 +39,8 @@ export const player = {
   repeatOne: '单曲',
   progress: '播放进度',
   volume: '音量',
+  mute: '静音',
+  unmute: '取消静音',
   toggleQueue: '切换队列',
   collapseQueueResize: '收起队列，调整宽度',
   moreOptions: '更多选项',


### PR DESCRIPTION
Hovering the speaker icon in the player bar showed no tooltip, so it wasn't obvious what clicking it would do.

* The button toggled volume to 0 (or restored the pre-mute level) but only exposed `aria-label="Volume"`, no `data-tooltip`.
* Add a `data-tooltip` that swaps between **Mute** and **Unmute** with the current state; `aria-label` now mirrors the same string so screen readers stay in sync.
* New `player.mute` / `player.unmute` keys land across all nine locales.

## Test plan
- [ ] Hover the speaker icon while audible: tooltip shows "Mute".
- [ ] Click to mute, then hover again: tooltip shows "Unmute".
- [ ] Switch to DE / FR / RU / ZH and confirm the tooltip is localised.