### PR TITLE
feat(library): capability probe + sync_state accessors (Phase C1+C7, PR-3a)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3832,10 +3832,14 @@ name = "psysonic-library"
 version = "1.47.0-dev"
 dependencies = [
  "psysonic-core",
+ "psysonic-integration",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "tauri",
+ "tokio",
+ "wiremock",
 ]
 
 [[package]]

--- a/src-tauri/crates/psysonic-integration/src/navidrome/mod.rs
+++ b/src-tauri/crates/psysonic-integration/src/navidrome/mod.rs
@@ -7,5 +7,6 @@
 mod client;
 pub mod covers;
 pub mod playlists;
+pub mod probe;
 pub mod queries;
 pub mod users;

--- a/src-tauri/crates/psysonic-integration/src/navidrome/probe.rs
+++ b/src-tauri/crates/psysonic-integration/src/navidrome/probe.rs
@@ -1,0 +1,116 @@
+//! Navidrome-side probes for the library-sync capability detection.
+//!
+//! Lives next to `client.rs` / `queries.rs` so the existing native-REST
+//! auth shape (`Authorization: Bearer …`) is reused. PR-3a only needs
+//! one probe — does the server expose the paginated `/api/song` bulk
+//! endpoint? — so this stays a free function rather than a client
+//! struct. The full `nd_list_songs`-style ingest loop lands with PR-3b.
+
+use super::client::{nd_err, nd_http_client};
+
+/// Returns `Ok(true)` when `GET /api/song?_start=0&_end=1` answers with
+/// a 2xx status, `Ok(false)` for 4xx (auth ok but endpoint missing or
+/// disabled) and 5xx surfaces as `Err`. The body is intentionally not
+/// inspected — empty libraries still respond with `[]` and a 200.
+///
+/// Spec §6.1 ties the result to the `NavidromeNativeBulk` capability
+/// flag. Wider call into the actual ingest path (`nd_list_songs` port)
+/// is PR-3b's job.
+pub async fn native_bulk_available(server_url: &str, token: &str) -> Result<bool, String> {
+    let client = nd_http_client();
+    let url = format!("{}/api/song?_start=0&_end=1", server_url.trim_end_matches('/'));
+    let resp = client
+        .get(url)
+        .header("X-ND-Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(nd_err)?;
+
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(true);
+    }
+    if status.is_client_error() {
+        // 401/403/404 — endpoint genuinely unavailable for this token /
+        // build. Treat as "no native bulk" and fall back to Subsonic.
+        return Ok(false);
+    }
+    Err(format!("HTTP {status}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method as wm_method, path as wm_path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_bulk_available_returns_true_on_200() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/api/song"))
+            .and(query_param("_start", "0"))
+            .and(query_param("_end", "1"))
+            .and(header("X-ND-Authorization", "Bearer tok-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+
+        let ok = native_bulk_available(&server.uri(), "tok-123").await.unwrap();
+        assert!(ok);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_bulk_available_returns_false_on_404() {
+        // Server is reachable, auth might be ok, but the endpoint just
+        // doesn't exist (older Navidrome, mod_rewrite mishap, …).
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/api/song"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let ok = native_bulk_available(&server.uri(), "tok").await.unwrap();
+        assert!(!ok);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_bulk_available_returns_false_on_401_auth_failure() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/api/song"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let ok = native_bulk_available(&server.uri(), "bad").await.unwrap();
+        assert!(!ok, "401 reads as `endpoint not available for this caller`");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_bulk_available_surfaces_5xx_as_error() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/api/song"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let err = native_bulk_available(&server.uri(), "tok").await.unwrap_err();
+        assert!(err.contains("503"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_bulk_available_strips_trailing_slash() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/api/song"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+
+        let with_slash = format!("{}/", server.uri());
+        assert!(native_bulk_available(&with_slash, "tok").await.unwrap());
+    }
+}

--- a/src-tauri/crates/psysonic-integration/src/subsonic/client.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/client.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 
 use super::auth::SubsonicCredentials;
 use super::error::{flatten_reqwest_error, SubsonicError};
-use super::types::{Album, AlbumSummary, ArtistIndex, ScanStatus, SearchResult, Song};
+use super::types::{Album, AlbumSummary, ArtistIndex, ScanStatus, SearchResult, ServerInfo, Song};
 
 /// Protocol level we advertise — pre-OpenSubsonic Subsonic baseline that
 /// Navidrome and other servers in the wild support. OpenSubsonic
@@ -112,6 +112,15 @@ impl SubsonicClient {
     pub async fn ping(&self) -> Result<(), SubsonicError> {
         let body = self.send("ping", &[]).await?;
         parse_envelope_status_only(&body)
+    }
+
+    /// C1 helper — `#ping` with the envelope metadata captured. Used by
+    /// the capability probe to detect server type (`navidrome` →
+    /// `UnstableTrackIds`) and OpenSubsonic support without issuing a
+    /// second request.
+    pub async fn server_info(&self) -> Result<ServerInfo, SubsonicError> {
+        let body = self.send("ping", &[]).await?;
+        parse_server_info(&body)
     }
 
     /// B2 — `getScanStatus`. Lightweight poll for huge libraries
@@ -381,6 +390,41 @@ fn map_error(code: i32, message: String) -> SubsonicError {
     } else {
         SubsonicError::Api { code, message }
     }
+}
+
+/// Inspect the `subsonic-response` envelope itself for server metadata.
+/// Used by `server_info()` and by the capability probe.
+fn parse_server_info(body: &str) -> Result<ServerInfo, SubsonicError> {
+    let envelope: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| SubsonicError::Decode(format!("envelope: {e}")))?;
+    let response = envelope
+        .get("subsonic-response")
+        .ok_or_else(|| SubsonicError::Decode("missing `subsonic-response`".into()))?;
+
+    if let Some(err) = response.get("error") {
+        let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(-1) as i32;
+        let message = err
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default()
+            .to_string();
+        return Err(map_error(code, message));
+    }
+
+    let status = response.get("status").and_then(|s| s.as_str()).unwrap_or_default();
+    if status != "ok" {
+        return Err(SubsonicError::Decode(format!("unexpected status `{status}`")));
+    }
+
+    Ok(ServerInfo {
+        server_type: response.get("type").and_then(|v| v.as_str()).map(|s| s.to_string()),
+        server_version: response
+            .get("serverVersion")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        api_version: response.get("version").and_then(|v| v.as_str()).map(|s| s.to_string()),
+        open_subsonic: response.get("openSubsonic").and_then(|v| v.as_bool()).unwrap_or(false),
+    })
 }
 
 /// B9 — pick every `every_n`-th id from a sorted list. Used by the
@@ -955,6 +999,69 @@ mod tests {
             raw_songs[1].get("replayGain"),
             album.get("song").unwrap().as_array().unwrap()[1].get("replayGain")
         );
+    }
+
+    // ── server_info / parse_server_info ────────────────────────────────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn server_info_extracts_navidrome_envelope_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "version": "1.16.1",
+                    "type": "navidrome",
+                    "serverVersion": "0.55.2",
+                    "openSubsonic": true
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let info = test_client(&server.uri()).server_info().await.unwrap();
+        assert_eq!(info.server_type.as_deref(), Some("navidrome"));
+        assert_eq!(info.server_version.as_deref(), Some("0.55.2"));
+        assert_eq!(info.api_version.as_deref(), Some("1.16.1"));
+        assert!(info.open_subsonic);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn server_info_falls_back_to_defaults_for_minimal_envelope() {
+        // Older Subsonic servers may omit type / serverVersion / openSubsonic.
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "version": "1.16.1" }
+            })))
+            .mount(&server)
+            .await;
+
+        let info = test_client(&server.uri()).server_info().await.unwrap();
+        assert!(info.server_type.is_none());
+        assert!(info.server_version.is_none());
+        assert!(!info.open_subsonic);
+        assert_eq!(info.api_version.as_deref(), Some("1.16.1"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn server_info_surfaces_wrong_credentials_as_code_40() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "failed",
+                    "error": { "code": 40, "message": "Wrong username or password" }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let err = test_client(&server.uri()).server_info().await.unwrap_err();
+        assert!(matches!(err, SubsonicError::Api { code: 40, .. }));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src-tauri/crates/psysonic-integration/src/subsonic/mod.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/mod.rs
@@ -12,4 +12,7 @@ pub use client::{
     fingerprint_sample, SubsonicClient, SUBSONIC_API_VERSION, SUBSONIC_CLIENT_ID,
 };
 pub use error::SubsonicError;
-pub use types::{Album, AlbumSummary, ArtistIndex, ArtistRef, IndexBucket, ScanStatus, SearchResult, Song};
+pub use types::{
+    Album, AlbumSummary, ArtistIndex, ArtistRef, IndexBucket, ScanStatus, SearchResult, ServerInfo,
+    Song,
+};

--- a/src-tauri/crates/psysonic-integration/src/subsonic/types.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/types.rs
@@ -7,6 +7,26 @@
 
 use serde::Deserialize;
 
+/// Envelope-level metadata returned by `#ping` (and present on every
+/// other response too). Read by the capability probe to detect the
+/// server family (Navidrome vs generic Subsonic) and the OpenSubsonic
+/// flag. Filled in from the `subsonic-response` object itself, not
+/// from a body key — these fields sit at the same level as `status`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ServerInfo {
+    /// Server software family — Navidrome reports `"navidrome"`, generic
+    /// Subsonic implementations report their own label. `None` when the
+    /// server omits the field (older Subsonic).
+    pub server_type: Option<String>,
+    /// Server build version, e.g. `"0.55.2"` on Navidrome.
+    pub server_version: Option<String>,
+    /// Subsonic API protocol level the server advertises.
+    pub api_version: Option<String>,
+    /// `true` when the server advertises OpenSubsonic extensions
+    /// (`isrc`, `played`, `bpm`, contributor arrays, …).
+    pub open_subsonic: bool,
+}
+
 /// `#getScanStatus` (since 1.15.0). `lastScan` is an ISO-8601 string on
 /// Navidrome (`responses.go` `ScanStatus.LastScan`); other servers may
 /// omit it during an active scan.

--- a/src-tauri/crates/psysonic-library/Cargo.toml
+++ b/src-tauri/crates/psysonic-library/Cargo.toml
@@ -7,8 +7,15 @@ publish = false
 
 [dependencies]
 psysonic-core = { path = "../psysonic-core" }
+psysonic-integration = { path = "../psysonic-integration" }
 
 tauri = { version = "2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "gzip", "brotli"] }
+tokio = { version = "1", features = ["rt"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "test-util"] }
+wiremock = { workspace = true }

--- a/src-tauri/crates/psysonic-library/src/lib.rs
+++ b/src-tauri/crates/psysonic-library/src/lib.rs
@@ -5,15 +5,13 @@
 //! - `repos`  — typed repositories over the v1 schema (track, album, artist, …)
 //! - `search` — FTS5 query helpers
 //! - `filter` — `FilterFieldRegistry` (Rust source of truth for Advanced Search)
-//!
-//! PR-1a lands the schema, the store, and skeletons of the repos / search /
-//! filter modules. Sync orchestration, Subsonic HTTP, Tauri commands, and the
-//! frontend bridge follow in later PRs.
+//! - `sync`   — capability probe + orchestrator (PR-3*)
 
 pub mod filter;
 pub mod repos;
 pub mod search;
 pub mod store;
+pub mod sync;
 
 pub use store::{LibraryStore, LIBRARY_DB_SCHEMA_VERSION};
 

--- a/src-tauri/crates/psysonic-library/src/repos/sync_state.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/sync_state.rs
@@ -75,6 +75,166 @@ impl<'a> SyncStateRepository<'a> {
             Ok(())
         })
     }
