### PR TITLE
chore(release): sync Cargo.lock workspace versions on promote

### DIFF
--- a/.github/workflows/promote-main-to-next.yml
+++ b/.github/workflows/promote-main-to-next.yml
@@ -75,7 +75,7 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/tauri.conf.json
+          git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
           if git diff --cached --quiet; then
             echo "No version bump changes to commit."
             exit 0

--- a/.github/workflows/promote-next-to-release.yml
+++ b/.github/workflows/promote-next-to-release.yml
@@ -47,7 +47,7 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/tauri.conf.json
+          git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
           if git diff --cached --quiet; then
             echo "No finalization changes to commit."
             exit 0

--- a/.github/workflows/reusable-channel-publish.yml
+++ b/.github/workflows/reusable-channel-publish.yml
@@ -447,7 +447,7 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/tauri.conf.json
+          git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
           if git diff --cached --quiet; then
             echo "No dev version bump required."
             exit 0
@@ -463,4 +463,4 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "chore(release): bump main to ${VERSION}" \
-            --body "Auto-generated after stable release: updates \`package.json\`, \`package-lock.json\`, \`src-tauri/Cargo.toml\`, and \`src-tauri/tauri.conf.json\` to the next development version."
+            --body "Auto-generated after stable release: updates \`package.json\`, \`package-lock.json\`, \`src-tauri/Cargo.toml\`, \`src-tauri/Cargo.lock\`, and \`src-tauri/tauri.conf.json\` to the next development version."

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -21,7 +21,7 @@ Direct push to these branches is not part of normal human workflow. Use PRs and 
 
 ## 2) Versioning rules (mandatory)
 
-Version is authoritative in `package.json` and `package-lock.json`.
+Version is authoritative in `package.json` and `package-lock.json`. Promotion workflows run `scripts/sync-tauri-version-from-package.js`, which also aligns `[workspace.package]` in `src-tauri/Cargo.toml`, `tauri.conf.json`, and the `psysonic*` workspace crate version fields in `src-tauri/Cargo.lock` (local `cargo build` alone does not commit that lock metadata).
 
 - `main` version format: `X.Y.Z-dev`
 - `next` version format: `X.Y.Z-rc.N`

--- a/scripts/sync-tauri-version-from-package.js
+++ b/scripts/sync-tauri-version-from-package.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /**
- * Align src-tauri/Cargo.toml and src-tauri/tauri.conf.json with package.json "version".
+ * Align src-tauri/Cargo.toml, src-tauri/tauri.conf.json, and workspace entries in
+ * src-tauri/Cargo.lock with package.json "version".
  * Used after npm version in promote workflows so bundle names match release semver.
  */
 const fs = require('fs');
@@ -28,3 +29,21 @@ const conf = JSON.parse(fs.readFileSync(confPath, 'utf8'));
 conf.version = version;
 fs.writeFileSync(confPath, JSON.stringify(conf, null, 2) + '\n');
 console.log(`tauri.conf.json -> ${version}`);
+
+/** @param {string} lockText */
+function syncCargoLockWorkspaceVersions(lockText, targetVersion) {
+  return lockText.replace(
+    /^(name = "psysonic[^"]*"\nversion = ")[^"]+"/gm,
+    `$1${targetVersion}"`,
+  );
+}
+
+const lockPath = path.join(root, 'src-tauri', 'Cargo.lock');
+let lock = fs.readFileSync(lockPath, 'utf8');
+const updatedLock = syncCargoLockWorkspaceVersions(lock, version);
+if (updatedLock !== lock) {
+  fs.writeFileSync(lockPath, updatedLock);
+  console.log(`Cargo.lock workspace crates -> ${version}`);
+} else {
+  console.log(`Cargo.lock workspace crates already at ${version}`);
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "psysonic"
-version = "1.46.0-dev"
+version = "1.47.0-dev"
 dependencies = [
  "biquad",
  "dasp_sample",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "psysonic-analysis"
-version = "1.46.0-dev"
+version = "1.47.0-dev"
 dependencies = [
  "ebur128",
  "futures-util",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "psysonic-audio"
-version = "1.46.0-dev"
+version = "1.47.0-dev"
 dependencies = [
  "biquad",
  "dasp_sample",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "psysonic-core"
-version = "1.46.0-dev"
+version = "1.47.0-dev"
 dependencies = [
  "libc",
  "serde",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "psysonic-integration"
-version = "1.46.0-dev"
+version = "1.47.0-dev"
 dependencies = [
  "discord-rich-presence",
  "futures-util",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "psysonic-syncfs"
-version = "1.46.0-dev"
+version = "1.47.0-dev"
 dependencies = [
  "futures-util",
  "id3",


### PR DESCRIPTION
## Summary

Promotion workflows already run `npm version` + `scripts/sync-tauri-version-from-package.js`, but only committed `package.json`, `package-lock.json`, `Cargo.toml`, and `tauri.conf.json`. **`src-tauri/Cargo.lock` workspace crate versions were left behind** (e.g. `1.46.0-dev` in lock while `Cargo.toml` was `1.47.0-dev`).

This PR:
- Extends the sync script to update all `psysonic*` `[[package]]` version lines in `Cargo.lock`
- Adds `src-tauri/Cargo.lock` to `git add` in **Promote main → next**, **Promote next → release**, and the post-release **main dev bump** PR
- Documents the behavior in `RELEASE_PROCESS.md`
- Aligns lock on `main` to `1.47.0-dev` (current channel version)

## How promote to release works (after merge)

1. **Promote next → release** resets `release` to `next`, runs `npm version` to strip `-rc.N` → `X.Y.Z`, then `sync-tauri-version-from-package.js` (now including lock).
2. Commits and pushes those files on `release`.
3. **Release channel** workflow builds/publishes; opens PR bumping `main` to `X.(Y+1).0-dev` with the same sync (lock included).

`cargo build` locally can refresh lock metadata too, but it is not part of the automated promote commit unless this script runs.

## Test plan

- [ ] `node scripts/sync-tauri-version-from-package.js` on a tree with mismatched lock → all six `psysonic*` entries match `package.json`
- [ ] After merge, next promote cycle commits lock alongside other version files