### PR TITLE
feat(library): Subsonic REST client for the sync engine (Phase B, PR-2)

### DIFF
--- a/src-tauri/crates/psysonic-integration/Cargo.toml
+++ b/src-tauri/crates/psysonic-integration/Cargo.toml
@@ -12,7 +12,7 @@ tauri = { version = "2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "time", "sync"] }
-reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "rustls", "blocking", "gzip", "brotli"] }
+reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "multipart", "query", "form", "rustls", "blocking", "gzip", "brotli"] }
 futures-util = "0.3"
 discord-rich-presence = "1.1"
 url = "2"

--- a/src-tauri/crates/psysonic-integration/src/lib.rs
+++ b/src-tauri/crates/psysonic-integration/src/lib.rs
@@ -4,6 +4,7 @@
 //! Domains:
 //! - `discord`     — Discord Rich Presence (album artwork via iTunes)
 //! - `navidrome`   — Navidrome's native REST API (admin: users/playlists/covers/queries)
+//! - `subsonic`    — Subsonic REST surface for the library-sync engine
 //! - `remote`      — radio-browser, last.fm, ICY-meta probe, generic CORS proxy
 //! - `bandsintown` — bandsintown events for an artist
 
@@ -15,3 +16,4 @@ pub mod bandsintown;
 pub mod discord;
 pub mod navidrome;
 pub mod remote;
+pub mod subsonic;

--- a/src-tauri/crates/psysonic-integration/src/subsonic/auth.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/auth.rs
@@ -1,0 +1,91 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Subsonic credentials in the legacy salted-md5 shape (spec v1.13+):
+/// the client sends `u` + `t = md5(password || salt)` + `s = salt`,
+/// never the plaintext password. The salt is per-request to defeat
+/// replay, but doesn't need to be cryptographically random — Subsonic's
+/// API treats it as an opaque uniqueness nonce.
+#[derive(Debug, Clone)]
+pub struct SubsonicCredentials {
+    pub username: String,
+    pub token: String,
+    pub salt: String,
+}
+
+impl SubsonicCredentials {
+    /// Derive a credentials triple from a plaintext password. Generates a
+    /// fresh salt and computes `md5(password || salt)`.
+    pub fn from_password(username: impl Into<String>, password: &str) -> Self {
+        let salt = fresh_salt();
+        let token = md5_hex(&format!("{password}{salt}"));
+        Self { username: username.into(), token, salt }
+    }
+
+    /// Use a caller-supplied salt + token. Intended for tests and for
+    /// callers that already cache the derivation result.
+    pub fn with_static(username: impl Into<String>, token: impl Into<String>, salt: impl Into<String>) -> Self {
+        Self { username: username.into(), token: token.into(), salt: salt.into() }
+    }
+}
+
+/// Per-process monotonically-advancing nonce mixed into the salt so the
+/// hot loop of `from_password` calls doesn't repeat itself even at the
+/// same nanosecond.
+static SALT_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn fresh_salt() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let counter = SALT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id() as u64;
+    format!("{:016x}{:08x}", nanos ^ pid.rotate_left(13), counter)
+}
+
+fn md5_hex(input: &str) -> String {
+    let digest = md5::compute(input.as_bytes());
+    format!("{digest:x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn from_password_computes_md5_token() {
+        // Force the salt by going through with_static for a deterministic check.
+        let salt = "abc123";
+        let password = "sesame";
+        let expected = md5_hex(&format!("{password}{salt}"));
+        let creds = SubsonicCredentials::with_static("user", &expected, salt);
+        assert_eq!(creds.token, expected);
+        assert_eq!(creds.token.len(), 32, "md5 hex must be 32 chars");
+    }
+
+    #[test]
+    fn fresh_salt_is_unique_across_rapid_calls() {
+        let mut seen: HashSet<String> = HashSet::new();
+        for _ in 0..1000 {
+            assert!(seen.insert(fresh_salt()), "fresh_salt repeated");
+        }
+    }
+
+    #[test]
+    fn from_password_produces_different_salts_per_call() {
+        let a = SubsonicCredentials::from_password("u", "pw");
+        let b = SubsonicCredentials::from_password("u", "pw");
+        assert_ne!(a.salt, b.salt);
+        assert_ne!(a.token, b.token, "different salt → different token");
+    }
+
+    #[test]
+    fn md5_hex_matches_known_vector() {
+        // md5("") = d41d8cd98f00b204e9800998ecf8427e
+        assert_eq!(md5_hex(""), "d41d8cd98f00b204e9800998ecf8427e");
+        // md5("abc") = 900150983cd24fb0d6963f7d28e17f72
+        assert_eq!(md5_hex("abc"), "900150983cd24fb0d6963f7d28e17f72");
+    }
+}