+
+    /// Read `capability_flags` (spec §6.1.1). Returns `None` when the
+    /// row doesn't exist; SQL DEFAULT is 0 so a freshly-ensured row
+    /// reads back as `Some(0)`.
+    pub fn get_capability_flags(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+    ) -> Result<Option<u32>, String> {
+        let raw: Option<i64> = self.store.with_conn(|conn| {
+            conn.query_row(
+                "SELECT capability_flags FROM sync_state \
+                 WHERE server_id = ?1 AND library_scope = ?2",
+                params![server_id, library_scope],
+                |row| row.get(0),
+            )
+            .optional()
+        })?;
+        Ok(raw.map(|v| v.max(0) as u32))
+    }
+
+    /// Write `capability_flags`. Upsert scoped to that one column.
+    pub fn set_capability_flags(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+        flags: u32,
+    ) -> Result<(), String> {
+        self.store.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO sync_state (server_id, library_scope, capability_flags) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(server_id, library_scope) DO UPDATE SET \
+                   capability_flags = excluded.capability_flags",
+                params![server_id, library_scope, flags as i64],
+            )?;
+            Ok(())
+        })
+    }
+
+    /// Read `sync_phase` (state-machine values per spec §6.2:
+    /// `idle` / `probing` / `initial_sync` / `ready` / `error`).
+    /// Returns `None` when the row doesn't exist; SQL DEFAULT is
+    /// `'idle'` so a freshly-ensured row reads back as `Some("idle")`.
+    pub fn get_sync_phase(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+    ) -> Result<Option<String>, String> {
+        self.store.with_conn(|conn| {
+            conn.query_row(
+                "SELECT sync_phase FROM sync_state \
+                 WHERE server_id = ?1 AND library_scope = ?2",
+                params![server_id, library_scope],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+        })
+    }
+
+    /// Write `sync_phase`. Upsert scoped to that one column.
+    pub fn set_sync_phase(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+        phase: &str,
+    ) -> Result<(), String> {
+        self.store.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO sync_state (server_id, library_scope, sync_phase) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(server_id, library_scope) DO UPDATE SET \
+                   sync_phase = excluded.sync_phase",
+                params![server_id, library_scope, phase],
+            )?;
+            Ok(())
+        })
+    }
+
+    /// Write `server_last_scan_iso` — server-reported timestamp of the
+    /// last completed scan, captured from `getScanStatus.lastScan`.
+    pub fn set_server_last_scan_iso(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+        last_scan_iso: Option<&str>,
+    ) -> Result<(), String> {
+        self.store.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO sync_state (server_id, library_scope, server_last_scan_iso) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(server_id, library_scope) DO UPDATE SET \
+                   server_last_scan_iso = excluded.server_last_scan_iso",
+                params![server_id, library_scope, last_scan_iso],
+            )?;
+            Ok(())
+        })
+    }
+
+    /// Write `indexes_last_modified_ms` — watermark for the file-tree
+    /// browse path (`getIndexes.lastModified`).
+    pub fn set_indexes_last_modified_ms(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+        last_modified_ms: i64,
+    ) -> Result<(), String> {
+        self.store.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO sync_state (server_id, library_scope, indexes_last_modified_ms) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(server_id, library_scope) DO UPDATE SET \
+                   indexes_last_modified_ms = excluded.indexes_last_modified_ms",
+                params![server_id, library_scope, last_modified_ms],
+            )?;
+            Ok(())
+        })
+    }
+
+    /// Write `artists_last_modified_ms` — watermark for the ID3 path
+    /// (`getArtists.lastModified`); §2.2.1 background poll keys off
+    /// this.
+    pub fn set_artists_last_modified_ms(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+        last_modified_ms: i64,
+    ) -> Result<(), String> {
+        self.store.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO sync_state (server_id, library_scope, artists_last_modified_ms) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(server_id, library_scope) DO UPDATE SET \
+                   artists_last_modified_ms = excluded.artists_last_modified_ms",
+                params![server_id, library_scope, last_modified_ms],
+            )?;
+            Ok(())
+        })
+    }
+
+    /// Write `library_tier` (spec §6.2.2 — `small` / `medium` / `huge`
+    /// / `unknown`). Drives the adaptive poll interval; PR-3d wires
+    /// the EWMA loop that picks this.
+    pub fn set_library_tier(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+        tier: &str,
+    ) -> Result<(), String> {
+        self.store.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO sync_state (server_id, library_scope, library_tier) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(server_id, library_scope) DO UPDATE SET \
+                   library_tier = excluded.library_tier",
+                params![server_id, library_scope, tier],
+            )?;
+            Ok(())
+        })
+    }
 }
 
 #[cfg(test)]
