### PR TITLE
feat(library): A7 migration-runner safety net + initial-sync cursor API (PR-1b)

### DIFF
--- a/src-tauri/crates/psysonic-library/src/repos/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/mod.rs
@@ -1,3 +1,5 @@
+pub mod sync_state;
 pub mod track;
 
+pub use sync_state::SyncStateRepository;
 pub use track::{TrackRepository, TrackRow};

--- a/src-tauri/crates/psysonic-library/src/repos/sync_state.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/sync_state.rs
@@ -1,0 +1,188 @@
+use rusqlite::{params, OptionalExtension};
+use serde_json::Value;
+
+use crate::store::LibraryStore;
+
+/// Repository over the `sync_state` row identified by `(server_id, library_scope)`.
+/// PR-1b exposes just enough of the row to drive resumable initial sync — the
+/// orchestrator-side helpers (poll stats, phase transitions, …) land with
+/// PR-3 when there's actual sync code to consume them.
+pub struct SyncStateRepository<'a> {
+    store: &'a LibraryStore,
+}
+
+impl<'a> SyncStateRepository<'a> {
+    pub fn new(store: &'a LibraryStore) -> Self {
+        Self { store }
+    }
+
+    /// Insert a default-valued row for this `(server_id, library_scope)` pair
+    /// if none exists. All non-PK columns fall back to their schema DEFAULTs
+    /// (`sync_phase='idle'`, `initial_sync_cursor_json='{}'`, …).
+    pub fn ensure(&self, server_id: &str, library_scope: &str) -> Result<(), String> {
+        self.store.with_conn(|conn| {
+            conn.execute(
+                "INSERT OR IGNORE INTO sync_state (server_id, library_scope) VALUES (?1, ?2)",
+                params![server_id, library_scope],
+            )?;
+            Ok(())
+        })
+    }
+
+    /// Read `initial_sync_cursor_json`. Returns `None` when the row doesn't
+    /// exist yet, `Some(Value)` otherwise (the schema DEFAULT is `'{}'`, so
+    /// a freshly-ensured row reads back as `Some(Object({}))`).
+    pub fn get_initial_sync_cursor(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+    ) -> Result<Option<Value>, String> {
+        let raw: Option<String> = self.store.with_conn(|conn| {
+            conn.query_row(
+                "SELECT initial_sync_cursor_json FROM sync_state \
+                 WHERE server_id = ?1 AND library_scope = ?2",
+                params![server_id, library_scope],
+                |row| row.get(0),
+            )
+            .optional()
+        })?;
+        match raw {
+            None => Ok(None),
+            Some(s) => serde_json::from_str(&s)
+                .map(Some)
+                .map_err(|e| format!("invalid initial_sync_cursor_json: {e}")),
+        }
+    }
+
+    /// Write `initial_sync_cursor_json`. Creates the row if needed; only the
+    /// cursor column is touched, all other columns keep their current values
+    /// (or their DEFAULTs on first insert).
+    pub fn set_initial_sync_cursor(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+        cursor: &Value,
+    ) -> Result<(), String> {
+        let json = serde_json::to_string(cursor).map_err(|e| e.to_string())?;
+        self.store.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO sync_state (server_id, library_scope, initial_sync_cursor_json) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(server_id, library_scope) DO UPDATE SET \
+                   initial_sync_cursor_json = excluded.initial_sync_cursor_json",
+                params![server_id, library_scope, json],
+            )?;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ensure_creates_row_with_default_cursor() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.ensure("s1", "").unwrap();
+
+        let cursor = repo.get_initial_sync_cursor("s1", "").unwrap();
+        assert_eq!(cursor, Some(json!({})), "DEFAULT must read back as empty object");
+    }
+
+    #[test]
+    fn ensure_is_idempotent() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.ensure("s1", "").unwrap();
+        repo.ensure("s1", "").unwrap();
+
+        let count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM sync_state", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn get_returns_none_for_missing_row() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        assert_eq!(repo.get_initial_sync_cursor("absent", "").unwrap(), None);
+    }
+
+    #[test]
+    fn set_roundtrips_nested_cursor_value() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        let cursor = json!({
+            "phase": "ingest_tracks",
+            "offset": 12_500,
+            "last_seen_id": "tr_abc",
+            "filters": { "library_id": "lib-1" },
+        });
+        repo.set_initial_sync_cursor("s1", "", &cursor).unwrap();
+        let got = repo.get_initial_sync_cursor("s1", "").unwrap();
+        assert_eq!(got, Some(cursor));
+    }
+
+    #[test]
+    fn set_overwrites_prior_cursor() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.set_initial_sync_cursor("s1", "", &json!({"offset": 1})).unwrap();
+        repo.set_initial_sync_cursor("s1", "", &json!({"offset": 2})).unwrap();
+        let got = repo.get_initial_sync_cursor("s1", "").unwrap();
+        assert_eq!(got, Some(json!({"offset": 2})));
+    }
+
+    #[test]
+    fn set_preserves_other_columns_on_upsert() {
+        // The ON CONFLICT clause must only touch the cursor column. Other
+        // DEFAULT-backed fields stay at their initial values across upserts.
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.set_initial_sync_cursor("s1", "", &json!({"x": 1})).unwrap();
+
+        // Mutate a sibling column out-of-band to detect any accidental reset.
+        store
+            .with_conn(|c| {
+                c.execute(
+                    "UPDATE sync_state SET sync_phase = 'ingesting' WHERE server_id = 's1'",
+                    [],
+                )
+            })
+            .unwrap();
+
+        // Second cursor write must not touch sync_phase.
+        repo.set_initial_sync_cursor("s1", "", &json!({"x": 2})).unwrap();
+        let phase: String = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT sync_phase FROM sync_state WHERE server_id = 's1'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(phase, "ingesting");
+    }
+
+    #[test]
+    fn library_scope_separates_rows_per_server() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.set_initial_sync_cursor("s1", "", &json!({"all": true})).unwrap();
+        repo.set_initial_sync_cursor("s1", "lib-1", &json!({"lib": "one"})).unwrap();
+
+        assert_eq!(
+            repo.get_initial_sync_cursor("s1", "").unwrap(),
+            Some(json!({"all": true}))
+        );
+        assert_eq!(
+            repo.get_initial_sync_cursor("s1", "lib-1").unwrap(),
+            Some(json!({"lib": "one"}))
+        );
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/repos/track.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track.rs
@@ -311,4 +311,32 @@ mod tests {
         assert_eq!(old_hit, 0, "delete-trigger must drop the stale FTS row");
         assert_eq!(new_hit, 1);
     }
