### PR TITLE
feat(library): sync supervisor + progress channel + DS-8 wiring (Phase C5/C6, PR-3d1)

### DIFF
--- a/src-tauri/crates/psysonic-library/src/sync/capability.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/capability.rs
@@ -72,6 +72,42 @@ pub struct CapabilityProbeResult {
     pub server_info: ServerInfo,
 }
 
+/// Run `CapabilityProbe::run` and persist the resulting flags +
+/// transition `sync_phase` from whatever it was to `probing` →
+/// `idle` (caller is responsible for advancing to `initial_sync` /
+/// `ready` once the appropriate runner starts).
+///
+/// PR-3d wires this in front of every initial / delta run so the
+/// stored `capability_flags` always reflects the current server.
+/// Returns the freshly resolved `(flags, server_info)` so callers
+/// can pick their `IngestStrategy` without re-reading SQLite.
+pub async fn probe_and_persist(
+    store: &crate::store::LibraryStore,
+    subsonic: &psysonic_integration::subsonic::SubsonicClient,
+    navidrome: Option<&NavidromeProbeCredentials>,
+    server_id: &str,
+    library_scope: &str,
+) -> Result<CapabilityProbeResult, psysonic_integration::subsonic::SubsonicError> {
+    let sync_state = crate::repos::SyncStateRepository::new(store);
+    sync_state
+        .ensure(server_id, library_scope)
+        .map_err(psysonic_integration::subsonic::SubsonicError::Transport)?;
+    sync_state
+        .set_sync_phase(server_id, library_scope, "probing")
+        .map_err(psysonic_integration::subsonic::SubsonicError::Transport)?;
+
+    let result = CapabilityProbe::run(subsonic, navidrome).await?;
+
+    sync_state
+        .set_capability_flags(server_id, library_scope, result.flags.bits())
+        .map_err(psysonic_integration::subsonic::SubsonicError::Transport)?;
+    sync_state
+        .set_sync_phase(server_id, library_scope, "idle")
+        .map_err(psysonic_integration::subsonic::SubsonicError::Transport)?;
+
+    Ok(result)
+}
+
 pub struct CapabilityProbe;
 
 impl CapabilityProbe {
@@ -349,6 +385,41 @@ mod tests {
             .await
             .unwrap();
         assert!(result.flags.contains(CapabilityFlags::NAVIDROME_NATIVE_BULK));
+    }
+
+    // ── probe_and_persist round-trip ──────────────────────────────────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_and_persist_writes_flags_and_resets_phase_to_idle() {
+        use crate::repos::SyncStateRepository;
+        use crate::store::LibraryStore;
+
+        let server = MockServer::start().await;
+        mount_subsonic_full_navidrome(&server).await;
+
+        let store = LibraryStore::open_in_memory();
+        let result = super::probe_and_persist(
+            &store,
+            &test_subsonic_client(&server.uri()),
+            None,
+            "s1",
+            "",
+        )
+        .await
+        .unwrap();
+
+        let sync_state = SyncStateRepository::new(&store);
+        let flags = sync_state.get_capability_flags("s1", "").unwrap().unwrap();
+        assert_eq!(flags, result.flags.bits());
+        assert!(flags & CapabilityFlags::OPEN_SUBSONIC != 0);
+        assert!(flags & CapabilityFlags::UNSTABLE_TRACK_IDS != 0);
+
+        // Phase ends at `idle` so the caller can transition to
+        // `initial_sync` / `ready` based on whether a sync is needed.
+        assert_eq!(
+            sync_state.get_sync_phase("s1", "").unwrap().as_deref(),
+            Some("idle")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src-tauri/crates/psysonic-library/src/sync/delta.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/delta.rs
@@ -28,7 +28,9 @@ use super::backoff::{with_jitter, Backoff};
 use super::capability::{CapabilityFlags, NavidromeProbeCredentials};
 use super::error::SyncError;
 use super::mapping::{navidrome_song_to_track_row, subsonic_song_to_track_row};
+use super::progress::{NoopProgress, Progress, ProgressEvent};
 use super::strategy::IngestStrategy;
+use super::tombstone::TombstoneReconciler;
 use crate::repos::{SyncStateRepository, TrackRepository, TrackRow};
 use crate::store::LibraryStore;
 
@@ -57,6 +59,10 @@ pub struct DeltaSyncReport {
     /// Track upserts performed during DS-4.
     pub changed_count: u32,
     pub remapped_count: u32,
+    /// Tombstone chunk stats from DS-8 — `0` when the runner wasn't
+    /// configured with `with_tombstone_budget`.
+    pub tombstones_checked: u32,
+    pub tombstones_deleted: u32,
 }
 
 pub struct DeltaSyncRunner<'a> {
@@ -69,6 +75,10 @@ pub struct DeltaSyncRunner<'a> {
     cancel: Option<Arc<std::sync::atomic::AtomicBool>>,
     batch_size: u32,
     sleep_enabled: bool,
+    /// DS-8 budget. `None` skips the tombstone chunk entirely; `Some(n)`
+    /// drives `TombstoneReconciler::reconcile_chunk(n)` after DS-4.
+    tombstone_budget: Option<u32>,
+    progress: Arc<dyn Progress + Send + Sync>,
 }
 
 impl<'a> DeltaSyncRunner<'a> {
@@ -89,6 +99,8 @@ impl<'a> DeltaSyncRunner<'a> {
             cancel: None,
             batch_size: DEFAULT_BATCH_SIZE,
             sleep_enabled: true,
+            tombstone_budget: None,
+            progress: Arc::new(NoopProgress),
         }
     }
 
@@ -111,6 +123,19 @@ impl<'a> DeltaSyncRunner<'a> {
 
     pub fn with_sleep_disabled(mut self) -> Self {
         self.sleep_enabled = false;
+        self
+    }
+
+    /// DS-8 — run a `TombstoneReconciler::reconcile_chunk(budget)`
+    /// pass after DS-4 ingest. Caller (PR-3d scheduler) decides
+    /// budget based on §6.7 threshold detection and per-tick limits.
+    pub fn with_tombstone_budget(mut self, budget: u32) -> Self {
+        self.tombstone_budget = Some(budget);
+        self
+    }
+
+    pub fn with_progress(mut self, progress: Arc<dyn Progress + Send + Sync>) -> Self {
+        self.progress = progress;
         self
     }
 
@@ -141,6 +166,9 @@ impl<'a> DeltaSyncRunner<'a> {
         // but S1 is skipped: `search3` doesn't carry a delta semantic.
         let strategy = self.delta_strategy();
         report.strategy = Some(strategy.as_tag().to_string());
+        self.progress.emit(ProgressEvent::PhaseChanged {
+            phase: format!("delta:{}", strategy.as_tag()),
+        });
         match strategy {
             IngestStrategy::N1 => self.run_n1_delta(&mut report).await?,
             IngestStrategy::S2 => self.run_s2_delta(&mut report).await?,
@@ -148,6 +176,29 @@ impl<'a> DeltaSyncRunner<'a> {
                 return Err(SyncError::StrategyUnsupported {
                     strategy: strategy.as_tag(),
                 })
+            }
+        }
+
+        // DS-8 — optional tombstone chunk (PR-3d wiring). Runs after
+        // ingest so newly-arrived rows are already in `track` before
+        // we probe `getSong` for stale ids.
+        if let Some(budget) = self.tombstone_budget {
+            if budget > 0 {
+                let mut reconciler =
+                    TombstoneReconciler::new(self.store, self.subsonic, &self.server_id);
+                if !self.sleep_enabled {
+                    reconciler = reconciler.with_sleep_disabled();
+                }
+                if let Some(flag) = &self.cancel {
+                    reconciler = reconciler.with_cancellation(Arc::clone(flag));
+                }
+                let stats = reconciler.reconcile_chunk(budget).await?;
+                report.tombstones_checked = stats.checked;
+                report.tombstones_deleted = stats.deleted;
+                self.progress.emit(ProgressEvent::Tombstoned {
+                    deleted_count: stats.deleted,
+                    checked_count: stats.checked,
+                });
             }
         }
 
@@ -168,6 +219,9 @@ impl<'a> DeltaSyncRunner<'a> {
         }
         self.stamp_last_delta(&sync_state)?;
 
+        self.progress.emit(ProgressEvent::Completed {
+            kind: "delta_sync".into(),
+        });
         Ok(report)
     }
 
@@ -885,6 +939,95 @@ mod tests {
             })
             .unwrap();
         assert!(last_delta.unwrap_or(0) > 0);
+    }
+
+    // ── DS-8: tombstone wire runs after DS-4 ─────────────────────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ds8_runs_tombstone_chunk_when_budget_set() {
+        let server = MockServer::start().await;
+        // Watermark change → DS-4 ingest path runs.
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getArtists.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "artists": {
+                        "lastModified": 1_716_840_000_000_i64,
+                        "ignoredArticles": "",
+                        "index": []
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+        // S2-delta: empty album list → no ingest, but DS-8 still runs.
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbumList2.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "albumList2": { "album": [] }
+                }
+            })))
+            .mount(&server)
+            .await;
+        // getSong probe — first id returns ok, second returns code 70.
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getSong.view"))
+            .and(query_param("id", "tr_alive"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "song": { "id": "tr_alive", "title": "Alive" }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getSong.view"))
+            .and(query_param("id", "tr_gone"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "failed",
+                    "error": { "code": 70, "message": "Song not found" }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "tr_alive", "al_x", 1_000);
+        seed_track(&store, "tr_gone", "al_x", 1_000);
+
+        let subsonic = test_subsonic(&server.uri());
+        let report = DeltaSyncRunner::new(
+            &store,
+            &subsonic,
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK),
+        )
+        .with_tombstone_budget(10)
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap();
+
+        assert_eq!(report.tombstones_checked, 2);
+        assert_eq!(report.tombstones_deleted, 1);
+
+        // tr_gone is now soft-deleted.
+        let gone_deleted: i64 = store
+            .with_conn(|c| {
+                c.query_row(
+                    "SELECT deleted FROM track WHERE id='tr_gone'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(gone_deleted, 1);
     }
 
     fn parse_test_iso(s: &str) -> i64 {

--- a/src-tauri/crates/psysonic-library/src/sync/initial.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial.rs
@@ -21,6 +21,7 @@ use super::capability::{CapabilityFlags, NavidromeProbeCredentials};
 use super::cursor::{CursorPhase, InitialSyncCursor, StrategyState};
 use super::error::SyncError;
 use super::mapping::{navidrome_song_to_track_row, subsonic_song_to_track_row};
+use super::progress::{NoopProgress, Progress, ProgressEvent};
 use super::strategy::IngestStrategy;
 use crate::repos::{RemapStats, SyncStateRepository, TrackRepository, TrackRow};
 use crate::store::LibraryStore;
@@ -52,6 +53,7 @@ pub struct InitialSyncRunner<'a> {
     cancel: Option<Arc<AtomicBool>>,
     batch_size: u32,
     sleep_enabled: bool,
+    progress: Arc<dyn Progress + Send + Sync>,
 }
 
 impl<'a> InitialSyncRunner<'a> {
@@ -72,7 +74,13 @@ impl<'a> InitialSyncRunner<'a> {
             cancel: None,
             batch_size: DEFAULT_BATCH_SIZE,
             sleep_enabled: true,
+            progress: Arc::new(NoopProgress),
         }
+    }
+
+    pub fn with_progress(mut self, progress: Arc<dyn Progress + Send + Sync>) -> Self {
+        self.progress = progress;
+        self
     }
 
     pub fn with_navidrome_credentials(mut self, creds: NavidromeProbeCredentials) -> Self {
@@ -113,6 +121,9 @@ impl<'a> InitialSyncRunner<'a> {
         sync_state
             .set_sync_phase(&self.server_id, &self.library_scope, "initial_sync")
             .map_err(SyncError::Storage)?;
+        self.progress.emit(ProgressEvent::PhaseChanged {
+            phase: "initial_sync".into(),
+        });
 
         let mut cursor = self.load_or_init_cursor(&sync_state)?;
         let mut report = InitialSyncReport {
@@ -167,6 +178,9 @@ impl<'a> InitialSyncRunner<'a> {
                 &Value::Object(serde_json::Map::new()),
             )
             .map_err(SyncError::Storage)?;
+        self.progress.emit(ProgressEvent::Completed {
+            kind: "initial_sync".into(),
+        });
 
         Ok(report)
     }

--- a/src-tauri/crates/psysonic-library/src/sync/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mod.rs
@@ -13,7 +13,9 @@ pub mod delta;
 pub mod error;
 pub mod initial;
 pub mod mapping;
+pub mod progress;
 pub mod strategy;
+pub mod supervisor;
 pub mod tombstone;
 
 pub use backoff::{with_jitter, Backoff};
@@ -23,5 +25,7 @@ pub use delta::{DeltaSyncReport, DeltaSyncRunner};
 pub use error::SyncError;
 pub use initial::{InitialSyncReport, InitialSyncRunner};
 pub use mapping::{navidrome_song_to_track_row, subsonic_song_to_track_row};
+pub use progress::{ChannelProgress, NoopProgress, Progress, ProgressEvent};
 pub use strategy::IngestStrategy;
+pub use supervisor::SyncSupervisor;
 pub use tombstone::{should_auto_reconcile, TombstoneReconciler, TombstoneReport};

--- a/src-tauri/crates/psysonic-library/src/sync/progress.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/progress.rs
@@ -1,0 +1,176 @@
+//! C6 — progress channel for the sync runners (spec §6 emit limit
+//! `≤2 events/s`). The runners call `Progress::emit` at phase
+//! transitions and per-batch checkpoints; the supervisor wraps an
+//! `mpsc::UnboundedSender` so the top crate (PR-5) can forward events
+//! to Tauri's emit surface.
+//!
+//! The throttle is intentionally simple — last-emit timestamp +
+//! min-interval gate, terminal events (Completed / Error) bypass the
+//! gate so the caller always sees the final state.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::repos::RemapEntry;
+
+/// Lean event union — server_id / library_scope context lives on the
+/// channel side (one supervisor = one scope). Top-crate code wraps
+/// these into Tauri events with their own envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProgressEvent {
+    PhaseChanged { phase: String },
+    IngestPage { ingested_total: u32, batch_count: u32 },
+    Remapped { entries: Vec<RemapEntry> },
+    Tombstoned { deleted_count: u32, checked_count: u32 },
+    Completed { kind: String },
+    Error { message: String },
+}
+
+impl ProgressEvent {
+    /// Terminal events always bypass the throttle so callers never
+    /// miss a "we're done" / "we crashed" signal.
+    pub fn always_emit(&self) -> bool {
+        matches!(self, Self::Completed { .. } | Self::Error { .. })
+    }
+}
+
+pub trait Progress: Send + Sync {
+    fn emit(&self, event: ProgressEvent);
+}
+
+/// No-op implementation. Used as the default when runners are called
+/// outside a supervisor (tests, future ad-hoc invocations).
+pub struct NoopProgress;
+
+impl Progress for NoopProgress {
+    fn emit(&self, _event: ProgressEvent) {}
+}
+
+/// `Progress` impl that forwards through a tokio mpsc channel,
+/// throttling non-terminal events to the configured `min_interval`.
+pub struct ChannelProgress {
+    sender: tokio::sync::mpsc::UnboundedSender<ProgressEvent>,
+    min_interval: Duration,
+    last_emit: Mutex<Option<Instant>>,
+}
+
+impl ChannelProgress {
+    /// 500 ms gate ≈ 2 events/s per spec §6.
+    pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(500);
+
+    pub fn new(sender: tokio::sync::mpsc::UnboundedSender<ProgressEvent>) -> Self {
+        Self::with_interval(sender, Self::DEFAULT_INTERVAL)
+    }
+
+    pub fn with_interval(
+        sender: tokio::sync::mpsc::UnboundedSender<ProgressEvent>,
+        min_interval: Duration,
+    ) -> Self {
+        Self {
+            sender,
+            min_interval,
+            last_emit: Mutex::new(None),
+        }
+    }
+}
+
+impl Progress for ChannelProgress {
+    fn emit(&self, event: ProgressEvent) {
+        if !event.always_emit() && !self.min_interval.is_zero() {
+            let mut last = self.last_emit.lock().expect("progress lock poisoned");
+            if let Some(prev) = *last {
+                if prev.elapsed() < self.min_interval {
+                    return; // dropped — too soon since last non-terminal emit
+                }
+            }
+            *last = Some(Instant::now());
+        }
+        // Receiver may have closed (consumer disconnected); ignoring
+        // the SendError is the right call — runner keeps going.
+        let _ = self.sender.send(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    #[test]
+    fn noop_progress_swallows_events_without_panicking() {
+        let p = NoopProgress;
+        p.emit(ProgressEvent::PhaseChanged { phase: "ingest".into() });
+        p.emit(ProgressEvent::Completed { kind: "initial_sync".into() });
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zero_interval_channel_emits_every_event() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let p = ChannelProgress::with_interval(tx, Duration::ZERO);
+        for i in 0..10 {
+            p.emit(ProgressEvent::IngestPage {
+                ingested_total: i,
+                batch_count: 1,
+            });
+        }
+        let mut received = 0;
+        while rx.try_recv().is_ok() {
+            received += 1;
+        }
+        assert_eq!(received, 10, "ZERO interval must not drop anything");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn terminal_events_bypass_throttle() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let p = ChannelProgress::with_interval(tx, Duration::from_secs(60));
+        // Two terminal events in quick succession — both must arrive.
+        p.emit(ProgressEvent::Completed { kind: "delta_sync".into() });
+        p.emit(ProgressEvent::Error { message: "boom".into() });
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(ProgressEvent::Completed { .. })
+        ));
+        assert!(matches!(rx.try_recv(), Ok(ProgressEvent::Error { .. })));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn non_terminal_events_collapse_under_throttle() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let p = ChannelProgress::with_interval(tx, Duration::from_millis(100));
+        // First emit lands. Second comes immediately after → throttled.
+        p.emit(ProgressEvent::PhaseChanged { phase: "a".into() });
+        p.emit(ProgressEvent::PhaseChanged { phase: "b".into() });
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(ProgressEvent::PhaseChanged { ref phase }) if phase == "a"
+        ));
+        assert!(rx.try_recv().is_err(), "second emit must have been dropped");
+
+        // After the gate expires, the next emit goes through.
+        thread::sleep(Duration::from_millis(120));
+        p.emit(ProgressEvent::PhaseChanged { phase: "c".into() });
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(ProgressEvent::PhaseChanged { ref phase }) if phase == "c"
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn closed_receiver_does_not_panic_the_sender() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let p = ChannelProgress::with_interval(tx, Duration::ZERO);
+        drop(rx); // consumer goes away
+        p.emit(ProgressEvent::PhaseChanged { phase: "x".into() });
+        // Test passes if we get here.
+    }
+
+    #[test]
+    fn always_emit_true_for_terminal_events() {
+        assert!(ProgressEvent::Completed { kind: "k".into() }.always_emit());
+        assert!(ProgressEvent::Error { message: "m".into() }.always_emit());
+        assert!(!ProgressEvent::PhaseChanged { phase: "p".into() }.always_emit());
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/sync/supervisor.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/supervisor.rs
@@ -1,0 +1,166 @@
+//! C5 — `SyncSupervisor`. Wraps the spawn / cancel / join lifecycle
+//! the top crate (PR-5) will use to run an `InitialSyncRunner` or
+//! `DeltaSyncRunner` from a Tauri command. The supervisor owns the
+//! cancellation `AtomicBool` and the `mpsc` receiver carrying
+//! progress events.
+//!
+//! Stays pure library — no Tauri imports here; PR-5 hooks the
+//! receiver to `AppHandle::emit`.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use super::error::SyncError;
+use super::progress::{ChannelProgress, Progress, ProgressEvent};
+
+pub struct SyncSupervisor {
+    cancel: Arc<AtomicBool>,
+    handle: Option<tokio::task::JoinHandle<Result<(), SyncError>>>,
+    progress_rx: Option<tokio::sync::mpsc::UnboundedReceiver<ProgressEvent>>,
+}
+
+impl SyncSupervisor {
+    /// Spawn a sync workload. `task` receives the cancellation flag
+    /// and a `Progress` handle backed by an internal mpsc channel.
+    /// Caller drives the receiver via `progress_receiver()` and waits
+    /// for completion via `join().await`.
+    pub fn spawn<F, Fut>(task: F) -> Self
+    where
+        F: FnOnce(Arc<AtomicBool>, Arc<dyn Progress + Send + Sync>) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Result<(), SyncError>> + Send + 'static,
+    {
+        Self::spawn_with_interval(task, ChannelProgress::DEFAULT_INTERVAL)
+    }
+
+    /// Variant that overrides the throttle interval — tests pass
+    /// `Duration::ZERO` so every event observed in
+    /// `progress_receiver()` matches the runner's emit order.
+    pub fn spawn_with_interval<F, Fut>(task: F, throttle: std::time::Duration) -> Self
+    where
+        F: FnOnce(Arc<AtomicBool>, Arc<dyn Progress + Send + Sync>) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Result<(), SyncError>> + Send + 'static,
+    {
+        let cancel = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let progress: Arc<dyn Progress + Send + Sync> =
+            Arc::new(ChannelProgress::with_interval(tx, throttle));
+        let cancel_clone = Arc::clone(&cancel);
+        let handle = tokio::task::spawn(async move { task(cancel_clone, progress).await });
+        Self {
+            cancel,
+            handle: Some(handle),
+            progress_rx: Some(rx),
+        }
+    }
+
+    /// Trip the cancellation flag. Runners check it between batches
+    /// and bail out with `SyncError::Cancelled` on the next iteration.
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.load(Ordering::SeqCst)
+    }
+
+    /// Take the progress receiver. Single consumer only — the
+    /// `Option::take` semantics mean later calls return `None`.
+    pub fn progress_receiver(
+        &mut self,
+    ) -> Option<tokio::sync::mpsc::UnboundedReceiver<ProgressEvent>> {
+        self.progress_rx.take()
+    }
+
+    /// Wait for the spawned task. Returns the task's `Result` —
+    /// `Ok(Ok(()))` on clean exit, `Ok(Err(SyncError))` on a
+    /// runner-level failure, `Err(JoinError)` only if the task
+    /// panicked, in which case we surface that as `SyncError::Storage`
+    /// so callers never need to know about tokio internals.
+    pub async fn join(mut self) -> Result<(), SyncError> {
+        let handle = self
+            .handle
+            .take()
+            .ok_or_else(|| SyncError::Storage("supervisor already joined".into()))?;
+        match handle.await {
+            Ok(inner) => inner,
+            Err(join_err) => Err(SyncError::Storage(format!(
+                "sync task panicked: {join_err}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn supervisor_runs_task_to_completion_and_emits_progress() {
+        let mut sup = SyncSupervisor::spawn_with_interval(
+            |_cancel, progress| async move {
+                progress.emit(ProgressEvent::PhaseChanged { phase: "ingest".into() });
+                progress.emit(ProgressEvent::Completed {
+                    kind: "initial_sync".into(),
+                });
+                Ok(())
+            },
+            Duration::ZERO,
+        );
+        let mut rx = sup.progress_receiver().expect("receiver still in place");
+        let result = sup.join().await;
+        assert!(result.is_ok());
+        let mut events = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            events.push(ev);
+        }
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], ProgressEvent::PhaseChanged { .. }));
+        assert!(matches!(events[1], ProgressEvent::Completed { .. }));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn supervisor_cancel_trips_atomic_flag_before_task_joins() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let started_clone = Arc::clone(&started);
+        let sup = SyncSupervisor::spawn(move |cancel, _progress| {
+            let started = started_clone;
+            async move {
+                started.notify_one();
+                // Spin until cancelled or 2s timeout.
+                for _ in 0..200 {
+                    if cancel.load(Ordering::SeqCst) {
+                        return Err(SyncError::Cancelled);
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Ok(())
+            }
+        });
+        started.notified().await;
+        sup.cancel();
+        assert!(sup.is_cancelled());
+        let result = sup.join().await;
+        assert!(matches!(result, Err(SyncError::Cancelled)));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn supervisor_propagates_task_panic_as_sync_error() {
+        let sup = SyncSupervisor::spawn(|_cancel, _progress| async move {
+            panic!("simulated task panic");
+        });
+        let result = sup.join().await;
+        assert!(matches!(result, Err(SyncError::Storage(_))));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn progress_receiver_take_returns_none_after_first_call() {
+        let mut sup = SyncSupervisor::spawn(|_cancel, _progress| async move { Ok(()) });
+        let first = sup.progress_receiver();
+        let second = sup.progress_receiver();
+        assert!(first.is_some());
+        assert!(second.is_none());
+        sup.join().await.unwrap();
+    }
+}


### PR DESCRIPTION
First half of PR-3d per cucadmuh's kickoff-Q2 split. Pure-Rust
lifecycle + progress infrastructure on top of PR-3a/b/c. Tauri
events stay in the top crate (PR-5); this PR only ships the
channel the top crate will subscribe to.

## C5 / C6 mapping + scope adds

- **C5 SyncSupervisor.** Spawns a sync workload inside a tokio task,
  owns the cancellation `AtomicBool`, and exposes a single-consumer
  mpsc receiver for `ProgressEvent`. `join()` returns the runner's
  `Result<(), SyncError>`; panics surface as `Storage` so callers
  never need to know about tokio internals.
- **C6 progress channel.** New `sync::progress` module:
  - `ProgressEvent` enum — `PhaseChanged` / `IngestPage` /
    `Remapped` / `Tombstoned` / `Completed` / `Error`.
  - `Progress` trait + `NoopProgress` default +
    `ChannelProgress` forwarding through tokio mpsc. Terminal
    events bypass the throttle.
- `InitialSyncRunner` + `DeltaSyncRunner` gain
  `with_progress(...)` builders. Defaults to `NoopProgress`.
- **DS-8 wire.** `DeltaSyncRunner::with_tombstone_budget(n)`
  drives `TombstoneReconciler::reconcile_chunk(n)` after DS-4
  ingest; shares cancellation + sleep override. Report gains
  `tombstones_checked` + `tombstones_deleted`.
- **`capability::probe_and_persist`.** Chains
  `CapabilityProbe::run` with `set_capability_flags` and a
  `probing → idle` phase transition. PR-3d2 will call this in
  front of every initial / delta run.

## References

- PR-3 kickoff Q2 split:
  `psysonic-workdocs/internal/collaboration/tasks/2026-05-library-track-store/questions/2026-05-19-pr3-kickoff.md`
- PR-3c review §7 (probe→flags wiring, DS-8 integration):
  `psysonic-workdocs/internal/collaboration/handoffs/2026-05-19-pr-798-review.md`
- Spec §6 (≤2 events/s emit limit), §6.7 (tombstone modes), §6.1
  (capability flags)

## Out of scope

- C8 adaptive scheduler / C9 request budget / C10 EWMA poll
  interval / C11 bandwidth + queue lane → PR-3d2
- Tauri event emit + invoke surface → PR-5
- DS-5 canonical matcher / DS-7 starred delta → Phase H / follow-up

## Test plan

- [x] `cargo test --workspace` — passes (118 in `psysonic-library`,
      105 in `psysonic-integration`)
- [x] `cargo clippy -p psysonic-library --all-targets -- -D warnings`
- [x] `./dev.sh backend-ci` — hot-path coverage gate green