### PR TITLE
feat(ui): scale the whole window with Interface Scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Interface Scale — covers the whole window
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#781](https://github.com/Psychotoxical/psysonic/pull/781)**
+
+* Settings → Appearance → Interface Scale now scales sidebar, queue, player bar, modals/portals and the fullscreen player alongside the main content — same behaviour as browser Ctrl+/−.
+
+
+
 ## [1.46.0] - 2026-05-18
 
 > **🙏 Special thanks to [@zz5zz](https://github.com/zz5zz)** for his tireless quirk-spotting and bug reports on the [Psysonic Discord](https://discord.gg/AMnDRErm4u) — several of the polish fixes in this release landed directly off the back of his messages.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -38,6 +38,7 @@
     "core:window:allow-create",
     "core:window:allow-set-size",
     "core:webview:allow-create-webview-window",
+    "core:webview:allow-set-webview-zoom",
     "process:allow-restart",
     "updater:default"
   ]

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -2,6 +2,7 @@ import React, { Suspense, useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ensurePlaybackServerActive } from '../utils/playback/playbackServer';
 import { invoke } from '@tauri-apps/api/core';
+import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { PanelRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import Sidebar from '../components/Sidebar';
@@ -122,6 +123,13 @@ export function AppShell() {
     useEqStore.getState().syncToRust();
   }, []);
 
+  useEffect(() => {
+    getCurrentWebview().setZoom(uiScale).catch(() => {
+      /* setZoom may fail on platforms where the capability is unavailable;
+         fall back silently so the rest of the shell still renders. */
+    });
+  }, [uiScale]);
+
   useNowPlayingTrayTitle(currentTrack, isPlaying);
 
   // Post-update changelog is now surfaced via a dismissible banner in the
@@ -178,7 +186,7 @@ export function AppShell() {
         />
       )}
       <main className="main-content">
-        <div className="main-content-zoom" style={uiScale !== 1 ? { zoom: uiScale } : undefined}>
+        <div className="main-content-zoom">
         <header className="content-header">
           <LiveSearch />
           <div className="spacer" />

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -311,6 +311,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Accessibility: OpenDyslexic font option in the Settings picker — bundled locally via @fontsource/opendyslexic, asymmetric glyph shapes for easier b/d, p/q tracking, Latin-only with translated subtitle in all 9 locales calling out the dyslexia-friendly intent and the Cyrillic/CJK fallback (PR #507)',
       'Settings: tri-state Clock Format (Auto / 24h / 12h) overriding the locale default for the queue ETA and the sleep-timer preview (PR #742)',
       'Servers: per-server library scan triggers (Quick / Full) and inline edit for existing profiles (PR #780)',
+      'Interface Scale: scales the entire window — sidebar, queue, player bar, modals and the fullscreen player follow the main content (PR #781)',
     ],
   },
 ] as const;


### PR DESCRIPTION
## Summary
- Drives `uiScale` through `getCurrentWebview().setZoom()` instead of the old `zoom: uiScale` CSS on `.main-content-zoom`. Sidebar, queue, player bar, portals/modals and the fullscreen player now scale alongside the main content (matching browser Ctrl+/− behaviour).
- Effect runs on mount and on every change so the persisted setting is reapplied on launch.

## Boundary
- Adds capability `core:webview:allow-set-webview-zoom`. No new invoke commands or events.

## Test plan
- [ ] Adjust `Settings → Appearance → Interface Scale` — sidebar, queue, player bar, modals/portals and fullscreen player scale with the main content.
- [ ] Queue drag-and-drop, WaveformSeek click and tracklist virtualization land on the right rows/positions at non-1.0 zoom.
- [ ] Setting persists across app restart.
- Verified on Windows + Linux. macOS unverified (no hardware).