### PR TITLE
feat(library): read-only Tauri command surface (Phase D1 part 1, PR-5a)

### DIFF
--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -1,0 +1,468 @@
+//! Tauri commands — read-only surface for PR-5a (spec §7.1). Mutating
+//! commands + sync lifecycle land in PR-5b. All commands take a
+//! `State<LibraryRuntime>` so the top crate's `setup()` can wire one
+//! shared `Arc<LibraryStore>` across the whole IPC surface.
+
+use rusqlite::params;
+use tauri::State;
+
+use crate::dto::{
+    local_tracks_max_updated_ms, LibraryTrackDto, LibraryTracksEnvelope, OfflinePathDto,
+    SyncStateDto, TrackArtifactDto, TrackFactDto, TrackRefDto,
+};
+use crate::repos::TrackRepository;
+use crate::runtime::LibraryRuntime;
+use crate::search::search_tracks;
+
+/// Cap for `library_get_tracks_batch` per spec §7.1 ("max 100 refs/call").
+const TRACKS_BATCH_LIMIT: usize = 100;
+
+#[tauri::command]
+pub fn library_get_status(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    library_scope: Option<String>,
+) -> Result<SyncStateDto, String> {
+    let scope = library_scope.unwrap_or_default();
+    let row: Option<SyncStateRow> = runtime
+        .store
+        .with_conn(|conn| {
+            conn.query_row(
+                "SELECT sync_phase, capability_flags, library_tier, last_full_sync_at, \
+                 last_delta_sync_at, next_poll_at, server_last_scan_iso, \
+                 indexes_last_modified_ms, artists_last_modified_ms, local_track_count, \
+                 server_track_count, last_error \
+                 FROM sync_state WHERE server_id = ?1 AND library_scope = ?2",
+                params![server_id, scope],
+                |r| {
+                    Ok(SyncStateRow {
+                        sync_phase: r.get(0)?,
+                        capability_flags: r.get::<_, i64>(1)?.max(0) as u32,
+                        library_tier: r.get(2)?,
+                        last_full_sync_at: r.get(3)?,
+                        last_delta_sync_at: r.get(4)?,
+                        next_poll_at: r.get(5)?,
+                        server_last_scan_iso: r.get(6)?,
+                        indexes_last_modified_ms: r.get(7)?,
+                        artists_last_modified_ms: r.get(8)?,
+                        local_track_count: r.get(9)?,
+                        server_track_count: r.get(10)?,
+                        last_error: r.get(11)?,
+                    })
+                },
+            )
+            .optional()
+        })
+        .map_err(|e| e.to_string())?;
+
+    let local_tracks_max_updated_ms = local_tracks_max_updated_ms(&runtime.store, &server_id)?;
+    let row = row.unwrap_or_default();
+    // `SyncStateRepository::ensure` is intentionally NOT called from
+    // the read path — `library_get_status` on a fresh server returns
+    // an "idle / unknown" stub without writing a row. PR-5b writes
+    // the row when `bind_session` lands.
+    Ok(SyncStateDto {
+        server_id,
+        library_scope: scope,
+        sync_phase: row.sync_phase,
+        capability_flags: row.capability_flags,
+        library_tier: row.library_tier,
+        last_full_sync_at: row.last_full_sync_at,
+        last_delta_sync_at: row.last_delta_sync_at,
+        next_poll_at: row.next_poll_at,
+        server_last_scan_iso: row.server_last_scan_iso,
+        indexes_last_modified_ms: row.indexes_last_modified_ms,
+        artists_last_modified_ms: row.artists_last_modified_ms,
+        local_track_count: row.local_track_count,
+        server_track_count: row.server_track_count,
+        last_error: row.last_error,
+        local_tracks_max_updated_ms,
+    })
+}
+
+#[tauri::command]
+pub fn library_search(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    query: String,
+    limit: Option<u32>,
+    offset: Option<u32>,
+    library_scope: Option<String>,
+) -> Result<LibraryTracksEnvelope, String> {
+    let _ = library_scope; // PR-5a accepts the arg for forward-compat; filter is wired in §5.13
+    let limit = limit.unwrap_or(100).clamp(1, 500);
+    let offset = offset.unwrap_or(0);
+    // `search_tracks` returns lean `TrackHit` rows for FTS; PR-5a
+    // re-fetches the full `TrackRow` per hit so the DTO carries every
+    // hot column. Acceptable for `limit ≤ 100`; PR-5d wires a single-
+    // statement SQL builder via the FilterRegistry.
+    let hits = search_tracks(&runtime.store, &server_id, &query, limit as i64 + offset as i64)?;
+    let mut paged: Vec<TrackRefDto> = hits
+        .into_iter()
+        .skip(offset as usize)
+        .map(|h| TrackRefDto {
+            server_id: h.server_id,
+            track_id: h.id,
+            content_hash: None,
+        })
+        .collect();
+    paged.truncate(limit as usize);
+
+    let total = paged.len() as u32;
+    let tracks = hydrate_refs(&runtime, &paged)?;
+    Ok(LibraryTracksEnvelope { tracks, total })
+}
+
+#[tauri::command]
+pub fn library_get_track(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    track_id: String,
+) -> Result<Option<LibraryTrackDto>, String> {
+    let repo = TrackRepository::new(&runtime.store);
+    Ok(repo
+        .find_one(&server_id, &track_id)?
+        .map(|row| LibraryTrackDto::from_row(&row)))
+}
+
+#[tauri::command]
+pub fn library_get_tracks_batch(
+    runtime: State<'_, LibraryRuntime>,
+    refs: Vec<TrackRefDto>,
+) -> Result<Vec<LibraryTrackDto>, String> {
+    if refs.len() > TRACKS_BATCH_LIMIT {
+        return Err(format!(
+            "library_get_tracks_batch: refs exceeds cap ({} > {})",
+            refs.len(),
+            TRACKS_BATCH_LIMIT
+        ));
+    }
+    hydrate_refs(&runtime, &refs)
+}
+
+#[tauri::command]
+pub fn library_get_tracks_by_album(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    album_id: String,
+) -> Result<Vec<LibraryTrackDto>, String> {
+    let rows = TrackRepository::new(&runtime.store).find_by_album(&server_id, &album_id)?;
+    Ok(rows.iter().map(LibraryTrackDto::from_row).collect())
+}
+
+#[tauri::command]
+pub fn library_get_artifact(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    track_id: String,
+    artifact_kind: String,
+    source_kind: Option<String>,
+    source_id: Option<String>,
+    format: Option<String>,
+) -> Result<Option<TrackArtifactDto>, String> {
+    runtime
+        .store
+        .with_conn(|conn| {
+            // Compose a flexible WHERE — source_kind / source_id /
+            // format optional so PR-7's lyrics path can call without
+            // a pinned `source_id` (returns the first match).
+            let mut sql = String::from(
+                "SELECT server_id, track_id, artifact_kind, format, source_kind, source_id, \
+                 language, content_text, content_bytes, not_found, content_hash, fetched_at, \
+                 expires_at FROM track_artifact \
+                 WHERE server_id = ?1 AND track_id = ?2 AND artifact_kind = ?3",
+            );
+            if source_kind.is_some() {
+                sql.push_str(" AND source_kind = ?4");
+            }
+            if source_id.is_some() {
+                sql.push_str(" AND source_id = ?5");
+            }
+            if format.is_some() {
+                sql.push_str(" AND format = ?6");
+            }
+            sql.push_str(" ORDER BY fetched_at DESC LIMIT 1");
+
+            let mut stmt = conn.prepare(&sql)?;
+            let mut bound: Vec<rusqlite::types::Value> = vec![
+                rusqlite::types::Value::Text(server_id.clone()),
+                rusqlite::types::Value::Text(track_id.clone()),
+                rusqlite::types::Value::Text(artifact_kind.clone()),
+            ];
+            if let Some(sk) = &source_kind {
+                bound.push(rusqlite::types::Value::Text(sk.clone()));
+            }
+            if let Some(si) = &source_id {
+                bound.push(rusqlite::types::Value::Text(si.clone()));
+            }
+            if let Some(fmt) = &format {
+                bound.push(rusqlite::types::Value::Text(fmt.clone()));
+            }
+
+            stmt.query_row(rusqlite::params_from_iter(bound.iter()), |r| {
+                Ok(TrackArtifactDto {
+                    server_id: r.get(0)?,
+                    track_id: r.get(1)?,
+                    artifact_kind: r.get(2)?,
+                    format: r.get(3)?,
+                    source_kind: r.get(4)?,
+                    source_id: r.get(5)?,
+                    language: r.get(6)?,
+                    content_text: r.get(7)?,
+                    content_bytes: r.get(8)?,
+                    not_found: r.get::<_, i64>(9)? != 0,
+                    content_hash: r.get(10)?,
+                    fetched_at: r.get(11)?,
+                    expires_at: r.get(12)?,
+                })
+            })
+            .optional()
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn library_get_facts(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    track_id: String,
+    fact_kinds: Option<Vec<String>>,
+) -> Result<Vec<TrackFactDto>, String> {
+    runtime
+        .store
+        .with_conn(|conn| {
+            let kinds = fact_kinds.unwrap_or_default();
+            if kinds.is_empty() {
+                let mut stmt = conn.prepare(
+                    "SELECT server_id, track_id, fact_kind, value_real, value_int, value_text, \
+                     unit, source_kind, source_id, confidence, content_hash, fetched_at, expires_at \
+                     FROM track_fact \
+                     WHERE server_id = ?1 AND track_id = ?2 \
+                     ORDER BY fact_kind ASC, fetched_at DESC",
+                )?;
+                let rows: rusqlite::Result<Vec<TrackFactDto>> = stmt
+                    .query_map(params![server_id, track_id], row_to_fact_dto)?
+                    .collect();
+                rows
+            } else {
+                // ANY value match across the provided fact_kinds.
+                let placeholders =
+                    (0..kinds.len()).map(|i| format!("?{}", i + 3)).collect::<Vec<_>>().join(", ");
+                let sql = format!(
+                    "SELECT server_id, track_id, fact_kind, value_real, value_int, value_text, \
+                     unit, source_kind, source_id, confidence, content_hash, fetched_at, expires_at \
+                     FROM track_fact \
+                     WHERE server_id = ?1 AND track_id = ?2 AND fact_kind IN ({placeholders}) \
+                     ORDER BY fact_kind ASC, fetched_at DESC"
+                );
+                let mut stmt = conn.prepare(&sql)?;
+                let mut bound: Vec<rusqlite::types::Value> = vec![
+                    rusqlite::types::Value::Text(server_id.clone()),
+                    rusqlite::types::Value::Text(track_id.clone()),
+                ];
+                for k in &kinds {
+                    bound.push(rusqlite::types::Value::Text(k.clone()));
+                }
+                let rows: rusqlite::Result<Vec<TrackFactDto>> = stmt
+                    .query_map(rusqlite::params_from_iter(bound.iter()), row_to_fact_dto)?
+                    .collect();
+                rows
+            }
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn library_get_offline_path(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    track_id: String,
+) -> Result<OfflinePathDto, String> {
+    let path = runtime
+        .store
+        .with_conn(|conn| {
+            conn.query_row(
+                "SELECT local_path FROM track_offline \
+                 WHERE server_id = ?1 AND track_id = ?2",
+                params![server_id, track_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+        })
+        .map_err(|e| e.to_string())?;
+    Ok(OfflinePathDto {
+        server_id,
+        track_id,
+        missing: path.is_none(),
+        local_path: path,
+    })
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+fn hydrate_refs(
+    runtime: &LibraryRuntime,
+    refs: &[TrackRefDto],
+) -> Result<Vec<LibraryTrackDto>, String> {
+    let pairs: Vec<(String, String)> = refs
+        .iter()
+        .map(|r| (r.server_id.clone(), r.track_id.clone()))
+        .collect();
+    let rows = TrackRepository::new(&runtime.store).find_batch(&pairs)?;
+    Ok(rows.iter().map(LibraryTrackDto::from_row).collect())
+}
+
+fn row_to_fact_dto(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackFactDto> {
+    Ok(TrackFactDto {
+        server_id: row.get(0)?,
+        track_id: row.get(1)?,
+        fact_kind: row.get(2)?,
+        value_real: row.get(3)?,
+        value_int: row.get(4)?,
+        value_text: row.get(5)?,
+        unit: row.get(6)?,
+        source_kind: row.get(7)?,
+        source_id: row.get(8)?,
+        confidence: row.get(9)?,
+        content_hash: row.get(10)?,
+        fetched_at: row.get(11)?,
+        expires_at: row.get(12)?,
+    })
+}
+
+#[derive(Default)]
+struct SyncStateRow {
+    sync_phase: String,
+    capability_flags: u32,
+    library_tier: String,
+    last_full_sync_at: Option<i64>,
+    last_delta_sync_at: Option<i64>,
+    next_poll_at: Option<i64>,
+    server_last_scan_iso: Option<String>,
+    indexes_last_modified_ms: Option<i64>,
+    artists_last_modified_ms: Option<i64>,
+    local_track_count: Option<i64>,
+    server_track_count: Option<i64>,
+    last_error: Option<String>,
+}
+
+use rusqlite::OptionalExtension;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repos::TrackRow;
+    use crate::store::LibraryStore;
+    use std::sync::Arc;
+
+    fn make_row(server: &str, id: &str, album_id: &str, track_no: i64) -> TrackRow {
+        TrackRow {
+            server_id: server.into(),
+            id: id.into(),
+            title: format!("Track {id}"),
+            title_sort: None,
+            artist: Some("A".into()),
+            artist_id: Some("ar1".into()),
+            album: "Album".into(),
+            album_id: Some(album_id.into()),
+            album_artist: Some("A".into()),
+            duration_sec: 240,
+            track_number: Some(track_no),
+            disc_number: Some(1),
+            year: None,
+            genre: None,
+            suffix: None,
+            bit_rate: None,
+            size_bytes: None,
+            cover_art_id: None,
+            starred_at: None,
+            user_rating: None,
+            play_count: None,
+            played_at: None,
+            server_path: Some(format!("/path/{id}.flac")),
+            library_id: None,
+            isrc: None,
+            mbid_recording: None,
+            bpm: None,
+            replay_gain_track_db: None,
+            replay_gain_album_db: None,
+            content_hash: Some(format!("hash-{id}")),
+            server_updated_at: None,
+            server_created_at: None,
+            deleted: false,
+            synced_at: 1,
+            raw_json: "{}".into(),
+        }
+    }
+
+    // The command functions take `tauri::State` which we can't easily
+    // construct in unit tests without a Tauri runtime. The tests below
+    // exercise the *underlying* logic by calling the equivalent
+    // `LibraryRuntime` + repo paths directly. Integration coverage with
+    // a real Tauri app lives outside this crate (PR-5c devtools test).
+
+    fn runtime(store: Arc<LibraryStore>) -> LibraryRuntime {
+        LibraryRuntime::new(store)
+    }
+
+    #[test]
+    fn get_status_returns_defaults_when_no_row_exists() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        let rt = runtime(store);
+        // Simulate command body — same logic as `library_get_status`.
+        let local_max = local_tracks_max_updated_ms(&rt.store, "s1").unwrap();
+        assert!(local_max.is_none());
+    }
+
+    #[test]
+    fn library_track_dto_from_row_preserves_hot_columns() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        TrackRepository::new(&store)
+            .upsert_batch(&[make_row("s1", "tr_1", "al_1", 5)])
+            .unwrap();
+        let found = TrackRepository::new(&store).find_one("s1", "tr_1").unwrap().unwrap();
+        let dto = LibraryTrackDto::from_row(&found);
+        assert_eq!(dto.id, "tr_1");
+        assert_eq!(dto.album_id.as_deref(), Some("al_1"));
+        assert_eq!(dto.track_number, Some(5));
+    }
+
+    #[test]
+    fn find_by_album_orders_by_disc_then_track_then_id() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                make_row("s1", "tr_b", "al_1", 2),
+                make_row("s1", "tr_a", "al_1", 1),
+                make_row("s1", "tr_c", "al_2", 1),
+            ])
+            .unwrap();
+        let album1 = TrackRepository::new(&store).find_by_album("s1", "al_1").unwrap();
+        let ids: Vec<&str> = album1.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["tr_a", "tr_b"]);
+    }
+
+    #[test]
+    fn find_batch_preserves_input_order_and_drops_unknowns() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                make_row("s1", "tr_1", "al_1", 1),
+                make_row("s1", "tr_2", "al_1", 2),
+            ])
+            .unwrap();
+        let pairs = vec![
+            ("s1".to_string(), "tr_2".to_string()),
+            ("s1".to_string(), "tr_missing".to_string()),
+            ("s1".to_string(), "tr_1".to_string()),
+        ];
+        let rows = TrackRepository::new(&store).find_batch(&pairs).unwrap();
+        let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["tr_2", "tr_1"]);
+    }
+
+    #[test]
+    fn batch_limit_constant_matches_spec_cap() {
+        assert_eq!(TRACKS_BATCH_LIMIT, 100);
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/dto.rs
+++ b/src-tauri/crates/psysonic-library/src/dto.rs
@@ -1,0 +1,377 @@
+//! Public DTOs the Tauri command surface returns. camelCase wire shape
+//! per `src-tauri/CLAUDE.md`. PR-5a only defines what the read-only
+//! commands need; PR-5b adds sync-progress / cancel-ack shapes.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::repos::TrackRow;
+use crate::store::LibraryStore;
+
+/// `library_get_status` payload — mirrors the `sync_state` row plus a
+/// few derived counters from `track`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncStateDto {
+    pub server_id: String,
+    pub library_scope: String,
+    #[serde(default)]
+    pub sync_phase: String,
+    #[serde(default)]
+    pub capability_flags: u32,
+    #[serde(default)]
+    pub library_tier: String,
+    pub last_full_sync_at: Option<i64>,
+    pub last_delta_sync_at: Option<i64>,
+    pub next_poll_at: Option<i64>,
+    pub server_last_scan_iso: Option<String>,
+    pub indexes_last_modified_ms: Option<i64>,
+    pub artists_last_modified_ms: Option<i64>,
+    pub local_track_count: Option<i64>,
+    pub server_track_count: Option<i64>,
+    pub last_error: Option<String>,
+    /// `MAX(server_updated_at)` over local non-deleted tracks — the
+    /// implicit "tracks watermark" the N1-delta uses.
+    pub local_tracks_max_updated_ms: Option<i64>,
+}
+
+/// `library_get_track` / `library_search` row shape — flat projection
+/// over `track`'s hot columns plus the raw JSON sub-tree. Frontend
+/// re-assembles its own `LibraryTrack` shape from this.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibraryTrackDto {
+    // Ref
+    pub server_id: String,
+    pub id: String,
+    pub content_hash: Option<String>,
+
+    // Hot columns
+    pub title: String,
+    pub title_sort: Option<String>,
+    pub artist: Option<String>,
+    pub artist_id: Option<String>,
+    pub album: String,
+    pub album_id: Option<String>,
+    pub album_artist: Option<String>,
+    pub duration_sec: i64,
+    pub track_number: Option<i64>,
+    pub disc_number: Option<i64>,
+    pub year: Option<i64>,
+    pub genre: Option<String>,
+    pub suffix: Option<String>,
+    pub bit_rate: Option<i64>,
+    pub size_bytes: Option<i64>,
+    pub cover_art_id: Option<String>,
+    pub starred_at: Option<i64>,
+    pub user_rating: Option<i64>,
+    pub play_count: Option<i64>,
+    pub played_at: Option<i64>,
+    pub server_path: Option<String>,
+    pub library_id: Option<String>,
+    pub isrc: Option<String>,
+    pub mbid_recording: Option<String>,
+    pub bpm: Option<i64>,
+    pub replay_gain_track_db: Option<f64>,
+    pub replay_gain_album_db: Option<f64>,
+
+    pub server_updated_at: Option<i64>,
+    pub server_created_at: Option<i64>,
+    pub synced_at: i64,
+
+    /// Original Subsonic / Navidrome song JSON the sync engine stored.
+    /// Frontend parses this lazily when it needs OpenSubsonic extras
+    /// (contributors, replayGain detail, …).
+    pub raw_json: Value,
+}
+
+impl LibraryTrackDto {
+    pub fn from_row(row: &TrackRow) -> Self {
+        let raw_json: Value = serde_json::from_str(&row.raw_json).unwrap_or(Value::Null);
+        Self {
+            server_id: row.server_id.clone(),
+            id: row.id.clone(),
+            content_hash: row.content_hash.clone(),
+            title: row.title.clone(),
+            title_sort: row.title_sort.clone(),
+            artist: row.artist.clone(),
+            artist_id: row.artist_id.clone(),
+            album: row.album.clone(),
+            album_id: row.album_id.clone(),
+            album_artist: row.album_artist.clone(),
+            duration_sec: row.duration_sec,
+            track_number: row.track_number,
+            disc_number: row.disc_number,
+            year: row.year,
+            genre: row.genre.clone(),
+            suffix: row.suffix.clone(),
+            bit_rate: row.bit_rate,
+            size_bytes: row.size_bytes,
+            cover_art_id: row.cover_art_id.clone(),
+            starred_at: row.starred_at,
+            user_rating: row.user_rating,
+            play_count: row.play_count,
+            played_at: row.played_at,
+            server_path: row.server_path.clone(),
+            library_id: row.library_id.clone(),
+            isrc: row.isrc.clone(),
+            mbid_recording: row.mbid_recording.clone(),
+            bpm: row.bpm,
+            replay_gain_track_db: row.replay_gain_track_db,
+            replay_gain_album_db: row.replay_gain_album_db,
+            server_updated_at: row.server_updated_at,
+            server_created_at: row.server_created_at,
+            synced_at: row.synced_at,
+            raw_json,
+        }
+    }
+}
+
+/// `library_get_tracks_batch` / `library_search` envelope.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibraryTracksEnvelope {
+    pub tracks: Vec<LibraryTrackDto>,
+    pub total: u32,
+}
+
+/// `library_get_artifact` payload — one row of `track_artifact`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackArtifactDto {
+    pub server_id: String,
+    pub track_id: String,
+    pub artifact_kind: String,
+    pub format: String,
+    pub source_kind: String,
+    pub source_id: String,
+    pub language: Option<String>,
+    pub content_text: Option<String>,
+    pub content_bytes: i64,
+    pub not_found: bool,
+    pub content_hash: Option<String>,
+    pub fetched_at: i64,
+    pub expires_at: Option<i64>,
+}
+
+/// `library_get_facts` row.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackFactDto {
+    pub server_id: String,
+    pub track_id: String,
+    pub fact_kind: String,
+    pub value_real: Option<f64>,
+    pub value_int: Option<i64>,
+    pub value_text: Option<String>,
+    pub unit: Option<String>,
+    pub source_kind: String,
+    pub source_id: String,
+    pub confidence: f64,
+    pub content_hash: Option<String>,
+    pub fetched_at: i64,
+    pub expires_at: Option<i64>,
+}
+
+/// `library_get_offline_path` outcome — either a path string or a
+/// `missing` flag so the frontend can show a hint without polling.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct OfflinePathDto {
+    pub server_id: String,
+    pub track_id: String,
+    pub local_path: Option<String>,
+    pub missing: bool,
+}
+
+/// Compact track reference used as input by `library_get_tracks_batch`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackRefDto {
+    pub server_id: String,
+    pub track_id: String,
+    #[serde(default)]
+    pub content_hash: Option<String>,
+}
+
+/// Read `MAX(server_updated_at)` for non-deleted tracks on this server
+/// — used by `SyncStateDto` so callers can show "tracks watermark" in
+/// Settings without a separate column.
+pub fn local_tracks_max_updated_ms(
+    store: &LibraryStore,
+    server_id: &str,
+) -> Result<Option<i64>, String> {
+    store
+        .with_conn(|c| {
+            c.query_row(
+                "SELECT MAX(server_updated_at) FROM track \
+                 WHERE server_id = ?1 AND deleted = 0",
+                rusqlite::params![server_id],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repos::TrackRepository;
+
+    fn sample_row() -> TrackRow {
+        TrackRow {
+            server_id: "s1".into(),
+            id: "tr_1".into(),
+            title: "Hello".into(),
+            title_sort: None,
+            artist: Some("World".into()),
+            artist_id: Some("ar_1".into()),
+            album: "An Album".into(),
+            album_id: Some("al_1".into()),
+            album_artist: Some("World".into()),
+            duration_sec: 240,
+            track_number: Some(3),
+            disc_number: Some(1),
+            year: Some(2024),
+            genre: Some("Ambient".into()),
+            suffix: Some("flac".into()),
+            bit_rate: Some(1000),
+            size_bytes: Some(32_000_000),
+            cover_art_id: Some("cv_1".into()),
+            starred_at: None,
+            user_rating: None,
+            play_count: Some(0),
+            played_at: None,
+            server_path: Some("/path/x.flac".into()),
+            library_id: Some("1".into()),
+            isrc: Some("USRC17607839".into()),
+            mbid_recording: Some("mb-1".into()),
+            bpm: Some(120),
+            replay_gain_track_db: Some(-1.2),
+            replay_gain_album_db: Some(-0.8),
+            content_hash: Some("deadbeef".into()),
+            server_updated_at: Some(1_700_000_000),
+            server_created_at: Some(1_699_000_000),
+            deleted: false,
+            synced_at: 1_700_000_500,
+            raw_json: r#"{"replayGain":{"trackGain":-1.2}}"#.into(),
+        }
+    }
+
+    #[test]
+    fn library_track_dto_serializes_field_names_camel_case() {
+        let dto = LibraryTrackDto::from_row(&sample_row());
+        let json = serde_json::to_value(&dto).unwrap();
+        // Spot-check critical wire keys — IPC contract.
+        for key in [
+            "serverId",
+            "contentHash",
+            "albumArtist",
+            "durationSec",
+            "trackNumber",
+            "discNumber",
+            "coverArtId",
+            "userRating",
+            "playCount",
+            "playedAt",
+            "serverPath",
+            "libraryId",
+            "mbidRecording",
+            "replayGainTrackDb",
+            "replayGainAlbumDb",
+            "serverUpdatedAt",
+            "syncedAt",
+            "rawJson",
+        ] {
+            assert!(
+                json.get(key).is_some(),
+                "expected camelCase key `{key}` in serialized DTO, got {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn library_track_dto_parses_raw_json_into_value() {
+        let dto = LibraryTrackDto::from_row(&sample_row());
+        let rg = dto
+            .raw_json
+            .get("replayGain")
+            .and_then(|v| v.get("trackGain"))
+            .and_then(|v| v.as_f64())
+            .unwrap();
+        assert!((rg - -1.2).abs() < 0.001);
+    }
+
+    #[test]
+    fn library_track_dto_falls_back_to_null_on_invalid_raw_json() {
+        let mut row = sample_row();
+        row.raw_json = "{not valid json}".into();
+        let dto = LibraryTrackDto::from_row(&row);
+        assert!(dto.raw_json.is_null(), "invalid JSON must surface as Value::Null");
+    }
+
+    #[test]
+    fn local_tracks_max_updated_returns_max_over_non_deleted_rows() {
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+        let mut r1 = sample_row();
+        r1.server_updated_at = Some(1_000);
+        let mut r2 = sample_row();
+        r2.id = "tr_2".into();
+        r2.server_updated_at = Some(3_000);
+        let mut r3 = sample_row();
+        r3.id = "tr_3".into();
+        r3.server_updated_at = Some(5_000);
+        r3.deleted = true;
+        repo.upsert_batch(&[r1, r2, r3]).unwrap();
+
+        assert_eq!(
+            local_tracks_max_updated_ms(&store, "s1").unwrap(),
+            Some(3_000),
+            "deleted rows must be excluded"
+        );
+    }
+
+    #[test]
+    fn track_ref_dto_roundtrips_through_json() {
+        let r = TrackRefDto {
+            server_id: "s1".into(),
+            track_id: "tr_1".into(),
+            content_hash: Some("h".into()),
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert_eq!(json.get("serverId").and_then(|v| v.as_str()), Some("s1"));
+        let back: TrackRefDto = serde_json::from_value(json).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn sync_state_dto_omits_null_optionals_cleanly() {
+        let dto = SyncStateDto {
+            server_id: "s1".into(),
+            library_scope: "".into(),
+            sync_phase: "idle".into(),
+            capability_flags: 0,
+            library_tier: "unknown".into(),
+            last_full_sync_at: None,
+            last_delta_sync_at: None,
+            next_poll_at: None,
+            server_last_scan_iso: None,
+            indexes_last_modified_ms: None,
+            artists_last_modified_ms: None,
+            local_track_count: None,
+            server_track_count: None,
+            last_error: None,
+            local_tracks_max_updated_ms: None,
+        };
+        let json = serde_json::to_value(dto).unwrap();
+        assert_eq!(
+            json.get("syncPhase").and_then(|v| v.as_str()),
+            Some("idle")
+        );
+        // `null` survives as JSON null, not omitted — explicit shape
+        // for the WebView so it can distinguish "missing" from
+        // "unset".
+        assert!(json.get("lastFullSyncAt").unwrap().is_null());
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/lib.rs
+++ b/src-tauri/crates/psysonic-library/src/lib.rs
@@ -7,11 +7,18 @@
 //! - `filter` — `FilterFieldRegistry` (Rust source of truth for Advanced Search)
 //! - `sync`   — capability probe + orchestrator (PR-3*)
 
+pub mod commands;
+pub mod dto;
 pub mod filter;
+pub mod payload;
 pub mod repos;
+pub mod runtime;
 pub mod search;
 pub mod store;
 pub mod sync;
+
+pub use payload::LibrarySyncProgressPayload;
+pub use runtime::LibraryRuntime;
 
 pub use store::{LibraryStore, LIBRARY_DB_SCHEMA_VERSION};
 

--- a/src-tauri/crates/psysonic-library/src/payload.rs
+++ b/src-tauri/crates/psysonic-library/src/payload.rs
@@ -1,0 +1,203 @@
+//! `ProgressEvent` → Tauri event payload mapper. PR-5a ships the
+//! transformation as a pure function so it's unit-testable without
+//! Tauri / supervisor wiring; PR-5b plugs the mpsc receiver into
+//! `AppHandle::emit("library:sync-progress", payload)`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::sync::progress::ProgressEvent;
+
+/// Wire shape for the `library:sync-progress` / `library:sync-idle`
+/// Tauri events. Carries the `serverId` + `libraryScope` so the
+/// frontend can demultiplex across multiple servers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibrarySyncProgressPayload {
+    pub server_id: String,
+    pub library_scope: String,
+    /// Discriminator: `"phase_changed"` / `"ingest_page"` /
+    /// `"remapped"` / `"tombstoned"` / `"completed"` / `"error"`.
+    pub kind: String,
+    pub phase: Option<String>,
+    pub ingested_total: Option<u32>,
+    pub batch_count: Option<u32>,
+    pub remapped_count: Option<u32>,
+    pub tombstones_checked: Option<u32>,
+    pub tombstones_deleted: Option<u32>,
+    pub completed_kind: Option<String>,
+    pub message: Option<String>,
+}
+
+impl LibrarySyncProgressPayload {
+    pub fn from_event(event: &ProgressEvent, server_id: &str, library_scope: &str) -> Self {
+        let mut payload = Self {
+            server_id: server_id.to_string(),
+            library_scope: library_scope.to_string(),
+            kind: String::new(),
+            phase: None,
+            ingested_total: None,
+            batch_count: None,
+            remapped_count: None,
+            tombstones_checked: None,
+            tombstones_deleted: None,
+            completed_kind: None,
+            message: None,
+        };
+        match event {
+            ProgressEvent::PhaseChanged { phase } => {
+                payload.kind = "phase_changed".into();
+                payload.phase = Some(phase.clone());
+            }
+            ProgressEvent::IngestPage {
+                ingested_total,
+                batch_count,
+            } => {
+                payload.kind = "ingest_page".into();
+                payload.ingested_total = Some(*ingested_total);
+                payload.batch_count = Some(*batch_count);
+            }
+            ProgressEvent::Remapped { entries } => {
+                payload.kind = "remapped".into();
+                payload.remapped_count = Some(entries.len() as u32);
+            }
+            ProgressEvent::Tombstoned {
+                deleted_count,
+                checked_count,
+            } => {
+                payload.kind = "tombstoned".into();
+                payload.tombstones_deleted = Some(*deleted_count);
+                payload.tombstones_checked = Some(*checked_count);
+            }
+            ProgressEvent::Completed { kind } => {
+                payload.kind = "completed".into();
+                payload.completed_kind = Some(kind.clone());
+            }
+            ProgressEvent::Error { message } => {
+                payload.kind = "error".into();
+                payload.message = Some(message.clone());
+            }
+        }
+        payload
+    }
+
+    /// Convenience constant for the event-name Tauri emits.
+    pub const PROGRESS_EVENT_NAME: &'static str = "library:sync-progress";
+    pub const IDLE_EVENT_NAME: &'static str = "library:sync-idle";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repos::RemapEntry;
+
+    #[test]
+    fn phase_changed_maps_to_phase_kind() {
+        let p = LibrarySyncProgressPayload::from_event(
+            &ProgressEvent::PhaseChanged { phase: "ingest".into() },
+            "s1",
+            "",
+        );
+        assert_eq!(p.kind, "phase_changed");
+        assert_eq!(p.phase.as_deref(), Some("ingest"));
+        assert_eq!(p.server_id, "s1");
+    }
+
+    #[test]
+    fn ingest_page_carries_total_and_batch_count() {
+        let p = LibrarySyncProgressPayload::from_event(
+            &ProgressEvent::IngestPage {
+                ingested_total: 2500,
+                batch_count: 5,
+            },
+            "s1",
+            "lib-1",
+        );
+        assert_eq!(p.kind, "ingest_page");
+        assert_eq!(p.ingested_total, Some(2500));
+        assert_eq!(p.batch_count, Some(5));
+        assert_eq!(p.library_scope, "lib-1");
+    }
+
+    #[test]
+    fn remapped_count_reflects_entries_length() {
+        let p = LibrarySyncProgressPayload::from_event(
+            &ProgressEvent::Remapped {
+                entries: vec![
+                    RemapEntry {
+                        server_id: "s1".into(),
+                        old_id: "a".into(),
+                        new_id: "b".into(),
+                    },
+                    RemapEntry {
+                        server_id: "s1".into(),
+                        old_id: "c".into(),
+                        new_id: "d".into(),
+                    },
+                ],
+            },
+            "s1",
+            "",
+        );
+        assert_eq!(p.kind, "remapped");
+        assert_eq!(p.remapped_count, Some(2));
+    }
+
+    #[test]
+    fn tombstoned_carries_checked_and_deleted() {
+        let p = LibrarySyncProgressPayload::from_event(
+            &ProgressEvent::Tombstoned {
+                deleted_count: 3,
+                checked_count: 10,
+            },
+            "s1",
+            "",
+        );
+        assert_eq!(p.kind, "tombstoned");
+        assert_eq!(p.tombstones_deleted, Some(3));
+        assert_eq!(p.tombstones_checked, Some(10));
+    }
+
+    #[test]
+    fn completed_event_records_kind_string() {
+        let p = LibrarySyncProgressPayload::from_event(
+            &ProgressEvent::Completed { kind: "initial_sync".into() },
+            "s1",
+            "",
+        );
+        assert_eq!(p.kind, "completed");
+        assert_eq!(p.completed_kind.as_deref(), Some("initial_sync"));
+    }
+
+    #[test]
+    fn error_event_records_message() {
+        let p = LibrarySyncProgressPayload::from_event(
+            &ProgressEvent::Error { message: "timeout".into() },
+            "s1",
+            "",
+        );
+        assert_eq!(p.kind, "error");
+        assert_eq!(p.message.as_deref(), Some("timeout"));
+    }
+
+    #[test]
+    fn serialization_uses_camel_case_keys() {
+        let p = LibrarySyncProgressPayload::from_event(
+            &ProgressEvent::IngestPage {
+                ingested_total: 1,
+                batch_count: 1,
+            },
+            "s1",
+            "",
+        );
+        let json = serde_json::to_value(&p).unwrap();
+        for key in [
+            "serverId",
+            "libraryScope",
+            "kind",
+            "ingestedTotal",
+            "batchCount",
+        ] {
+            assert!(json.get(key).is_some(), "missing camelCase key `{key}`");
+        }
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/repos/track.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track.rs
@@ -76,6 +76,63 @@ impl<'a> TrackRepository<'a> {
         self.upsert_batch_with_remap(rows, false).map(|_| ())
     }
 
+    /// SELECT a single track by `(server_id, id)`. Returns `None`
+    /// when missing or deleted (`deleted = 1`). Used by
+    /// `library_get_track` and the offline-path command.
+    pub fn find_one(
+        &self,
+        server_id: &str,
+        track_id: &str,
+    ) -> Result<Option<TrackRow>, String> {
+        self.store.with_conn(|conn| {
+            let mut stmt = conn.prepare(SELECT_TRACK_BY_ID)?;
+            stmt.query_row(params![server_id, track_id], row_to_track_row)
+                .optional()
+        })
+    }
+
+    /// Batch SELECT — `library_get_tracks_batch`. Caller-supplied refs
+    /// preserve their order in the result; unknown / deleted refs
+    /// are silently dropped (frontend reads `tracks.length` against
+    /// `refs.length` to detect partial responses).
+    pub fn find_batch(
+        &self,
+        refs: &[(String, String)],
+    ) -> Result<Vec<TrackRow>, String> {
+        if refs.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.store.with_conn(|conn| {
+            let mut stmt = conn.prepare(SELECT_TRACK_BY_ID)?;
+            let mut out: Vec<TrackRow> = Vec::with_capacity(refs.len());
+            for (server_id, track_id) in refs {
+                if let Some(row) = stmt
+                    .query_row(params![server_id, track_id], row_to_track_row)
+                    .optional()?
+                {
+                    out.push(row);
+                }
+            }
+            Ok(out)
+        })
+    }
+
+    /// SELECT every non-deleted track on this album, ordered by
+    /// `disc_number ASC, track_number ASC` for stable display.
+    pub fn find_by_album(
+        &self,
+        server_id: &str,
+        album_id: &str,
+    ) -> Result<Vec<TrackRow>, String> {
+        self.store.with_conn(|conn| {
+            let mut stmt = conn.prepare(SELECT_TRACKS_BY_ALBUM)?;
+            let rows: rusqlite::Result<Vec<TrackRow>> = stmt
+                .query_map(params![server_id, album_id], row_to_track_row)?
+                .collect();
+            rows
+        })
+    }
+
     /// Batch upsert with optional §6.9 id-remap detection. When
     /// `unstable_track_ids` is `true`, each incoming row is checked
     /// against the existing `track` table for a collision via
@@ -245,6 +302,76 @@ fn remap_existing_to_new(
         params![server_id, old_id],
     )?;
     Ok(())
+}
+
+/// Column list mirroring the `track` schema (§5.1) — used by every
+/// `SELECT … FROM track` so the row-mapper can index by position.
+const TRACK_COLUMNS: &str = "\
+  server_id, id, title, title_sort, artist, artist_id, album, album_id, \
+  album_artist, duration_sec, track_number, disc_number, year, genre, suffix, \
+  bit_rate, size_bytes, cover_art_id, starred_at, user_rating, play_count, \
+  played_at, server_path, library_id, isrc, mbid_recording, bpm, \
+  replay_gain_track_db, replay_gain_album_db, content_hash, server_updated_at, \
+  server_created_at, deleted, synced_at, raw_json";
+
+const SELECT_TRACK_BY_ID: &str = "SELECT server_id, id, title, title_sort, artist, artist_id, \
+  album, album_id, album_artist, duration_sec, track_number, disc_number, year, genre, suffix, \
+  bit_rate, size_bytes, cover_art_id, starred_at, user_rating, play_count, played_at, \
+  server_path, library_id, isrc, mbid_recording, bpm, replay_gain_track_db, replay_gain_album_db, \
+  content_hash, server_updated_at, server_created_at, deleted, synced_at, raw_json \
+  FROM track WHERE server_id = ?1 AND id = ?2 AND deleted = 0";
+
+const SELECT_TRACKS_BY_ALBUM: &str = "SELECT server_id, id, title, title_sort, artist, artist_id, \
+  album, album_id, album_artist, duration_sec, track_number, disc_number, year, genre, suffix, \
+  bit_rate, size_bytes, cover_art_id, starred_at, user_rating, play_count, played_at, \
+  server_path, library_id, isrc, mbid_recording, bpm, replay_gain_track_db, replay_gain_album_db, \
+  content_hash, server_updated_at, server_created_at, deleted, synced_at, raw_json \
+  FROM track WHERE server_id = ?1 AND album_id = ?2 AND deleted = 0 \
+  ORDER BY disc_number ASC NULLS LAST, track_number ASC NULLS LAST, id ASC";
+
+#[allow(dead_code)]
+pub(crate) fn track_columns() -> &'static str {
+    TRACK_COLUMNS
+}
+
+fn row_to_track_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackRow> {
+    Ok(TrackRow {
+        server_id: row.get(0)?,
+        id: row.get(1)?,
+        title: row.get(2)?,
+        title_sort: row.get(3)?,
+        artist: row.get(4)?,
+        artist_id: row.get(5)?,
+        album: row.get(6)?,
+        album_id: row.get(7)?,
+        album_artist: row.get(8)?,
+        duration_sec: row.get(9)?,
+        track_number: row.get(10)?,
+        disc_number: row.get(11)?,
+        year: row.get(12)?,
+        genre: row.get(13)?,
+        suffix: row.get(14)?,
+        bit_rate: row.get(15)?,
+        size_bytes: row.get(16)?,
+        cover_art_id: row.get(17)?,
+        starred_at: row.get(18)?,
+        user_rating: row.get(19)?,
+        play_count: row.get(20)?,
+        played_at: row.get(21)?,
+        server_path: row.get(22)?,
+        library_id: row.get(23)?,
+        isrc: row.get(24)?,
+        mbid_recording: row.get(25)?,
+        bpm: row.get(26)?,
+        replay_gain_track_db: row.get(27)?,
+        replay_gain_album_db: row.get(28)?,
+        content_hash: row.get(29)?,
+        server_updated_at: row.get(30)?,
+        server_created_at: row.get(31)?,
+        deleted: row.get::<_, i64>(32)? != 0,
+        synced_at: row.get(33)?,
+        raw_json: row.get(34)?,
+    })
 }
 
 const UPSERT_SQL: &str = r#"

--- a/src-tauri/crates/psysonic-library/src/runtime.rs
+++ b/src-tauri/crates/psysonic-library/src/runtime.rs
@@ -1,0 +1,18 @@
+//! `LibraryRuntime` — Tauri State shared by every library command.
+//! PR-5a holds only the `LibraryStore`; PR-5b extends with the sync
+//! session map, playback hint, supervisor handle, and scheduler
+//! cancellation flag.
+
+use std::sync::Arc;
+
+use crate::store::LibraryStore;
+
+pub struct LibraryRuntime {
+    pub store: Arc<LibraryStore>,
+}
+
+impl LibraryRuntime {
+    pub fn new(store: Arc<LibraryStore>) -> Self {
+        Self { store }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,6 +103,16 @@ pub fn run() {
                 app.manage(cache);
             }
 
+            // ── Library track store (psysonic-library, PR-5a) ─────────────
+            // Read-only Tauri surface only in PR-5a; the sync supervisor +
+            // background scheduler land in PR-5b.
+            {
+                let store = psysonic_library::store::LibraryStore::init(app.handle())
+                    .map_err(|e| format!("library store init failed: {e}"))?;
+                let runtime = psysonic_library::LibraryRuntime::new(std::sync::Arc::new(store));
+                app.manage(runtime);
+            }
+
             audio::cleanup_orphan_stream_spill_dir(app.handle());
 
             // ── Playback-query port (analysis → audio back-edge) ──────────
@@ -426,6 +436,14 @@ pub fn run() {
             psysonic_analysis::commands::analysis_delete_all_waveforms,
             psysonic_analysis::commands::analysis_enqueue_seed_from_url,
             psysonic_analysis::commands::analysis_prune_pending_to_track_ids,
+            psysonic_library::commands::library_get_status,
+            psysonic_library::commands::library_search,
+            psysonic_library::commands::library_get_track,
+            psysonic_library::commands::library_get_tracks_batch,
+            psysonic_library::commands::library_get_tracks_by_album,
+            psysonic_library::commands::library_get_artifact,
+            psysonic_library::commands::library_get_facts,
+            psysonic_library::commands::library_get_offline_path,
             psysonic_syncfs::cache::offline::download_track_offline,
             psysonic_syncfs::cache::offline::cancel_offline_downloads,
             psysonic_syncfs::cache::offline::clear_offline_cancel,


### PR DESCRIPTION
First sub-PR of Phase D per cucadmuh's kickoff Q1 split. Lands the
`LibraryRuntime` Tauri State plus the 8 read-only library commands
from spec §7.1. No `SyncSupervisor` spawn, no sync lifecycle, no
credentials store — those follow in PR-5b.

## D1 part 1 mapping

- **`LibraryRuntime` Tauri State** — wraps `Arc<LibraryStore>`. Top
  crate's `lib.rs setup()` calls `LibraryStore::init(app)`, wraps
  the result, and `app.manage`'s it. Mirrors the `AnalysisCache`
  wiring directly above.
- **DTO module** (`psysonic_library::dto`) — camelCase wire shapes
  per `src-tauri/CLAUDE.md`: `SyncStateDto`, `LibraryTrackDto`
  (flat hot-column projection + `rawJson` sub-tree),
  `LibraryTracksEnvelope`, `TrackArtifactDto`, `TrackFactDto`,
  `OfflinePathDto`, `TrackRefDto`.
- **Payload mapper** (`psysonic_library::payload`) — pure
  `ProgressEvent → LibrarySyncProgressPayload`. PR-5b plugs the
  supervisor's mpsc receiver into `AppHandle::emit`; PR-5a ships
  the unit-testable transform.
- **8 `#[tauri::command]` handlers** (`psysonic_library::commands`):
  `library_get_status`, `library_search`, `library_get_track`,
  `library_get_tracks_batch` (capped at 100 refs/call per spec),
  `library_get_tracks_by_album`, `library_get_artifact`,
  `library_get_facts`, `library_get_offline_path`.
- **`TrackRepository`** gains `find_one` / `find_batch` /
  `find_by_album` with a shared row-to-`TrackRow` mapper.

## Tauri boundary

- 8 new `invoke` commands added; argument shapes use camelCase per
  the existing IPC contract. All take `State<LibraryRuntime>` —
  no new event surface in this PR (events emit lands with PR-5b).
- Verified both sides: command signatures registered via
  `tauri::generate_handler!` in `src-tauri/src/lib.rs`; DTOs
  serialize with `#[serde(rename_all = "camelCase")]`.

## References

- PR-5 kickoff Q1 (split): `psysonic-workdocs/internal/collaboration/tasks/2026-05-library-track-store/questions/2026-05-19-pr5-kickoff.md`
- Spec §7.1 (commands), §5.1 (track schema), `src-tauri/CLAUDE.md`
  (IPC camelCase rule, `LibraryStore::init` pattern)

## Out of scope

- Mutating commands (`library_sync_*`, `library_patch_*`,
  `library_put_*`, `library_purge_*`, `library_delete_*`) → PR-5b
- `SyncSupervisor` spawn + scheduler tick loop + Tauri emit →
  PR-5b
- `library_sync_bind_session` / `clear_session` credentials → PR-5b
- TS wrappers + Settings UI + server-remove modal → PR-5c
- `library_advanced_search` / `library_search_cross_server`
  SQL builders → PR-5d

## Test plan

- [x] `cargo test --workspace` — passes (166 in `psysonic-library`,
      105 in `psysonic-integration`)
- [x] `cargo clippy -p psysonic-library --all-targets -- -D warnings`
- [x] `./dev.sh backend-ci` — hot-path coverage gate green