### PR TITLE
feat(library): search3 raw envelope fidelity for S1 ingest (PR-3b follow-up)

### DIFF
--- a/src-tauri/crates/psysonic-integration/src/subsonic/client.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/client.rs
@@ -217,6 +217,33 @@ impl SubsonicClient {
         self.fetch("search3", &params, "searchResult3").await
     }
 
+    /// Variant of `search3` returning the raw `serde_json::Value` for
+    /// the `searchResult3` body alongside the typed projection. The S1
+    /// ingest path (PR-3b InitialSyncRunner) needs the per-song raw
+    /// sub-trees verbatim for `track.raw_json`, so unknown OpenSubsonic
+    /// extensions (`replayGain`, `contributors`, …) survive ingest
+    /// instead of being lost in the typed reserialise (ADR-7).
+    pub async fn search3_with_raw(
+        &self,
+        query: &str,
+        song_count: u32,
+        song_offset: u32,
+        music_folder_id: Option<&str>,
+    ) -> Result<(SearchResult, serde_json::Value), SubsonicError> {
+        let song_count_s = song_count.to_string();
+        let song_offset_s = song_offset.to_string();
+        let mut params: Vec<(&str, &str)> = vec![
+            ("query", query),
+            ("songCount", song_count_s.as_str()),
+            ("songOffset", song_offset_s.as_str()),
+        ];
+        if let Some(id) = music_folder_id {
+            params.push(("musicFolderId", id));
+        }
+        let body = self.send("search3", &params).await?;
+        parse_envelope_with_raw(&body, "searchResult3")
+    }
+
     /// B6 — `getSong(id)`. Returns `SubsonicError::NotFound` when the
     /// server replies with error code 70 (spec §2.6) — the tombstone
     /// reconciler matches on that variant directly.
