### PR TITLE
fix(settings): clock format "auto" follows the app's UI language

### DIFF
--- a/src/components/PlaybackDelayModal.tsx
+++ b/src/components/PlaybackDelayModal.tsx
@@ -46,7 +46,7 @@ export interface PlaybackDelayModalProps {
 }
 
 export default function PlaybackDelayModal({ open, onClose, anchorRef }: PlaybackDelayModalProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const {
     isPlaying,
     currentTrack,
@@ -157,7 +157,7 @@ export default function PlaybackDelayModal({ open, onClose, anchorRef }: Playbac
   const clockFormat = useAuthStore(s => s.clockFormat);
   const previewSeconds = hoverSeconds ?? customSeconds;
   const previewAtMs = previewSeconds != null ? nowTick + previewSeconds * 1000 : null;
-  const previewClock = previewAtMs != null ? formatClockTime(previewAtMs, clockFormat) : null;
+  const previewClock = previewAtMs != null ? formatClockTime(previewAtMs, clockFormat, i18n.language) : null;
 
   if (!open) return null;
 

--- a/src/components/queuePanel/QueueHeader.tsx
+++ b/src/components/queuePanel/QueueHeader.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { ChevronDown, ListMusic } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { usePlayerStore } from '../../store/playerStore';
 import { useAuthStore } from '../../store/authStore';
@@ -26,6 +27,7 @@ export function QueueHeader({
   const currentTime = usePlayerStore((s) => Math.floor(s.currentTime / 30) * 30);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const clockFormat = useAuthStore((s) => s.clockFormat);
+  const { i18n } = useTranslation();
 
   const totalSecs = useMemo(() =>
     queue.reduce((acc: number, track: Track) => acc + (track.duration || 0), 0),
@@ -42,7 +44,7 @@ export function QueueHeader({
   if (queue.length > 0) {
     if (durationMode === 'total') dur = formatLongDuration(Math.floor(totalSecs));
     else if (durationMode === 'remaining') dur = `-${formatLongDuration(Math.floor(remainingSecs))}`;
-    else dur = formatClockTime(Date.now() + remainingSecs * 1000, clockFormat);
+    else dur = formatClockTime(Date.now() + remainingSecs * 1000, clockFormat, i18n.language);
   }
 
   const nextMode: DurationMode =

--- a/src/utils/format/formatClockTime.ts
+++ b/src/utils/format/formatClockTime.ts
@@ -2,12 +2,14 @@ import type { ClockFormat } from '../../store/authStoreTypes';
 
 /**
  * Localized wall-clock `HH:MM` for a timestamp (sleep-timer / queue-ETA labels).
- * `clockFormat` overrides the system locale's `hour12` default — pass `'auto'`
- * or omit to keep locale-driven behaviour.
+ * `clockFormat` overrides the locale's `hour12` default. `'auto'` (or omitted)
+ * defers to `locale` — pass `i18n.language` so the App's UI language picks the
+ * 12h/24h convention; the JS engine's default locale is unreliable inside
+ * WebKitGTK and often resolves to `en-US` regardless of OS `LC_TIME`.
  */
-export function formatClockTime(timestampMs: number, clockFormat?: ClockFormat): string {
+export function formatClockTime(timestampMs: number, clockFormat?: ClockFormat, locale?: string): string {
   const hour12 = clockFormat === '24h' ? false : clockFormat === '12h' ? true : undefined;
-  return new Date(timestampMs).toLocaleTimeString(undefined, {
+  return new Date(timestampMs).toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit',
     hour12,


### PR DESCRIPTION
## Summary

- `formatClockTime` with `clockFormat = 'auto'` passed `undefined` as the locale to `toLocaleTimeString`, which falls through to the JS engine's default. In WebKitGTK that often resolves to `en-US` regardless of `LC_TIME` / `timedatectl`, so users on a 24h system saw 12h AM/PM in the queue ETA and sleep-timer preview.
- Pass `i18n.language` through to the formatter so the UI language drives the 12h/24h convention — same approach already used by the theme-scheduler hour picker in `AppearanceTab.tsx`.
- Explicit `12h` / `24h` choices still override.

## Test plan

- [ ] Settings → System → Clock Format: set to `Auto (system locale)`, UI language `English` → queue ETA renders `07:20 PM`.
- [ ] Same with UI language `Deutsch` / `Norsk bokmål` / `Français` → queue ETA renders `19:20`.
- [ ] Settings → System → Clock Format: `24h` while UI is English → renders `19:20` (explicit override wins).
- [ ] PlaybackDelayModal preview line follows the same rule.