### PR TITLE
chore(aur): bump PKGBUILD to 1.46.0

### DIFF
--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Psychotoxic <psychotoxic@gmx.de>
 pkgname=psysonic
-pkgver=1.45.0
+pkgver=1.46.0
 pkgrel=1
 pkgdesc="Desktop music player for Subsonic API-compatible servers (Navidrome, Gonic, etc.)"
 arch=('x86_64')


### PR DESCRIPTION
## Summary
- AUR `PKGBUILD` `pkgver` 1.45.0 → 1.46.0 (matches `app-v1.46.0` release tarball).
- Already pushed to the AUR remote (`Update to v1.46.0`, hash `78c02a8`); this keeps the in-repo copy in sync.

## Test plan
- [ ] AUR helper resolves `psysonic` at 1.46.0
- [ ] `makepkg -si` builds cleanly against `app-v1.46.0.tar.gz`