### PR TITLE
fix(ui): round play and enqueue buttons on cards and rails

### DIFF
--- a/src/styles/components/album-row-container.css
+++ b/src/styles/components/album-row-container.css
@@ -236,7 +236,7 @@
   color: var(--ctp-crust);
   border: none;
   padding: 8px 20px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/styles/components/tracklist.css
+++ b/src/styles/components/tracklist.css
@@ -269,7 +269,7 @@
   height: 24px;
   padding: 0;
   border: none;
-  border-radius: var(--radius-sm);
+  border-radius: 50%;
   background: var(--accent);
   color: var(--ctp-crust);
   cursor: pointer;


### PR DESCRIPTION
## Summary
- Album-card play and enqueue overlay buttons revert to `var(--radius-full)` (pill).
- Track-row play button in album track list / artist top tracks reverts to `50%` (circle).
- Partial revert of PR #745 — other surfaces from the consistency sweep stay on `var(--radius-sm)`.

## Test plan
- [ ] Hover an album card on Home / Albums grid → play + enqueue buttons render as pills.
- [ ] Open an album → play button next to track number renders as a circle, hover swap unchanged.
- [ ] Artist detail top tracks → same circular play button.
- [ ] No regression on Hero, album-row nav arrows, badges, pills (still square).