### PR TITLE
docs: add TELEMETRY.md, link it from the README Privacy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Psysonic is built for self-hosted music collections. Your library is yours.
 * No analytics harvesting
 * No hidden tracking
 
+See [TELEMETRY.md](TELEMETRY.md) for the telemetry stance and [PRIVACY.md](PRIVACY.md) for how each opt-in integration handles data.
+
 ---
 
 # Community & Support

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,65 @@
+# Privacy & Telemetry
+
+Privacy is not an afterthought in Psysonic. It has been part of the project’s foundation from the very beginning.
+
+Psysonic was built with the clear intention of giving users control over their own music experience without silently observing what they do. We believe that people should be able to use software on their own systems without being monitored by the developers behind it.
+
+## No Telemetry
+
+Psysonic does **not** collect telemetry.
+
+That means:
+
+- no usage statistics
+- no background tracking
+- no hidden analytics
+- no hardware or system profiling
+- no automatic crash or behavior reporting
+- no data harvesting of any kind
+
+Psysonic itself does not collect, store, sell, analyze, or transmit personal usage data.
+
+## A Conscious Decision
+
+We are aware that telemetry can make software development easier.
+
+Anonymous usage statistics, crash reports, platform information, and diagnostic data can help developers find bugs faster, understand which systems are used most often, and prioritize fixes more efficiently.
+
+However, we made a conscious decision not to build Psysonic around that model.
+
+For us, respecting user privacy is more important than collecting additional data for convenience. Modern software already tracks more than enough, often by default and often without users fully understanding what is being collected. Psysonic intentionally takes a different approach.
+
+## External Services Are Opt-In
+
+Some Psysonic features can communicate with external services, such as:
+
+- Last.fm
+- Bandsintown
+- Discord Rich Presence
+
+These integrations are optional and clearly presented as opt-in features. They are never required for using Psysonic.
+
+If you enable one of these integrations, data may be transmitted to the respective external service provider as part of how that service works. Psysonic itself does not collect or process that data for its own analytics.
+
+You decide which integrations you want to use.
+
+## Community Feedback Instead of Silent Tracking
+
+Instead of telemetry, Psysonic relies on direct community feedback.
+
+Bug reports, feature requests, platform issues, and general discussions happen openly through community channels such as Discord and Telegram. Additional contact options, including WhatsApp and Facebook groups, are planned for the future.
+
+We prefer talking to users directly over silently collecting information in the background.
+
+This approach may sometimes require more communication, but it also keeps the relationship between the project and its users transparent and respectful.
+
+## Our Position
+
+Psysonic is built for people who want to enjoy their own music collection on their own terms.
+
+No hidden tracking.  
+No telemetry by default.  
+No analytics quietly running in the background.
+
+This is intentional, and it is not planned to change.
+


### PR DESCRIPTION
## Summary
- New top-level `TELEMETRY.md` documenting the no-telemetry stance and opt-in nature of external integrations.
- README Privacy section gains a link line pointing to `TELEMETRY.md` (policy) and the existing `PRIVACY.md` (per-integration data flow).

## Test plan
- [ ] `TELEMETRY.md` renders on GitHub.
- [ ] README Privacy section shows the two links and they resolve to the right files.