### PR TITLE
docs: credit zz5zz for ongoing bug & quirk reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.46.0] - 2026-05-05
 
+> **🙏 Special thanks to [@zz5zz](https://github.com/zz5zz)** for his tireless quirk-spotting and bug reports on the [Psysonic Discord](https://discord.gg/AMnDRErm4u) — several of the polish fixes in this release landed directly off the back of his messages.
+
 ## Under the Hood — Refactoring & Test Suite
 
 **By [@cucadmuh](https://github.com/cucadmuh) + [@Psychotoxical](https://github.com/Psychotoxical)**

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -49,6 +49,7 @@ const CONTRIBUTOR_ENTRIES = [
     since: '1.32.0',
     contributions: [
       'Norwegian (Bokmål) translation (PR #101)',
+      'Ongoing bug & quirk reports via Discord (PRs #747, #750 et al.)',
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Add a second line to zz5zz's existing contributor block in \`settingsCredits.ts\` covering the continuous stream of Discord bug reports, alongside the original Norwegian (Bokmål) translation credit.
- Add a \"Special thanks\" banner at the top of the 1.46.0 \`CHANGELOG.md\` section pointing to the Psysonic Discord — several of this release's polish fixes (PR #747, #750 and others) came directly out of zz5zz's reports.

## Test plan

- [ ] Settings → System → Contributors: zz5zz's card now lists two contributions; original line unchanged.
- [ ] CHANGELOG renders the new blockquote banner immediately under \`## [1.46.0] - 2026-05-05\`, with working links to the GitHub profile and the Discord invite.