### PR TITLE
feat(library): scaffold psysonic-library crate (Phase A foundation, PR-1a)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3723,6 +3723,7 @@ dependencies = [
  "psysonic-audio",
  "psysonic-core",
  "psysonic-integration",
+ "psysonic-library",
  "psysonic-syncfs",
  "reqwest",
  "ringbuf",
@@ -3824,6 +3825,17 @@ dependencies = [
  "tokio",
  "url",
  "wiremock",
+]
+
+[[package]]
+name = "psysonic-library"
+version = "1.47.0-dev"
+dependencies = [
+ "psysonic-core",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tauri",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ tauri-build = { version = "2", features = [] }
 psysonic-core = { path = "crates/psysonic-core" }
 psysonic-analysis = { path = "crates/psysonic-analysis" }
 psysonic-audio = { path = "crates/psysonic-audio" }
+psysonic-library = { path = "crates/psysonic-library" }
 psysonic-syncfs = { path = "crates/psysonic-syncfs" }
 psysonic-integration = { path = "crates/psysonic-integration" }
 tauri = { version = "2", features = ["tray-icon", "image-png"] }

--- a/src-tauri/crates/psysonic-library/Cargo.toml
+++ b/src-tauri/crates/psysonic-library/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "psysonic-library"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+psysonic-core = { path = "../psysonic-core" }
+
+tauri = { version = "2" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+rusqlite = { version = "0.39", features = ["bundled"] }

--- a/src-tauri/crates/psysonic-library/migrations/001_initial.sql
+++ b/src-tauri/crates/psysonic-library/migrations/001_initial.sql
@@ -1,0 +1,247 @@
+-- psysonic-library v1 schema — see implementation-spec.ru.md §5.1–§5.3
+-- Tables are ordered so FK targets exist before their referrers.
+
+-- Migration-runner bookkeeping (§5.7). Defined here so the schema file is
+-- self-describing — `LibraryStore::run_migrations` also creates this table
+-- defensively before applying migrations, which keeps both paths idempotent.
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  version    INTEGER PRIMARY KEY,
+  applied_at INTEGER NOT NULL
+);
+
+CREATE TABLE canonical_track (
+  id          TEXT PRIMARY KEY,
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL
+);
+
+CREATE TABLE canonical_identity (
+  canonical_id  TEXT NOT NULL,
+  kind          TEXT NOT NULL,
+  value         TEXT NOT NULL,
+  confidence    REAL NOT NULL DEFAULT 1.0,
+  PRIMARY KEY (kind, value),
+  FOREIGN KEY (canonical_id) REFERENCES canonical_track(id)
+);
+
+CREATE TABLE sync_state (
+  server_id                TEXT NOT NULL,
+  library_scope            TEXT NOT NULL DEFAULT '',
+  normalized_base_url      TEXT NOT NULL DEFAULT '',
+  server_fingerprint_ok    INTEGER,
+  fingerprint_checked_at   INTEGER,
+  capability_flags         INTEGER NOT NULL DEFAULT 0,
+  last_full_sync_at        INTEGER,
+  last_delta_sync_at       INTEGER,
+  server_last_scan_iso     TEXT,
+  indexes_last_modified_ms INTEGER,
+  artists_last_modified_ms INTEGER,
+  server_track_count       INTEGER,
+  local_track_count        INTEGER,
+  artist_count             INTEGER,
+  library_tier             TEXT NOT NULL DEFAULT 'unknown',
+  poll_stats_json          TEXT NOT NULL DEFAULT '{}',
+  next_poll_at             INTEGER,
+  initial_sync_cursor_json TEXT NOT NULL DEFAULT '{}',
+  sync_phase               TEXT NOT NULL DEFAULT 'idle',
+  last_error               TEXT,
+  PRIMARY KEY (server_id, library_scope)
+);
+
+CREATE TABLE artist (
+  server_id    TEXT NOT NULL,
+  id           TEXT NOT NULL,
+  name         TEXT NOT NULL,
+  album_count  INTEGER,
+  synced_at    INTEGER NOT NULL,
+  raw_json     TEXT,
+  PRIMARY KEY (server_id, id)
+);
+
+CREATE TABLE album (
+  server_id     TEXT NOT NULL,
+  id            TEXT NOT NULL,
+  name          TEXT NOT NULL,
+  artist        TEXT,
+  artist_id     TEXT,
+  song_count    INTEGER,
+  duration_sec  INTEGER,
+  year          INTEGER,
+  genre         TEXT,
+  cover_art_id  TEXT,
+  starred_at    INTEGER,
+  synced_at     INTEGER NOT NULL,
+  raw_json      TEXT,
+  PRIMARY KEY (server_id, id)
+);
+
+CREATE TABLE track (
+  server_id            TEXT NOT NULL,
+  id                   TEXT NOT NULL,
+  title                TEXT NOT NULL,
+  title_sort           TEXT,
+  artist               TEXT,
+  artist_id            TEXT,
+  album                TEXT NOT NULL DEFAULT '',
+  album_id             TEXT,
+  album_artist         TEXT,
+  duration_sec         INTEGER NOT NULL DEFAULT 0,
+  track_number         INTEGER,
+  disc_number          INTEGER,
+  year                 INTEGER,
+  genre                TEXT,
+  suffix               TEXT,
+  bit_rate             INTEGER,
+  size_bytes           INTEGER,
+  cover_art_id         TEXT,
+  starred_at           INTEGER,
+  user_rating          INTEGER,
+  play_count           INTEGER,
+  played_at            INTEGER,
+  server_path          TEXT,
+  library_id           TEXT,
+  isrc                 TEXT,
+  mbid_recording       TEXT,
+  bpm                  INTEGER,
+  replay_gain_track_db REAL,
+  replay_gain_album_db REAL,
+  content_hash         TEXT,
+  server_updated_at    INTEGER,
+  server_created_at    INTEGER,
+  deleted              INTEGER NOT NULL DEFAULT 0,
+  synced_at            INTEGER NOT NULL,
+  raw_json             TEXT NOT NULL,
+  PRIMARY KEY (server_id, id)
+);
+
+CREATE VIRTUAL TABLE track_fts USING fts5(
+  title, artist, album, album_artist, genre,
+  content='track', content_rowid='rowid',
+  tokenize='unicode61 remove_diacritics 2'
+);
+
+CREATE TRIGGER track_ai AFTER INSERT ON track BEGIN
+  INSERT INTO track_fts(rowid, title, artist, album, album_artist, genre)
+  VALUES (new.rowid, new.title, new.artist, new.album, new.album_artist, new.genre);
+END;
+
+CREATE TRIGGER track_ad AFTER DELETE ON track BEGIN
+  INSERT INTO track_fts(track_fts, rowid, title, artist, album, album_artist, genre)
+  VALUES ('delete', old.rowid, old.title, old.artist, old.album, old.album_artist, old.genre);
+END;
+
+CREATE TRIGGER track_au AFTER UPDATE ON track BEGIN
+  INSERT INTO track_fts(track_fts, rowid, title, artist, album, album_artist, genre)
+  VALUES ('delete', old.rowid, old.title, old.artist, old.album, old.album_artist, old.genre);
+  INSERT INTO track_fts(rowid, title, artist, album, album_artist, genre)
+  VALUES (new.rowid, new.title, new.artist, new.album, new.album_artist, new.genre);
+END;
+
+CREATE TABLE track_extension (
+  server_id   TEXT NOT NULL,
+  track_id    TEXT NOT NULL,
+  kind        TEXT NOT NULL,
+  version     INTEGER NOT NULL DEFAULT 1,
+  payload     BLOB NOT NULL,
+  updated_at  INTEGER NOT NULL,
+  PRIMARY KEY (server_id, track_id, kind),
+  FOREIGN KEY (server_id, track_id) REFERENCES track(server_id, id)
+);
+
+-- NO FK to track: survives library purge when user keeps the cached file (§5.14).
+CREATE TABLE track_offline (
+  server_id         TEXT NOT NULL,
+  track_id          TEXT NOT NULL,
+  local_path        TEXT NOT NULL,
+  file_size_bytes   INTEGER,
+  suffix            TEXT,
+  content_hash      TEXT NOT NULL DEFAULT '',
+  server_path       TEXT,
+  cached_at         INTEGER NOT NULL,
+  last_verified_at  INTEGER,
+  PRIMARY KEY (server_id, track_id)
+);
+
+CREATE TABLE track_id_history (
+  server_id    TEXT NOT NULL,
+  old_id       TEXT NOT NULL,
+  new_id       TEXT NOT NULL,
+  content_hash TEXT,
+  server_path  TEXT,
+  remapped_at  INTEGER NOT NULL,
+  PRIMARY KEY (server_id, old_id)
+);
+
+CREATE TABLE track_fact (
+  server_id     TEXT NOT NULL,
+  track_id      TEXT NOT NULL,
+  fact_kind     TEXT NOT NULL,
+  value_real    REAL,
+  value_int     INTEGER,
+  value_text    TEXT,
+  unit          TEXT,
+  source_kind   TEXT NOT NULL,
+  source_id     TEXT NOT NULL,
+  source_detail TEXT,
+  confidence    REAL NOT NULL DEFAULT 1.0,
+  content_hash  TEXT,
+  fetched_at    INTEGER NOT NULL,
+  expires_at    INTEGER,
+  PRIMARY KEY (server_id, track_id, fact_kind, source_kind, source_id),
+  FOREIGN KEY (server_id, track_id) REFERENCES track(server_id, id)
+);
+
+CREATE TABLE track_artifact (
+  server_id     TEXT NOT NULL,
+  track_id      TEXT NOT NULL,
+  artifact_kind TEXT NOT NULL,
+  format        TEXT NOT NULL,
+  language      TEXT,
+  source_kind   TEXT NOT NULL,
+  source_id     TEXT NOT NULL,
+  content_text  TEXT,
+  content_blob  BLOB,
+  content_bytes INTEGER NOT NULL DEFAULT 0,
+  not_found     INTEGER NOT NULL DEFAULT 0,
+  content_hash  TEXT,
+  fetched_at    INTEGER NOT NULL,
+  expires_at    INTEGER,
+  PRIMARY KEY (server_id, track_id, artifact_kind, source_kind, source_id, format),
+  FOREIGN KEY (server_id, track_id) REFERENCES track(server_id, id)
+);
+
+CREATE TABLE track_canonical_link (
+  server_id     TEXT NOT NULL,
+  track_id      TEXT NOT NULL,
+  canonical_id  TEXT NOT NULL,
+  match_method  TEXT NOT NULL,
+  confidence    REAL NOT NULL,
+  linked_at     INTEGER NOT NULL,
+  PRIMARY KEY (server_id, track_id),
+  FOREIGN KEY (server_id, track_id) REFERENCES track(server_id, id),
+  FOREIGN KEY (canonical_id) REFERENCES canonical_track(id)
+);
+
+CREATE TABLE canonical_enrichment_link (
+  canonical_id    TEXT NOT NULL,
+  enrichment_kind TEXT NOT NULL,
+  owner_server_id TEXT NOT NULL,
+  owner_track_id  TEXT NOT NULL,
+  share_policy    TEXT NOT NULL DEFAULT 'isrc_match',
+  linked_at       INTEGER NOT NULL,
+  PRIMARY KEY (canonical_id, enrichment_kind, owner_server_id, owner_track_id),
+  FOREIGN KEY (canonical_id) REFERENCES canonical_track(id)
+);
+
+CREATE INDEX idx_track_album   ON track(server_id, album_id)               WHERE deleted = 0;
+CREATE INDEX idx_track_artist  ON track(server_id, artist_id)              WHERE deleted = 0;
+CREATE INDEX idx_track_updated ON track(server_id, server_updated_at DESC) WHERE deleted = 0;
+CREATE INDEX idx_track_starred ON track(server_id, starred_at)             WHERE deleted = 0 AND starred_at IS NOT NULL;
+CREATE INDEX idx_track_library ON track(server_id, library_id)             WHERE deleted = 0;
+CREATE INDEX idx_track_bpm     ON track(server_id, bpm)                    WHERE deleted = 0 AND bpm IS NOT NULL;
+CREATE INDEX idx_track_isrc    ON track(isrc)                              WHERE deleted = 0 AND isrc IS NOT NULL;
+CREATE INDEX idx_track_fact_lookup     ON track_fact(server_id, track_id, fact_kind);
+CREATE INDEX idx_track_artifact_lookup ON track_artifact(server_id, track_id, artifact_kind);
+CREATE INDEX idx_track_offline_hash    ON track_offline(server_id, content_hash);
+CREATE INDEX idx_track_id_history_new  ON track_id_history(server_id, new_id);
+CREATE INDEX idx_canonical_identity_lookup ON canonical_identity(kind, value);

--- a/src-tauri/crates/psysonic-library/src/filter.rs
+++ b/src-tauri/crates/psysonic-library/src/filter.rs
@@ -1,0 +1,161 @@
+//! `FilterFieldRegistry` — Rust source of truth for Advanced Search filter
+//! fields (spec §5.13.3 / P38). The full SQL builder (`AdvancedSearchQuery`,
+//! §5.13.5) and the Tauri command surface (§5.13.6) come later; PR-1a
+//! ships the registry shape + the v1 fields + the entity-routing rule.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EntityKind {
+    Track,
+    Album,
+    Artist,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FilterOp {
+    /// FTS5 MATCH (`track_fts`). Only valid on the `text` field in v1.
+    Fts,
+    Eq,
+    /// Membership test against a list of values. (Not yet in v1; reserved.)
+    In,
+    Gte,
+    Lte,
+    Between,
+    /// Boolean field — value side is ignored, presence = `IS NOT NULL`.
+    IsTrue,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FilterStatus {
+    /// v1: built into the SQL builder and exercised by parity tests.
+    V1,
+    /// Schema present, builder hook to come post-v1.
+    SchemaV1UiLater,
+    /// Reserved column / planned-but-not-built.
+    Planned,
+    /// Out of scope for v1 entirely.
+    Future,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FilterField {
+    pub id: &'static str,
+    pub entities: &'static [EntityKind],
+    pub ops: &'static [FilterOp],
+    pub status: FilterStatus,
+}
+
+/// Static v1 registry. Adding a row here is the only thing required to expose
+/// a new filter field (plus, when the storage isn't yet a hot column / index,
+/// a separate `00X_*.sql` migration — see §5.7). No new invoke is needed.
+pub const FILTER_FIELD_REGISTRY: &[FilterField] = &[
+    FilterField {
+        id: "text",
+        entities: &[EntityKind::Track, EntityKind::Album, EntityKind::Artist],
+        ops: &[FilterOp::Fts],
+        status: FilterStatus::V1,
+    },
+    FilterField {
+        id: "genre",
+        entities: &[EntityKind::Track, EntityKind::Album],
+        ops: &[FilterOp::Eq],
+        status: FilterStatus::V1,
+    },
+    FilterField {
+        id: "year",
+        entities: &[EntityKind::Track, EntityKind::Album],
+        ops: &[FilterOp::Gte, FilterOp::Lte, FilterOp::Between],
+        status: FilterStatus::V1,
+    },
+    FilterField {
+        id: "starred",
+        entities: &[EntityKind::Track, EntityKind::Album, EntityKind::Artist],
+        ops: &[FilterOp::IsTrue],
+        status: FilterStatus::V1,
+    },
+    FilterField {
+        id: "user_rating",
+        entities: &[EntityKind::Track],
+        ops: &[FilterOp::Gte, FilterOp::Eq],
+        status: FilterStatus::Planned,
+    },
+    FilterField {
+        id: "suffix",
+        entities: &[EntityKind::Track],
+        ops: &[FilterOp::Eq, FilterOp::In],
+        status: FilterStatus::Planned,
+    },
+    FilterField {
+        id: "bit_rate",
+        entities: &[EntityKind::Track],
+        ops: &[FilterOp::Gte, FilterOp::Lte, FilterOp::Between],
+        status: FilterStatus::Planned,
+    },
+    FilterField {
+        id: "bpm",
+        entities: &[EntityKind::Track],
+        ops: &[FilterOp::Gte, FilterOp::Lte, FilterOp::Between],
+        status: FilterStatus::SchemaV1UiLater,
+    },
+];
+
+pub fn lookup(id: &str) -> Option<&'static FilterField> {
+    FILTER_FIELD_REGISTRY.iter().find(|f| f.id == id)
+}
+
+/// `true` when this filter field is applicable for a request that targets
+/// the given entity. Per §5.13.3 the routing rule is a *skip*, not an error:
+/// if the request asks for `entityTypes = [album, artist]` and a clause names
+/// a track-only field, the clause is silently dropped.
+pub fn applies_to(field: &FilterField, entity: EntityKind) -> bool {
+    field.entities.contains(&entity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_contains_all_v1_fields() {
+        for id in ["text", "genre", "year", "starred"] {
+            let f = lookup(id).unwrap_or_else(|| panic!("missing v1 field `{id}`"));
+            assert_eq!(f.status, FilterStatus::V1, "`{id}` must be V1");
+        }
+    }
+
+    #[test]
+    fn bpm_is_schema_v1_but_ui_later() {
+        // §5.13.3: bpm has a hot column + index from day one, but is hidden
+        // from the v1 UI until §5.13.4 dual-storage resolution lands.
+        assert_eq!(lookup("bpm").unwrap().status, FilterStatus::SchemaV1UiLater);
+    }
+
+    #[test]
+    fn text_routes_to_all_three_entities() {
+        let f = lookup("text").unwrap();
+        assert!(applies_to(f, EntityKind::Track));
+        assert!(applies_to(f, EntityKind::Album));
+        assert!(applies_to(f, EntityKind::Artist));
+    }
+
+    #[test]
+    fn track_only_field_is_skipped_for_album_entity() {
+        let f = lookup("user_rating").unwrap();
+        assert!(applies_to(f, EntityKind::Track));
+        assert!(!applies_to(f, EntityKind::Album));
+        assert!(!applies_to(f, EntityKind::Artist));
+    }
+
+    #[test]
+    fn unknown_field_lookup_returns_none() {
+        assert!(lookup("nope").is_none());
+    }
+
+    #[test]
+    fn registry_has_no_duplicate_ids() {
+        let mut ids: Vec<&str> = FILTER_FIELD_REGISTRY.iter().map(|f| f.id).collect();
+        ids.sort();
+        let len_before = ids.len();
+        ids.dedup();
+        assert_eq!(ids.len(), len_before, "duplicate filter field id detected");
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/lib.rs
+++ b/src-tauri/crates/psysonic-library/src/lib.rs
@@ -1,0 +1,21 @@
+//! `psysonic-library` — unified track store and (future) sync engine.
+//!
+//! v1 scope (this crate, across PR-1..PR-7):
+//! - `store`  — SQLite connection, WAL config, versioned migration runner
+//! - `repos`  — typed repositories over the v1 schema (track, album, artist, …)
+//! - `search` — FTS5 query helpers
+//! - `filter` — `FilterFieldRegistry` (Rust source of truth for Advanced Search)
+//!
+//! PR-1a lands the schema, the store, and skeletons of the repos / search /
+//! filter modules. Sync orchestration, Subsonic HTTP, Tauri commands, and the
+//! frontend bridge follow in later PRs.
+
+pub mod filter;
+pub mod repos;
+pub mod search;
+pub mod store;
+
+pub use store::{LibraryStore, LIBRARY_DB_SCHEMA_VERSION};
+
+// Re-export logging facade so submodules can write `crate::app_eprintln!()`.
+pub use psysonic_core::{app_deprintln, app_eprintln, logging};

--- a/src-tauri/crates/psysonic-library/src/repos/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/mod.rs
@@ -1,0 +1,3 @@
+pub mod track;
+
+pub use track::{TrackRepository, TrackRow};

--- a/src-tauri/crates/psysonic-library/src/repos/track.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track.rs
@@ -1,0 +1,314 @@
+use rusqlite::params;
+
+use crate::store::LibraryStore;
+
+/// One row of the `track` table — every hot column from spec §5.1 plus
+/// `raw_json` (the full normalized SubsonicSong). Sync code (PR-2/PR-3) is
+/// expected to project ingested payloads into this shape, not to talk SQL
+/// directly.
+#[derive(Debug, Clone)]
+pub struct TrackRow {
+    pub server_id: String,
+    pub id: String,
+    pub title: String,
+    pub title_sort: Option<String>,
+    pub artist: Option<String>,
+    pub artist_id: Option<String>,
+    pub album: String,
+    pub album_id: Option<String>,
+    pub album_artist: Option<String>,
+    pub duration_sec: i64,
+    pub track_number: Option<i64>,
+    pub disc_number: Option<i64>,
+    pub year: Option<i64>,
+    pub genre: Option<String>,
+    pub suffix: Option<String>,
+    pub bit_rate: Option<i64>,
+    pub size_bytes: Option<i64>,
+    pub cover_art_id: Option<String>,
+    pub starred_at: Option<i64>,
+    pub user_rating: Option<i64>,
+    pub play_count: Option<i64>,
+    pub played_at: Option<i64>,
+    pub server_path: Option<String>,
+    pub library_id: Option<String>,
+    pub isrc: Option<String>,
+    pub mbid_recording: Option<String>,
+    pub bpm: Option<i64>,
+    pub replay_gain_track_db: Option<f64>,
+    pub replay_gain_album_db: Option<f64>,
+    pub content_hash: Option<String>,
+    pub server_updated_at: Option<i64>,
+    pub server_created_at: Option<i64>,
+    pub deleted: bool,
+    pub synced_at: i64,
+    pub raw_json: String,
+}
+
+pub struct TrackRepository<'a> {
+    store: &'a LibraryStore,
+}
+
+impl<'a> TrackRepository<'a> {
+    pub fn new(store: &'a LibraryStore) -> Self {
+        Self { store }
+    }
+
+    /// Batch upsert. Wrapped in a single transaction; sync code can call with
+    /// chunks of ~500 rows to hit the §5.1 perf target.
+    pub fn upsert_batch(&self, rows: &[TrackRow]) -> Result<(), String> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        self.store.with_conn_mut(|conn| {
+            let tx = conn.transaction()?;
+            {
+                let mut stmt = tx.prepare(UPSERT_SQL)?;
+                for r in rows {
+                    stmt.execute(params![
+                        r.server_id,
+                        r.id,
+                        r.title,
+                        r.title_sort,
+                        r.artist,
+                        r.artist_id,
+                        r.album,
+                        r.album_id,
+                        r.album_artist,
+                        r.duration_sec,
+                        r.track_number,
+                        r.disc_number,
+                        r.year,
+                        r.genre,
+                        r.suffix,
+                        r.bit_rate,
+                        r.size_bytes,
+                        r.cover_art_id,
+                        r.starred_at,
+                        r.user_rating,
+                        r.play_count,
+                        r.played_at,
+                        r.server_path,
+                        r.library_id,
+                        r.isrc,
+                        r.mbid_recording,
+                        r.bpm,
+                        r.replay_gain_track_db,
+                        r.replay_gain_album_db,
+                        r.content_hash,
+                        r.server_updated_at,
+                        r.server_created_at,
+                        if r.deleted { 1_i64 } else { 0 },
+                        r.synced_at,
+                        r.raw_json,
+                    ])?;
+                }
+            }
+            tx.commit()?;
+            Ok(())
+        })
+    }
+}
+
+const UPSERT_SQL: &str = r#"
+INSERT INTO track (
+  server_id, id, title, title_sort, artist, artist_id, album, album_id,
+  album_artist, duration_sec, track_number, disc_number, year, genre, suffix,
+  bit_rate, size_bytes, cover_art_id, starred_at, user_rating, play_count,
+  played_at, server_path, library_id, isrc, mbid_recording, bpm,
+  replay_gain_track_db, replay_gain_album_db, content_hash, server_updated_at,
+  server_created_at, deleted, synced_at, raw_json
+) VALUES (
+  ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17,
+  ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32,
+  ?33, ?34, ?35
+)
+ON CONFLICT(server_id, id) DO UPDATE SET
+  title                = excluded.title,
+  title_sort           = excluded.title_sort,
+  artist               = excluded.artist,
+  artist_id            = excluded.artist_id,
+  album                = excluded.album,
+  album_id             = excluded.album_id,
+  album_artist         = excluded.album_artist,
+  duration_sec         = excluded.duration_sec,
+  track_number         = excluded.track_number,
+  disc_number          = excluded.disc_number,
+  year                 = excluded.year,
+  genre                = excluded.genre,
+  suffix               = excluded.suffix,
+  bit_rate             = excluded.bit_rate,
+  size_bytes           = excluded.size_bytes,
+  cover_art_id         = excluded.cover_art_id,
+  starred_at           = excluded.starred_at,
+  user_rating          = excluded.user_rating,
+  play_count           = excluded.play_count,
+  played_at            = excluded.played_at,
+  server_path          = excluded.server_path,
+  library_id           = excluded.library_id,
+  isrc                 = excluded.isrc,
+  mbid_recording       = excluded.mbid_recording,
+  bpm                  = excluded.bpm,
+  replay_gain_track_db = excluded.replay_gain_track_db,
+  replay_gain_album_db = excluded.replay_gain_album_db,
+  content_hash         = excluded.content_hash,
+  server_updated_at    = excluded.server_updated_at,
+  server_created_at    = excluded.server_created_at,
+  deleted              = excluded.deleted,
+  synced_at            = excluded.synced_at,
+  raw_json             = excluded.raw_json
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(server: &str, id: &str, title: &str) -> TrackRow {
+        TrackRow {
+            server_id: server.into(),
+            id: id.into(),
+            title: title.into(),
+            title_sort: None,
+            artist: Some("The Artist".into()),
+            artist_id: Some("ar1".into()),
+            album: "An Album".into(),
+            album_id: Some("al1".into()),
+            album_artist: Some("The Artist".into()),
+            duration_sec: 240,
+            track_number: Some(3),
+            disc_number: Some(1),
+            year: Some(2024),
+            genre: Some("Ambient".into()),
+            suffix: Some("flac".into()),
+            bit_rate: Some(1000),
+            size_bytes: Some(32_000_000),
+            cover_art_id: Some("cv1".into()),
+            starred_at: None,
+            user_rating: None,
+            play_count: Some(0),
+            played_at: None,
+            server_path: Some("Artist/Album/03.flac".into()),
+            library_id: Some("lib-1".into()),
+            isrc: None,
+            mbid_recording: None,
+            bpm: None,
+            replay_gain_track_db: None,
+            replay_gain_album_db: None,
+            content_hash: Some("hash-abc".into()),
+            server_updated_at: Some(1_700_000_000),
+            server_created_at: Some(1_699_000_000),
+            deleted: false,
+            synced_at: 1_700_000_500,
+            raw_json: r#"{"id":"t1"}"#.into(),
+        }
+    }
+
+    #[test]
+    fn upsert_inserts_new_rows() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[row("s1", "t1", "First"), row("s1", "t2", "Second")])
+            .unwrap();
+        let count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn upsert_updates_existing_rows() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[row("s1", "t1", "Original")]).unwrap();
+
+        let mut updated = row("s1", "t1", "Updated");
+        updated.bpm = Some(128);
+        updated.starred_at = Some(1_700_000_999);
+        repo.upsert_batch(&[updated]).unwrap();
+
+        let (title, bpm, starred): (String, Option<i64>, Option<i64>) = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT title, bpm, starred_at FROM track WHERE server_id='s1' AND id='t1'",
+                    [],
+                    |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+                )
+            })
+            .unwrap();
+        assert_eq!(title, "Updated");
+        assert_eq!(bpm, Some(128));
+        assert_eq!(starred, Some(1_700_000_999));
+
+        let count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(count, 1, "upsert must not duplicate the row");
+    }
+
+    #[test]
+    fn upsert_empty_batch_is_noop() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[]).unwrap();
+    }
+
+    #[test]
+    fn upsert_keeps_server_scope_separate() {
+        // Same `id` on two different servers must produce two rows
+        // (PRIMARY KEY is composite).
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[row("s1", "t1", "From S1"), row("s2", "t1", "From S2")])
+            .unwrap();
+        let count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn upsert_populates_fts_via_trigger() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[row("s1", "t1", "Aurora Boreal")]).unwrap();
+        let fts_hit: i64 = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT COUNT(*) FROM track_fts WHERE track_fts MATCH 'aurora'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(fts_hit, 1);
+    }
+
+    #[test]
+    fn upsert_update_refreshes_fts_via_trigger() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[row("s1", "t1", "Old Title")]).unwrap();
+        repo.upsert_batch(&[row("s1", "t1", "Brand New Title")]).unwrap();
+
+        let old_hit: i64 = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT COUNT(*) FROM track_fts WHERE track_fts MATCH 'old'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        let new_hit: i64 = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT COUNT(*) FROM track_fts WHERE track_fts MATCH 'brand'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(old_hit, 0, "delete-trigger must drop the stale FTS row");
+        assert_eq!(new_hit, 1);
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/search.rs
+++ b/src-tauri/crates/psysonic-library/src/search.rs
@@ -1,0 +1,140 @@
+//! FTS5-backed track search. Skeleton landed in PR-1a — the multi-server +
+//! libraryScope + bm25 ranking shape from spec §5.9 will be filled in by the
+//! sync / search PRs.
+
+use rusqlite::params;
+
+use crate::store::LibraryStore;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackHit {
+    pub server_id: String,
+    pub id: String,
+    pub title: String,
+    pub artist: Option<String>,
+    pub album: String,
+}
+
+/// Run a single-server FTS5 match against `track_fts`, returning rows in
+/// bm25 order. `query` is passed straight to FTS5 — callers are expected to
+/// sanitise / quote user input (see §5.13.5: parameterised only).
+pub fn search_tracks(
+    store: &LibraryStore,
+    server_id: &str,
+    query: &str,
+    limit: i64,
+) -> Result<Vec<TrackHit>, String> {
+    store.with_conn(|conn| {
+        let mut stmt = conn.prepare(
+            r#"
+            SELECT t.server_id, t.id, t.title, t.artist, t.album
+              FROM track_fts f
+              JOIN track t ON t.rowid = f.rowid
+             WHERE track_fts MATCH ?1
+               AND t.server_id = ?2
+               AND t.deleted = 0
+             ORDER BY bm25(track_fts)
+             LIMIT ?3
+            "#,
+        )?;
+        let rows = stmt
+            .query_map(params![query, server_id, limit], |r| {
+                Ok(TrackHit {
+                    server_id: r.get(0)?,
+                    id: r.get(1)?,
+                    title: r.get(2)?,
+                    artist: r.get(3)?,
+                    album: r.get(4)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repos::{TrackRepository, TrackRow};
+
+    fn row(server: &str, id: &str, title: &str, artist: &str, album: &str) -> TrackRow {
+        TrackRow {
+            server_id: server.into(),
+            id: id.into(),
+            title: title.into(),
+            title_sort: None,
+            artist: Some(artist.into()),
+            artist_id: None,
+            album: album.into(),
+            album_id: None,
+            album_artist: Some(artist.into()),
+            duration_sec: 200,
+            track_number: None,
+            disc_number: None,
+            year: None,
+            genre: None,
+            suffix: None,
+            bit_rate: None,
+            size_bytes: None,
+            cover_art_id: None,
+            starred_at: None,
+            user_rating: None,
+            play_count: None,
+            played_at: None,
+            server_path: None,
+            library_id: None,
+            isrc: None,
+            mbid_recording: None,
+            bpm: None,
+            replay_gain_track_db: None,
+            replay_gain_album_db: None,
+            content_hash: None,
+            server_updated_at: None,
+            server_created_at: None,
+            deleted: false,
+            synced_at: 1,
+            raw_json: "{}".into(),
+        }
+    }
+
+    #[test]
+    fn match_finds_track_by_title() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                row("s1", "t1", "Aurora", "Anna", "Skylines"),
+                row("s1", "t2", "Sunset", "Beth", "Skylines"),
+            ])
+            .unwrap();
+        let hits = search_tracks(&store, "s1", "aurora", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, "t1");
+    }
+
+    #[test]
+    fn match_filters_by_server_id() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                row("s1", "t1", "Aurora", "Anna", "Skylines"),
+                row("s2", "t1", "Aurora", "Anna", "Skylines"),
+            ])
+            .unwrap();
+        let hits = search_tracks(&store, "s2", "aurora", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].server_id, "s2");
+    }
+
+    #[test]
+    fn match_skips_deleted_rows() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[row("s1", "t1", "Aurora", "Anna", "Skylines")])
+            .unwrap();
+        let mut gone = row("s1", "t1", "Aurora", "Anna", "Skylines");
+        gone.deleted = true;
+        repo.upsert_batch(&[gone]).unwrap();
+        let hits = search_tracks(&store, "s1", "aurora", 10).unwrap();
+        assert!(hits.is_empty());
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -1,0 +1,191 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use rusqlite::{params, Connection};
+use tauri::Manager;
+
+/// Schema version applied to a fresh DB / current head of `migrations/`.
+/// Bump whenever a new `NNN_*.sql` is added; PR-1b will tighten the
+/// breaking-bump handshake (P22).
+pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 1;
+
+/// Embedded migrations. Order matters: ascending `version`, applied once each
+/// and recorded in `schema_migrations`.
+const MIGRATIONS: &[(i64, &str)] = &[(1, include_str!("../migrations/001_initial.sql"))];
+
+pub struct LibraryStore {
+    conn: Mutex<Connection>,
+}
+
+impl LibraryStore {
+    pub fn init(app: &tauri::AppHandle) -> Result<Self, String> {
+        let db_path = library_db_path(app)?;
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
+        configure_connection(&conn).map_err(|e| e.to_string())?;
+        run_migrations(&conn).map_err(|e| e.to_string())?;
+        Ok(Self { conn: Mutex::new(conn) })
+    }
+
+    /// Build an in-memory DB with the production schema applied.
+    /// WAL pragma is skipped — `:memory:` doesn't support journal-mode changes
+    /// (mirrors `psysonic_analysis::AnalysisCache::open_in_memory`).
+    pub fn open_in_memory() -> Self {
+        let conn = Connection::open_in_memory().expect("in-memory connection");
+        conn.pragma_update(None, "foreign_keys", "ON").expect("pragma foreign_keys");
+        run_migrations(&conn).expect("schema migration");
+        Self { conn: Mutex::new(conn) }
+    }
+
+    /// Borrow the inner connection. Returned guard locks the mutex — keep the
+    /// scope tight so other repo calls don't stall.
+    pub(crate) fn with_conn<R>(
+        &self,
+        f: impl FnOnce(&Connection) -> rusqlite::Result<R>,
+    ) -> Result<R, String> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| "library store lock poisoned".to_string())?;
+        f(&conn).map_err(|e| e.to_string())
+    }
+
+    pub(crate) fn with_conn_mut<R>(
+        &self,
+        f: impl FnOnce(&mut Connection) -> rusqlite::Result<R>,
+    ) -> Result<R, String> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|_| "library store lock poisoned".to_string())?;
+        f(&mut conn).map_err(|e| e.to_string())
+    }
+}
+
+fn library_db_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let base = app.path().app_data_dir().map_err(|e| e.to_string())?;
+    Ok(base.join("library.sqlite"))
+}
+
+fn configure_connection(conn: &Connection) -> rusqlite::Result<()> {
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "synchronous", "NORMAL")?;
+    conn.pragma_update(None, "temp_store", "MEMORY")?;
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+    Ok(())
+}
+
+fn run_migrations(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (
+           version    INTEGER PRIMARY KEY,
+           applied_at INTEGER NOT NULL
+         );",
+    )?;
+    for (version, sql) in MIGRATIONS {
+        let already: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM schema_migrations WHERE version = ?1",
+            params![version],
+            |row| row.get(0),
+        )?;
+        if already > 0 {
+            continue;
+        }
+        conn.execute_batch(sql)?;
+        conn.execute(
+            "INSERT INTO schema_migrations (version, applied_at) VALUES (?1, strftime('%s','now'))",
+            params![version],
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_in_memory_creates_all_expected_tables() {
+        let store = LibraryStore::open_in_memory();
+        let tables = store
+            .with_conn(|c| {
+                let mut stmt =
+                    c.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")?;
+                let rows: rusqlite::Result<Vec<String>> =
+                    stmt.query_map([], |r| r.get::<_, String>(0))?.collect();
+                rows
+            })
+            .unwrap();
+
+        // FTS5 creates internal shadow tables (_data, _idx, _docsize, _config).
+        // We just assert that every base table from §5.1 is present.
+        for expected in [
+            "album",
+            "artist",
+            "canonical_enrichment_link",
+            "canonical_identity",
+            "canonical_track",
+            "schema_migrations",
+            "sync_state",
+            "track",
+            "track_artifact",
+            "track_canonical_link",
+            "track_extension",
+            "track_fact",
+            "track_id_history",
+            "track_offline",
+        ] {
+            assert!(
+                tables.iter().any(|t| t == expected),
+                "missing table `{expected}` — got {tables:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn schema_migrations_records_head_version() {
+        let store = LibraryStore::open_in_memory();
+        let versions: Vec<i64> = store
+            .with_conn(|c| {
+                let mut stmt =
+                    c.prepare("SELECT version FROM schema_migrations ORDER BY version")?;
+                let rows: rusqlite::Result<Vec<i64>> =
+                    stmt.query_map([], |r| r.get(0))?.collect();
+                rows
+            })
+            .unwrap();
+        assert_eq!(versions, vec![LIBRARY_DB_SCHEMA_VERSION]);
+    }
+
+    #[test]
+    fn run_migrations_is_idempotent_across_reopens() {
+        // Same connection, second pass must not re-execute the SQL.
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn(run_migrations)
+            .expect("second migration pass must be a no-op");
+        let count: i64 = store
+            .with_conn(|c| {
+                c.query_row("SELECT COUNT(*) FROM schema_migrations", [], |r| r.get(0))
+            })
+            .unwrap();
+        assert_eq!(count, 1, "no duplicate schema_migrations rows");
+    }
+
+    #[test]
+    fn fts_virtual_table_exists() {
+        let store = LibraryStore::open_in_memory();
+        let count: i64 = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE name='track_fts'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+}


### PR DESCRIPTION
Adds the `psysonic-library` workspace crate — Phase A foundation of the
unified track store and (future) sync engine.

Scope: spec phases A1–A6 only. A7 (migration-runner edge cases,
`initial_sync_cursor_json` API, P22 breaking-migration hook) follows as
a stacked PR-1b on top of this branch.

## A1–A6 mapping

- **A1** — crate skeleton at `src-tauri/crates/psysonic-library/`.
- **A2** — `migrations/001_initial.sql`: full v1 schema (§5.1 / §5.2 /
  §5.3) — `schema_migrations`, `sync_state`, `track`, `album`, `artist`,
  `track_fts` + ai/ad/au triggers, `track_extension`, `track_offline`,
  `track_id_history`, `track_fact`, `track_artifact`, `canonical_track`,
  `canonical_identity`, `track_canonical_link`,
  `canonical_enrichment_link`, all §5.2 partial indexes.
- **A3** — `repos::TrackRepository::upsert_batch` — 35-column
  transactional upsert with `ON CONFLICT(server_id, id)` all-fields
  rewrite; FTS rows follow via the triggers.
- **A4** — `search::search_tracks` (FTS5 bm25, single-server scope) and
  `filter::FilterFieldRegistry` (Rust source of truth, P38) covering v1
  fields `text` / `genre` / `year` / `starred`, plus `bpm`
  (schema-v1-UI-later) and `user_rating` / `suffix` / `bit_rate`
  (planned).
- **A5** — workspace wired via `psysonic-library = { path = … }` in the
  top crate's `[dependencies]`; `members = ["crates/*"]` already picks
  the new crate up.
- **A6** — `store::LibraryStore::init(&AppHandle)`: WAL +
  `foreign_keys = ON` connection at `{app_data_dir}/library.sqlite`
  (intentionally distinct from `psysonic-analysis`, which uses
  `app_config_dir`, per §5.1). Idempotent embedded migration runner;
  `LIBRARY_DB_SCHEMA_VERSION = 1`. `open_in_memory()` test harness
  mirrors `psysonic_analysis::AnalysisCache::open_in_memory`.

## Files

```
src-tauri/Cargo.toml                                             (workspace dep)
src-tauri/Cargo.lock                                             (new package)
src-tauri/crates/psysonic-library/Cargo.toml
src-tauri/crates/psysonic-library/migrations/001_initial.sql
src-tauri/crates/psysonic-library/src/lib.rs
src-tauri/crates/psysonic-library/src/store.rs
src-tauri/crates/psysonic-library/src/repos/mod.rs
src-tauri/crates/psysonic-library/src/repos/track.rs
src-tauri/crates/psysonic-library/src/search.rs
src-tauri/crates/psysonic-library/src/filter.rs
```

## Tauri boundary

No new `invoke` commands, no events, no capability changes. PR-1 stays
purely internal Rust — the only Tauri-side touchpoint is reading
`app_data_dir()` inside `LibraryStore::init`.

## References

- Spec: `psysonic-workdocs/internal/collaboration/tasks/2026-05-library-track-store/implementation-spec.ru.md`
- Kickoff Q&A: `…/questions/2026-05-19-pr1-kickoff-approach.md`
- PR-1a handoff Q&A: `…/questions/2026-05-19-pr1a-handoff.md`

## Out of scope (later PRs)

- Subsonic HTTP client + sync orchestration → PR-2 / PR-3
- Tauri commands + Settings UI → PR-5
- Frontend consumers + QA fixtures → PR-7
- `psysonic-library` is deliberately not added to
  `hot-path-files.txt` yet — coverage gate kicks in once sync/search
  is on a user-visible hot path.

## Test plan

- [x] `cargo test --workspace` — 408 tests pass (19 new in
      `psysonic-library`)
- [x] `cargo clippy -p psysonic-library --all-targets -- -D warnings`
- [x] `./dev.sh backend-ci` — hot-path coverage gate green across the
      existing 11 hot-path files