@@ -964,6 +991,63 @@ mod tests {
         // doesn't mirror — exactly what `track.raw_json` needs.
         assert_eq!(raw.get("replayGain"), song.get("replayGain"));
         assert_eq!(raw.get("contributors"), song.get("contributors"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn search3_with_raw_keeps_song_extensions_in_raw_tree() {
+        let server = MockServer::start().await;
+        let result_body = json!({
+            "song": [
+                { "id": "tr_1", "title": "One",  "replayGain": { "trackGain": -1.5 } },
+                { "id": "tr_2", "title": "Two", "contributors": [{ "role": "producer" }] }
+            ]
+        });
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "searchResult3": result_body.clone() }
+            })))
+            .mount(&server)
+            .await;
+
+        let (typed, raw) = test_client(&server.uri())
+            .search3_with_raw("", 100, 0, None)
+            .await
+            .unwrap();
+        assert_eq!(typed.song.len(), 2);
+
+        // Raw value preserves the typed-struct-incompatible fields.
+        let raw_songs = raw.get("song").and_then(|v| v.as_array()).expect("song array");
+        assert_eq!(raw_songs.len(), 2);
+        assert_eq!(
+            raw_songs[0].get("replayGain"),
+            result_body.get("song").unwrap().as_array().unwrap()[0].get("replayGain")
+        );
+        assert_eq!(
+            raw_songs[1].get("contributors"),
+            result_body.get("song").unwrap().as_array().unwrap()[1].get("contributors")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn search3_with_raw_empty_envelope_maps_to_empty_search_result() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "searchResult3": {} }
+            })))
+            .mount(&server)
+            .await;
+        let (typed, raw) = test_client(&server.uri())
+            .search3_with_raw("", 50, 0, None)
+            .await
+            .unwrap();
+        assert!(typed.song.is_empty());
+        assert!(typed.album.is_empty());
+        // Empty `searchResult3: {}` survives as an empty Object in raw,
+        // not Null — runner relies on this for the `get("song")` path.
+        assert!(raw.is_object());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src-tauri/crates/psysonic-library/src/sync/initial.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial.rs
@@ -342,9 +342,9 @@ impl<'a> InitialSyncRunner<'a> {
         loop {
             self.check_cancellation()?;
             let scope = self.library_scope_opt();
-            let result = retry_with_backoff(
+            let (result, raw_body) = retry_with_backoff(
                 self,
-                || self.subsonic.search3("", self.batch_size, offset, scope),
+                || self.subsonic.search3_with_raw("", self.batch_size, offset, scope),
                 SyncError::from,
             )
             .await?;
@@ -353,10 +353,22 @@ impl<'a> InitialSyncRunner<'a> {
                 break;
             }
 
+            // Pull the per-song raw sub-trees from the envelope (ADR-7) —
+            // typed `Song` reserialise drops unknown OpenSubsonic fields
+            // like `replayGain` / contributor arrays, so we feed the
+            // original JSON into `track.raw_json` whenever it's there.
+            let raw_songs = raw_body
+                .get("song")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
             let synced_at = now_unix_ms();
             let mut rows: Vec<TrackRow> = Vec::with_capacity(result.song.len());
-            for song in &result.song {
-                let raw = serde_json::to_value(song).unwrap_or(Value::Null);
+            for (i, song) in result.song.iter().enumerate() {
+                let raw = raw_songs
+                    .get(i)
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::to_value(song).unwrap_or(Value::Null));
                 rows.push(subsonic_song_to_track_row(
                     &self.server_id,
                     song,
@@ -983,6 +995,89 @@ mod tests {
             err,
             SyncError::CursorIncompatible { .. } | SyncError::StrategyUnsupported { .. }
         ));
+    }
+
+    // ── S1 raw_json carries OpenSubsonic extensions verbatim ──────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn s1_ingest_preserves_open_subsonic_fields_in_track_raw_json() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .and(query_param("songOffset", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "searchResult3": {
+                        "song": [
+                            {
+                                "id": "tr_1",
+                                "title": "With Extensions",
+                                "duration": 240,
+                                "replayGain": { "trackGain": -1.2, "albumGain": -0.8 },
+                                "contributors": [
+                                    { "role": "producer", "artistId": "ar_9", "name": "Prod" }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "searchResult3": {} }
+            })))
+            .mount(&server)
+            .await;
+        mount_minimal_artists(&server).await;
+
+        let store = LibraryStore::open_in_memory();
+        let subsonic = test_subsonic(&server.uri());
+        InitialSyncRunner::new(
+            &store,
+            &subsonic,
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK),
+        )
+        .with_batch_size(10)
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap();
+
+        // raw_json column must contain the OpenSubsonic-only fields,
+        // not just the typed projection — ADR-7 fidelity.
+        let raw: String = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT raw_json FROM track WHERE server_id='s1' AND id='tr_1'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert!(parsed.get("replayGain").is_some(), "raw json keeps replayGain");
+        assert!(parsed.get("contributors").is_some(), "raw json keeps contributors");
+
+        // Typed projection also picked up replayGain via the mapping
+        // helper — both paths agree on the hot column.
+        let (rg_t, rg_a): (Option<f64>, Option<f64>) = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT replay_gain_track_db, replay_gain_album_db \
+                     FROM track WHERE server_id='s1' AND id='tr_1'",
+                    [],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+            })
+            .unwrap();
+        assert_eq!(rg_t, Some(-1.2));
+        assert_eq!(rg_a, Some(-0.8));
     }
 
     // ── S2 happy path: getAlbumList2 → getAlbum-per-id loop ───────────


### PR DESCRIPTION
Picks up cucadmuh's PR-3b review minor 1 — the S1 path was
reserialising the typed `Song` for `track.raw_json`, dropping unknown
OpenSubsonic extensions (`replayGain`, `contributors`, …). N1 and S2
already carry the raw sub-tree verbatim; S1 now matches.

## Changes

- `subsonic::SubsonicClient::search3_with_raw` — returns
  `(SearchResult, serde_json::Value)`. Mirror of `get_song_with_raw` /
  `get_album_with_raw` from PR-2b; reuses `parse_envelope_with_raw`
  so error 70 + `Api { code, .. }` mapping stays consistent.
- `sync::initial::run_s1` calls `search3_with_raw` and feeds each
  song's raw sub-tree into `subsonic_song_to_track_row` instead of a
  typed reserialise. Mapping helper picks up `replayGain` from the
  raw value as before.

## References

- PR-3b review: `psysonic-workdocs/internal/collaboration/handoffs/2026-05-19-pr-796-review.md`
- Spec ADR-7 (`track.raw_json` carries the original envelope sub-tree)

## Test plan

- [x] `cargo test --workspace` — passes (93 in `psysonic-library`,
      105 in `psysonic-integration`)
- [x] `cargo clippy -p psysonic-library --all-targets -- -D warnings`
- [x] `cargo clippy -p psysonic-integration --all-targets -- -D warnings`
- [x] `./dev.sh backend-ci` — hot-path coverage gate green