### PR TITLE
fix(now-playing): empty state uses theme-aware text color

### DIFF
--- a/src/styles/components/now-playing-page-2.css
+++ b/src/styles/components/now-playing-page-2.css
@@ -630,7 +630,7 @@
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-muted);
   padding: 40px 0;
 }
 


### PR DESCRIPTION
## Summary

- `.np-empty-state` (the \"Nothing playing yet. Start a track!\" copy + music-note icon shown on the Now Playing page when nothing is queued) was hardcoded to `rgba(255, 255, 255, 0.5)`. On light themes that renders as white text on a white background — the message and icon disappear.
- Switch to `var(--text-muted)`, matching the mobile `.mp-empty` rule (`src/styles/layout/empty-state.css`) and the shared `.empty-state` utility in `loading-empty.css`.
- One-line CSS change, no JSX / i18n touched.

## Test plan

- [x] Open the Now Playing page with an empty queue on a dark theme (e.g. Mocha) → icon + text visible, unchanged from before.
- [x] Switch to a light theme (e.g. Latte, Vision Light) → icon + text now legible against the bright background.