--- a/src-tauri/crates/psysonic-integration/src/subsonic/client.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/client.rs
@@ -1,0 +1,698 @@
+//! `SubsonicClient` — read-only Subsonic REST surface needed by the
+//! library-sync engine (phase B per spec §10 / PR-2). Auth is the legacy
+//! salted-md5 token (spec v1.13+); request shape is GET to
+//! `{base}/rest/{method}.view?u&t&s&v&c&f=json&…`.
+//!
+//! This client is pure Rust — **no `#[tauri::command]`**. Tauri commands
+//! that talk to the library live in PR-5 / phase D.
+
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+
+use super::auth::SubsonicCredentials;
+use super::error::{flatten_reqwest_error, SubsonicError};
+use super::types::{Album, AlbumSummary, ArtistIndex, ScanStatus, SearchResult, Song};
+
+/// Protocol level we advertise — pre-OpenSubsonic Subsonic baseline that
+/// Navidrome and other servers in the wild support. OpenSubsonic
+/// extensions deserialize when present (additive on the wire).
+pub const SUBSONIC_API_VERSION: &str = "1.16.1";
+
+/// Subsonic `c` parameter — server logs and rate-limiters key off this.
+pub const SUBSONIC_CLIENT_ID: &str = "psysonic";
+
+pub struct SubsonicClient {
+    base_url: String,
+    credentials: SubsonicCredentials,
+    http: reqwest::Client,
+}
+
+impl SubsonicClient {
+    /// Build a client with our default HTTP setup (gzip, JSON, no funky
+    /// pooling tweaks — Subsonic gateways are simpler than the Navidrome
+    /// native-REST path).
+    pub fn new(base_url: impl Into<String>, credentials: SubsonicCredentials) -> Self {
+        Self::with_http(base_url, credentials, default_http_client())
+    }
+
+    /// Build a client with a caller-supplied `reqwest::Client`. Used by
+    /// tests (custom timeouts, no UA cap) and by callers that want to
+    /// share a pool across multiple Subsonic servers.
+    pub fn with_http(
+        base_url: impl Into<String>,
+        credentials: SubsonicCredentials,
+        http: reqwest::Client,
+    ) -> Self {
+        let mut url = base_url.into();
+        while url.ends_with('/') {
+            url.pop();
+        }
+        Self { base_url: url, credentials, http }
+    }
+
+    /// B1 — ping. Returns `Ok(())` when the server replied with
+    /// `status="ok"`; surfaces `SubsonicError::Api{40,…}` for invalid
+    /// credentials and the usual transport / status errors otherwise.
+    pub async fn ping(&self) -> Result<(), SubsonicError> {
+        let body = self.send("ping", &[]).await?;
+        parse_envelope_status_only(&body)
+    }
+
+    /// B2 — `getScanStatus`. Lightweight poll for huge libraries
+    /// (spec §2.3 / §6.2.2).
+    pub async fn get_scan_status(&self) -> Result<ScanStatus, SubsonicError> {
+        self.fetch("getScanStatus", &[], "scanStatus").await
+    }
+
+    /// B5 — `getIndexes(musicFolderId?, ifModifiedSince?)`. File-tree
+    /// browse with conditional fetch — when `ifModifiedSince` matches the
+    /// server's `lastScan`, the response body is empty but the
+    /// `lastModified` watermark is still returned (spec §3.1).
+    pub async fn get_indexes(
+        &self,
+        music_folder_id: Option<&str>,
+        if_modified_since_ms: Option<i64>,
+    ) -> Result<ArtistIndex, SubsonicError> {
+        let ims = if_modified_since_ms.map(|n| n.to_string());
+        let mut params: Vec<(&str, &str)> = Vec::new();
+        if let Some(id) = music_folder_id {
+            params.push(("musicFolderId", id));
+        }
+        if let Some(ref s) = ims {
+            params.push(("ifModifiedSince", s));
+        }
+        self.fetch("getIndexes", &params, "indexes").await
+    }
+
+    /// B8 — `getArtists(musicFolderId?)`. ID3-path artist index. Always
+    /// returns full body; clients compare `last_modified_ms` against the
+    /// watermark in `sync_state` to decide whether a delta pass is needed
+    /// (spec §2.2.1).
+    pub async fn get_artists(
+        &self,
+        music_folder_id: Option<&str>,
+    ) -> Result<ArtistIndex, SubsonicError> {
+        let mut params: Vec<(&str, &str)> = Vec::new();
+        if let Some(id) = music_folder_id {
+            params.push(("musicFolderId", id));
+        }
+        self.fetch("getArtists", &params, "artists").await
+    }
+
+    /// B3a — `getAlbumList2(type, size, offset, musicFolderId?)`. Returns
+    /// just the album summaries; the caller follows up with `get_album`
+    /// per id to enumerate songs.
+    pub async fn get_album_list2(
+        &self,
+        list_type: &str,
+        size: u32,
+        offset: u32,
+        music_folder_id: Option<&str>,
+    ) -> Result<Vec<AlbumSummary>, SubsonicError> {
+        let size_s = size.to_string();
+        let offset_s = offset.to_string();
+        let mut params: Vec<(&str, &str)> = vec![
+            ("type", list_type),
+            ("size", size_s.as_str()),
+            ("offset", offset_s.as_str()),
+        ];
+        if let Some(id) = music_folder_id {
+            params.push(("musicFolderId", id));
+        }
+        let wrapped: AlbumListWrapper =
+            self.fetch("getAlbumList2", &params, "albumList2").await?;
+        Ok(wrapped.album)
+    }
+
+    /// B3b — `getAlbum(id)`. Returns the album metadata plus the full song list.
+    pub async fn get_album(&self, album_id: &str) -> Result<Album, SubsonicError> {
+        self.fetch("getAlbum", &[("id", album_id)], "album").await
+    }
+
+    /// B4 — `search3(query, songCount, songOffset, musicFolderId?)`.
+    /// Navidrome accepts an empty query and returns all songs paged —
+    /// spec §2.4 documents that quirk and Psysonic already relies on it.
+    pub async fn search3(
+        &self,
+        query: &str,
+        song_count: u32,
+        song_offset: u32,
+        music_folder_id: Option<&str>,
+    ) -> Result<SearchResult, SubsonicError> {
+        let song_count_s = song_count.to_string();
+        let song_offset_s = song_offset.to_string();
+        let mut params: Vec<(&str, &str)> = vec![
+            ("query", query),
+            ("songCount", song_count_s.as_str()),
+            ("songOffset", song_offset_s.as_str()),
+        ];
+        if let Some(id) = music_folder_id {
+            params.push(("musicFolderId", id));
+        }
+        self.fetch("search3", &params, "searchResult3").await
+    }
+
+    /// B6 — `getSong(id)`. Returns `SubsonicError::NotFound` when the
+    /// server replies with error code 70 (spec §2.6) — the tombstone
+    /// reconciler matches on that variant directly.
+    pub async fn get_song(&self, song_id: &str) -> Result<Song, SubsonicError> {
+        self.fetch("getSong", &[("id", song_id)], "song").await
+    }
+
+    async fn fetch<T: DeserializeOwned>(
+        &self,
+        method: &str,
+        extra: &[(&str, &str)],
+        body_key: &str,
+    ) -> Result<T, SubsonicError> {
+        let body = self.send(method, extra).await?;
+        parse_envelope(&body, body_key)
+    }
+
+    async fn send(&self, method: &str, extra: &[(&str, &str)]) -> Result<String, SubsonicError> {
+        let auth = [
+            ("u", self.credentials.username.as_str()),
+            ("t", self.credentials.token.as_str()),
+            ("s", self.credentials.salt.as_str()),
+            ("v", SUBSONIC_API_VERSION),
+            ("c", SUBSONIC_CLIENT_ID),
+            ("f", "json"),
+        ];
+        let mut query: Vec<(&str, &str)> = auth.to_vec();
+        query.extend_from_slice(extra);
+
+        let resp = self
+            .http
+            .get(format!("{}/rest/{method}.view", self.base_url))
+            .query(&query)
+            .send()
+            .await
+            .map_err(|e| SubsonicError::Transport(flatten_reqwest_error(e)))?;
+
+        if !resp.status().is_success() {
+            return Err(SubsonicError::HttpStatus(resp.status()));
+        }
+        resp.text()
+            .await
+            .map_err(|e| SubsonicError::Transport(flatten_reqwest_error(e)))
+    }
+}
+
+#[derive(Deserialize)]
+struct AlbumListWrapper {
+    #[serde(default)]
+    album: Vec<AlbumSummary>,
+}
+
+fn default_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent(format!("Psysonic/{} (Tauri)", env!("CARGO_PKG_VERSION")))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+/// Parse the standard Subsonic envelope. Maps `error.code = 70` to the
+/// dedicated `NotFound` variant; surfaces every other failed status as
+/// `Api { code, message }`. On success, deserializes the body keyed by
+/// `body_key` (e.g. `"album"`, `"artists"`, `"scanStatus"`).
+fn parse_envelope<T: DeserializeOwned>(body: &str, body_key: &str) -> Result<T, SubsonicError> {
+    let envelope: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| SubsonicError::Decode(format!("envelope: {e}")))?;
+    let response = envelope
+        .get("subsonic-response")
+        .ok_or_else(|| SubsonicError::Decode("missing `subsonic-response`".into()))?;
+
+    if let Some(err) = response.get("error") {
+        let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(-1) as i32;
+        let message = err
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default()
+            .to_string();
+        return Err(map_error(code, message));
+    }
+
+    let status = response.get("status").and_then(|s| s.as_str()).unwrap_or_default();
+    if status != "ok" {
+        return Err(SubsonicError::Decode(format!("unexpected status `{status}`")));
+    }
+
+    let body_val = response
+        .get(body_key)
+        .ok_or_else(|| SubsonicError::Decode(format!("missing body key `{body_key}`")))?
+        .clone();
+    serde_json::from_value(body_val)
+        .map_err(|e| SubsonicError::Decode(format!("body `{body_key}`: {e}")))
+}
+
+/// Variant of `parse_envelope` for endpoints that carry no body (only
+/// `ping` in PR-2). Returns `Ok(())` when `status="ok"` and falls back to
+/// the same error mapping.
+fn parse_envelope_status_only(body: &str) -> Result<(), SubsonicError> {
+    let envelope: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| SubsonicError::Decode(format!("envelope: {e}")))?;
+    let response = envelope
+        .get("subsonic-response")
+        .ok_or_else(|| SubsonicError::Decode("missing `subsonic-response`".into()))?;
+
+    if let Some(err) = response.get("error") {
+        let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(-1) as i32;
+        let message = err
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default()
+            .to_string();
+        return Err(map_error(code, message));
+    }
+
+    let status = response.get("status").and_then(|s| s.as_str()).unwrap_or_default();
+    match status {
+        "ok" => Ok(()),
+        other => Err(SubsonicError::Decode(format!("unexpected status `{other}`"))),
+    }
+}
+
+fn map_error(code: i32, message: String) -> SubsonicError {
+    if code == 70 {
+        SubsonicError::NotFound
+    } else {
+        SubsonicError::Api { code, message }
+    }
+}
+
+/// B9 — pick every `every_n`-th id from a sorted list. Used by the
+/// server-fingerprint pass on re-add: 1 % of cached track ids are
+/// probed via `get_song` and any 404 (`NotFound`) means the server's
+/// id space drifted (spec §5.6, P19). The actual probing + comparison
+/// is glue code in `psysonic-library` (PR-3 territory); this crate
+/// just ships the deterministic sampling primitive so both sides use
+/// the same selection logic.
+pub fn fingerprint_sample(track_ids: &[String], every_n: usize) -> Vec<&String> {
+    if every_n == 0 {
+        return Vec::new();
+    }
+    track_ids
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| i % every_n == 0)
+        .map(|(_, id)| id)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method as wm_method, path as wm_path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // ── parse_envelope unit tests (no HTTP) ────────────────────────────────
+
+    #[test]
+    fn parse_envelope_extracts_body_on_ok_status() {
+        let body = json!({
+            "subsonic-response": {
+                "status": "ok",
+                "version": "1.16.1",
+                "scanStatus": {
+                    "scanning": false,
+                    "count": 42
+                }
+            }
+        })
+        .to_string();
+        let s: ScanStatus = parse_envelope(&body, "scanStatus").unwrap();
+        assert_eq!(s.count, Some(42));
+    }
+
+    #[test]
+    fn parse_envelope_maps_code_70_to_not_found() {
+        let body = json!({
+            "subsonic-response": {
+                "status": "failed",
+                "error": { "code": 70, "message": "Song not found" }
+            }
+        })
+        .to_string();
+        let err = parse_envelope::<Song>(&body, "song").unwrap_err();
+        assert!(matches!(err, SubsonicError::NotFound));
+    }
+
+    #[test]
+    fn parse_envelope_surfaces_other_error_codes_as_api_variant() {
+        let body = json!({
+            "subsonic-response": {
+                "status": "failed",
+                "error": { "code": 40, "message": "Wrong username or password" }
+            }
+        })
+        .to_string();
+        let err = parse_envelope::<Song>(&body, "song").unwrap_err();
+        match err {
+            SubsonicError::Api { code, message } => {
+                assert_eq!(code, 40);
+                assert!(message.contains("Wrong"));
+            }
+            other => panic!("expected Api, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_envelope_rejects_missing_body_key() {
+        let body = json!({
+            "subsonic-response": { "status": "ok" }
+        })
+        .to_string();
+        let err = parse_envelope::<Song>(&body, "song").unwrap_err();
+        assert!(matches!(err, SubsonicError::Decode(_)));
+    }
+
+    #[test]
+    fn parse_envelope_status_only_accepts_empty_ok() {
+        let body = json!({ "subsonic-response": { "status": "ok", "version": "1.16.1" } }).to_string();
+        parse_envelope_status_only(&body).unwrap();
+    }
+
+    // ── fingerprint_sample ────────────────────────────────────────────────
+
+    #[test]
+    fn fingerprint_sample_picks_every_nth_id() {
+        let ids: Vec<String> = (0..10).map(|i| format!("tr_{i}")).collect();
+        let sample = fingerprint_sample(&ids, 4);
+        assert_eq!(
+            sample.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+            vec!["tr_0", "tr_4", "tr_8"]
+        );
+    }
+
+    #[test]
+    fn fingerprint_sample_is_deterministic_across_runs() {
+        let ids: Vec<String> = (0..500).map(|i| format!("tr_{i:04}")).collect();
+        let a = fingerprint_sample(&ids, 100);
+        let b = fingerprint_sample(&ids, 100);
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 5, "500/100 = 5 samples");
+    }
+
+    #[test]
+    fn fingerprint_sample_zero_n_is_empty() {
+        let ids: Vec<String> = vec!["a".into(), "b".into()];
+        assert!(fingerprint_sample(&ids, 0).is_empty());
+    }
+
+    // ── SubsonicClient wiremock end-to-end ────────────────────────────────
+
+    fn test_credentials() -> SubsonicCredentials {
+        SubsonicCredentials::with_static("user", "deadbeef", "saltsalt")
+    }
+
+    fn test_client(uri: &str) -> SubsonicClient {
+        SubsonicClient::new(uri, test_credentials())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ping_sends_auth_params_and_returns_ok() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .and(query_param("u", "user"))
+            .and(query_param("t", "deadbeef"))
+            .and(query_param("s", "saltsalt"))
+            .and(query_param("v", SUBSONIC_API_VERSION))
+            .and(query_param("c", SUBSONIC_CLIENT_ID))
+            .and(query_param("f", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "version": "1.16.1" }
+            })))
+            .mount(&server)
+            .await;
+
+        test_client(&server.uri()).ping().await.expect("ping must succeed");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ping_surfaces_wrong_credentials_as_code_40() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "failed",
+                    "error": { "code": 40, "message": "Wrong username or password" }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let err = test_client(&server.uri()).ping().await.unwrap_err();
+        assert!(matches!(err, SubsonicError::Api { code: 40, .. }));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_song_returns_typed_song() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getSong.view"))
+            .and(query_param("id", "tr_1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "song": {
+                        "id": "tr_1",
+                        "title": "Aurora",
+                        "artist": "Anna",
+                        "albumId": "al_1",
+                        "duration": 240,
+                        "track": 3
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let song = test_client(&server.uri()).get_song("tr_1").await.unwrap();
+        assert_eq!(song.title, "Aurora");
+        assert_eq!(song.album_id.as_deref(), Some("al_1"));
+        assert_eq!(song.track_number, Some(3));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_song_maps_error_70_to_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getSong.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "failed",
+                    "error": { "code": 70, "message": "Song not found" }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let err = test_client(&server.uri()).get_song("missing").await.unwrap_err();
+        assert!(matches!(err, SubsonicError::NotFound));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_scan_status_parses_typed_struct() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getScanStatus.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "scanStatus": {
+                        "scanning": true,
+                        "count": 9001,
+                        "folderCount": 12
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let s = test_client(&server.uri()).get_scan_status().await.unwrap();
+        assert!(s.scanning);
+        assert_eq!(s.count, Some(9001));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_indexes_forwards_optional_if_modified_since() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getIndexes.view"))
+            .and(query_param("ifModifiedSince", "1716840000000"))
+            .and(query_param("musicFolderId", "lib-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "indexes": {
+                        "lastModified": 1716840000000_i64,
+                        "ignoredArticles": "The",
+                        "index": []
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let ix = test_client(&server.uri())
+            .get_indexes(Some("lib-1"), Some(1_716_840_000_000))
+            .await
+            .unwrap();
+        assert_eq!(ix.last_modified_ms, Some(1_716_840_000_000));
+        assert!(ix.index.is_empty(), "empty body when nothing changed");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_artists_omits_music_folder_when_none() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getArtists.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "artists": {
+                        "lastModified": 1716840000000_i64,
+                        "ignoredArticles": "",
+                        "index": [
+                            { "name": "A", "artist": [
+                                { "id": "ar_1", "name": "Anna" }
+                            ]}
+                        ]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let ix = test_client(&server.uri()).get_artists(None).await.unwrap();
+        assert_eq!(ix.index.len(), 1);
+        assert_eq!(ix.index[0].artist[0].name, "Anna");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_album_list2_unwraps_album_array() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbumList2.view"))
+            .and(query_param("type", "alphabeticalByName"))
+            .and(query_param("size", "500"))
+            .and(query_param("offset", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "albumList2": {
+                        "album": [
+                            { "id": "al_1", "name": "First" },
+                            { "id": "al_2", "name": "Second" }
+                        ]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let albums = test_client(&server.uri())
+            .get_album_list2("alphabeticalByName", 500, 0, None)
+            .await
+            .unwrap();
+        assert_eq!(albums.len(), 2);
+        assert_eq!(albums[1].id, "al_2");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_album_includes_song_list() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbum.view"))
+            .and(query_param("id", "al_1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "album": {
+                        "id": "al_1",
+                        "name": "Test Album",
+                        "songCount": 2,
+                        "song": [
+                            { "id": "tr_1", "title": "One",  "track": 1 },
+                            { "id": "tr_2", "title": "Two",  "track": 2 }
+                        ]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let album = test_client(&server.uri()).get_album("al_1").await.unwrap();
+        assert_eq!(album.song.len(), 2);
+        assert_eq!(album.song[0].title, "One");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn search3_handles_empty_query_navidrome_quirk() {
+        // Spec §2.4: Navidrome accepts empty query → returns all songs paged.
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .and(query_param("query", ""))
+            .and(query_param("songCount", "100"))
+            .and(query_param("songOffset", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "searchResult3": {
+                        "song": [
+                            { "id": "tr_1", "title": "One" },
+                            { "id": "tr_2", "title": "Two" }
+                        ]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let sr = test_client(&server.uri()).search3("", 100, 0, None).await.unwrap();
+        assert_eq!(sr.song.len(), 2);
+        assert!(sr.artist.is_empty());
+        assert!(sr.album.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn base_url_trailing_slash_does_not_double_up() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok" }
+            })))
+            .mount(&server)
+            .await;
+
+        // Append a trailing slash + and additional slashes — the constructor
+        // strips them so the request path stays `/rest/ping.view`, not
+        // `//rest/ping.view`.
+        let url = format!("{}///", server.uri());
+        SubsonicClient::new(url, test_credentials())
+            .ping()
+            .await
+            .expect("ping with trailing slashes must reach the same endpoint");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_500_returns_http_status_error_without_decode() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let err = test_client(&server.uri()).ping().await.unwrap_err();
+        match err {
+            SubsonicError::HttpStatus(s) => assert_eq!(s.as_u16(), 500),
+            other => panic!("expected HttpStatus, got {other:?}"),
+        }
+    }
+}

--- a/src-tauri/crates/psysonic-integration/src/subsonic/error.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/error.rs
@@ -1,0 +1,76 @@
+use std::fmt;
+
+/// Errors surfaced by `SubsonicClient`. Designed for the sync engine
+/// (PR-3): `NotFound` exists as a first-class variant so the tombstone
+/// reconciler can match Subsonic error code 70 without parsing strings.
+///
+/// Spec §2.6 — code 70 = "The requested data was not found".
+#[derive(Debug)]
+pub enum SubsonicError {
+    /// Transport failure (DNS, TCP, TLS, body read). Wraps the flattened
+    /// reqwest error chain so toasts can surface the real cause.
+    Transport(String),
+
+    /// Server replied with a non-2xx HTTP status before the JSON envelope
+    /// was inspectable.
+    HttpStatus(reqwest::StatusCode),
+
+    /// Subsonic-level failure (`status = "failed"` in the envelope).
+    Api { code: i32, message: String },
+
+    /// Convenience for the common error code 70. Equivalent to
+    /// `Api { code: 70, .. }` and produced by the same parser.
+    NotFound,
+
+    /// Response body wasn't the expected JSON shape.
+    Decode(String),
+}
+
+impl fmt::Display for SubsonicError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SubsonicError::Transport(m) => write!(f, "subsonic transport: {m}"),
+            SubsonicError::HttpStatus(s) => write!(f, "subsonic http status: {s}"),
+            SubsonicError::Api { code, message } => {
+                write!(f, "subsonic api error {code}: {message}")
+            }
+            SubsonicError::NotFound => write!(f, "subsonic: not found (code 70)"),
+            SubsonicError::Decode(m) => write!(f, "subsonic decode: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for SubsonicError {}
+
+/// Flatten a `reqwest::Error` source chain into one readable string —
+/// mirrors `psysonic-integration::navidrome::nd_err` so the two clients
+/// surface comparable diagnostic text.
+pub(crate) fn flatten_reqwest_error(e: reqwest::Error) -> String {
+    let mut msg = e.to_string();
+    let mut src: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(&e);
+    while let Some(s) = src {
+        msg.push_str(" | ");
+        msg.push_str(&s.to_string());
+        src = s.source();
+    }
+    msg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_includes_error_code_for_api_variant() {
+        let e = SubsonicError::Api { code: 40, message: "Wrong username or password".into() };
+        let s = e.to_string();
+        assert!(s.contains("40"));
+        assert!(s.contains("Wrong username"));
+    }
+
+    #[test]
+    fn not_found_renders_with_code_70_for_log_search() {
+        let s = SubsonicError::NotFound.to_string();
+        assert!(s.contains("70"), "got {s}");
+    }
+}

--- a/src-tauri/crates/psysonic-integration/src/subsonic/mod.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/mod.rs
@@ -1,0 +1,15 @@
+//! Subsonic REST client — read-only endpoints the library-sync engine
+//! consumes (phase B per spec §10). See `client::SubsonicClient` for the
+//! entry point.
+
+pub mod auth;
+pub mod client;
+pub mod error;
+pub mod types;
+
+pub use auth::SubsonicCredentials;
+pub use client::{
+    fingerprint_sample, SubsonicClient, SUBSONIC_API_VERSION, SUBSONIC_CLIENT_ID,
+};
+pub use error::SubsonicError;
+pub use types::{Album, AlbumSummary, ArtistIndex, ArtistRef, IndexBucket, ScanStatus, SearchResult, Song};

--- a/src-tauri/crates/psysonic-integration/src/subsonic/types.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/types.rs
@@ -1,0 +1,287 @@
+//! Response structs for the Subsonic REST API surface PR-2 needs.
+//!
+//! Only the hot fields the sync engine reads are typed; everything else
+//! survives via the raw JSON the client also returns (PR-3 wires the
+//! `raw_json` column on `track`). Unknown fields are simply ignored on
+//! deserialize — additive OpenSubsonic extensions never break parsing.
+
+use serde::Deserialize;
+
+/// `#getScanStatus` (since 1.15.0). `lastScan` is an ISO-8601 string on
+/// Navidrome (`responses.go` `ScanStatus.LastScan`); other servers may
+/// omit it during an active scan.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ScanStatus {
+    pub scanning: bool,
+    #[serde(default)]
+    pub count: Option<i64>,
+    #[serde(rename = "folderCount", default)]
+    pub folder_count: Option<i64>,
+    #[serde(rename = "lastScan", default)]
+    pub last_scan: Option<String>,
+}
+
+/// `#getIndexes` (file-structure browse) and `#getArtists` (ID3 browse)
+/// share the same shape on the wire: a top-level `lastModified` watermark
+/// plus a list of letter buckets.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ArtistIndex {
+    /// `lastModified` is ms since epoch (spec §2.2 — response metadata,
+    /// not a request param).
+    #[serde(rename = "lastModified", default)]
+    pub last_modified_ms: Option<i64>,
+    #[serde(rename = "ignoredArticles", default)]
+    pub ignored_articles: Option<String>,
+    #[serde(default)]
+    pub index: Vec<IndexBucket>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct IndexBucket {
+    pub name: String,
+    #[serde(default)]
+    pub artist: Vec<ArtistRef>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ArtistRef {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "albumCount", default)]
+    pub album_count: Option<i64>,
+    #[serde(rename = "coverArt", default)]
+    pub cover_art: Option<String>,
+}
+
+/// `#getAlbumList2` — page of album summaries (no song list).
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct AlbumSummary {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub artist: Option<String>,
+    #[serde(rename = "artistId", default)]
+    pub artist_id: Option<String>,
+    #[serde(rename = "songCount", default)]
+    pub song_count: Option<i64>,
+    #[serde(default)]
+    pub duration: Option<i64>,
+    #[serde(default)]
+    pub year: Option<i64>,
+    #[serde(default)]
+    pub genre: Option<String>,
+    #[serde(rename = "coverArt", default)]
+    pub cover_art: Option<String>,
+    #[serde(default)]
+    pub starred: Option<String>,
+}
+
+/// `#getAlbum` — album + its full song list.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct Album {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub artist: Option<String>,
+    #[serde(rename = "artistId", default)]
+    pub artist_id: Option<String>,
+    #[serde(rename = "songCount", default)]
+    pub song_count: Option<i64>,
+    #[serde(default)]
+    pub duration: Option<i64>,
+    #[serde(default)]
+    pub year: Option<i64>,
+    #[serde(default)]
+    pub genre: Option<String>,
+    #[serde(rename = "coverArt", default)]
+    pub cover_art: Option<String>,
+    #[serde(default)]
+    pub song: Vec<Song>,
+}
+
+/// `#search3` — three parallel lists, any of which may be empty.
+#[derive(Debug, Clone, Deserialize, PartialEq, Default)]
+pub struct SearchResult {
+    #[serde(default)]
+    pub artist: Vec<ArtistRef>,
+    #[serde(default)]
+    pub album: Vec<AlbumSummary>,
+    #[serde(default)]
+    pub song: Vec<Song>,
+}
+
+/// `#getSong` / nested in `#getAlbum`. Only the hot columns from
+/// spec §5.1 are typed; everything else (OpenSubsonic extensions, contributor
+/// arrays, …) is ignored at this layer and recovered from `raw_json` later.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct Song {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub artist: Option<String>,
+    #[serde(rename = "artistId", default)]
+    pub artist_id: Option<String>,
+    #[serde(default)]
+    pub album: Option<String>,
+    #[serde(rename = "albumId", default)]
+    pub album_id: Option<String>,
+    #[serde(rename = "albumArtist", default)]
+    pub album_artist: Option<String>,
+    /// Subsonic reports `duration` in whole seconds.
+    #[serde(default)]
+    pub duration: Option<i64>,
+    #[serde(rename = "track", default)]
+    pub track_number: Option<i64>,
+    #[serde(rename = "discNumber", default)]
+    pub disc_number: Option<i64>,
+    #[serde(default)]
+    pub year: Option<i64>,
+    #[serde(default)]
+    pub genre: Option<String>,
+    #[serde(default)]
+    pub suffix: Option<String>,
+    #[serde(rename = "bitRate", default)]
+    pub bit_rate: Option<i64>,
+    /// Server reports `size` in bytes.
+    #[serde(default)]
+    pub size: Option<i64>,
+    #[serde(rename = "coverArt", default)]
+    pub cover_art: Option<String>,
+    #[serde(default)]
+    pub starred: Option<String>,
+    #[serde(rename = "userRating", default)]
+    pub user_rating: Option<i64>,
+    #[serde(rename = "playCount", default)]
+    pub play_count: Option<i64>,
+    #[serde(default)]
+    pub played: Option<String>,
+    /// Server-side relative path (Navidrome populates; some servers don't).
+    #[serde(default)]
+    pub path: Option<String>,
+    /// `libraryId` (Navidrome native) or `musicFolderId` (Subsonic generic).
+    /// We accept both keys — Navidrome uses `libraryId` on OpenSubsonic
+    /// responses, generic Subsonic stays on `musicFolderId`.
+    #[serde(default, alias = "libraryId", alias = "musicFolderId")]
+    pub library_id: Option<String>,
+    #[serde(default)]
+    pub isrc: Option<String>,
+    #[serde(default)]
+    pub bpm: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn song_deserialize_accepts_minimal_navidrome_payload() {
+        let payload = r#"{
+            "id": "tr_1",
+            "title": "Hello",
+            "artist": "World",
+            "duration": 240,
+            "track": 3,
+            "year": 2024,
+            "suffix": "flac",
+            "bitRate": 1000,
+            "size": 32000000,
+            "coverArt": "cv_1",
+            "libraryId": "1",
+            "isrc": "USRC17607839"
+        }"#;
+        let song: Song = serde_json::from_str(payload).unwrap();
+        assert_eq!(song.id, "tr_1");
+        assert_eq!(song.title, "Hello");
+        assert_eq!(song.duration, Some(240));
+        assert_eq!(song.track_number, Some(3));
+        assert_eq!(song.library_id.as_deref(), Some("1"));
+        assert_eq!(song.isrc.as_deref(), Some("USRC17607839"));
+    }
+
+    #[test]
+    fn song_alias_falls_back_to_music_folder_id() {
+        // Generic Subsonic still ships `musicFolderId`, not Navidrome's
+        // `libraryId` — make sure we don't lose it.
+        let payload = r#"{"id":"a","title":"t","musicFolderId":"7"}"#;
+        let song: Song = serde_json::from_str(payload).unwrap();
+        assert_eq!(song.library_id.as_deref(), Some("7"));
+    }
+
+    #[test]
+    fn song_ignores_unknown_open_subsonic_fields() {
+        // OpenSubsonic ships extras like `played`, `replayGain`, `artists`
+        // (contributor list), etc. We don't type them; they must not error.
+        let payload = r#"{
+            "id": "tr_1",
+            "title": "Hello",
+            "replayGain": { "trackGain": -1.2, "albumGain": -0.8 },
+            "artists": [{ "id": "ar_1", "name": "W" }],
+            "contributors": []
+        }"#;
+        let song: Song = serde_json::from_str(payload).unwrap();
+        assert_eq!(song.id, "tr_1");
+        assert!(song.artist.is_none());
+    }
+
+    #[test]
+    fn album_with_songs_round_trips() {
+        let payload = r#"{
+            "id": "al_1",
+            "name": "Test Album",
+            "artist": "Artist",
+            "artistId": "ar_1",
+            "songCount": 2,
+            "song": [
+                {"id": "tr_1", "title": "One", "track": 1},
+                {"id": "tr_2", "title": "Two", "track": 2}
+            ]
+        }"#;
+        let album: Album = serde_json::from_str(payload).unwrap();
+        assert_eq!(album.name, "Test Album");
+        assert_eq!(album.song.len(), 2);
+        assert_eq!(album.song[1].title, "Two");
+    }
+
+    #[test]
+    fn artist_index_parses_last_modified_watermark() {
+        let payload = r#"{
+            "lastModified": 1716840000000,
+            "ignoredArticles": "The El La",
+            "index": [
+                {"name": "A", "artist": [
+                    {"id": "ar_1", "name": "Anna"},
+                    {"id": "ar_2", "name": "Alex", "albumCount": 3}
+                ]},
+                {"name": "B", "artist": []}
+            ]
+        }"#;
+        let ai: ArtistIndex = serde_json::from_str(payload).unwrap();
+        assert_eq!(ai.last_modified_ms, Some(1716840000000));
+        assert_eq!(ai.index.len(), 2);
+        assert_eq!(ai.index[0].artist.len(), 2);
+        assert_eq!(ai.index[0].artist[1].album_count, Some(3));
+    }
+
+    #[test]
+    fn search_result_defaults_empty_lists() {
+        // search3 with no hits returns just `{"searchResult3": {}}`.
+        let sr: SearchResult = serde_json::from_str("{}").unwrap();
+        assert!(sr.artist.is_empty());
+        assert!(sr.album.is_empty());
+        assert!(sr.song.is_empty());
+    }
+
+    #[test]
+    fn scan_status_parses_navidrome_shape() {
+        let payload = r#"{
+            "scanning": false,
+            "count": 12345,
+            "folderCount": 100,
+            "lastScan": "2024-06-01T12:00:00Z"
+        }"#;
+        let s: ScanStatus = serde_json::from_str(payload).unwrap();
+        assert!(!s.scanning);
+        assert_eq!(s.count, Some(12345));
+        assert_eq!(s.last_scan.as_deref(), Some("2024-06-01T12:00:00Z"));
+    }
+}


### PR DESCRIPTION
Phase B (B1–B9 per spec §10) — pure-Rust Subsonic client that the
library-sync engine (PR-3) will drive. No Tauri commands, no events;
the surface lands inside `psysonic-integration` as a sibling of the
existing `navidrome` native-REST module.

## B1–B9 mapping

- **B1** — `SubsonicClient` + `ping` over `/rest/{method}.view`. Auth
  via legacy salted-md5 token (spec v1.13+, advertised as 1.16.1).
  `SubsonicCredentials` derives `token = md5(password || salt)` with a
  fresh per-process salt nonce.
- **B2** — `get_scan_status` → `ScanStatus`. Lightweight poll for the
  Huge-tier path (§6.2.2).
- **B3** — `get_album_list2(type, size, offset, musicFolderId?)` +
  `get_album(id)`. The two-call pattern the sync engine walks during
  initial ingest (§6.3).
- **B4** — `search3(query, songCount, songOffset, musicFolderId?)`.
  Empty query → all songs paged (Navidrome quirk, §2.4).
- **B5** — `get_indexes(musicFolderId?, ifModifiedSince?)`. Conditional
  fetch for the file-tree fallback (S3 / §3.1).
- **B6** — `get_song(id)`. Error code 70 maps to the dedicated
  `SubsonicError::NotFound` variant so the tombstone reconciler can
  match on the variant instead of parsing strings.
- **B8** — `get_artists(musicFolderId?)`. ID3-path artist index; clients
  compare `ArtistIndex.last_modified_ms` against the local watermark
  to decide if a delta pass is needed (§2.2.1).
- **B9** — `fingerprint_sample` helper picks every-Nth track id for the
  server-fingerprint verify pass. Deterministic so reruns probe the
  same tracks. The verify-and-compare glue itself is library-side
  (PR-3 territory).

## Files

```
src-tauri/crates/psysonic-integration/Cargo.toml         (reqwest features)
src-tauri/crates/psysonic-integration/src/lib.rs         (pub mod subsonic)
src-tauri/crates/psysonic-integration/src/subsonic/mod.rs
src-tauri/crates/psysonic-integration/src/subsonic/auth.rs
src-tauri/crates/psysonic-integration/src/subsonic/client.rs
src-tauri/crates/psysonic-integration/src/subsonic/error.rs
src-tauri/crates/psysonic-integration/src/subsonic/types.rs
```

## `Cargo.toml` change

Adds `query` + `form` + `multipart` to `psysonic-integration`'s reqwest
feature set. PR-2's client needs `query`; the other two were already
used by existing `navidrome::covers` / `remote::lastfm` code and only
worked via top-crate feature unification. Aligning the crate's own
deps means `cargo test -p psysonic-integration` now compiles without
depending on the workspace build.

## References

- Spec §2 (Subsonic API surface), §2.4 (empty-query paging), §2.6
  (error 70), §3.1 (Navidrome `getIndexes` behavior), §10 Phase B,
  §13 Round 7 (merge target)

## Out of scope

- Capability detection → PR-3 / C1
- Navidrome native bulk path → uses existing
  `psysonic-integration::navidrome::queries`
- Fixtures harness expansion (G1) → later PRs

## Test plan

- [x] `cargo test --workspace` — 453 tests pass (33 new in
      `psysonic-integration::subsonic`)
- [x] `cargo clippy -p psysonic-integration --all-targets -- -D warnings`
- [x] `./dev.sh backend-ci` — hot-path coverage gate green across the
      existing 11 hot-path files