@@ -183,6 +343,111 @@ mod tests {
         assert_eq!(
             repo.get_initial_sync_cursor("s1", "lib-1").unwrap(),
             Some(json!({"lib": "one"}))
+        );
+    }
+
+    // ── PR-3a: capability_flags, sync_phase, watermarks, library_tier ────
+
+    #[test]
+    fn capability_flags_roundtrip() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.ensure("s1", "").unwrap();
+        assert_eq!(repo.get_capability_flags("s1", "").unwrap(), Some(0));
+        repo.set_capability_flags("s1", "", 0x002 | 0x010).unwrap();
+        assert_eq!(repo.get_capability_flags("s1", "").unwrap(), Some(0x012));
+    }
+
+    #[test]
+    fn capability_flags_returns_none_for_missing_row() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        assert_eq!(repo.get_capability_flags("absent", "").unwrap(), None);
+    }
+
+    #[test]
+    fn capability_flags_set_creates_row_with_other_defaults() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.set_capability_flags("s1", "", 0x008).unwrap();
+        // sync_phase defaulted to 'idle' on the implicit insert.
+        assert_eq!(repo.get_sync_phase("s1", "").unwrap().as_deref(), Some("idle"));
+    }
+
+    #[test]
+    fn sync_phase_default_is_idle_after_ensure() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.ensure("s1", "").unwrap();
+        assert_eq!(repo.get_sync_phase("s1", "").unwrap().as_deref(), Some("idle"));
+    }
+
+    #[test]
+    fn sync_phase_transitions_through_state_machine_values() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        for phase in ["probing", "initial_sync", "ready", "error", "idle"] {
+            repo.set_sync_phase("s1", "", phase).unwrap();
+            assert_eq!(
+                repo.get_sync_phase("s1", "").unwrap().as_deref(),
+                Some(phase)
+            );
+        }
+    }
+
+    #[test]
+    fn watermark_setters_preserve_each_other() {
+        // Each setter must scope its `ON CONFLICT … DO UPDATE` to its own
+        // column. Set three and read all three back unchanged.
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.set_server_last_scan_iso("s1", "", Some("2026-05-01T12:00:00Z")).unwrap();
+        repo.set_indexes_last_modified_ms("s1", "", 1_700_000_000_000).unwrap();
+        repo.set_artists_last_modified_ms("s1", "", 1_700_000_500_000).unwrap();
+
+        let (iso, idx_ms, art_ms): (Option<String>, Option<i64>, Option<i64>) = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT server_last_scan_iso, indexes_last_modified_ms, artists_last_modified_ms \
+                     FROM sync_state WHERE server_id = 's1'",
+                    [],
+                    |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+                )
+            })
+            .unwrap();
+        assert_eq!(iso.as_deref(), Some("2026-05-01T12:00:00Z"));
+        assert_eq!(idx_ms, Some(1_700_000_000_000));
+        assert_eq!(art_ms, Some(1_700_000_500_000));
+    }
+
+    #[test]
+    fn library_tier_roundtrip() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.set_library_tier("s1", "", "huge").unwrap();
+        let tier: String = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT library_tier FROM sync_state WHERE server_id = 's1'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(tier, "huge");
+    }
+
+    #[test]
+    fn capability_flags_set_does_not_clobber_cursor() {
+        // Cross-check: setting flags must not reset
+        // `initial_sync_cursor_json` back to '{}'.
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.set_initial_sync_cursor("s1", "", &json!({"offset": 42})).unwrap();
+        repo.set_capability_flags("s1", "", 0x002).unwrap();
+        assert_eq!(
+            repo.get_initial_sync_cursor("s1", "").unwrap(),
+            Some(json!({"offset": 42}))
         );
     }
 }