+
+    #[test]
+    fn upsert_500_rows_completes_well_under_perf_budget() {
+        // Spec §5.1 / AC A3: `upsert_batch` should land 500 rows under 100ms
+        // typical. The CI threshold is 5× that to absorb slow runners and
+        // the difference between debug and release; any regression past it
+        // is real signal.
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        let rows: Vec<TrackRow> = (0..500)
+            .map(|i| row("s1", &format!("t{i:04}"), &format!("Track {i:04}")))
+            .collect();
+
+        let start = std::time::Instant::now();
+        repo.upsert_batch(&rows).unwrap();
+        let elapsed = start.elapsed();
+
+        let stored: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(stored, 500);
+
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "upsert_batch(500 rows) took {elapsed:?}; AC A3 target is <100ms typical, \
+             test fails past 5× that"
+        );
+    }
 }

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -4,14 +4,35 @@ use std::sync::Mutex;
 use rusqlite::{params, Connection};
 use tauri::Manager;
 
-/// Schema version applied to a fresh DB / current head of `migrations/`.
-/// Bump whenever a new `NNN_*.sql` is added; PR-1b will tighten the
-/// breaking-bump handshake (P22).
+/// Current head of the embedded migrations. Bump each time a new
+/// `migrations/NNN_*.sql` is added.
 pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 1;
 
