### PR TITLE
fix(live): listener timestamp wraps to its own line with a clock icon

### DIFF
--- a/src/components/NowPlayingDropdown.tsx
+++ b/src/components/NowPlayingDropdown.tsx
@@ -3,7 +3,7 @@ import { getNowPlaying } from '../api/subsonicScrobble';
 import type { SubsonicNowPlaying } from '../api/subsonicTypes';
 import React, { useState, useEffect, useRef, useCallback, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { PlayCircle, User, Radio, RefreshCw } from 'lucide-react';
+import { PlayCircle, User, Clock, Radio, RefreshCw } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { usePlayerStore } from '../store/playerStore';
 import { useTranslation } from 'react-i18next';
@@ -170,10 +170,17 @@ export default function NowPlayingDropdown() {
                   <div style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column', gap: '2px' }}>
                     <div className="truncate" style={{ fontSize: '13px', fontWeight: 600, color: 'var(--text-primary)' }}>{stream.title}</div>
                     <div className="truncate" style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{stream.artist}</div>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginTop: '2px', fontSize: '11px', color: 'var(--text-secondary)' }}>
-                      <User size={10} />
-                      <span className="truncate">{stream.username} ({stream.playerName || 'Web'})</span>
-                      {stream.minutesAgo > 0 && <span>• {t('nowPlaying.minutesAgo', { n: stream.minutesAgo })}</span>}
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', marginTop: '2px', fontSize: '11px', color: 'var(--text-secondary)' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '4px', minWidth: 0 }}>
+                        <User size={10} style={{ flexShrink: 0 }} />
+                        <span className="truncate">{stream.username} ({stream.playerName || 'Web'})</span>
+                      </div>
+                      {stream.minutesAgo > 0 && (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '4px', minWidth: 0 }}>
+                          <Clock size={10} style={{ flexShrink: 0 }} />
+                          <span className="truncate">{t('nowPlaying.minutesAgo', { n: stream.minutesAgo })}</span>
+                        </div>
+                      )}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

- In the Live dropdown ("Who is listening?"), the per-listener row had username + client + relative timestamp ("• Xm ago") laid out in a single flex row. With a long `username (psysonic/1.46.0-dev)` string the timestamp got squeezed and broke vertically into `1m` / `ago`.
- Split the meta block into two rows inside the existing column container: user icon + name on row 1, clock icon + `Xm ago` on row 2. Both rows use the same `gap: 4px` so the timestamp aligns with the username text.
- No i18n / API / store changes; pure layout tweak in `NowPlayingDropdown.tsx`.

## Test plan

- [ ] Open the Live dropdown with at least one listener whose `username (client)` is long enough to truncate → the relative timestamp now sits on its own row underneath, prefixed with a clock icon, and no longer wraps.
- [ ] Open with a short username → layout still looks tidy (two short rows, both with leading icons).
- [ ] Listener with `minutesAgo === 0` → only the user row renders, no clock row.