--- a/src-tauri/crates/psysonic-library/src/sync/capability.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/capability.rs
@@ -1,0 +1,381 @@
+//! C1 — Capability probe (spec §6.1 / §6.1.1).
+//!
+//! Drives the Subsonic client + an optional Navidrome native probe to
+//! populate `sync_state.capability_flags` before initial sync picks its
+//! ingest strategy (§6.3). PR-3a only writes flags from the responses;
+//! interpretation lives in PR-3b's `IngestStrategy` selector.
+
+use psysonic_integration::navidrome::probe::native_bulk_available;
+use psysonic_integration::subsonic::{ServerInfo, SubsonicClient, SubsonicError};
+
+/// Bitfield matching spec §6.1.1. `u32` storage so the `sync_state`
+/// table can keep it as a single integer column (`capability_flags
+/// INTEGER NOT NULL DEFAULT 0`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CapabilityFlags(u32);
+
+impl CapabilityFlags {
+    /// N1 — Navidrome native `/api/song` paginated ingest.
+    pub const NAVIDROME_NATIVE_BULK: u32 = 0x001;
+    /// S1 — Subsonic `search3` empty-query bulk ingest.
+    pub const SUBSONIC_SEARCH3_BULK: u32 = 0x002;
+    /// `getScanStatus` available (Subsonic 1.15+); cheap-poll tier signal.
+    pub const SCAN_STATUS_AVAILABLE: u32 = 0x004;
+    /// Server advertises OpenSubsonic extensions (`isrc`, `played`,
+    /// `bpm`, contributor arrays, …).
+    pub const OPEN_SUBSONIC: u32 = 0x008;
+    /// Track ids may shift across server re-indexing — sync engine must
+    /// run the `track_id_history` remap pass (§6.9, P33). Always set
+    /// for Navidrome.
+    pub const UNSTABLE_TRACK_IDS: u32 = 0x010;
+    /// S3 — `getIndexes` / `getMusicDirectory` available (file-tree
+    /// fallback when ID3 endpoints are missing entirely).
+    pub const FILE_TREE_BROWSE: u32 = 0x020;
+
+    pub fn new(bits: u32) -> Self {
+        Self(bits)
+    }
+
+    pub fn bits(self) -> u32 {
+        self.0
+    }
+
+    pub fn contains(self, flag: u32) -> bool {
+        self.0 & flag == flag
+    }
+
+    pub fn insert(&mut self, flag: u32) {
+        self.0 |= flag;
+    }
+
+    pub fn remove(&mut self, flag: u32) {
+        self.0 &= !flag;
+    }
+}
+
+/// Optional input for `CapabilityProbe::run` — Navidrome native API
+/// needs its own bearer token (separate from the Subsonic salted-md5
+/// auth). When `None`, the `NavidromeNativeBulk` bit stays clear and
+/// sync falls back to Subsonic strategies.
+#[derive(Debug, Clone)]
+pub struct NavidromeProbeCredentials {
+    pub server_url: String,
+    pub bearer_token: String,
+}
+
+/// Outcome of the capability probe — both the bitfield (stored in
+/// `sync_state.capability_flags`) and the raw `ServerInfo` envelope
+/// metadata (callers may want to log `serverVersion` etc.).
+#[derive(Debug, Clone)]
+pub struct CapabilityProbeResult {
+    pub flags: CapabilityFlags,
+    pub server_info: ServerInfo,
+}
+
+pub struct CapabilityProbe;
+
+impl CapabilityProbe {
+    /// Run the §6.1 probe chain. Returns the resolved flags plus the
+    /// envelope metadata captured from the Subsonic ping.
+    ///
+    /// The Subsonic ping is the only failure-blocking probe — if it
+    /// returns `Err`, the server is unreachable / wrong creds / wrong
+    /// URL, and no other capability can be determined. Every other
+    /// probe is best-effort: it sets its flag on success and leaves it
+    /// clear on any error.
+    pub async fn run(
+        subsonic: &SubsonicClient,
+        navidrome: Option<&NavidromeProbeCredentials>,
+    ) -> Result<CapabilityProbeResult, SubsonicError> {
+        let server_info = subsonic.server_info().await?;
+
+        let mut flags = CapabilityFlags::default();
+
+        if server_info.open_subsonic {
+            flags.insert(CapabilityFlags::OPEN_SUBSONIC);
+        }
+        // Navidrome rebuilds its track id space on full re-scan; spec
+        // §6.9 / P33 makes the remap pass mandatory for those servers.
+        if matches!(server_info.server_type.as_deref(), Some("navidrome")) {
+            flags.insert(CapabilityFlags::UNSTABLE_TRACK_IDS);
+        }
+
+        // `search3` with songCount=1 is the cheapest way to confirm the
+        // bulk-ingest endpoint is usable on this server (Navidrome
+        // accepts empty query; some forks reject it).
+        if subsonic.search3("", 1, 0, None).await.is_ok() {
+            flags.insert(CapabilityFlags::SUBSONIC_SEARCH3_BULK);
+        }
+
+        if subsonic.get_scan_status().await.is_ok() {
+            flags.insert(CapabilityFlags::SCAN_STATUS_AVAILABLE);
+        }
+
+        if subsonic.get_indexes(None, None).await.is_ok() {
+            flags.insert(CapabilityFlags::FILE_TREE_BROWSE);
+        }
+
+        if let Some(creds) = navidrome {
+            match native_bulk_available(&creds.server_url, &creds.bearer_token).await {
+                Ok(true) => flags.insert(CapabilityFlags::NAVIDROME_NATIVE_BULK),
+                Ok(false) => {}
+                Err(_) => {
+                    // Probe transport failed but Subsonic ping worked —
+                    // assume the native endpoint is unavailable for this
+                    // setup and let sync fall back to S1/S2.
+                }
+            }
+        }
+
+        Ok(CapabilityProbeResult { flags, server_info })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use psysonic_integration::subsonic::{SubsonicClient, SubsonicCredentials};
+    use serde_json::json;
+    use wiremock::matchers::{header, method as wm_method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // ── CapabilityFlags bitfield ─────────────────────────────────────────
+
+    #[test]
+    fn capability_flags_contains_respects_individual_bits() {
+        let mut f = CapabilityFlags::default();
+        assert!(!f.contains(CapabilityFlags::OPEN_SUBSONIC));
+        f.insert(CapabilityFlags::OPEN_SUBSONIC);
+        assert!(f.contains(CapabilityFlags::OPEN_SUBSONIC));
+        assert!(!f.contains(CapabilityFlags::NAVIDROME_NATIVE_BULK));
+    }
+
+    #[test]
+    fn capability_flags_insert_is_idempotent() {
+        let mut f = CapabilityFlags::default();
+        f.insert(CapabilityFlags::SUBSONIC_SEARCH3_BULK);
+        let after_first = f.bits();
+        f.insert(CapabilityFlags::SUBSONIC_SEARCH3_BULK);
+        assert_eq!(f.bits(), after_first);
+    }
+
+    #[test]
+    fn capability_flags_remove_clears_only_the_named_bit() {
+        let mut f = CapabilityFlags::new(
+            CapabilityFlags::OPEN_SUBSONIC | CapabilityFlags::UNSTABLE_TRACK_IDS,
+        );
+        f.remove(CapabilityFlags::OPEN_SUBSONIC);
+        assert!(!f.contains(CapabilityFlags::OPEN_SUBSONIC));
+        assert!(f.contains(CapabilityFlags::UNSTABLE_TRACK_IDS));
+    }
+
+    #[test]
+    fn capability_flags_bit_values_match_spec_table() {
+        // Spec §6.1.1 hex values — pin the wire format so future
+        // schema-migration writers don't shift them silently.
+        assert_eq!(CapabilityFlags::NAVIDROME_NATIVE_BULK, 0x001);
+        assert_eq!(CapabilityFlags::SUBSONIC_SEARCH3_BULK, 0x002);
+        assert_eq!(CapabilityFlags::SCAN_STATUS_AVAILABLE, 0x004);
+        assert_eq!(CapabilityFlags::OPEN_SUBSONIC, 0x008);
+        assert_eq!(CapabilityFlags::UNSTABLE_TRACK_IDS, 0x010);
+        assert_eq!(CapabilityFlags::FILE_TREE_BROWSE, 0x020);
+    }
+
+    // ── CapabilityProbe wiremock harness ─────────────────────────────────
+
+    fn test_subsonic_client(uri: &str) -> SubsonicClient {
+        SubsonicClient::with_static_credentials(
+            uri,
+            SubsonicCredentials::with_static("user", "tok", "salt"),
+            reqwest::Client::new(),
+        )
+    }
+
+    fn ok_envelope(body_key: &str, body: serde_json::Value) -> serde_json::Value {
+        json!({
+            "subsonic-response": {
+                "status": "ok",
+                "version": "1.16.1",
+                body_key: body,
+            }
+        })
+    }
+
+    fn mount_ok(server: &MockServer, route: &'static str, body_key: &'static str) {
+        // We can't await inside a sync helper without making it async;
+        // probe tests construct the mocks inline for clarity. Helper
+        // kept here for documentation only — see individual tests.
+        let _ = (server, route, body_key);
+    }
+
+    async fn mount_subsonic_full_navidrome(server: &MockServer) {
+        // ping → navidrome + openSubsonic
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "version": "1.16.1",
+                    "type": "navidrome",
+                    "serverVersion": "0.55.2",
+                    "openSubsonic": true
+                }
+            })))
+            .mount(server)
+            .await;
+        // search3 empty query
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_envelope(
+                "searchResult3",
+                json!({ "song": [{ "id": "x", "title": "y" }] }),
+            )))
+            .mount(server)
+            .await;
+        // getScanStatus
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getScanStatus.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_envelope(
+                "scanStatus",
+                json!({ "scanning": false }),
+            )))
+            .mount(server)
+            .await;
+        // getIndexes
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getIndexes.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_envelope(
+                "indexes",
+                json!({ "lastModified": 0, "ignoredArticles": "", "index": [] }),
+            )))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_sets_all_subsonic_bits_on_a_fully_capable_navidrome_server() {
+        let _ = mount_ok;
+        let server = MockServer::start().await;
+        mount_subsonic_full_navidrome(&server).await;
+
+        let result = CapabilityProbe::run(&test_subsonic_client(&server.uri()), None)
+            .await
+            .unwrap();
+        assert!(result.flags.contains(CapabilityFlags::SUBSONIC_SEARCH3_BULK));
+        assert!(result.flags.contains(CapabilityFlags::SCAN_STATUS_AVAILABLE));
+        assert!(result.flags.contains(CapabilityFlags::FILE_TREE_BROWSE));
+        assert!(result.flags.contains(CapabilityFlags::OPEN_SUBSONIC));
+        assert!(result.flags.contains(CapabilityFlags::UNSTABLE_TRACK_IDS));
+        // No navidrome probe creds passed → N1 stays clear.
+        assert!(!result.flags.contains(CapabilityFlags::NAVIDROME_NATIVE_BULK));
+        assert_eq!(result.server_info.server_type.as_deref(), Some("navidrome"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_returns_err_when_subsonic_ping_fails() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "failed",
+                    "error": { "code": 40, "message": "Wrong credentials" }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let err = CapabilityProbe::run(&test_subsonic_client(&server.uri()), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SubsonicError::Api { code: 40, .. }));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_keeps_optional_bits_clear_when_their_endpoint_fails() {
+        // Minimal Subsonic-like server: ping ok, search3 ok, but
+        // scanStatus + getIndexes 4xx. UnstableTrackIds + OpenSubsonic
+        // stay clear because the ping envelope omits them.
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "version": "1.13" }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_envelope(
+                "searchResult3",
+                json!({}),
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getScanStatus.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "failed",
+                    "error": { "code": 30, "message": "Method not available" }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getIndexes.view"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let result = CapabilityProbe::run(&test_subsonic_client(&server.uri()), None)
+            .await
+            .unwrap();
+        assert!(result.flags.contains(CapabilityFlags::SUBSONIC_SEARCH3_BULK));
+        assert!(!result.flags.contains(CapabilityFlags::SCAN_STATUS_AVAILABLE));
+        assert!(!result.flags.contains(CapabilityFlags::FILE_TREE_BROWSE));
+        assert!(!result.flags.contains(CapabilityFlags::OPEN_SUBSONIC));
+        assert!(!result.flags.contains(CapabilityFlags::UNSTABLE_TRACK_IDS));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_sets_navidrome_native_bulk_when_credentials_succeed() {
+        let server = MockServer::start().await;
+        mount_subsonic_full_navidrome(&server).await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/api/song"))
+            .and(header("X-ND-Authorization", "Bearer nd-tok"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+
+        let nav = NavidromeProbeCredentials {
+            server_url: server.uri(),
+            bearer_token: "nd-tok".into(),
+        };
+        let result = CapabilityProbe::run(&test_subsonic_client(&server.uri()), Some(&nav))
+            .await
+            .unwrap();
+        assert!(result.flags.contains(CapabilityFlags::NAVIDROME_NATIVE_BULK));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_leaves_navidrome_native_bulk_clear_when_endpoint_404s() {
+        let server = MockServer::start().await;
+        mount_subsonic_full_navidrome(&server).await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/api/song"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let nav = NavidromeProbeCredentials {
+            server_url: server.uri(),
+            bearer_token: "nd-tok".into(),
+        };
+        let result = CapabilityProbe::run(&test_subsonic_client(&server.uri()), Some(&nav))
+            .await
+            .unwrap();
+        assert!(!result.flags.contains(CapabilityFlags::NAVIDROME_NATIVE_BULK));
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/sync/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mod.rs
@@ -1,0 +1,8 @@
+//! Sync orchestrator. PR-3a lands the foundation — `CapabilityProbe`
+//! (C1) and the extended `SyncStateRepository` accessors (C7); the
+//! `InitialSyncRunner` / `DeltaSyncRunner` / background scheduler land
+//! in PR-3b…d.
+
+pub mod capability;
+
+pub use capability::{CapabilityFlags, CapabilityProbe, NavidromeProbeCredentials};


### PR DESCRIPTION
First sub-PR of Phase C (sync orchestrator). Lands the foundation
PR-3b's `InitialSyncRunner` consumes — pure plumbing, no runners or
background tasks yet.

## C1+C7 mapping

- **C1 capability probe.** `psysonic_library::sync::CapabilityProbe::run`
  drives the §6.1 probe chain: Subsonic ping (envelope metadata for
  server-type / OpenSubsonic), then best-effort probes for search3 /
  getScanStatus / getIndexes, plus an optional Navidrome native bulk
  probe via `NavidromeProbeCredentials`. `CapabilityFlags(u32)`
  matches the §6.1.1 bitfield (`NavidromeNativeBulk` /
  `SubsonicSearch3Bulk` / `ScanStatusAvailable` / `OpenSubsonic` /
  `UnstableTrackIds` / `FileTreeBrowse`).
- **C7 sync_state accessors.** `SyncStateRepository` gains
  `get_capability_flags` / `set_capability_flags`, `get_sync_phase` /
  `set_sync_phase`, plus column-scoped setters for
  `server_last_scan_iso`, `indexes_last_modified_ms`,
  `artists_last_modified_ms`, `library_tier`. Every setter scopes its
  `ON CONFLICT … DO UPDATE` to its own column.

## Supporting changes in `psysonic-integration`

- `subsonic::SubsonicClient::server_info()` extracts `ServerInfo`
  (server_type, server_version, api_version, open_subsonic) from the
  ping envelope. Re-uses `send()` so the auth lifecycle is unchanged.
- `navidrome::probe::native_bulk_available(url, token)` issues
  `GET /api/song?_start=0&_end=1` with Bearer auth. Returns
  `Ok(true)` on 2xx, `Ok(false)` on 4xx, `Err` on 5xx.

## Dependency wiring

- `psysonic-library` → `psysonic-integration` (sync needs the
  Subsonic + Navidrome clients). DAG stays acyclic — integration does
  not depend on library.

## References

- PR-3 kickoff answer: `psysonic-workdocs/internal/collaboration/tasks/2026-05-library-track-store/questions/2026-05-19-pr3-kickoff.md`
- Spec §6.1 / §6.1.1 (capability detection bitfield), §6.2 (sync
  phase state machine), §6.2.2 (library_tier)

## Out of scope

- `IngestStrategy` selection from flags → PR-3b
- N1 ingest loop (`nd_list_songs` port) → PR-3b
- `DeltaSyncRunner` + tombstones → PR-3c
- Background task / cancellation / progress → PR-3d
- `LIBRARY_DB_MIN_COMPATIBLE_VERSION` breaking-bump hook stays at its
  PR-1b stub.

## Test plan

- [x] `cargo test --workspace` — 486 tests pass (23 new across
      library + integration)
- [x] `cargo clippy -p psysonic-library --all-targets -- -D warnings`
- [x] `cargo clippy -p psysonic-integration --all-targets -- -D warnings`
- [x] `./dev.sh backend-ci` — hot-path coverage gate green