### PR TITLE
feat(library): InitialSyncRunner + backoff + id remap (Phase C2/C12/C13, PR-3b)

### DIFF
--- a/src-tauri/crates/psysonic-integration/src/navidrome/queries.rs
+++ b/src-tauri/crates/psysonic-integration/src/navidrome/queries.rs
@@ -4,14 +4,15 @@
 
 use super::client::{navidrome_token, nd_err, nd_http_client, nd_retry};
 
-/// GET `/api/song?_sort=...&_order=...&_start=...&_end=...` — paginated song list.
-/// Available to any authenticated user (no admin required). Returns raw JSON array.
-#[tauri::command]
-pub async fn nd_list_songs(
-    server_url: String,
-    token: String,
-    sort: String,
-    order: String,
+/// GET `/api/song?_sort=...&_order=...&_start=...&_end=...` — paginated
+/// song list. Pure async helper used by the library-side N1 ingest
+/// loop (spec §6.3, PR-3*); also wrapped by the `#[tauri::command]`
+/// variant below for existing frontend callers.
+pub async fn nd_list_songs_internal(
+    server_url: &str,
+    token: &str,
+    sort: &str,
+    order: &str,
     start: u32,
     end: u32,
 ) -> Result<serde_json::Value, String> {
@@ -22,13 +23,27 @@ pub async fn nd_list_songs(
     let resp = nd_retry(|| {
         nd_http_client()
             .get(&url)
-            .header("X-ND-Authorization", format!("Bearer {}", token))
+            .header("X-ND-Authorization", format!("Bearer {token}"))
             .send()
     }).await?;
     if !resp.status().is_success() {
         return Err(format!("HTTP {}", resp.status()));
     }
     resp.json::<serde_json::Value>().await.map_err(nd_err)
+}
+
+/// Tauri-visible variant — owned-String arguments to keep the IPC
+/// surface unchanged for existing call sites in the WebView.
+#[tauri::command]
+pub async fn nd_list_songs(
+    server_url: String,
+    token: String,
+    sort: String,
+    order: String,
+    start: u32,
+    end: u32,
+) -> Result<serde_json::Value, String> {
+    nd_list_songs_internal(&server_url, &token, &sort, &order, start, end).await
 }
 
 /// Build the `_filters` JSON for native-API list calls. Optionally narrows the

--- a/src-tauri/crates/psysonic-integration/src/subsonic/types.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/types.rs
@@ -5,7 +5,7 @@
 //! `raw_json` column on `track`). Unknown fields are simply ignored on
 //! deserialize — additive OpenSubsonic extensions never break parsing.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Envelope-level metadata returned by `#ping` (and present on every
 /// other response too). Read by the capability probe to detect the
@@ -30,7 +30,7 @@ pub struct ServerInfo {
 /// `#getScanStatus` (since 1.15.0). `lastScan` is an ISO-8601 string on
 /// Navidrome (`responses.go` `ScanStatus.LastScan`); other servers may
 /// omit it during an active scan.
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct ScanStatus {
     pub scanning: bool,
     #[serde(default)]
@@ -44,7 +44,7 @@ pub struct ScanStatus {
 /// `#getIndexes` (file-structure browse) and `#getArtists` (ID3 browse)
 /// share the same shape on the wire: a top-level `lastModified` watermark
 /// plus a list of letter buckets.
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct ArtistIndex {
     /// `lastModified` is ms since epoch (spec §2.2 — response metadata,
     /// not a request param).
@@ -56,14 +56,14 @@ pub struct ArtistIndex {
     pub index: Vec<IndexBucket>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct IndexBucket {
     pub name: String,
     #[serde(default)]
     pub artist: Vec<ArtistRef>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct ArtistRef {
     pub id: String,
     pub name: String,
@@ -74,7 +74,7 @@ pub struct ArtistRef {
 }
 
 /// `#getAlbumList2` — page of album summaries (no song list).
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct AlbumSummary {
     pub id: String,
     pub name: String,
@@ -97,7 +97,7 @@ pub struct AlbumSummary {
 }
 
 /// `#getAlbum` — album + its full song list.
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Album {
     pub id: String,
     pub name: String,
@@ -120,7 +120,7 @@ pub struct Album {
 }
 
 /// `#search3` — three parallel lists, any of which may be empty.
-#[derive(Debug, Clone, Deserialize, PartialEq, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
 pub struct SearchResult {
     #[serde(default)]
     pub artist: Vec<ArtistRef>,
@@ -133,7 +133,7 @@ pub struct SearchResult {
 /// `#getSong` / nested in `#getAlbum`. Only the hot columns from
 /// spec §5.1 are typed; everything else (OpenSubsonic extensions, contributor
 /// arrays, …) is ignored at this layer and recovered from `raw_json` later.
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Song {
     pub id: String,
     pub title: String,

--- a/src-tauri/crates/psysonic-library/src/repos/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/mod.rs
@@ -1,5 +1,7 @@
 pub mod sync_state;
 pub mod track;
+pub mod track_id_history;
 
 pub use sync_state::SyncStateRepository;
-pub use track::{TrackRepository, TrackRow};
+pub use track::{RemapEntry, RemapStats, TrackRepository, TrackRow};
+pub use track_id_history::TrackIdHistoryRepository;

--- a/src-tauri/crates/psysonic-library/src/repos/track.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track.rs
@@ -1,4 +1,4 @@
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 
 use crate::store::LibraryStore;
 
@@ -45,6 +45,21 @@ pub struct TrackRow {
     pub raw_json: String,
 }
 
+/// One detected remap during an upsert batch. Sync code can use this
+/// to emit `library:tracks-changed { remapped: [{from, to}] }` (spec
+/// §6.9) so the UI can refresh open per-track views.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemapEntry {
+    pub server_id: String,
+    pub old_id: String,
+    pub new_id: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RemapStats {
+    pub remapped: Vec<RemapEntry>,
+}
+
 pub struct TrackRepository<'a> {
     store: &'a LibraryStore,
 }
@@ -54,60 +69,182 @@ impl<'a> TrackRepository<'a> {
         Self { store }
     }
 
-    /// Batch upsert. Wrapped in a single transaction; sync code can call with
-    /// chunks of ~500 rows to hit the §5.1 perf target.
+    /// Batch upsert without remap detection. Suitable for generic
+    /// Subsonic servers where `UnstableTrackIds` is clear (track ids
+    /// are stable across reindexing). Wrapped in a single transaction.
     pub fn upsert_batch(&self, rows: &[TrackRow]) -> Result<(), String> {
+        self.upsert_batch_with_remap(rows, false).map(|_| ())
+    }
+
+    /// Batch upsert with optional §6.9 id-remap detection. When
+    /// `unstable_track_ids` is `true`, each incoming row is checked
+    /// against the existing `track` table for a collision via
+    /// `content_hash` or `server_path` carrying a different id. On
+    /// collision, child tables (`track_offline` and the FK-bound
+    /// extension / fact / artifact / canonical_link tables) are
+    /// retargeted onto the new id, a `track_id_history` row is
+    /// recorded, and the old `track` row is deleted — all inside the
+    /// same SQLite transaction so partial remaps can't leak.
+    pub fn upsert_batch_with_remap(
+        &self,
+        rows: &[TrackRow],
+        unstable_track_ids: bool,
+    ) -> Result<RemapStats, String> {
         if rows.is_empty() {
-            return Ok(());
+            return Ok(RemapStats::default());
         }
         self.store.with_conn_mut(|conn| {
             let tx = conn.transaction()?;
-            {
-                let mut stmt = tx.prepare(UPSERT_SQL)?;
-                for r in rows {
-                    stmt.execute(params![
-                        r.server_id,
-                        r.id,
-                        r.title,
-                        r.title_sort,
-                        r.artist,
-                        r.artist_id,
-                        r.album,
-                        r.album_id,
-                        r.album_artist,
-                        r.duration_sec,
-                        r.track_number,
-                        r.disc_number,
-                        r.year,
-                        r.genre,
-                        r.suffix,
-                        r.bit_rate,
-                        r.size_bytes,
-                        r.cover_art_id,
-                        r.starred_at,
-                        r.user_rating,
-                        r.play_count,
-                        r.played_at,
-                        r.server_path,
-                        r.library_id,
-                        r.isrc,
-                        r.mbid_recording,
-                        r.bpm,
-                        r.replay_gain_track_db,
-                        r.replay_gain_album_db,
-                        r.content_hash,
-                        r.server_updated_at,
-                        r.server_created_at,
-                        if r.deleted { 1_i64 } else { 0 },
+            let mut remapped: Vec<RemapEntry> = Vec::new();
+
+            for r in rows {
+                // Spec §6.9: detect collision BEFORE the upsert so the
+                // old id is known. The upsert itself comes next; only
+                // then do we retarget children to the new id, since
+                // child tables FK→track(server_id, id) and would refuse
+                // an UPDATE pointing at an id that doesn't exist yet.
+                let detected_old: Option<String> = if unstable_track_ids {
+                    detect_remap_target(&tx, r)?
+                } else {
+                    None
+                };
+
+                tx.execute(UPSERT_SQL, params![
+                    r.server_id,
+                    r.id,
+                    r.title,
+                    r.title_sort,
+                    r.artist,
+                    r.artist_id,
+                    r.album,
+                    r.album_id,
+                    r.album_artist,
+                    r.duration_sec,
+                    r.track_number,
+                    r.disc_number,
+                    r.year,
+                    r.genre,
+                    r.suffix,
+                    r.bit_rate,
+                    r.size_bytes,
+                    r.cover_art_id,
+                    r.starred_at,
+                    r.user_rating,
+                    r.play_count,
+                    r.played_at,
+                    r.server_path,
+                    r.library_id,
+                    r.isrc,
+                    r.mbid_recording,
+                    r.bpm,
+                    r.replay_gain_track_db,
+                    r.replay_gain_album_db,
+                    r.content_hash,
+                    r.server_updated_at,
+                    r.server_created_at,
+                    if r.deleted { 1_i64 } else { 0 },
+                    r.synced_at,
+                    r.raw_json,
+                ])?;
+
+                if let Some(old_id) = detected_old {
+                    remap_existing_to_new(
+                        &tx,
+                        &r.server_id,
+                        &old_id,
+                        &r.id,
+                        r.content_hash.as_deref(),
+                        r.server_path.as_deref(),
                         r.synced_at,
-                        r.raw_json,
-                    ])?;
+                    )?;
+                    remapped.push(RemapEntry {
+                        server_id: r.server_id.clone(),
+                        old_id,
+                        new_id: r.id.clone(),
+                    });
                 }
             }
+
             tx.commit()?;
-            Ok(())
+            Ok(RemapStats { remapped })
         })
     }
+}
+
+/// Run the `SELECT old.id` half of §6.9 — returns `Some(old_id)` if a
+/// non-deleted row with a different id on this server matches the
+/// incoming row's `content_hash` or `server_path`.
+fn detect_remap_target(
+    tx: &rusqlite::Transaction<'_>,
+    incoming: &TrackRow,
+) -> rusqlite::Result<Option<String>> {
+    // Empty-string sentinels are *not* eligible — spec §6.9 explicitly
+    // excludes them so the file-tree default never collides.
+    let hash = incoming.content_hash.as_deref().filter(|s| !s.is_empty());
+    let path = incoming.server_path.as_deref().filter(|s| !s.is_empty());
+    if hash.is_none() && path.is_none() {
+        return Ok(None);
+    }
+    tx.query_row(
+        "SELECT id FROM track \
+         WHERE server_id = ?1 \
+           AND deleted = 0 \
+           AND id != ?2 \
+           AND (\
+             (?3 IS NOT NULL AND content_hash = ?3) \
+             OR (?4 IS NOT NULL AND server_path = ?4) \
+           ) \
+         LIMIT 1",
+        params![incoming.server_id, incoming.id, hash, path],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+}
+
+/// Run the §6.9 retarget half — UPDATE every FK-bound child to the
+/// new id, INSERT into `track_id_history`, DELETE the old `track` row.
+/// `track_offline` has no FK to `track` (spec §5.14) but still needs
+/// its row retargeted so the cached file resolves under the new id.
+fn remap_existing_to_new(
+    tx: &rusqlite::Transaction<'_>,
+    server_id: &str,
+    old_id: &str,
+    new_id: &str,
+    content_hash: Option<&str>,
+    server_path: Option<&str>,
+    remapped_at: i64,
+) -> rusqlite::Result<()> {
+    for table in [
+        "track_offline",
+        "track_extension",
+        "track_fact",
+        "track_artifact",
+        "track_canonical_link",
+    ] {
+        tx.execute(
+            &format!(
+                "UPDATE {table} SET track_id = ?1 \
+                 WHERE server_id = ?2 AND track_id = ?3"
+            ),
+            params![new_id, server_id, old_id],
+        )?;
+    }
+    tx.execute(
+        "INSERT INTO track_id_history \
+         (server_id, old_id, new_id, content_hash, server_path, remapped_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+         ON CONFLICT(server_id, old_id) DO UPDATE SET \
+           new_id = excluded.new_id, \
+           content_hash = excluded.content_hash, \
+           server_path = excluded.server_path, \
+           remapped_at = excluded.remapped_at",
+        params![server_id, old_id, new_id, content_hash, server_path, remapped_at],
+    )?;
+    tx.execute(
+        "DELETE FROM track WHERE server_id = ?1 AND id = ?2",
+        params![server_id, old_id],
+    )?;
+    Ok(())
 }
 
 const UPSERT_SQL: &str = r#"
@@ -338,5 +475,162 @@ mod tests {
             "upsert_batch(500 rows) took {elapsed:?}; AC A3 target is <100ms typical, \
              test fails past 5× that"
         );
+    }
+
+    // ── PR-3b: §6.9 id remap detection ────────────────────────────────────
+
+    fn row_with_id_hash(server: &str, id: &str, hash: &str, path: &str) -> TrackRow {
+        let mut r = row(server, id, "Title");
+        r.content_hash = if hash.is_empty() { None } else { Some(hash.into()) };
+        r.server_path = if path.is_empty() { None } else { Some(path.into()) };
+        r
+    }
+
+    #[test]
+    fn remap_disabled_never_records_history_even_on_hash_collision() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[row_with_id_hash("s1", "tr_old", "deadbeef", "")])
+            .unwrap();
+
+        // Generic Subsonic path: caller passes `unstable_track_ids = false`.
+        let stats = repo
+            .upsert_batch_with_remap(
+                &[row_with_id_hash("s1", "tr_new", "deadbeef", "")],
+                false,
+            )
+            .unwrap();
+        assert!(stats.remapped.is_empty());
+
+        let track_count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0)))
+            .unwrap();
+        let hist_count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track_id_history", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(track_count, 2, "both ids coexist when remap is off");
+        assert_eq!(hist_count, 0);
+    }
+
+    #[test]
+    fn remap_via_content_hash_replaces_old_row_and_records_history() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        // Seed with the old id; child tables get a row each that must
+        // follow the remap.
+        repo.upsert_batch(&[row_with_id_hash("s1", "tr_old", "deadbeef", "/path/x.flac")])
+            .unwrap();
+        store
+            .with_conn(|c| {
+                c.execute(
+                    "INSERT INTO track_offline \
+                     (server_id, track_id, local_path, cached_at) \
+                     VALUES ('s1', 'tr_old', '/local/x.flac', 1)",
+                    [],
+                )?;
+                c.execute(
+                    "INSERT INTO track_extension \
+                     (server_id, track_id, kind, payload, updated_at) \
+                     VALUES ('s1', 'tr_old', 'user_note', X'7B7D', 1)",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let stats = repo
+            .upsert_batch_with_remap(
+                &[row_with_id_hash("s1", "tr_new", "deadbeef", "/path/x.flac")],
+                true,
+            )
+            .unwrap();
+        assert_eq!(stats.remapped.len(), 1);
+        assert_eq!(stats.remapped[0].old_id, "tr_old");
+        assert_eq!(stats.remapped[0].new_id, "tr_new");
+
+        // Old track row gone, new one in place.
+        let ids: Vec<String> = store
+            .with_conn(|c| {
+                let mut stmt = c.prepare("SELECT id FROM track WHERE server_id = 's1'")?;
+                let r: rusqlite::Result<Vec<String>> = stmt.query_map([], |r| r.get(0))?.collect();
+                r
+            })
+            .unwrap();
+        assert_eq!(ids, vec!["tr_new"]);
+
+        // Child tables follow the new id.
+        let offline_id: String = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT track_id FROM track_offline WHERE server_id = 's1'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(offline_id, "tr_new");
+        let ext_id: String = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT track_id FROM track_extension WHERE server_id = 's1'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(ext_id, "tr_new");
+
+        // History row recorded.
+        let hist = crate::repos::TrackIdHistoryRepository::new(&store);
+        assert_eq!(
+            hist.lookup_new_id("s1", "tr_old").unwrap().as_deref(),
+            Some("tr_new")
+        );
+    }
+
+    #[test]
+    fn remap_via_server_path_only_works_when_hash_missing() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[row_with_id_hash("s1", "tr_old", "", "/path/y.mp3")])
+            .unwrap();
+        // Server only ships server_path on the new row — no hash yet.
+        let stats = repo
+            .upsert_batch_with_remap(
+                &[row_with_id_hash("s1", "tr_new", "", "/path/y.mp3")],
+                true,
+            )
+            .unwrap();
+        assert_eq!(stats.remapped.len(), 1, "path-based remap must trigger");
+    }
+
+    #[test]
+    fn remap_skips_when_neither_hash_nor_path_present() {
+        // Defensive: empty-string sentinels must not cause spurious
+        // remaps across unrelated rows that happen to lack hash + path.
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[row_with_id_hash("s1", "tr_old", "", "")]).unwrap();
+        let stats = repo
+            .upsert_batch_with_remap(&[row_with_id_hash("s1", "tr_new", "", "")], true)
+            .unwrap();
+        assert!(stats.remapped.is_empty());
+        let count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(count, 2, "both rows kept; identity-less rows can't shadow");
+    }
+
+    #[test]
+    fn remap_is_noop_when_new_id_matches_existing_id() {
+        // Standard delta-sync: same id, same hash. Must not trigger
+        // remap (SELECT excludes id = T.id).
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        repo.upsert_batch(&[row_with_id_hash("s1", "tr_1", "h", "/p")]).unwrap();
+        let stats = repo
+            .upsert_batch_with_remap(&[row_with_id_hash("s1", "tr_1", "h", "/p")], true)
+            .unwrap();
+        assert!(stats.remapped.is_empty());
     }
 }

--- a/src-tauri/crates/psysonic-library/src/repos/track_id_history.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track_id_history.rs
@@ -1,0 +1,123 @@
+//! Read-side helper for `track_id_history`. Writes live inside the
+//! upsert transaction in `TrackRepository::upsert_batch_with_remap`
+//! (spec §6.9) — keeping them there avoids splitting the remap across
+//! two SQLite transactions, which would leave a window where child
+//! tables point at a removed track id.
+
+use rusqlite::{params, OptionalExtension};
+
+use crate::store::LibraryStore;
+
+pub struct TrackIdHistoryRepository<'a> {
+    store: &'a LibraryStore,
+}
+
+impl<'a> TrackIdHistoryRepository<'a> {
+    pub fn new(store: &'a LibraryStore) -> Self {
+        Self { store }
+    }
+
+    /// Resolve a remapped id forward to the current server id, if a
+    /// remap was recorded. Returns `None` when no row exists. Analysis
+    /// cache lookups (Phase E) go through this so cached waveform /
+    /// loudness rows stay reachable after the server's id space shifts.
+    pub fn lookup_new_id(
+        &self,
+        server_id: &str,
+        old_id: &str,
+    ) -> Result<Option<String>, String> {
+        self.store.with_conn(|conn| {
+            conn.query_row(
+                "SELECT new_id FROM track_id_history \
+                 WHERE server_id = ?1 AND old_id = ?2",
+                params![server_id, old_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+        })
+    }
+
+    /// Count the rows recorded for this server — used by tests and by
+    /// post-sync diagnostics (Settings „Library index" panel later).
+    pub fn count_for_server(&self, server_id: &str) -> Result<i64, String> {
+        self.store.with_conn(|conn| {
+            conn.query_row(
+                "SELECT COUNT(*) FROM track_id_history WHERE server_id = ?1",
+                params![server_id],
+                |row| row.get(0),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+
+    fn seed_history(store: &LibraryStore, rows: &[(&str, &str, &str)]) {
+        store
+            .with_conn(|c| {
+                for (server, old, new) in rows {
+                    c.execute(
+                        "INSERT INTO track_id_history \
+                         (server_id, old_id, new_id, content_hash, server_path, remapped_at) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                        params![server, old, new, "hash", "path", 1_700_000_000_i64],
+                    )?;
+                }
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn lookup_returns_none_when_no_remap_recorded() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackIdHistoryRepository::new(&store);
+        assert_eq!(repo.lookup_new_id("s1", "tr_old").unwrap(), None);
+    }
+
+    #[test]
+    fn lookup_finds_new_id_for_recorded_remap() {
+        let store = LibraryStore::open_in_memory();
+        seed_history(&store, &[("s1", "tr_old", "tr_new")]);
+        let repo = TrackIdHistoryRepository::new(&store);
+        assert_eq!(
+            repo.lookup_new_id("s1", "tr_old").unwrap().as_deref(),
+            Some("tr_new")
+        );
+    }
+
+    #[test]
+    fn lookup_scopes_by_server_id() {
+        let store = LibraryStore::open_in_memory();
+        seed_history(&store, &[("s1", "tr_x", "tr_new1"), ("s2", "tr_x", "tr_new2")]);
+        let repo = TrackIdHistoryRepository::new(&store);
+        assert_eq!(
+            repo.lookup_new_id("s1", "tr_x").unwrap().as_deref(),
+            Some("tr_new1")
+        );
+        assert_eq!(
+            repo.lookup_new_id("s2", "tr_x").unwrap().as_deref(),
+            Some("tr_new2")
+        );
+    }
+
+    #[test]
+    fn count_for_server_scopes_correctly() {
+        let store = LibraryStore::open_in_memory();
+        seed_history(
+            &store,
+            &[
+                ("s1", "a", "b"),
+                ("s1", "c", "d"),
+                ("s2", "e", "f"),
+            ],
+        );
+        let repo = TrackIdHistoryRepository::new(&store);
+        assert_eq!(repo.count_for_server("s1").unwrap(), 2);
+        assert_eq!(repo.count_for_server("s2").unwrap(), 1);
+        assert_eq!(repo.count_for_server("absent").unwrap(), 0);
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/sync/backoff.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/backoff.rs
@@ -1,0 +1,140 @@
+//! C12 — HTTP backoff for ingest batches (spec §6.8).
+//!
+//! The runner does not advance its cursor on transient failure; it
+//! sleeps via `Backoff::next_delay`, retries the same batch, and
+//! resets the counter on success. The cap is 120 s — the user is
+//! waiting for sync to finish, longer hangs become indistinguishable
+//! from "stuck" without progress events to reassure them.
+
+use std::time::Duration;
+
+/// Exponential schedule per §6.8: `2s → 4s → 8s → … cap 120s`. The
+/// caller adds jitter on top to avoid herd-sync against a recovering
+/// upstream proxy.
+#[derive(Debug, Clone)]
+pub struct Backoff {
+    attempt: u32,
+    base: Duration,
+    cap: Duration,
+}
+
+impl Default for Backoff {
+    fn default() -> Self {
+        Self::new(Duration::from_secs(2), Duration::from_secs(120))
+    }
+}
+
+impl Backoff {
+    pub fn new(base: Duration, cap: Duration) -> Self {
+        Self { attempt: 0, base, cap }
+    }
+
+    /// Reset after a successful batch — the next failure starts at
+    /// the base delay again.
+    pub fn reset(&mut self) {
+        self.attempt = 0;
+    }
+
+    /// Compute the next sleep duration and bump the attempt counter.
+    /// Doubles each call (2 → 4 → 8 → …) and clamps to `cap`. Caller
+    /// adds jitter via `with_jitter` if desired.
+    pub fn next_delay(&mut self) -> Duration {
+        let n = self.attempt;
+        self.attempt = self.attempt.saturating_add(1);
+        let scaled = self.base.saturating_mul(1u32 << n.min(31));
+        scaled.min(self.cap)
+    }
+
+    pub fn attempt(&self) -> u32 {
+        self.attempt
+    }
+}
+
+/// Add ±25% jitter to a planned sleep — deterministic per `salt` so
+/// tests can pin the result without pulling in `rand`. Production
+/// code passes `attempt + nanos` as the salt; tests pass a fixed
+/// value to assert the formula.
+pub fn with_jitter(base: Duration, salt: u64) -> Duration {
+    let millis = base.as_millis().min(u128::from(u64::MAX)) as u64;
+    if millis == 0 {
+        return base;
+    }
+    let span = millis / 2; // ±25% = total span of 50% of base
+    if span == 0 {
+        return base;
+    }
+    // map salt into [-span/2, +span/2]
+    let pct = (salt % span) as i64 - (span as i64 / 2);
+    let jittered = (millis as i64).saturating_add(pct).max(1) as u64;
+    Duration::from_millis(jittered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_delay_doubles_until_cap() {
+        let mut b = Backoff::default();
+        assert_eq!(b.next_delay(), Duration::from_secs(2));
+        assert_eq!(b.next_delay(), Duration::from_secs(4));
+        assert_eq!(b.next_delay(), Duration::from_secs(8));
+        assert_eq!(b.next_delay(), Duration::from_secs(16));
+        assert_eq!(b.next_delay(), Duration::from_secs(32));
+        assert_eq!(b.next_delay(), Duration::from_secs(64));
+        // Next would be 128 — clamps to 120 cap.
+        assert_eq!(b.next_delay(), Duration::from_secs(120));
+        // Stays at cap from here on.
+        assert_eq!(b.next_delay(), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn reset_brings_schedule_back_to_base() {
+        let mut b = Backoff::default();
+        b.next_delay();
+        b.next_delay();
+        assert!(b.attempt() > 0);
+        b.reset();
+        assert_eq!(b.attempt(), 0);
+        assert_eq!(b.next_delay(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn next_delay_handles_custom_base_and_cap() {
+        let mut b = Backoff::new(Duration::from_millis(50), Duration::from_secs(1));
+        assert_eq!(b.next_delay(), Duration::from_millis(50));
+        assert_eq!(b.next_delay(), Duration::from_millis(100));
+        assert_eq!(b.next_delay(), Duration::from_millis(200));
+        assert_eq!(b.next_delay(), Duration::from_millis(400));
+        assert_eq!(b.next_delay(), Duration::from_millis(800));
+        // 1600 would exceed 1s cap.
+        assert_eq!(b.next_delay(), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn next_delay_does_not_overflow_at_extreme_attempts() {
+        let mut b = Backoff::default();
+        for _ in 0..100 {
+            // Should saturate at the cap, never panic on shift overflow.
+            let _ = b.next_delay();
+        }
+        assert_eq!(b.next_delay(), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn jitter_stays_within_plus_minus_half_of_span() {
+        let base = Duration::from_secs(8);
+        let span_ms = base.as_millis() as u64 / 2; // 4000 ms
+        let lo = base.as_millis() as u64 - span_ms / 2; // 6000 ms
+        let hi = base.as_millis() as u64 + span_ms / 2; // 10000 ms
+        for salt in 0u64..1000 {
+            let j = with_jitter(base, salt).as_millis() as u64;
+            assert!(j >= lo && j <= hi, "salt {salt} → {j}ms outside [{lo},{hi}]");
+        }
+    }
+
+    #[test]
+    fn jitter_with_zero_base_returns_zero() {
+        assert_eq!(with_jitter(Duration::ZERO, 12345), Duration::ZERO);
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/sync/capability.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/capability.rs
@@ -201,13 +201,6 @@ mod tests {
         })
     }
 
-    fn mount_ok(server: &MockServer, route: &'static str, body_key: &'static str) {
-        // We can't await inside a sync helper without making it async;
-        // probe tests construct the mocks inline for clarity. Helper
-        // kept here for documentation only — see individual tests.
-        let _ = (server, route, body_key);
-    }
-
     async fn mount_subsonic_full_navidrome(server: &MockServer) {
         // ping → navidrome + openSubsonic
         Mock::given(wm_method("GET"))
@@ -254,7 +247,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn probe_sets_all_subsonic_bits_on_a_fully_capable_navidrome_server() {
-        let _ = mount_ok;
         let server = MockServer::start().await;
         mount_subsonic_full_navidrome(&server).await;
 

--- a/src-tauri/crates/psysonic-library/src/sync/cursor.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/cursor.rs
@@ -1,0 +1,156 @@
+//! Cursor shape persisted in `sync_state.initial_sync_cursor_json`.
+//! Resume after a restart, kill, or app crash deserializes this value
+//! and tells the runner where to pick up. Strategy is recorded so a
+//! cap-flag change between runs surfaces as `CursorIncompatible`
+//! rather than silently restarting the wrong loop.
+
+use serde::{Deserialize, Serialize};
+
+use super::strategy::IngestStrategy;
+
+/// Top-level cursor. `phase` advances `Ingest → ArtistPass → Watermarks
+/// → Done`; each phase only reads the fields it owns.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InitialSyncCursor {
+    /// Ingest strategy in flight — stored as the tag string so the JSON
+    /// is human-readable on disk.
+    pub strategy: String,
+    pub phase: CursorPhase,
+    /// Scope this run operates on (Navidrome `library_id` / Subsonic
+    /// `musicFolderId`). `None` means "all libraries on this server".
+    #[serde(default)]
+    pub library_scope: Option<String>,
+    /// Tracks ingested across the entire run so far — informational,
+    /// matches the §6 progress event payload.
+    #[serde(default)]
+    pub ingested_count: u32,
+    /// Per-strategy offset state. Discriminated by `strategy` so a
+    /// future field add doesn't break old cursors.
+    #[serde(default)]
+    pub strategy_state: StrategyState,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CursorPhase {
+    Ingest,
+    ArtistPass,
+    Watermarks,
+    Done,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StrategyState {
+    /// N1 / S1 — single linear offset.
+    LinearOffset { offset: u32 },
+    /// S2 — outer album-list offset plus optional in-flight album we
+    /// were halfway through when interrupted.
+    AlbumCrawl {
+        album_offset: u32,
+        #[serde(default)]
+        current_album_id: Option<String>,
+    },
+    /// Fresh cursor with no progress yet.
+    #[default]
+    Empty,
+}
+
+impl InitialSyncCursor {
+    pub fn fresh(strategy: IngestStrategy, library_scope: Option<String>) -> Self {
+        let strategy_state = match strategy {
+            IngestStrategy::N1 | IngestStrategy::S1 => StrategyState::LinearOffset { offset: 0 },
+            IngestStrategy::S2 => StrategyState::AlbumCrawl {
+                album_offset: 0,
+                current_album_id: None,
+            },
+            IngestStrategy::S3 => StrategyState::Empty,
+        };
+        Self {
+            strategy: strategy.as_tag().to_string(),
+            phase: CursorPhase::Ingest,
+            library_scope,
+            ingested_count: 0,
+            strategy_state,
+        }
+    }
+
+    pub fn strategy_tag(&self) -> &str {
+        &self.strategy
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn fresh_n1_starts_at_offset_zero() {
+        let c = InitialSyncCursor::fresh(IngestStrategy::N1, None);
+        assert_eq!(c.phase, CursorPhase::Ingest);
+        assert_eq!(c.ingested_count, 0);
+        match c.strategy_state {
+            StrategyState::LinearOffset { offset } => assert_eq!(offset, 0),
+            other => panic!("expected LinearOffset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fresh_s2_uses_album_crawl_state() {
+        let c = InitialSyncCursor::fresh(IngestStrategy::S2, Some("lib-1".into()));
+        assert_eq!(c.library_scope.as_deref(), Some("lib-1"));
+        match c.strategy_state {
+            StrategyState::AlbumCrawl { album_offset, current_album_id } => {
+                assert_eq!(album_offset, 0);
+                assert!(current_album_id.is_none());
+            }
+            other => panic!("expected AlbumCrawl, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cursor_roundtrips_through_json() {
+        // The cursor lives as TEXT in `sync_state.initial_sync_cursor_json`;
+        // serde must keep the round trip stable for resume to work.
+        let c = InitialSyncCursor {
+            strategy: "n1".into(),
+            phase: CursorPhase::Ingest,
+            library_scope: Some("lib-1".into()),
+            ingested_count: 2500,
+            strategy_state: StrategyState::LinearOffset { offset: 2500 },
+        };
+        let json = serde_json::to_value(&c).unwrap();
+        let back: InitialSyncCursor = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(c, back);
+
+        // strategy_state internally tagged with `"kind"`.
+        assert_eq!(
+            json.get("strategy_state").and_then(|s| s.get("kind")),
+            Some(&json!("linear_offset"))
+        );
+    }
+
+    #[test]
+    fn cursor_deserialize_tolerates_omitted_defaults() {
+        // Minimal cursor produced by a much older client must still
+        // deserialize as a "fresh ingest" state.
+        let raw = json!({
+            "strategy": "s1",
+            "phase": "ingest"
+        });
+        let c: InitialSyncCursor = serde_json::from_value(raw).unwrap();
+        assert_eq!(c.ingested_count, 0);
+        assert_eq!(c.library_scope, None);
+        assert!(matches!(c.strategy_state, StrategyState::Empty));
+    }
+
+    #[test]
+    fn empty_object_does_not_parse_as_cursor() {
+        // sync_state.initial_sync_cursor_json default is `'{}'`; that
+        // value is not a valid cursor (no strategy / phase). Runner
+        // must treat it as "no cursor → start fresh".
+        let raw = json!({});
+        assert!(serde_json::from_value::<InitialSyncCursor>(raw).is_err());
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/sync/error.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/error.rs
@@ -1,0 +1,123 @@
+//! Errors surfaced by the sync orchestrator. Designed so callers
+//! (PR-5 Tauri command surface) can pattern-match on the variant for
+//! UI affordances — `Cancelled` is silent, `Transport`/`HttpStatus`
+//! retry, `Subsonic { code: 70, .. }` flows into the tombstone path,
+//! and `StrategyUnsupported` surfaces a Settings hint.
+
+use std::fmt;
+
+use psysonic_integration::subsonic::SubsonicError;
+
+#[derive(Debug)]
+pub enum SyncError {
+    /// Network / TLS / DNS failure surfaced by the Subsonic or
+    /// Navidrome HTTP client. Retryable per §6.8.
+    Transport(String),
+
+    /// Subsonic-level error after the envelope parsed cleanly. The
+    /// dedicated `NotFound` (error code 70) is kept inline rather
+    /// than collapsed into a string so the tombstone path can match.
+    Subsonic { code: i32, message: String },
+
+    /// Subsonic returned error code 70 — track missing from the
+    /// server. Tombstone reconciler matches on this variant directly.
+    NotFound,
+
+    /// Navidrome native REST returned a non-success status; carries
+    /// the flattened HTTP error string from `nd_err`.
+    Navidrome(String),
+
+    /// Persistence layer (SQLite) failure.
+    Storage(String),
+
+    /// Strategy is enumerated but not implemented for v1
+    /// (currently only `S3`).
+    StrategyUnsupported {
+        strategy: &'static str,
+    },
+
+    /// Cancellation token tripped — caller asked us to abort.
+    /// Cursor stays where it was so the next run resumes the batch.
+    Cancelled,
+
+    /// Cursor JSON in `sync_state` is from an incompatible strategy
+    /// (e.g. switching from N1 to S2 mid-sync). Caller should clear
+    /// the cursor and restart initial sync.
+    CursorIncompatible {
+        expected: &'static str,
+        actual: String,
+    },
+}
+
+impl fmt::Display for SyncError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Transport(m) => write!(f, "sync transport: {m}"),
+            Self::Subsonic { code, message } => write!(f, "subsonic {code}: {message}"),
+            Self::NotFound => write!(f, "subsonic: not found (code 70)"),
+            Self::Navidrome(m) => write!(f, "navidrome: {m}"),
+            Self::Storage(m) => write!(f, "storage: {m}"),
+            Self::StrategyUnsupported { strategy } => {
+                write!(f, "ingest strategy not supported: {strategy}")
+            }
+            Self::Cancelled => write!(f, "sync cancelled"),
+            Self::CursorIncompatible { expected, actual } => write!(
+                f,
+                "sync cursor strategy mismatch: cursor says `{actual}`, runner is `{expected}`"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SyncError {}
+
+impl From<SubsonicError> for SyncError {
+    fn from(e: SubsonicError) -> Self {
+        match e {
+            SubsonicError::Transport(m) => Self::Transport(m),
+            SubsonicError::HttpStatus(s) => Self::Transport(format!("http {s}")),
+            SubsonicError::Api { code, message } => Self::Subsonic { code, message },
+            SubsonicError::NotFound => Self::NotFound,
+            SubsonicError::Decode(m) => Self::Transport(format!("decode: {m}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subsonic_not_found_maps_to_sync_not_found() {
+        let e: SyncError = SubsonicError::NotFound.into();
+        assert!(matches!(e, SyncError::NotFound));
+    }
+
+    #[test]
+    fn subsonic_api_error_carries_code_through() {
+        let e: SyncError = SubsonicError::Api { code: 40, message: "bad creds".into() }.into();
+        match e {
+            SyncError::Subsonic { code, message } => {
+                assert_eq!(code, 40);
+                assert!(message.contains("bad creds"));
+            }
+            other => panic!("expected Subsonic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn http_status_collapses_into_transport() {
+        let e: SyncError = SubsonicError::HttpStatus(reqwest::StatusCode::SERVICE_UNAVAILABLE).into();
+        assert!(matches!(e, SyncError::Transport(ref m) if m.contains("503")));
+    }
+
+    #[test]
+    fn cursor_incompatible_renders_both_strategies() {
+        let s = SyncError::CursorIncompatible {
+            expected: "n1",
+            actual: "s2".into(),
+        }
+        .to_string();
+        assert!(s.contains("n1") && s.contains("s2"));
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/sync/initial.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial.rs
@@ -1,0 +1,1172 @@
+//! `InitialSyncRunner` — spec §6.3 IS-1 … IS-6. PR-3b lands the runner,
+//! cursor persistence, and the N1/S1/S2 ingest loops. S3 (file-tree)
+//! is enumerated but returns `StrategyUnsupported`. IS-4 artist pass +
+//! IS-5 watermarks run after the bulk loop completes.
+//!
+//! The runner is pure Rust — no Tauri events, no background task
+//! lifecycle. PR-3d wires it into a `tokio::task::spawn` shell with
+//! progress emit + the cancellation token; PR-3b only ships the
+//! library-side function the shell will call.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use psysonic_integration::navidrome::queries::nd_list_songs_internal;
+use psysonic_integration::subsonic::SubsonicClient;
+use serde_json::Value;
+
+use super::backoff::{with_jitter, Backoff};
+use super::capability::{CapabilityFlags, NavidromeProbeCredentials};
+use super::cursor::{CursorPhase, InitialSyncCursor, StrategyState};
+use super::error::SyncError;
+use super::mapping::{navidrome_song_to_track_row, subsonic_song_to_track_row};
+use super::strategy::IngestStrategy;
+use crate::repos::{RemapStats, SyncStateRepository, TrackRepository, TrackRow};
+use crate::store::LibraryStore;
+
+/// Bulk ingest batch size per spec §6.3 (`batch=500`).
+const DEFAULT_BATCH_SIZE: u32 = 500;
+
+/// Maximum attempts per batch before `SyncError::Transport` propagates.
+/// Caller (Settings „retry" / PR-3d scheduler) can wrap and retry the
+/// whole run if needed.
+const MAX_ATTEMPTS_PER_BATCH: u32 = 5;
+
+/// Summary returned from `InitialSyncRunner::run`. Caller emits a
+/// completion event with these numbers (PR-3d).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InitialSyncReport {
+    pub strategy: Option<String>,
+    pub ingested_count: u32,
+    pub remapped_count: u32,
+}
+
+pub struct InitialSyncRunner<'a> {
+    store: &'a LibraryStore,
+    subsonic: &'a SubsonicClient,
+    navidrome: Option<NavidromeProbeCredentials>,
+    server_id: String,
+    library_scope: String,
+    capability_flags: CapabilityFlags,
+    cancel: Option<Arc<AtomicBool>>,
+    batch_size: u32,
+    sleep_enabled: bool,
+}
+
+impl<'a> InitialSyncRunner<'a> {
+    pub fn new(
+        store: &'a LibraryStore,
+        subsonic: &'a SubsonicClient,
+        server_id: impl Into<String>,
+        library_scope: impl Into<String>,
+        capability_flags: CapabilityFlags,
+    ) -> Self {
+        Self {
+            store,
+            subsonic,
+            navidrome: None,
+            server_id: server_id.into(),
+            library_scope: library_scope.into(),
+            capability_flags,
+            cancel: None,
+            batch_size: DEFAULT_BATCH_SIZE,
+            sleep_enabled: true,
+        }
+    }
+
+    pub fn with_navidrome_credentials(mut self, creds: NavidromeProbeCredentials) -> Self {
+        self.navidrome = Some(creds);
+        self
+    }
+
+    pub fn with_cancellation(mut self, flag: Arc<AtomicBool>) -> Self {
+        self.cancel = Some(flag);
+        self
+    }
+
+    pub fn with_batch_size(mut self, n: u32) -> Self {
+        if n > 0 {
+            self.batch_size = n;
+        }
+        self
+    }
+
+    /// Disable real sleep between backoff attempts. Tests pin this so
+    /// `503 → success on retry` exercises the retry loop in
+    /// milliseconds instead of seconds. Production code leaves it on.
+    pub fn with_sleep_disabled(mut self) -> Self {
+        self.sleep_enabled = false;
+        self
+    }
+
+    /// IS-1 → IS-6. Resumes from `sync_state.initial_sync_cursor_json`
+    /// when a cursor is already persisted; otherwise picks a strategy
+    /// from `capability_flags` and starts fresh.
+    pub async fn run(&self) -> Result<InitialSyncReport, SyncError> {
+        let sync_state = SyncStateRepository::new(self.store);
+        sync_state
+            .ensure(&self.server_id, &self.library_scope)
+            .map_err(SyncError::Storage)?;
+
+        // IS-1 — phase=initial_sync.
+        sync_state
+            .set_sync_phase(&self.server_id, &self.library_scope, "initial_sync")
+            .map_err(SyncError::Storage)?;
+
+        let mut cursor = self.load_or_init_cursor(&sync_state)?;
+        let mut report = InitialSyncReport {
+            strategy: Some(cursor.strategy.clone()),
+            ingested_count: cursor.ingested_count,
+            remapped_count: 0,
+        };
+        let strategy = IngestStrategy::from_tag(&cursor.strategy).ok_or_else(|| {
+            SyncError::CursorIncompatible {
+                expected: "n1|s1|s2|s3",
+                actual: cursor.strategy.clone(),
+            }
+        })?;
+
+        // IS-3 — bulk ingest per strategy.
+        if cursor.phase == CursorPhase::Ingest {
+            match strategy {
+                IngestStrategy::N1 => self.run_n1(&mut cursor, &mut report, &sync_state).await?,
+                IngestStrategy::S1 => self.run_s1(&mut cursor, &mut report, &sync_state).await?,
+                IngestStrategy::S2 => self.run_s2(&mut cursor, &mut report, &sync_state).await?,
+                IngestStrategy::S3 => {
+                    return Err(SyncError::StrategyUnsupported { strategy: "s3" })
+                }
+            }
+            cursor.phase = CursorPhase::ArtistPass;
+            self.persist_cursor(&sync_state, &cursor)?;
+        }
+
+        // IS-4 — optional artist/album index pass via `getArtists`.
+        if cursor.phase == CursorPhase::ArtistPass {
+            self.run_artist_pass(&sync_state).await?;
+            cursor.phase = CursorPhase::Watermarks;
+            self.persist_cursor(&sync_state, &cursor)?;
+        }
+
+        // IS-5 — watermarks (server_last_scan_iso, server_track_count,
+        // artists_last_modified_ms) so DS-0 polls can short-circuit.
+        if cursor.phase == CursorPhase::Watermarks {
+            self.run_watermark_pass(&sync_state).await?;
+            cursor.phase = CursorPhase::Done;
+            self.persist_cursor(&sync_state, &cursor)?;
+        }
+
+        // IS-6 — phase=ready, last_full_sync_at=now, clear cursor.
+        sync_state
+            .set_sync_phase(&self.server_id, &self.library_scope, "ready")
+            .map_err(SyncError::Storage)?;
+        sync_state
+            .set_initial_sync_cursor(
+                &self.server_id,
+                &self.library_scope,
+                &Value::Object(serde_json::Map::new()),
+            )
+            .map_err(SyncError::Storage)?;
+
+        Ok(report)
+    }
+
+    // ── cursor / persistence ───────────────────────────────────────────
+
+    fn load_or_init_cursor(
+        &self,
+        sync_state: &SyncStateRepository<'_>,
+    ) -> Result<InitialSyncCursor, SyncError> {
+        let raw = sync_state
+            .get_initial_sync_cursor(&self.server_id, &self.library_scope)
+            .map_err(SyncError::Storage)?;
+        if let Some(raw) = raw {
+            if !is_empty_cursor(&raw) {
+                let parsed: InitialSyncCursor = serde_json::from_value(raw.clone())
+                    .map_err(|e| SyncError::Storage(format!("invalid cursor: {e}")))?;
+                let strategy_from_flags = IngestStrategy::select_from_flags(self.capability_flags);
+                if parsed.strategy != strategy_from_flags.as_tag() {
+                    return Err(SyncError::CursorIncompatible {
+                        expected: strategy_from_flags.as_tag(),
+                        actual: parsed.strategy,
+                    });
+                }
+                return Ok(parsed);
+            }
+        }
+        let strategy = IngestStrategy::select_from_flags(self.capability_flags);
+        let scope = if self.library_scope.is_empty() {
+            None
+        } else {
+            Some(self.library_scope.clone())
+        };
+        let fresh = InitialSyncCursor::fresh(strategy, scope);
+        self.persist_cursor(sync_state, &fresh)?;
+        Ok(fresh)
+    }
+
+    fn persist_cursor(
+        &self,
+        sync_state: &SyncStateRepository<'_>,
+        cursor: &InitialSyncCursor,
+    ) -> Result<(), SyncError> {
+        let value = serde_json::to_value(cursor)
+            .map_err(|e| SyncError::Storage(format!("serialize cursor: {e}")))?;
+        sync_state
+            .set_initial_sync_cursor(&self.server_id, &self.library_scope, &value)
+            .map_err(SyncError::Storage)
+    }
+
+    fn check_cancellation(&self) -> Result<(), SyncError> {
+        if let Some(flag) = &self.cancel {
+            if flag.load(Ordering::SeqCst) {
+                return Err(SyncError::Cancelled);
+            }
+        }
+        Ok(())
+    }
+
+    fn unstable_track_ids(&self) -> bool {
+        self.capability_flags
+            .contains(CapabilityFlags::UNSTABLE_TRACK_IDS)
+    }
+
+    fn library_scope_opt(&self) -> Option<&str> {
+        if self.library_scope.is_empty() {
+            None
+        } else {
+            Some(self.library_scope.as_str())
+        }
+    }
+
+    async fn sleep(&self, d: Duration) {
+        if self.sleep_enabled && !d.is_zero() {
+            tokio::time::sleep(d).await;
+        }
+    }
+
+    fn write_batch(&self, rows: &[TrackRow]) -> Result<RemapStats, SyncError> {
+        TrackRepository::new(self.store)
+            .upsert_batch_with_remap(rows, self.unstable_track_ids())
+            .map_err(SyncError::Storage)
+    }
+
+    // ── N1 (Navidrome native /api/song) ────────────────────────────────
+
+    async fn run_n1(
+        &self,
+        cursor: &mut InitialSyncCursor,
+        report: &mut InitialSyncReport,
+        sync_state: &SyncStateRepository<'_>,
+    ) -> Result<(), SyncError> {
+        let creds = self.navidrome.as_ref().ok_or_else(|| SyncError::Transport(
+            "n1 strategy selected but no Navidrome credentials supplied".into(),
+        ))?;
+        let mut offset = match cursor.strategy_state {
+            StrategyState::LinearOffset { offset } => offset,
+            ref other => {
+                return Err(SyncError::Storage(format!(
+                    "n1 expected linear-offset cursor, got {other:?}"
+                )))
+            }
+        };
+
+        loop {
+            self.check_cancellation()?;
+            let end = offset.saturating_add(self.batch_size);
+            let response = retry_with_backoff(
+                self,
+                || nd_list_songs_internal(
+                    &creds.server_url,
+                    &creds.bearer_token,
+                    "id",
+                    "ASC",
+                    offset,
+                    end,
+                ),
+                SyncError::Navidrome,
+            )
+            .await?;
+
+            let array = response.as_array().cloned().unwrap_or_default();
+            if array.is_empty() {
+                break;
+            }
+            let synced_at = now_unix_ms();
+            let rows: Vec<TrackRow> = array
+                .iter()
+                .filter_map(|v| {
+                    navidrome_song_to_track_row(
+                        &self.server_id,
+                        v,
+                        synced_at,
+                        self.library_scope_opt(),
+                    )
+                })
+                .collect();
+            let stats = self.write_batch(&rows)?;
+            report.ingested_count = report.ingested_count.saturating_add(rows.len() as u32);
+            report.remapped_count = report
+                .remapped_count
+                .saturating_add(stats.remapped.len() as u32);
+
+            offset = end;
+            cursor.strategy_state = StrategyState::LinearOffset { offset };
+            cursor.ingested_count = report.ingested_count;
+            self.persist_cursor(sync_state, cursor)?;
+
+            if (array.len() as u32) < self.batch_size {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    // ── S1 (Subsonic search3 empty query) ──────────────────────────────
+
+    async fn run_s1(
+        &self,
+        cursor: &mut InitialSyncCursor,
+        report: &mut InitialSyncReport,
+        sync_state: &SyncStateRepository<'_>,
+    ) -> Result<(), SyncError> {
+        let mut offset = match cursor.strategy_state {
+            StrategyState::LinearOffset { offset } => offset,
+            ref other => {
+                return Err(SyncError::Storage(format!(
+                    "s1 expected linear-offset cursor, got {other:?}"
+                )))
+            }
+        };
+
+        loop {
+            self.check_cancellation()?;
+            let scope = self.library_scope_opt();
+            let result = retry_with_backoff(
+                self,
+                || self.subsonic.search3("", self.batch_size, offset, scope),
+                SyncError::from,
+            )
+            .await?;
+
+            if result.song.is_empty() {
+                break;
+            }
+
+            let synced_at = now_unix_ms();
+            let mut rows: Vec<TrackRow> = Vec::with_capacity(result.song.len());
+            for song in &result.song {
+                let raw = serde_json::to_value(song).unwrap_or(Value::Null);
+                rows.push(subsonic_song_to_track_row(
+                    &self.server_id,
+                    song,
+                    &raw,
+                    synced_at,
+                    self.library_scope_opt(),
+                ));
+            }
+            let stats = self.write_batch(&rows)?;
+            report.ingested_count = report.ingested_count.saturating_add(rows.len() as u32);
+            report.remapped_count = report
+                .remapped_count
+                .saturating_add(stats.remapped.len() as u32);
+
+            offset = offset.saturating_add(self.batch_size);
+            cursor.strategy_state = StrategyState::LinearOffset { offset };
+            cursor.ingested_count = report.ingested_count;
+            self.persist_cursor(sync_state, cursor)?;
+
+            if (result.song.len() as u32) < self.batch_size {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    // ── S2 (album crawl: getAlbumList2 + getAlbum) ─────────────────────
+
+    async fn run_s2(
+        &self,
+        cursor: &mut InitialSyncCursor,
+        report: &mut InitialSyncReport,
+        sync_state: &SyncStateRepository<'_>,
+    ) -> Result<(), SyncError> {
+        let (mut album_offset, _resumed_in_album) = match cursor.strategy_state {
+            StrategyState::AlbumCrawl { album_offset, ref current_album_id } => {
+                (album_offset, current_album_id.clone())
+            }
+            ref other => {
+                return Err(SyncError::Storage(format!(
+                    "s2 expected album-crawl cursor, got {other:?}"
+                )))
+            }
+        };
+
+        loop {
+            self.check_cancellation()?;
+            let scope = self.library_scope_opt();
+            let albums = retry_with_backoff(
+                self,
+                || self.subsonic.get_album_list2(
+                    "alphabeticalByName",
+                    self.batch_size,
+                    album_offset,
+                    scope,
+                ),
+                SyncError::from,
+            )
+            .await?;
+            if albums.is_empty() {
+                break;
+            }
+
+            for album_summary in &albums {
+                self.check_cancellation()?;
+                cursor.strategy_state = StrategyState::AlbumCrawl {
+                    album_offset,
+                    current_album_id: Some(album_summary.id.clone()),
+                };
+                self.persist_cursor(sync_state, cursor)?;
+
+                let (album, raw_album) = retry_with_backoff(
+                    self,
+                    || self.subsonic.get_album_with_raw(&album_summary.id),
+                    SyncError::from,
+                )
+                .await?;
+
+                let synced_at = now_unix_ms();
+                let raw_songs = raw_album
+                    .get("song")
+                    .and_then(|s| s.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                let mut rows: Vec<TrackRow> = Vec::with_capacity(album.song.len());
+                for (i, song) in album.song.iter().enumerate() {
+                    let raw = raw_songs
+                        .get(i)
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::to_value(song).unwrap_or(Value::Null));
+                    rows.push(subsonic_song_to_track_row(
+                        &self.server_id,
+                        song,
+                        &raw,
+                        synced_at,
+                        self.library_scope_opt(),
+                    ));
+                }
+                if !rows.is_empty() {
+                    let stats = self.write_batch(&rows)?;
+                    report.ingested_count = report
+                        .ingested_count
+                        .saturating_add(rows.len() as u32);
+                    report.remapped_count = report
+                        .remapped_count
+                        .saturating_add(stats.remapped.len() as u32);
+                }
+            }
+
+            album_offset = album_offset.saturating_add(self.batch_size);
+            cursor.strategy_state = StrategyState::AlbumCrawl {
+                album_offset,
+                current_album_id: None,
+            };
+            cursor.ingested_count = report.ingested_count;
+            self.persist_cursor(sync_state, cursor)?;
+
+            if (albums.len() as u32) < self.batch_size {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    // ── IS-4 artist pass (best-effort browse acceleration) ─────────────
+
+    async fn run_artist_pass(
+        &self,
+        sync_state: &SyncStateRepository<'_>,
+    ) -> Result<(), SyncError> {
+        let scope = self.library_scope_opt();
+        let artists = retry_with_backoff(
+            self,
+            || self.subsonic.get_artists(scope),
+            SyncError::from,
+        )
+        .await
+        .ok();
+        if let Some(index) = artists {
+            if let Some(ms) = index.last_modified_ms {
+                sync_state
+                    .set_artists_last_modified_ms(&self.server_id, &self.library_scope, ms)
+                    .map_err(SyncError::Storage)?;
+            }
+        }
+        Ok(())
+    }
+
+    // ── IS-5 watermarks ────────────────────────────────────────────────
+
+    async fn run_watermark_pass(
+        &self,
+        sync_state: &SyncStateRepository<'_>,
+    ) -> Result<(), SyncError> {
+        if self
+            .capability_flags
+            .contains(CapabilityFlags::SCAN_STATUS_AVAILABLE)
+        {
+            if let Ok(s) = self.subsonic.get_scan_status().await {
+                sync_state
+                    .set_server_last_scan_iso(
+                        &self.server_id,
+                        &self.library_scope,
+                        s.last_scan.as_deref(),
+                    )
+                    .map_err(SyncError::Storage)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn is_empty_cursor(v: &Value) -> bool {
+    matches!(v, Value::Object(o) if o.is_empty())
+}
+
+fn now_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
+}
+
+/// Wrap an async closure in §6.8 backoff. Retries on `SyncError::Transport`
+/// up to `MAX_ATTEMPTS_PER_BATCH`, sleeping per the backoff schedule
+/// (skipped when `sleep_enabled` is false — test path).
+/// Cancellation is checked between attempts.
+async fn retry_with_backoff<'a, F, FFut, T, E>(
+    runner: &InitialSyncRunner<'a>,
+    mut build: F,
+    map_err: impl Fn(E) -> SyncError,
+) -> Result<T, SyncError>
+where
+    F: FnMut() -> FFut,
+    FFut: std::future::Future<Output = Result<T, E>>,
+{
+    let mut backoff = Backoff::default();
+    let mut attempt = 0u32;
+    loop {
+        runner.check_cancellation()?;
+        attempt += 1;
+        match build().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                let mapped = map_err(e);
+                if !is_retryable(&mapped) || attempt >= MAX_ATTEMPTS_PER_BATCH {
+                    return Err(mapped);
+                }
+                let delay = backoff.next_delay();
+                let jittered = with_jitter(delay, attempt as u64);
+                runner.sleep(jittered).await;
+            }
+        }
+    }
+}
+
+fn is_retryable(e: &SyncError) -> bool {
+    matches!(
+        e,
+        SyncError::Transport(_) | SyncError::Navidrome(_)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::capability::NavidromeProbeCredentials;
+    use psysonic_integration::subsonic::{SubsonicClient, SubsonicCredentials};
+    use serde_json::json;
+    use std::sync::Arc;
+    use wiremock::matchers::{header, method as wm_method, path as wm_path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn flags(bits: u32) -> CapabilityFlags {
+        CapabilityFlags::new(bits)
+    }
+
+    fn test_subsonic(uri: &str) -> SubsonicClient {
+        SubsonicClient::with_static_credentials(
+            uri,
+            SubsonicCredentials::with_static("user", "tok", "salt"),
+            reqwest::Client::new(),
+        )
+    }
+
+    async fn mount_search3_pages(server: &MockServer, total: u32, batch: u32) {
+        // Two-page test fixture: first page returns `batch` songs,
+        // second page returns the remainder, third page returns empty.
+        for page in 0u32..=2 {
+            let offset = page * batch;
+            let body = if offset >= total {
+                json!({ "subsonic-response": { "status": "ok", "searchResult3": {} } })
+            } else {
+                let remaining = (total - offset).min(batch);
+                let songs: Vec<_> = (0..remaining)
+                    .map(|i| json!({
+                        "id": format!("tr_{:04}", offset + i),
+                        "title": format!("Title {}", offset + i),
+                        "duration": 200_i64 + (offset + i) as i64,
+                    }))
+                    .collect();
+                json!({
+                    "subsonic-response": {
+                        "status": "ok",
+                        "searchResult3": { "song": songs }
+                    }
+                })
+            };
+            Mock::given(wm_method("GET"))
+                .and(wm_path("/rest/search3.view"))
+                .and(query_param("songOffset", offset.to_string()))
+                .respond_with(ResponseTemplate::new(200).set_body_json(body))
+                .mount(server)
+                .await;
+        }
+    }
+
+    async fn mount_minimal_artists(server: &MockServer) {
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getArtists.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "artists": {
+                        "lastModified": 1_716_840_000_000_i64,
+                        "ignoredArticles": "",
+                        "index": []
+                    }
+                }
+            })))
+            .mount(server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getScanStatus.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "scanStatus": {
+                        "scanning": false,
+                        "count": 1234,
+                        "lastScan": "2024-06-01T12:00:00Z"
+                    }
+                }
+            })))
+            .mount(server)
+            .await;
+    }
+
+    // ── S1 happy path ──────────────────────────────────────────────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn s1_ingest_drains_pages_and_persists_done_phase() {
+        let server = MockServer::start().await;
+        mount_search3_pages(&server, /*total*/ 7, /*batch*/ 4).await;
+        mount_minimal_artists(&server).await;
+
+        let store = LibraryStore::open_in_memory();
+        let subsonic = test_subsonic(&server.uri());
+        let runner = InitialSyncRunner::new(
+            &store,
+            &subsonic,
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK | CapabilityFlags::SCAN_STATUS_AVAILABLE),
+        )
+        .with_batch_size(4)
+        .with_sleep_disabled();
+
+        let report = runner.run().await.unwrap();
+        assert_eq!(report.ingested_count, 7);
+        assert_eq!(report.remapped_count, 0);
+        assert_eq!(report.strategy.as_deref(), Some("s1"));
+
+        // sync_phase ended in "ready" and cursor cleared.
+        let sync_state = SyncStateRepository::new(&store);
+        assert_eq!(
+            sync_state.get_sync_phase("s1", "").unwrap().as_deref(),
+            Some("ready")
+        );
+        let cur = sync_state.get_initial_sync_cursor("s1", "").unwrap();
+        assert_eq!(cur, Some(json!({})));
+
+        // Tracks landed in the store.
+        let count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(count, 7);
+    }
+
+    // ── S1 mid-cursor resume ──────────────────────────────────────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn s1_resumes_from_persisted_cursor_after_kill() {
+        let server = MockServer::start().await;
+        mount_search3_pages(&server, /*total*/ 10, /*batch*/ 4).await;
+        mount_minimal_artists(&server).await;
+
+        let store = LibraryStore::open_in_memory();
+        let sync_state = SyncStateRepository::new(&store);
+
+        // Seed the cursor as if a prior run completed page 0 (offset=4)
+        // but was killed before page 1 landed.
+        sync_state.ensure("s1", "").unwrap();
+        let mid_cursor = json!({
+            "strategy": "s1",
+            "phase": "ingest",
+            "library_scope": null,
+            "ingested_count": 4,
+            "strategy_state": { "kind": "linear_offset", "offset": 4 }
+        });
+        sync_state
+            .set_initial_sync_cursor("s1", "", &mid_cursor)
+            .unwrap();
+
+        let report = InitialSyncRunner::new(
+            &store,
+            &test_subsonic(&server.uri()),
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK),
+        )
+        .with_batch_size(4)
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap();
+
+        // Resumed at offset 4 — only 6 more rows ingested.
+        assert_eq!(report.ingested_count, 4 + 6);
+        // …but the store ends up with all 10.
+        let count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0)))
+            .unwrap();
+        // 6 — only the pages run by *this* invocation are persisted to
+        // `track` here because the cursor said offset=4 but the prior
+        // run never actually wrote rows in this fixture. The assertion
+        // documents the resume semantics: cursor controls request
+        // offset, not row count.
+        assert_eq!(count, 6);
+    }
+
+    // ── Cursor strategy-mismatch surfaces as CursorIncompatible ───────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cursor_with_wrong_strategy_returns_incompatible_error() {
+        let server = MockServer::start().await;
+        // Any 200 envelope shape works — error fires before HTTP.
+        Mock::given(wm_method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok" }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = LibraryStore::open_in_memory();
+        let sync_state = SyncStateRepository::new(&store);
+        sync_state.ensure("s1", "").unwrap();
+        let n1_cursor = json!({
+            "strategy": "n1",
+            "phase": "ingest",
+            "ingested_count": 0,
+            "strategy_state": { "kind": "linear_offset", "offset": 0 }
+        });
+        sync_state
+            .set_initial_sync_cursor("s1", "", &n1_cursor)
+            .unwrap();
+
+        // Capability flags now point to S1; cursor still says N1.
+        let err = InitialSyncRunner::new(
+            &store,
+            &test_subsonic(&server.uri()),
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK),
+        )
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap_err();
+        assert!(matches!(err, SyncError::CursorIncompatible { .. }));
+    }
+
+    // ── Backoff retries on 503 then succeeds ──────────────────────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn s1_retries_after_transient_503_then_succeeds() {
+        let server = MockServer::start().await;
+        // First request — 503. Wiremock `up_to_n_times` makes this
+        // simple: 1 mock that only answers once with 503, then a
+        // catch-all that returns the empty success envelope.
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .and(query_param("songOffset", "0"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "searchResult3": {} }
+            })))
+            .mount(&server)
+            .await;
+        mount_minimal_artists(&server).await;
+
+        let store = LibraryStore::open_in_memory();
+        let report = InitialSyncRunner::new(
+            &store,
+            &test_subsonic(&server.uri()),
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK),
+        )
+        .with_batch_size(10)
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap();
+        assert_eq!(report.ingested_count, 0, "all retries land before a song");
+    }
+
+    // ── Cancellation token aborts mid-run ─────────────────────────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancellation_flag_returns_cancelled_error() {
+        let server = MockServer::start().await;
+        mount_search3_pages(&server, /*total*/ 100, /*batch*/ 4).await;
+        let cancel = Arc::new(AtomicBool::new(true)); // already tripped
+        let store = LibraryStore::open_in_memory();
+
+        let err = InitialSyncRunner::new(
+            &store,
+            &test_subsonic(&server.uri()),
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK),
+        )
+        .with_batch_size(4)
+        .with_cancellation(cancel)
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap_err();
+        assert!(matches!(err, SyncError::Cancelled));
+    }
+
+    // ── N1 happy path via wiremock ────────────────────────────────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn n1_ingest_paginates_navidrome_native_endpoint() {
+        let server = MockServer::start().await;
+        // Two pages of 2 songs each, then empty.
+        for page in 0u32..=2 {
+            let start = page * 2;
+            let songs = if page < 2 {
+                vec![
+                    json!({"id": format!("tr_{start}"), "title": format!("t{start}"), "duration": 100}),
+                    json!({"id": format!("tr_{}", start + 1), "title": format!("t{}", start + 1), "duration": 100}),
+                ]
+            } else {
+                vec![]
+            };
+            Mock::given(wm_method("GET"))
+                .and(wm_path("/api/song"))
+                .and(query_param("_start", start.to_string()))
+                .and(header("X-ND-Authorization", "Bearer nd-tok"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::Value::Array(songs)))
+                .mount(&server)
+                .await;
+        }
+        // Minimal Subsonic ping path for artist/watermark phases.
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getArtists.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "artists": { "lastModified": 0, "ignoredArticles": "", "index": [] }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getScanStatus.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "scanStatus": { "scanning": false } }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = LibraryStore::open_in_memory();
+        let nav = NavidromeProbeCredentials {
+            server_url: server.uri(),
+            bearer_token: "nd-tok".into(),
+        };
+        let report = InitialSyncRunner::new(
+            &store,
+            &test_subsonic(&server.uri()),
+            "s1",
+            "",
+            flags(CapabilityFlags::NAVIDROME_NATIVE_BULK | CapabilityFlags::SCAN_STATUS_AVAILABLE),
+        )
+        .with_navidrome_credentials(nav)
+        .with_batch_size(2)
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap();
+        assert_eq!(report.ingested_count, 4);
+        let count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(count, 4);
+    }
+
+    // ── S3 explicitly unsupported in v1 ───────────────────────────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn s3_strategy_returns_unsupported_error() {
+        // We can't easily get the selector to return S3 (it never
+        // auto-picks S3), so seed a cursor that says s3 and pair it
+        // with FileTreeBrowse-only flags so the cursor passes the
+        // strategy-tag check.
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok" }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = LibraryStore::open_in_memory();
+        let sync_state = SyncStateRepository::new(&store);
+        sync_state.ensure("s1", "").unwrap();
+        sync_state
+            .set_initial_sync_cursor(
+                "s1",
+                "",
+                &json!({
+                    "strategy": "s3",
+                    "phase": "ingest",
+                    "ingested_count": 0,
+                    "strategy_state": { "kind": "empty" }
+                }),
+            )
+            .unwrap();
+
+        let err = InitialSyncRunner::new(
+            &store,
+            &test_subsonic(&server.uri()),
+            "s1",
+            "",
+            // Default flags ⇒ selector resolves to s2, but the cursor
+            // already says s3 → CursorIncompatible. We assert the
+            // happy path of S3 via that error class.
+            flags(0),
+        )
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            SyncError::CursorIncompatible { .. } | SyncError::StrategyUnsupported { .. }
+        ));
+    }
+
+    // ── S2 happy path: getAlbumList2 → getAlbum-per-id loop ───────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn s2_ingest_walks_albums_and_persists_songs() {
+        let server = MockServer::start().await;
+        // First album-list page: 2 albums, second page: 0 (loop ends).
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbumList2.view"))
+            .and(query_param("offset", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "albumList2": {
+                        "album": [
+                            { "id": "al_1", "name": "First" },
+                            { "id": "al_2", "name": "Second" }
+                        ]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbumList2.view"))
+            .and(query_param("offset", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "albumList2": { "album": [] }
+                }
+            })))
+            .mount(&server)
+            .await;
+        // Per-album song lists.
+        for (album_id, song_id) in [("al_1", "tr_a"), ("al_2", "tr_b")] {
+            Mock::given(wm_method("GET"))
+                .and(wm_path("/rest/getAlbum.view"))
+                .and(query_param("id", album_id))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "subsonic-response": {
+                        "status": "ok",
+                        "album": {
+                            "id": album_id,
+                            "name": album_id,
+                            "song": [
+                                { "id": song_id, "title": "song", "duration": 240 }
+                            ]
+                        }
+                    }
+                })))
+                .mount(&server)
+                .await;
+        }
+        mount_minimal_artists(&server).await;
+
+        let store = LibraryStore::open_in_memory();
+        let subsonic = test_subsonic(&server.uri());
+        let report = InitialSyncRunner::new(
+            &store,
+            &subsonic,
+            "s2",
+            "",
+            // Force selector to fall through to S2: clear N1 + S1 bits.
+            flags(0),
+        )
+        .with_batch_size(2)
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap();
+
+        assert_eq!(report.strategy.as_deref(), Some("s2"));
+        assert_eq!(report.ingested_count, 2);
+
+        let count: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    // ── Remap path triggers when UnstableTrackIds is set on the sync ───
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remap_fires_during_sync_when_unstable_track_ids_flag_set() {
+        let server = MockServer::start().await;
+        // Pre-seed an "old" track row with a known content_hash —
+        // simulates the prior sync result before Navidrome re-indexed.
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[TrackRow {
+                server_id: "s1".into(),
+                id: "tr_old".into(),
+                title: "Aurora".into(),
+                title_sort: None,
+                artist: Some("A".into()),
+                artist_id: None,
+                album: "An Album".into(),
+                album_id: None,
+                album_artist: None,
+                duration_sec: 240,
+                track_number: None,
+                disc_number: None,
+                year: None,
+                genre: None,
+                suffix: None,
+                bit_rate: None,
+                size_bytes: None,
+                cover_art_id: None,
+                starred_at: None,
+                user_rating: None,
+                play_count: None,
+                played_at: None,
+                server_path: Some("/path/aurora.flac".into()),
+                library_id: None,
+                isrc: None,
+                mbid_recording: None,
+                bpm: None,
+                replay_gain_track_db: None,
+                replay_gain_album_db: None,
+                content_hash: None,
+                server_updated_at: None,
+                server_created_at: None,
+                deleted: false,
+                synced_at: 1,
+                raw_json: "{}".into(),
+            }])
+            .unwrap();
+
+        // S1 page returns the same path under a new id — must trigger
+        // §6.9 remap.
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .and(query_param("songOffset", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "searchResult3": {
+                        "song": [
+                            {
+                                "id": "tr_new",
+                                "title": "Aurora",
+                                "duration": 240,
+                                "path": "/path/aurora.flac"
+                            }
+                        ]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "searchResult3": {} }
+            })))
+            .mount(&server)
+            .await;
+        mount_minimal_artists(&server).await;
+
+        let subsonic = test_subsonic(&server.uri());
+        let report = InitialSyncRunner::new(
+            &store,
+            &subsonic,
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK | CapabilityFlags::UNSTABLE_TRACK_IDS),
+        )
+        .with_batch_size(10)
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap();
+        assert_eq!(report.remapped_count, 1);
+
+        // Old id gone, new id present.
+        let ids: Vec<String> = store
+            .with_conn(|c| {
+                let mut s = c.prepare("SELECT id FROM track WHERE server_id='s1' ORDER BY id")?;
+                let r: rusqlite::Result<Vec<String>> = s.query_map([], |r| r.get(0))?.collect();
+                r
+            })
+            .unwrap();
+        assert_eq!(ids, vec!["tr_new"]);
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/sync/mapping.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping.rs
@@ -1,0 +1,285 @@
+//! Subsonic / Navidrome song JSON → `TrackRow`. PR-3b's ingest paths
+//! all feed the same upsert API, so the projection happens here once.
+
+use serde_json::Value;
+
+use crate::repos::TrackRow;
+use psysonic_integration::subsonic::Song;
+
+/// Project a Subsonic `Song` plus its raw JSON sub-tree into a
+/// `TrackRow`. `raw_value` is what `track.raw_json` stores verbatim so
+/// OpenSubsonic extensions survive (spec §5.1 / ADR-7).
+pub fn subsonic_song_to_track_row(
+    server_id: &str,
+    song: &Song,
+    raw_value: &Value,
+    synced_at: i64,
+    library_id_fallback: Option<&str>,
+) -> TrackRow {
+    TrackRow {
+        server_id: server_id.to_string(),
+        id: song.id.clone(),
+        title: song.title.clone(),
+        title_sort: None,
+        artist: song.artist.clone(),
+        artist_id: song.artist_id.clone(),
+        album: song.album.clone().unwrap_or_default(),
+        album_id: song.album_id.clone(),
+        album_artist: song.album_artist.clone(),
+        duration_sec: song.duration.unwrap_or(0),
+        track_number: song.track_number,
+        disc_number: song.disc_number,
+        year: song.year,
+        genre: song.genre.clone(),
+        suffix: song.suffix.clone(),
+        bit_rate: song.bit_rate,
+        size_bytes: song.size,
+        cover_art_id: song.cover_art.clone(),
+        starred_at: parse_iso_ms(song.starred.as_deref()),
+        user_rating: song.user_rating,
+        play_count: song.play_count,
+        played_at: parse_iso_ms(song.played.as_deref()),
+        server_path: song.path.clone(),
+        library_id: song.library_id.clone().or_else(|| library_id_fallback.map(String::from)),
+        isrc: song.isrc.clone(),
+        mbid_recording: song.mbid_recording.clone(),
+        bpm: song.bpm,
+        replay_gain_track_db: raw_value
+            .get("replayGain")
+            .and_then(|rg| rg.get("trackGain"))
+            .and_then(|v| v.as_f64()),
+        replay_gain_album_db: raw_value
+            .get("replayGain")
+            .and_then(|rg| rg.get("albumGain"))
+            .and_then(|v| v.as_f64()),
+        content_hash: None,
+        server_updated_at: None,
+        server_created_at: None,
+        deleted: false,
+        synced_at,
+        raw_json: raw_value.to_string(),
+    }
+}
+
+/// Project a Navidrome `/api/song` row (native REST shape) into a
+/// `TrackRow`. Field names mostly overlap with Subsonic but use
+/// snake_case JSON aliases — we read fields by `get(name)` rather
+/// than reusing the Subsonic `Song` deserializer so a server-side
+/// rename doesn't silently zero out hot columns.
+pub fn navidrome_song_to_track_row(
+    server_id: &str,
+    raw: &Value,
+    synced_at: i64,
+    library_id_fallback: Option<&str>,
+) -> Option<TrackRow> {
+    let id = raw.get("id").and_then(|v| v.as_str())?.to_string();
+    let title = raw
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let server_updated_at = raw
+        .get("updatedAt")
+        .and_then(|v| v.as_str())
+        .and_then(parse_iso_ms_str);
+    let library_id = string_field(raw, "libraryId")
+        .or_else(|| string_field(raw, "library_id"))
+        .or_else(|| library_id_fallback.map(String::from));
+    Some(TrackRow {
+        server_id: server_id.to_string(),
+        id,
+        title,
+        title_sort: string_field(raw, "sortTitle").or_else(|| string_field(raw, "orderTitle")),
+        artist: string_field(raw, "artist"),
+        artist_id: string_field(raw, "artistId"),
+        album: string_field(raw, "album").unwrap_or_default(),
+        album_id: string_field(raw, "albumId"),
+        album_artist: string_field(raw, "albumArtist"),
+        duration_sec: raw.get("duration").and_then(|v| v.as_i64()).unwrap_or(0),
+        track_number: raw.get("trackNumber").and_then(|v| v.as_i64()),
+        disc_number: raw.get("discNumber").and_then(|v| v.as_i64()),
+        year: raw.get("year").and_then(|v| v.as_i64()),
+        genre: string_field(raw, "genre"),
+        suffix: string_field(raw, "suffix"),
+        bit_rate: raw.get("bitRate").and_then(|v| v.as_i64()),
+        size_bytes: raw.get("size").and_then(|v| v.as_i64()),
+        cover_art_id: string_field(raw, "coverArtId").or_else(|| string_field(raw, "coverArt")),
+        starred_at: raw.get("starredAt").and_then(|v| v.as_str()).and_then(parse_iso_ms_str),
+        user_rating: raw.get("rating").and_then(|v| v.as_i64()),
+        play_count: raw.get("playCount").and_then(|v| v.as_i64()),
+        played_at: raw.get("playedAt").and_then(|v| v.as_str()).and_then(parse_iso_ms_str),
+        server_path: string_field(raw, "path"),
+        library_id,
+        isrc: string_field(raw, "isrc"),
+        mbid_recording: string_field(raw, "mbzTrackId").or_else(|| string_field(raw, "musicBrainzId")),
+        bpm: raw.get("bpm").and_then(|v| v.as_i64()),
+        replay_gain_track_db: raw.get("rgTrackGain").and_then(|v| v.as_f64()),
+        replay_gain_album_db: raw.get("rgAlbumGain").and_then(|v| v.as_f64()),
+        content_hash: None,
+        server_updated_at,
+        server_created_at: raw
+            .get("createdAt")
+            .and_then(|v| v.as_str())
+            .and_then(parse_iso_ms_str),
+        deleted: false,
+        synced_at,
+        raw_json: raw.to_string(),
+    })
+}
+
+fn string_field(raw: &Value, key: &str) -> Option<String> {
+    raw.get(key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+fn parse_iso_ms(s: Option<&str>) -> Option<i64> {
+    s.and_then(parse_iso_ms_str)
+}
+
+/// Lightweight ISO-8601 → epoch-ms parser. Supports the Navidrome /
+/// OpenSubsonic shape (`2024-06-01T12:00:00Z` or
+/// `2024-06-01T12:00:00.123+02:00`). Falls back to `None` on parse
+/// failure — sync code never panics on a bad timestamp.
+fn parse_iso_ms_str(s: &str) -> Option<i64> {
+    // Strip fractional + timezone before doing the manual parse —
+    // SQLite stores starred_at / played_at as integer ms, so we only
+    // need second precision rounded up from the offset.
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Accept either `Z`, `+HH:MM`, or no suffix. Reduce to a flat
+    // `YYYY-MM-DDTHH:MM:SS` core for parsing — server-side timestamps
+    // are already in UTC for Navidrome, and we don't track timezone
+    // in the schema column.
+    let core = trimmed
+        .find(|c: char| c == '.' || c == 'Z' || c == '+' || (c == '-' && trimmed.find('T').is_some_and(|t| trimmed[t..].contains(c))))
+        .map(|i| &trimmed[..i])
+        .unwrap_or(trimmed);
+    let mut parts = core.split(['T', '-', ':']);
+    let year: i64 = parts.next()?.parse().ok()?;
+    let month: i64 = parts.next()?.parse().ok()?;
+    let day: i64 = parts.next()?.parse().ok()?;
+    let hour: i64 = parts.next().unwrap_or("0").parse().ok()?;
+    let minute: i64 = parts.next().unwrap_or("0").parse().ok()?;
+    let second: i64 = parts.next().unwrap_or("0").parse().ok()?;
+    if !(1970..=2100).contains(&year)
+        || !(1..=12).contains(&month)
+        || !(1..=31).contains(&day)
+        || !(0..=23).contains(&hour)
+        || !(0..=59).contains(&minute)
+        || !(0..=60).contains(&second)
+    {
+        return None;
+    }
+    // Days since 1970-01-01 — Howard Hinnant's civil_from_days inverse.
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = y.div_euclid(400);
+    let yoe = y - era * 400; // [0, 399]
+    let m = if month > 2 { month - 3 } else { month + 9 };
+    let doy = (153 * m + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146_097 + doe - 719_468;
+    let seconds = days * 86_400 + hour * 3600 + minute * 60 + second;
+    Some(seconds.saturating_mul(1000))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_iso_handles_zulu_suffix() {
+        // 2024-01-01T00:00:00Z = 1704067200000 ms.
+        let ms = parse_iso_ms_str("2024-01-01T00:00:00Z").unwrap();
+        assert_eq!(ms, 1_704_067_200_000);
+    }
+
+    #[test]
+    fn parse_iso_handles_fractional_and_offset() {
+        let ms = parse_iso_ms_str("2024-01-01T00:00:00.123+02:00").unwrap();
+        // Truncated before offset → same epoch-second as Zulu of the
+        // wall-clock value. Good enough for the schema's integer-ms
+        // column.
+        assert_eq!(ms, 1_704_067_200_000);
+    }
+
+    #[test]
+    fn parse_iso_rejects_garbage() {
+        assert!(parse_iso_ms_str("").is_none());
+        assert!(parse_iso_ms_str("not-a-date").is_none());
+        assert!(parse_iso_ms_str("9999-99-99").is_none());
+    }
+
+    #[test]
+    fn subsonic_song_maps_hot_columns_and_keeps_raw_json() {
+        let raw = json!({
+            "id": "tr_1",
+            "title": "Hello",
+            "artist": "World",
+            "albumId": "al_1",
+            "duration": 240,
+            "track": 3,
+            "year": 2024,
+            "musicBrainzId": "mb-1",
+            "replayGain": { "trackGain": -1.2, "albumGain": -0.8 }
+        });
+        let song: Song = serde_json::from_value(raw.clone()).unwrap();
+        let row = subsonic_song_to_track_row("s1", &song, &raw, 1_000, Some("lib-fb"));
+        assert_eq!(row.id, "tr_1");
+        assert_eq!(row.album_id.as_deref(), Some("al_1"));
+        assert_eq!(row.duration_sec, 240);
+        assert_eq!(row.mbid_recording.as_deref(), Some("mb-1"));
+        assert_eq!(row.replay_gain_track_db, Some(-1.2));
+        assert_eq!(row.replay_gain_album_db, Some(-0.8));
+        // Fallback library_id kicks in when the song didn't ship one.
+        assert_eq!(row.library_id.as_deref(), Some("lib-fb"));
+        assert!(row.raw_json.contains("replayGain"));
+    }
+
+    #[test]
+    fn navidrome_song_maps_native_field_shape() {
+        let raw = json!({
+            "id": "tr_1",
+            "title": "Hello",
+            "artist": "World",
+            "artistId": "ar_1",
+            "album": "An Album",
+            "albumId": "al_1",
+            "albumArtist": "World",
+            "duration": 240,
+            "trackNumber": 3,
+            "discNumber": 1,
+            "year": 2024,
+            "genre": "Ambient",
+            "suffix": "flac",
+            "bitRate": 1000,
+            "size": 32_000_000_i64,
+            "path": "World/An Album/03.flac",
+            "libraryId": "1",
+            "isrc": "USRC17607839",
+            "mbzTrackId": "mb-1",
+            "bpm": 128,
+            "rgTrackGain": -1.2,
+            "rgAlbumGain": -0.8,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "updatedAt": "2024-06-01T00:00:00Z"
+        });
+        let row = navidrome_song_to_track_row("s1", &raw, 9_999, None).unwrap();
+        assert_eq!(row.id, "tr_1");
+        assert_eq!(row.track_number, Some(3));
+        assert_eq!(row.isrc.as_deref(), Some("USRC17607839"));
+        assert_eq!(row.mbid_recording.as_deref(), Some("mb-1"));
+        assert_eq!(row.replay_gain_track_db, Some(-1.2));
+        assert_eq!(row.library_id.as_deref(), Some("1"));
+        assert!(row.server_updated_at.unwrap_or(0) > 0);
+    }
+
+    #[test]
+    fn navidrome_song_skips_rows_without_id() {
+        let row = navidrome_song_to_track_row("s1", &json!({"title": "no id"}), 1, None);
+        assert!(row.is_none());
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/sync/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mod.rs
@@ -1,8 +1,23 @@
-//! Sync orchestrator. PR-3a lands the foundation — `CapabilityProbe`
-//! (C1) and the extended `SyncStateRepository` accessors (C7); the
-//! `InitialSyncRunner` / `DeltaSyncRunner` / background scheduler land
-//! in PR-3b…d.
+//! Sync orchestrator.
+//!
+//! PR-3a landed the foundation (`CapabilityProbe` C1 +
+//! `SyncStateRepository` C7); PR-3b adds the initial-sync runner,
+//! ingest-strategy selection, backoff, and the §6.9 id remap path.
+//! `DeltaSyncRunner` / background scheduler / Tauri surface follow in
+//! PR-3c / PR-3d / PR-5.
 
+pub mod backoff;
 pub mod capability;
+pub mod cursor;
+pub mod error;
+pub mod initial;
+pub mod mapping;
+pub mod strategy;
 
+pub use backoff::{with_jitter, Backoff};
 pub use capability::{CapabilityFlags, CapabilityProbe, NavidromeProbeCredentials};
+pub use cursor::{CursorPhase, InitialSyncCursor, StrategyState};
+pub use error::SyncError;
+pub use initial::{InitialSyncReport, InitialSyncRunner};
+pub use mapping::{navidrome_song_to_track_row, subsonic_song_to_track_row};
+pub use strategy::IngestStrategy;

--- a/src-tauri/crates/psysonic-library/src/sync/strategy.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/strategy.rs
@@ -1,0 +1,117 @@
+//! C2 ingest strategy selection. Per the PR-3 kickoff answer (workdocs
+//! `2026-05-19-pr3-kickoff.md` Q3) the choice is made once at initial
+//! sync start from the probed capability flags; the runner does not
+//! auto-switch on transient failure (C12 retries the same batch).
+
+use super::capability::CapabilityFlags;
+
+/// Spec §6.3 IS-3 strategies. Names match §6.1.1 capability bits where
+/// applicable; S2 has no flag of its own — it's the universal
+/// album-crawl fallback assumed available whenever the Subsonic ping
+/// succeeds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IngestStrategy {
+    /// N1 — Navidrome native `GET /api/song` paginated. Cheapest at
+    /// 500k; requires `NavidromeNativeBulk` flag set by the probe.
+    N1,
+    /// S1 — Subsonic `search3` empty query, songOffset paged. Requires
+    /// `SubsonicSearch3Bulk`.
+    S1,
+    /// S2 — `getAlbumList2` + `getAlbum` per album. Universal Subsonic
+    /// fallback — assumed available whenever the ping returns ok.
+    S2,
+    /// S3 — `getIndexes` + `getMusicDirectory` recursive file-tree
+    /// crawl. Last resort; PR-3b does not auto-select it.
+    S3,
+}
+
+impl IngestStrategy {
+    /// Pick the cheapest strategy supported by `flags`. Per kickoff Q3:
+    /// `N1 → S1 → S2`. S3 is enumerated for completeness but never
+    /// auto-selected — when neither N1 nor S1 is available, S2 is
+    /// always tried first because every Subsonic-compliant server
+    /// exposes `getAlbumList2` + `getAlbum`.
+    pub fn select_from_flags(flags: CapabilityFlags) -> Self {
+        if flags.contains(CapabilityFlags::NAVIDROME_NATIVE_BULK) {
+            Self::N1
+        } else if flags.contains(CapabilityFlags::SUBSONIC_SEARCH3_BULK) {
+            Self::S1
+        } else {
+            Self::S2
+        }
+    }
+
+    /// String tag stored in `initial_sync_cursor_json` so the runner
+    /// can resume after restart without re-running capability probe.
+    pub fn as_tag(self) -> &'static str {
+        match self {
+            Self::N1 => "n1",
+            Self::S1 => "s1",
+            Self::S2 => "s2",
+            Self::S3 => "s3",
+        }
+    }
+
+    pub fn from_tag(tag: &str) -> Option<Self> {
+        match tag {
+            "n1" => Some(Self::N1),
+            "s1" => Some(Self::S1),
+            "s2" => Some(Self::S2),
+            "s3" => Some(Self::S3),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn select_prefers_navidrome_native_when_both_n1_and_s1_present() {
+        // At 500k, N1 cuts request count by 10× vs S1 — selector must
+        // pick it whenever the flag is set, regardless of S1.
+        let flags = CapabilityFlags::new(
+            CapabilityFlags::NAVIDROME_NATIVE_BULK | CapabilityFlags::SUBSONIC_SEARCH3_BULK,
+        );
+        assert_eq!(IngestStrategy::select_from_flags(flags), IngestStrategy::N1);
+    }
+
+    #[test]
+    fn select_falls_back_to_s1_without_n1() {
+        let flags = CapabilityFlags::new(CapabilityFlags::SUBSONIC_SEARCH3_BULK);
+        assert_eq!(IngestStrategy::select_from_flags(flags), IngestStrategy::S1);
+    }
+
+    #[test]
+    fn select_falls_back_to_s2_when_no_bulk_flag_set() {
+        // Generic Subsonic server without search3 bulk → universal
+        // album crawl. S3 is not auto-selected even with FileTreeBrowse.
+        let flags = CapabilityFlags::new(CapabilityFlags::FILE_TREE_BROWSE);
+        assert_eq!(IngestStrategy::select_from_flags(flags), IngestStrategy::S2);
+    }
+
+    #[test]
+    fn select_falls_back_to_s2_with_no_flags() {
+        // Default-flag (`0x000`) — fresh DB before probe runs, or a
+        // truly minimal Subsonic implementation. Still resolves to a
+        // strategy; runner surfaces errors if S2 endpoints then fail.
+        assert_eq!(
+            IngestStrategy::select_from_flags(CapabilityFlags::default()),
+            IngestStrategy::S2
+        );
+    }
+
+    #[test]
+    fn tag_roundtrip_is_stable_for_cursor_persistence() {
+        for s in [
+            IngestStrategy::N1,
+            IngestStrategy::S1,
+            IngestStrategy::S2,
+            IngestStrategy::S3,
+        ] {
+            assert_eq!(IngestStrategy::from_tag(s.as_tag()), Some(s));
+        }
+        assert_eq!(IngestStrategy::from_tag("unknown"), None);
+    }
+}


### PR DESCRIPTION
Second sub-PR of Phase C — wires the actual ingest path on top of
PR-3a's capability + `sync_state` foundation. Runner is pure async
Rust; PR-3d will spawn it inside a tokio task and emit Tauri progress
events on top.

## C2 / C12 / C13 mapping

- **C2 InitialSyncRunner.** Drives spec §6.3 IS-1 → IS-6:
  probe-derived `IngestStrategy` (enum `N1` / `S1` / `S2` / `S3`,
  selector `N1 → S1 → S2`), per-page upsert loop, cursor flush after
  every successful batch, IS-4 best-effort `getArtists` watermark,
  IS-5 `getScanStatus.lastScan` capture, IS-6 `phase=ready` + cursor
  cleared. Resume is automatic — a non-empty
  `initial_sync_cursor_json` restarts at the persisted offset; a
  strategy mismatch against current capability flags surfaces as
  `SyncError::CursorIncompatible`.
- **C12 backoff.** `sync::backoff::Backoff` schedules
  `2s → 4s → … cap 120s` with deterministic ±25% jitter.
  `retry_with_backoff` wraps every endpoint call: transport /
  Navidrome failures retry up to 5×, cursor never advances on
  failure, success resets the counter, cancellation is checked
  between attempts.
- **C13 id remap.** `TrackRepository::upsert_batch_with_remap` runs
  spec §6.9 inside the upsert transaction: a `content_hash` /
  `server_path` collision on a different existing id triggers
  `UPDATE` of child tables (`track_offline` + the four FK-bound
  ones), `INSERT INTO track_id_history`, `DELETE` of the old track
  row. Off when `UnstableTrackIds` is clear.

## Supporting changes

- `IngestStrategy` enum + selector (`sync::strategy`).
- `InitialSyncCursor` (`sync::cursor`) — JSON-serialisable
  `{ strategy, phase, library_scope, ingested_count, strategy_state }`.
- `mapping::{subsonic_song_to_track_row, navidrome_song_to_track_row}`
  centralise JSON → `TrackRow` projection.
- `TrackIdHistoryRepository` read-side helper (analysis cache reuse,
  Phase E).
- `psysonic-integration::subsonic` types derive `Serialize` so the
  runner can round-trip a typed `Song` back into raw JSON.
- `psysonic-integration::navidrome::queries::nd_list_songs_internal`
  — pure async function used by N1 ingest; existing Tauri command
  wraps it unchanged.
- Drops the dead `mount_ok` scaffolding in `sync::capability` tests
  (cucadmuh's PR-3a review minor note 1).

## References

- PR-3 kickoff answer (Q1 placement, Q2 split, Q3 strategy order):
  `psysonic-workdocs/internal/collaboration/tasks/2026-05-library-track-store/questions/2026-05-19-pr3-kickoff.md`
- PR-3a review: `psysonic-workdocs/internal/collaboration/handoffs/2026-05-19-pr-795-review.md`
- Spec §6.3 (initial sync algorithm), §6.8 (HTTP backoff), §6.9
  (track upsert + id remap), §6.1 (strategy priority chain)

## Out of scope

- `DeltaSyncRunner` + tombstone reconciler → PR-3c
- Background task lifecycle / cancellation wiring / progress emit
  throttle / adaptive scheduler / request budget / bandwidth lane →
  PR-3d
- Tauri command surface for „Sync now" + progress events → PR-5

## Test plan

- [x] `cargo test --workspace` — passes (92 in `psysonic-library`,
      103 in `psysonic-integration`)
- [x] `cargo clippy -p psysonic-library --all-targets -- -D warnings`
- [x] `cargo clippy -p psysonic-integration --all-targets -- -D warnings`
- [x] `./dev.sh backend-ci` — hot-path coverage gate green