-/// Embedded migrations. Order matters: ascending `version`, applied once each
-/// and recorded in `schema_migrations`.
-const MIGRATIONS: &[(i64, &str)] = &[(1, include_str!("../migrations/001_initial.sql"))];
+/// Lowest applied schema version the current code can advance from purely
+/// additively. If a DB carries a version below this, the breaking-bump hook
+/// fires (spec §5.7 / P22): the library is treated as incompatible, must be
+/// dropped, and initial sync must restart.
+///
+/// At v1 launch this equals `LIBRARY_DB_SCHEMA_VERSION` — no real DB can
+/// trip the hook. Bump independently of `SCHEMA_VERSION` only when a
+/// migration cannot be expressed additively.
+pub const LIBRARY_DB_MIN_COMPATIBLE_VERSION: i64 = 1;
+
+pub(crate) const INITIAL_SQL: &str = include_str!("../migrations/001_initial.sql");
+
+/// Embedded migrations. Ordered ascending by `version`; the runner sorts
+/// defensively before applying so the source order can stay readable.
+const MIGRATIONS: &[(i64, &str)] = &[(1, INITIAL_SQL)];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MigrationOutcome {
+    /// Every missing migration was applied (or the DB was already at head).
+    Applied,
+    /// The DB carried a schema below `LIBRARY_DB_MIN_COMPATIBLE_VERSION`,
+    /// so the breaking-bump hook fired. Callers should treat the library
+    /// data as discarded and trigger a fresh initial sync (P22).
+    BreakingBump,
+}
 
 pub struct LibraryStore {
     conn: Mutex<Connection>,
@@ -77,14 +98,46 @@ fn configure_connection(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
-fn run_migrations(conn: &Connection) -> rusqlite::Result<()> {
+fn run_migrations(conn: &Connection) -> rusqlite::Result<MigrationOutcome> {
+    run_migrations_with(
+        conn,
+        MIGRATIONS,
+        LIBRARY_DB_MIN_COMPATIBLE_VERSION,
+        handle_breaking_schema_bump,
+    )
+}
+
+/// Test-friendly entry point. Production code goes through `run_migrations`,
+/// which fixes `migrations`, `min_compatible`, and `hook` to the prod values.
+pub(crate) fn run_migrations_with(
+    conn: &Connection,
+    migrations: &[(i64, &str)],
+    min_compatible: i64,
+    hook: fn(&Connection, i64, i64) -> rusqlite::Result<()>,
+) -> rusqlite::Result<MigrationOutcome> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS schema_migrations (
            version    INTEGER PRIMARY KEY,
            applied_at INTEGER NOT NULL
          );",
     )?;
-    for (version, sql) in MIGRATIONS {
+
+    // Breaking-bump detection only meaningful for already-initialised DBs.
+    let max_applied: Option<i64> = conn.query_row(
+        "SELECT MAX(version) FROM schema_migrations",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    if let Some(max_applied) = max_applied {
+        if max_applied < min_compatible {
+            hook(conn, max_applied, LIBRARY_DB_SCHEMA_VERSION)?;
+            return Ok(MigrationOutcome::BreakingBump);
+        }
+    }
+
+    let mut ordered: Vec<(i64, &str)> = migrations.iter().map(|(v, s)| (*v, *s)).collect();
+    ordered.sort_by_key(|(v, _)| *v);
+    for (version, sql) in ordered {
         let already: i64 = conn.query_row(
             "SELECT COUNT(*) FROM schema_migrations WHERE version = ?1",
             params![version],
@@ -99,6 +152,19 @@ fn run_migrations(conn: &Connection) -> rusqlite::Result<()> {
             params![version],
         )?;
     }
+    Ok(MigrationOutcome::Applied)
+}
+
+/// P22 breaking-schema-bump hook. PR-1b ships a no-op stub: the function
+/// signature, call site, and `MigrationOutcome::BreakingBump` signal are in
+/// place, but the actual library-drop + sync-reset logic lands when the
+/// first real breaking bump happens. Until then the constants guarantee the
+/// hook never fires on production data.
+fn handle_breaking_schema_bump(
+    _conn: &Connection,
+    _max_applied: i64,
+    _target_version: i64,
+) -> rusqlite::Result<()> {
     Ok(())
 }
 
@@ -119,8 +185,6 @@ mod tests {
             })
             .unwrap();
 
-        // FTS5 creates internal shadow tables (_data, _idx, _docsize, _config).
-        // We just assert that every base table from §5.1 is present.
         for expected in [
             "album",
             "artist",
@@ -161,11 +225,11 @@ mod tests {
 
     #[test]
     fn run_migrations_is_idempotent_across_reopens() {
-        // Same connection, second pass must not re-execute the SQL.
         let store = LibraryStore::open_in_memory();
-        store
+        let outcome = store
             .with_conn(run_migrations)
             .expect("second migration pass must be a no-op");
+        assert_eq!(outcome, MigrationOutcome::Applied);
         let count: i64 = store
             .with_conn(|c| {
                 c.query_row("SELECT COUNT(*) FROM schema_migrations", [], |r| r.get(0))
@@ -187,5 +251,129 @@ mod tests {
             })
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    // ── PR-1b: edge-case tests via the test-only `run_migrations_with` ─────
+
+    /// `ALTER TABLE artist ADD COLUMN bio TEXT;` — minimal additive fixture,
+    /// nullable column with no default. Mirrors the §5.7 additive-first rule.
+    const FIXTURE_002_ADD_BIO: &str = "ALTER TABLE artist ADD COLUMN bio TEXT;";
+
+    fn no_op_hook(_c: &Connection, _from: i64, _to: i64) -> rusqlite::Result<()> {
+        Ok(())
+    }
+
+    fn always_fail_hook(_c: &Connection, _from: i64, _to: i64) -> rusqlite::Result<()> {
+        panic!("breaking-bump hook must NOT fire in this test");
+    }
+
+    #[test]
+    fn additive_migration_preserves_existing_data() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn(|c| {
+                c.execute(
+                    "INSERT INTO artist (server_id, id, name, synced_at) \
+                     VALUES ('s1', 'a1', 'Existing Artist', 1)",
+                    [],
+                )
+            })
+            .unwrap();
+
+        let outcome = store
+            .with_conn(|c| {
+                run_migrations_with(
+                    c,
+                    &[(1, INITIAL_SQL), (2, FIXTURE_002_ADD_BIO)],
+                    LIBRARY_DB_MIN_COMPATIBLE_VERSION,
+                    always_fail_hook,
+                )
+            })
+            .unwrap();
+        assert_eq!(outcome, MigrationOutcome::Applied);
+
+        let (name, bio): (String, Option<String>) = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT name, bio FROM artist WHERE id = 'a1'",
+                    [],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+            })
+            .unwrap();
+        assert_eq!(name, "Existing Artist");
+        assert!(bio.is_none());
+
+        let versions: Vec<i64> = store
+            .with_conn(|c| {
+                let mut stmt =
+                    c.prepare("SELECT version FROM schema_migrations ORDER BY version")?;
+                let rows: rusqlite::Result<Vec<i64>> =
+                    stmt.query_map([], |r| r.get(0))?.collect();
+                rows
+            })
+            .unwrap();
+        assert_eq!(versions, vec![1, 2]);
+    }
+
+    #[test]
+    fn runner_sorts_unsorted_migration_slice_before_applying() {
+        // If a future contributor lists migrations out of order in the
+        // source slice, the runner must still apply them ascending.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+
+        let outcome = run_migrations_with(
+            &conn,
+            &[(2, FIXTURE_002_ADD_BIO), (1, INITIAL_SQL)],
+            LIBRARY_DB_MIN_COMPATIBLE_VERSION,
+            always_fail_hook,
+        )
+        .unwrap();
+        assert_eq!(outcome, MigrationOutcome::Applied);
+
+        let versions: Vec<i64> = {
+            let mut stmt = conn
+                .prepare("SELECT version FROM schema_migrations ORDER BY applied_at, version")
+                .unwrap();
+            let rows: rusqlite::Result<Vec<i64>> =
+                stmt.query_map([], |r| r.get(0)).unwrap().collect();
+            rows.unwrap()
+        };
+        assert_eq!(versions, vec![1, 2]);
+    }
+
+    #[test]
+    fn breaking_bump_hook_fires_when_db_below_min_compatible() {
+        // Simulate a future code release where MIN_COMPATIBLE was bumped to
+        // 2 but the DB still carries only version 1.
+        let store = LibraryStore::open_in_memory();
+        let outcome = store
+            .with_conn(|c| {
+                run_migrations_with(
+                    c,
+                    &[(1, INITIAL_SQL), (2, FIXTURE_002_ADD_BIO)],
+                    2, // pretend MIN_COMPATIBLE has been bumped past current applied
+                    no_op_hook,
+                )
+            })
+            .unwrap();
+        assert_eq!(outcome, MigrationOutcome::BreakingBump);
+    }
+
+    #[test]
+    fn breaking_bump_hook_does_not_fire_on_fresh_db() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+        let outcome = run_migrations_with(
+            &conn,
+            MIGRATIONS,
+            // Even a wildly future min_compatible must not trip on a fresh DB:
+            // no rows in schema_migrations means "nothing to migrate from".
+            999,
+            always_fail_hook,
+        )
+        .unwrap();
+        assert_eq!(outcome, MigrationOutcome::Applied);
     }
 }


### PR DESCRIPTION
PR-1b — Phase A7 infrastructure stacked on PR-1a (#791). Production
behaviour is unchanged at v1 launch; everything here is plumbing that
PR-3 will consume.

Stacked on `feat/library-store-pr1`. Once #791 merges into the
integration branch (`feat/library-store`), this PR's base will be
retargeted to `feat/library-store` and rebased per spec §13 / Round 7.

## A7 mapping

- **A7.1 migration-runner edge cases** — `store::run_migrations_with`
  takes an explicit migration slice, a `min_compatible` threshold, and
  a breaking-bump hook. Prod `run_migrations` fixes those to the head
  consts + a no-op stub. Slice is sorted defensively before applying.
- **A7.2 P22 breaking-bump hook (stub)** — new
  `LIBRARY_DB_MIN_COMPATIBLE_VERSION` constant (= `SCHEMA_VERSION` at
  v1 launch); `MigrationOutcome::{Applied, BreakingBump}` signals the
  outcome; `handle_breaking_schema_bump` is a documented no-op until
  the first real breaking bump.
- **A7.3 initial-sync cursor API** — `SyncStateRepository::ensure`,
  `get_initial_sync_cursor`, `set_initial_sync_cursor` over
  `sync_state.initial_sync_cursor_json` via `serde_json::Value`.
  Cursor-only `ON CONFLICT … DO UPDATE` so phase / poll-stats / tier
  survive cursor writes intact.

## Tests added (11)

- Additive 002-style migration preserves prior data (§5.7 integration
  test).
- Runner sorts an unsorted source slice before applying.
- Breaking-bump hook fires when `max_applied < min_compatible` on a
  non-empty DB.
- Breaking-bump hook does not fire on a fresh DB even with extreme
  `min_compatible`.
- `SyncStateRepository`: ensure + idempotency, get returns `None` for
  missing row, set round-trips a nested `Value`, set overwrites, set
  preserves sibling columns on upsert, `library_scope` separates rows
  per server.

## Out of scope

- End-to-end "kill mid-500k-sync → resume same cursor" stays with
  PR-3 / C2 (kickoff Q&A 2026-05-19).
- 500-row upsert micro-bench (AC A3) — picked up in PR-1b/PR-3
  later, not in this commit (review-handoff §4 follow-up).

## References

- Spec §5.7, §13 Round 7, §17.2 DoD
- PR-1a review: `psysonic-workdocs/internal/collaboration/handoffs/2026-05-19-pr-791-review.md`
- Kickoff Q&A + handoff Q&A under `.../questions/`

## Test plan

- [x] `cargo test --workspace` — 419 tests pass (30 in
      `psysonic-library`, 11 new in this PR)
- [x] `cargo clippy -p psysonic-library --all-targets -- -D warnings`