### PR TITLE
feat(library): sync lifecycle + mutate + purge Tauri surface (Phase D1 part 2, PR-5b)

### DIFF
--- a/src-tauri/crates/psysonic-integration/src/navidrome/mod.rs
+++ b/src-tauri/crates/psysonic-integration/src/navidrome/mod.rs
@@ -10,3 +10,5 @@ pub mod playlists;
 pub mod probe;
 pub mod queries;
 pub mod users;
+
+pub use client::navidrome_token;

--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -3,16 +3,31 @@
 //! `State<LibraryRuntime>` so the top crate's `setup()` can wire one
 //! shared `Arc<LibraryStore>` across the whole IPC surface.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use rusqlite::params;
-use tauri::State;
+use serde_json::Value;
+use tauri::{AppHandle, Emitter, Manager, State};
+
+use psysonic_integration::navidrome::navidrome_token;
+use psysonic_integration::subsonic::SubsonicClient;
 
 use crate::dto::{
-    local_tracks_max_updated_ms, LibraryTrackDto, LibraryTracksEnvelope, OfflinePathDto,
-    SyncStateDto, TrackArtifactDto, TrackFactDto, TrackRefDto,
+    local_tracks_max_updated_ms, ArtifactInputDto, FactInputDto, LibraryTrackDto,
+    LibraryTracksEnvelope, OfflinePathDto, PurgeReportDto, SyncJobDto, SyncStateDto,
+    TrackArtifactDto, TrackFactDto, TrackRefDto,
 };
-use crate::repos::TrackRepository;
-use crate::runtime::LibraryRuntime;
+use crate::payload::LibrarySyncProgressPayload;
+use crate::repos::{SyncStateRepository, TrackRepository};
+use crate::runtime::{CurrentJob, LibraryRuntime, SyncSession};
 use crate::search::search_tracks;
+use crate::sync::bandwidth::PlaybackHint;
+use crate::sync::capability::{probe_and_persist, CapabilityFlags, NavidromeProbeCredentials};
+use crate::sync::delta::DeltaSyncRunner;
+use crate::sync::initial::InitialSyncRunner;
+use crate::sync::progress::{ChannelProgress, Progress, ProgressEvent};
+use crate::sync::tombstone::should_auto_reconcile;
 
 /// Cap for `library_get_tracks_batch` per spec §7.1 ("max 100 refs/call").
 const TRACKS_BATCH_LIMIT: usize = 100;
@@ -347,6 +362,591 @@ struct SyncStateRow {
 }
 
 use rusqlite::OptionalExtension;
+
+// ──────────────────────────────────────────────────────────────────────
+//  PR-5b — session / lifecycle / mutate / purge
+// ──────────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn library_sync_bind_session(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    base_url: String,
+    username: String,
+    password: String,
+    library_scope: Option<String>,
+) -> Result<(), String> {
+    // Try a Navidrome native-API auth once at bind time. Spec §6.1 +
+    // PR-5 kickoff Q5: this primes the bearer cache for N1 probe /
+    // ingest without making every command pass a token. Non-Navidrome
+    // servers (Subsonic-only) fall back gracefully — failure here is
+    // not blocking, sync still works via the Subsonic salted-md5 path.
+    let navidrome_token_cached = navidrome_token(&base_url, &username, &password).await.ok();
+
+    let session = SyncSession {
+        server_id: server_id.clone(),
+        base_url: base_url.clone(),
+        username: username.clone(),
+        password: password.clone(),
+        navidrome_token: navidrome_token_cached.clone(),
+        library_scope: library_scope.clone(),
+    };
+    runtime.set_session(session);
+
+    // Run the probe + persist capability flags. Failure to probe is a
+    // bind-time error — caller should fix credentials / URL.
+    let subsonic = SubsonicClient::new(base_url, username, password);
+    let navidrome_creds = navidrome_token_cached.map(|tok| NavidromeProbeCredentials {
+        server_url: subsonic_base_url_from(&runtime, &server_id),
+        bearer_token: tok,
+    });
+    let scope = library_scope.as_deref().unwrap_or_default();
+    probe_and_persist(
+        &runtime.store,
+        &subsonic,
+        navidrome_creds.as_ref(),
+        &server_id,
+        scope,
+    )
+    .await
+    .map_err(|e| format!("bind probe failed: {e}"))?;
+    Ok(())
+}
+
+fn subsonic_base_url_from(runtime: &LibraryRuntime, server_id: &str) -> String {
+    runtime
+        .get_session(server_id)
+        .map(|s| s.base_url)
+        .unwrap_or_default()
+}
+
+#[tauri::command]
+pub fn library_sync_clear_session(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+) -> Result<(), String> {
+    runtime.clear_session(&server_id);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn library_set_playback_hint(
+    runtime: State<'_, LibraryRuntime>,
+    hint: String,
+) -> Result<(), String> {
+    let parsed = match hint.as_str() {
+        "idle" => PlaybackHint::Idle,
+        "playing" => PlaybackHint::Playing,
+        "prefetch_active" => PlaybackHint::PrefetchActive,
+        other => return Err(format!("unknown playback hint: `{other}`")),
+    };
+    runtime.set_playback_hint(parsed);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn library_sync_start(
+    app: AppHandle,
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    mode: String,
+    library_scope: Option<String>,
+) -> Result<SyncJobDto, String> {
+    let session = runtime.get_session(&server_id).ok_or_else(|| {
+        format!("no bound session for server `{server_id}` — call library_sync_bind_session first")
+    })?;
+    let scope = library_scope.clone().or(session.library_scope.clone()).unwrap_or_default();
+    let capability_flags = load_capability_flags(&runtime, &server_id, &scope)?;
+
+    let kind = match mode.as_str() {
+        "full" => "initial_sync",
+        "delta" => "delta_sync",
+        other => return Err(format!("unknown sync mode: `{other}`")),
+    };
+    let job_id = format!("{}_{}", server_id, now_unix_ms());
+    let cancel = Arc::new(AtomicBool::new(false));
+    let job = CurrentJob {
+        job_id: job_id.clone(),
+        server_id: server_id.clone(),
+        kind: kind.to_string(),
+        cancel: Arc::clone(&cancel),
+    };
+    runtime.set_current_job(job);
+
+    // Spawn the runner in a detached task. Progress events flow
+    // through an mpsc channel to the orchestrator that emits Tauri
+    // events; the runner doesn't need an AppHandle.
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ProgressEvent>();
+    let progress: Arc<dyn Progress + Send + Sync> =
+        Arc::new(ChannelProgress::new(tx));
+
+    let store = Arc::clone(&runtime.store);
+    let session_clone = session.clone();
+    let scope_for_task = scope.clone();
+    let kind_for_task = kind.to_string();
+    let cancel_for_task = Arc::clone(&cancel);
+    let job_id_for_task = job_id.clone();
+
+    let runner_handle: tokio::task::JoinHandle<Result<(), String>> = tokio::task::spawn(async move {
+        let subsonic = SubsonicClient::new(
+            session_clone.base_url.clone(),
+            session_clone.username.clone(),
+            session_clone.password.clone(),
+        );
+        let navidrome_creds = session_clone.navidrome_token.clone().map(|tok| {
+            NavidromeProbeCredentials {
+                server_url: session_clone.base_url.clone(),
+                bearer_token: tok,
+            }
+        });
+
+        let result: Result<(), String> = if kind_for_task == "initial_sync" {
+            let mut runner = InitialSyncRunner::new(
+                &store,
+                &subsonic,
+                session_clone.server_id.clone(),
+                scope_for_task.clone(),
+                capability_flags,
+            )
+            .with_cancellation(Arc::clone(&cancel_for_task))
+            .with_progress(Arc::clone(&progress));
+            if let Some(creds) = navidrome_creds.clone() {
+                runner = runner.with_navidrome_credentials(creds);
+            }
+            runner.run().await.map(|_| ()).map_err(|e| e.to_string())
+        } else {
+            // Delta — Mode A manual integrity uses the DeltaMismatch
+            // budget for tombstones when the local/server count gap
+            // is over threshold; otherwise a small budget keeps the
+            // background-like pass cheap.
+            let tombstone_budget = compute_tombstone_budget(&store, &session_clone.server_id, &scope_for_task);
+            let mut runner = DeltaSyncRunner::new(
+                &store,
+                &subsonic,
+                session_clone.server_id.clone(),
+                scope_for_task.clone(),
+                capability_flags,
+            )
+            .with_cancellation(Arc::clone(&cancel_for_task))
+            .with_progress(Arc::clone(&progress));
+            if tombstone_budget > 0 {
+                runner = runner.with_tombstone_budget(tombstone_budget);
+            }
+            if let Some(creds) = navidrome_creds.clone() {
+                runner = runner.with_navidrome_credentials(creds);
+            }
+            runner.run().await.map(|_| ()).map_err(|e| e.to_string())
+        };
+
+        // Closing the mpsc sender by dropping `progress` so the
+        // orchestrator's drain loop terminates.
+        drop(progress);
+        let _ = job_id_for_task; // silence unused on Err
+        result
+    });
+
+    // Orchestrator: drain progress + emit Tauri events, then emit
+    // sync-idle when the runner exits.
+    let app_for_emit = app.clone();
+    let server_id_for_emit = server_id.clone();
+    let scope_for_emit = scope.clone();
+    let kind_for_emit = kind.to_string();
+    let job_id_for_emit = job_id.clone();
+    tokio::task::spawn(async move {
+        // Drain progress events; loop ends when sender is dropped.
+        while let Some(event) = rx.recv().await {
+            let payload = LibrarySyncProgressPayload::from_event(
+                &event,
+                &server_id_for_emit,
+                &scope_for_emit,
+            );
+            let _ = app_for_emit
+                .emit(LibrarySyncProgressPayload::PROGRESS_EVENT_NAME, &payload);
+        }
+        // Wait for the runner to finish + emit sync-idle.
+        let outcome = match runner_handle.await {
+            Ok(Ok(())) => SyncIdleAck::ok(&server_id_for_emit, &scope_for_emit, &kind_for_emit),
+            Ok(Err(msg)) => SyncIdleAck::err(&server_id_for_emit, &scope_for_emit, &kind_for_emit, &msg),
+            Err(join_err) => SyncIdleAck::err(
+                &server_id_for_emit,
+                &scope_for_emit,
+                &kind_for_emit,
+                &format!("sync task panicked: {join_err}"),
+            ),
+        };
+        let _ = app_for_emit.emit(LibrarySyncProgressPayload::IDLE_EVENT_NAME, &outcome);
+
+        // Clear the slot only if it still names us — sync_start may
+        // have already overwritten with a newer job.
+        if let Some(state) = app_for_emit.try_state::<LibraryRuntime>() {
+            state.clear_current_job_if_matches(&job_id_for_emit);
+        }
+    });
+
+    Ok(SyncJobDto {
+        job_id,
+        server_id,
+        kind: kind.to_string(),
+    })
+}
+
+#[tauri::command]
+pub fn library_sync_cancel(
+    runtime: State<'_, LibraryRuntime>,
+    job_id: Option<String>,
+) -> Result<(), String> {
+    // `job_id` is informational — there's at most one in-flight job
+    // per `LibraryRuntime` at a time. If it's supplied and doesn't
+    // match, treat as no-op (the named job already finished).
+    if let Some(id) = &job_id {
+        if runtime.current_job().is_none_or(|j| &j.job_id != id) {
+            return Ok(());
+        }
+    }
+    runtime.cancel_current_job();
+    Ok(())
+}
+
+#[tauri::command]
+pub fn library_patch_track(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    track_id: String,
+    patch: Value,
+) -> Result<(), String> {
+    // Sparse JSON patch — only the fields explicitly present in
+    // `patch` are applied; absent keys leave the column untouched.
+    // Spec §6.5 patch-on-use: `starred_at`, `user_rating`,
+    // `play_count`, `played_at`.
+    let starred_at = patch.get("starredAt").and_then(|v| v.as_i64());
+    let user_rating = patch.get("userRating").and_then(|v| v.as_i64());
+    let play_count = patch.get("playCount").and_then(|v| v.as_i64());
+    let played_at = patch.get("playedAt").and_then(|v| v.as_i64());
+
+    runtime
+        .store
+        .with_conn(|conn| {
+            // One UPDATE per field present — keeps SQL simple and
+            // matches the spec's per-field patch semantics.
+            if let Some(v) = starred_at {
+                conn.execute(
+                    "UPDATE track SET starred_at = ?3 \
+                     WHERE server_id = ?1 AND id = ?2",
+                    params![server_id, track_id, v],
+                )?;
+            }
+            if let Some(v) = user_rating {
+                conn.execute(
+                    "UPDATE track SET user_rating = ?3 \
+                     WHERE server_id = ?1 AND id = ?2",
+                    params![server_id, track_id, v],
+                )?;
+            }
+            if let Some(v) = play_count {
+                conn.execute(
+                    "UPDATE track SET play_count = ?3 \
+                     WHERE server_id = ?1 AND id = ?2",
+                    params![server_id, track_id, v],
+                )?;
+            }
+            if let Some(v) = played_at {
+                conn.execute(
+                    "UPDATE track SET played_at = ?3 \
+                     WHERE server_id = ?1 AND id = ?2",
+                    params![server_id, track_id, v],
+                )?;
+            }
+            Ok(())
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn library_put_artifact(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    track_id: String,
+    artifact: ArtifactInputDto,
+) -> Result<(), String> {
+    let now = now_unix_ms();
+    runtime
+        .store
+        .with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO track_artifact \
+                 (server_id, track_id, artifact_kind, format, language, source_kind, source_id, \
+                  content_text, content_blob, content_bytes, not_found, content_hash, \
+                  fetched_at, expires_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14) \
+                 ON CONFLICT(server_id, track_id, artifact_kind, source_kind, source_id, format) \
+                 DO UPDATE SET \
+                   language = excluded.language, \
+                   content_text = excluded.content_text, \
+                   content_blob = excluded.content_blob, \
+                   content_bytes = excluded.content_bytes, \
+                   not_found = excluded.not_found, \
+                   content_hash = excluded.content_hash, \
+                   fetched_at = excluded.fetched_at, \
+                   expires_at = excluded.expires_at",
+                params![
+                    server_id,
+                    track_id,
+                    artifact.artifact_kind,
+                    artifact.format,
+                    artifact.language,
+                    artifact.source_kind,
+                    artifact.source_id,
+                    artifact.content_text,
+                    artifact.content_blob,
+                    artifact.content_bytes,
+                    if artifact.not_found { 1_i64 } else { 0 },
+                    artifact.content_hash,
+                    now,
+                    artifact.expires_at,
+                ],
+            )?;
+            Ok(())
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn library_put_fact(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    track_id: String,
+    fact: FactInputDto,
+) -> Result<(), String> {
+    let now = now_unix_ms();
+    runtime
+        .store
+        .with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO track_fact \
+                 (server_id, track_id, fact_kind, value_real, value_int, value_text, unit, \
+                  source_kind, source_id, source_detail, confidence, content_hash, \
+                  fetched_at, expires_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, ?10, ?11, ?12, ?13) \
+                 ON CONFLICT(server_id, track_id, fact_kind, source_kind, source_id) \
+                 DO UPDATE SET \
+                   value_real = excluded.value_real, \
+                   value_int = excluded.value_int, \
+                   value_text = excluded.value_text, \
+                   unit = excluded.unit, \
+                   confidence = excluded.confidence, \
+                   content_hash = excluded.content_hash, \
+                   fetched_at = excluded.fetched_at, \
+                   expires_at = excluded.expires_at",
+                params![
+                    server_id,
+                    track_id,
+                    fact.fact_kind,
+                    fact.value_real,
+                    fact.value_int,
+                    fact.value_text,
+                    fact.unit,
+                    fact.source_kind,
+                    fact.source_id,
+                    fact.confidence,
+                    fact.content_hash,
+                    now,
+                    fact.expires_at,
+                ],
+            )?;
+            Ok(())
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn library_purge_server(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    include_analysis: Option<bool>,
+    include_offline: Option<bool>,
+) -> Result<PurgeReportDto, String> {
+    let _ = include_analysis; // analysis_cache cross-purge wires in PR-6.
+    let include_offline = include_offline.unwrap_or(false);
+
+    let mut report = PurgeReportDto::default();
+    runtime
+        .store
+        .with_conn_mut(|conn| {
+            let tx = conn.transaction()?;
+            let track_count: i64 =
+                tx.query_row("SELECT COUNT(*) FROM track WHERE server_id = ?1", params![server_id], |r| r.get(0))?;
+            let album_count: i64 =
+                tx.query_row("SELECT COUNT(*) FROM album WHERE server_id = ?1", params![server_id], |r| r.get(0))?;
+            let artist_count: i64 =
+                tx.query_row("SELECT COUNT(*) FROM artist WHERE server_id = ?1", params![server_id], |r| r.get(0))?;
+            let offline_count: i64 =
+                tx.query_row("SELECT COUNT(*) FROM track_offline WHERE server_id = ?1", params![server_id], |r| r.get(0))?;
+            let offline_bytes: Option<i64> = tx
+                .query_row(
+                    "SELECT SUM(file_size_bytes) FROM track_offline WHERE server_id = ?1",
+                    params![server_id],
+                    |r| r.get(0),
+                )
+                .ok();
+
+            // Tear down child rows first (no cascade configured) so
+            // the FK constraints on track stay happy.
+            tx.execute(
+                "DELETE FROM track_extension WHERE server_id = ?1",
+                params![server_id],
+            )?;
+            tx.execute(
+                "DELETE FROM track_fact WHERE server_id = ?1",
+                params![server_id],
+            )?;
+            tx.execute(
+                "DELETE FROM track_artifact WHERE server_id = ?1",
+                params![server_id],
+            )?;
+            tx.execute(
+                "DELETE FROM track_canonical_link WHERE server_id = ?1",
+                params![server_id],
+            )?;
+            tx.execute(
+                "DELETE FROM track_id_history WHERE server_id = ?1",
+                params![server_id],
+            )?;
+            tx.execute(
+                "DELETE FROM track WHERE server_id = ?1",
+                params![server_id],
+            )?;
+            tx.execute(
+                "DELETE FROM album WHERE server_id = ?1",
+                params![server_id],
+            )?;
+            tx.execute(
+                "DELETE FROM artist WHERE server_id = ?1",
+                params![server_id],
+            )?;
+            tx.execute(
+                "DELETE FROM sync_state WHERE server_id = ?1",
+                params![server_id],
+            )?;
+            if include_offline {
+                tx.execute(
+                    "DELETE FROM track_offline WHERE server_id = ?1",
+                    params![server_id],
+                )?;
+            }
+            tx.commit()?;
+
+            report.tracks_deleted = track_count.max(0) as u32;
+            report.albums_deleted = album_count.max(0) as u32;
+            report.artists_deleted = artist_count.max(0) as u32;
+            report.offline_rows_deleted = if include_offline {
+                offline_count.max(0) as u32
+            } else {
+                0
+            };
+            report.bytes_freed = if include_offline {
+                offline_bytes.unwrap_or(0).max(0)
+            } else {
+                0
+            };
+            Ok(())
+        })
+        .map_err(|e| e.to_string())?;
+
+    // Drop any bound session / current job for this server — credentials
+    // out of memory, ongoing job cancelled.
+    runtime.clear_session(&server_id);
+    if let Some(job) = runtime.current_job() {
+        if job.server_id == server_id {
+            job.cancel.store(true, Ordering::SeqCst);
+        }
+    }
+    Ok(report)
+}
+
+#[tauri::command]
+pub fn library_delete_server_data(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+) -> Result<(), String> {
+    library_purge_server(runtime, server_id, Some(false), Some(true)).map(|_| ())
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+fn load_capability_flags(
+    runtime: &LibraryRuntime,
+    server_id: &str,
+    library_scope: &str,
+) -> Result<CapabilityFlags, String> {
+    let bits = SyncStateRepository::new(&runtime.store)
+        .get_capability_flags(server_id, library_scope)?
+        .unwrap_or(0);
+    Ok(CapabilityFlags::new(bits))
+}
+
+fn compute_tombstone_budget(
+    store: &crate::store::LibraryStore,
+    server_id: &str,
+    library_scope: &str,
+) -> u32 {
+    let sync_state = SyncStateRepository::new(store);
+    let local = sync_state
+        .get_local_track_count(server_id, library_scope)
+        .ok()
+        .flatten()
+        .unwrap_or(0)
+        .max(0) as u32;
+    let server = sync_state
+        .get_server_track_count(server_id, library_scope)
+        .ok()
+        .flatten()
+        .unwrap_or(0)
+        .max(0) as u32;
+    if should_auto_reconcile(local, server, crate::sync::scheduler::DEFAULT_TOMBSTONE_THRESHOLD_PCT) {
+        crate::sync::budget::RequestBudget::DELTA_MISMATCH_CAP
+    } else {
+        0
+    }
+}
+
+fn now_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncIdleAck {
+    server_id: String,
+    library_scope: String,
+    kind: String,
+    ok: bool,
+    error: Option<String>,
+}
+
+impl SyncIdleAck {
+    fn ok(server_id: &str, scope: &str, kind: &str) -> Self {
+        Self {
+            server_id: server_id.to_string(),
+            library_scope: scope.to_string(),
+            kind: kind.to_string(),
+            ok: true,
+            error: None,
+        }
+    }
+    fn err(server_id: &str, scope: &str, kind: &str, message: &str) -> Self {
+        Self {
+            server_id: server_id.to_string(),
+            library_scope: scope.to_string(),
+            kind: kind.to_string(),
+            ok: false,
+            error: Some(message.to_string()),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/crates/psysonic-library/src/dto.rs
+++ b/src-tauri/crates/psysonic-library/src/dto.rs
@@ -194,6 +194,82 @@ pub struct TrackRefDto {
     pub content_hash: Option<String>,
 }
 
+/// Input to `library_put_artifact`. Same shape as `TrackArtifactDto`
+/// minus the server-supplied `server_id` / `track_id` (provided as
+/// command args) and `fetched_at` (stamped server-side from `now`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactInputDto {
+    pub artifact_kind: String,
+    pub format: String,
+    pub source_kind: String,
+    pub source_id: String,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub content_text: Option<String>,
+    #[serde(default)]
+    pub content_blob: Option<Vec<u8>>,
+    #[serde(default)]
+    pub content_bytes: i64,
+    #[serde(default)]
+    pub not_found: bool,
+    #[serde(default)]
+    pub content_hash: Option<String>,
+    #[serde(default)]
+    pub expires_at: Option<i64>,
+}
+
+/// Input to `library_put_fact`. Shape matches `TrackFactDto` minus the
+/// indices.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FactInputDto {
+    pub fact_kind: String,
+    #[serde(default)]
+    pub value_real: Option<f64>,
+    #[serde(default)]
+    pub value_int: Option<i64>,
+    #[serde(default)]
+    pub value_text: Option<String>,
+    #[serde(default)]
+    pub unit: Option<String>,
+    pub source_kind: String,
+    pub source_id: String,
+    #[serde(default = "default_confidence")]
+    pub confidence: f64,
+    #[serde(default)]
+    pub content_hash: Option<String>,
+    #[serde(default)]
+    pub expires_at: Option<i64>,
+}
+
+fn default_confidence() -> f64 {
+    1.0
+}
+
+/// `library_purge_server` outcome.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PurgeReportDto {
+    pub tracks_deleted: u32,
+    pub albums_deleted: u32,
+    pub artists_deleted: u32,
+    pub offline_rows_deleted: u32,
+    /// Total bytes freed across the purged scopes (best-effort).
+    pub bytes_freed: i64,
+}
+
+/// `library_sync_start` ack.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncJobDto {
+    pub job_id: String,
+    pub server_id: String,
+    /// `"initial_sync"` or `"delta_sync"`.
+    pub kind: String,
+}
+
 /// Read `MAX(server_updated_at)` for non-deleted tracks on this server
 /// — used by `SyncStateDto` so callers can show "tracks watermark" in
 /// Settings without a separate column.

--- a/src-tauri/crates/psysonic-library/src/runtime.rs
+++ b/src-tauri/crates/psysonic-library/src/runtime.rs
@@ -1,18 +1,219 @@
 //! `LibraryRuntime` — Tauri State shared by every library command.
-//! PR-5a holds only the `LibraryStore`; PR-5b extends with the sync
-//! session map, playback hint, supervisor handle, and scheduler
-//! cancellation flag.
+//!
+//! PR-5a held only the store. PR-5b extends with the per-server sync
+//! session map (credentials live in process memory only — same trust
+//! boundary as today's WebView-held passwords), the current playback
+//! hint, an `Option<SyncSupervisor>` for in-flight start/cancel, and
+//! a long-lived cancellation flag for the background-scheduler task
+//! the top crate spawns in `setup()`.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
 
 use crate::store::LibraryStore;
+use crate::sync::bandwidth::PlaybackHint;
+
+/// Per-server credentials cache for the sync runner. Lives only in
+/// `LibraryRuntime` process memory; `library_sync_clear_session`
+/// removes it on logout / index disable / purge.
+#[derive(Debug, Clone)]
+pub struct SyncSession {
+    pub server_id: String,
+    pub base_url: String,
+    pub username: String,
+    pub password: String,
+    /// Navidrome native API bearer cached from the `/auth/login`
+    /// response at bind time. `None` when the server isn't Navidrome
+    /// or the optional Navidrome auth failed (Subsonic-only path).
+    pub navidrome_token: Option<String>,
+    pub library_scope: Option<String>,
+}
+
+/// Currently-running initial / delta / manual integrity job
+/// metadata. Holding the `SyncSupervisor` in the mutex (as the
+/// PR-5 kickoff sketch suggested) would block `library_sync_cancel`
+/// behind whoever's running the supervisor's join — instead we keep
+/// just the cancel handle + identity, and the job-orchestrator task
+/// owns the supervisor / receiver / join.
+#[derive(Debug, Clone)]
+pub struct CurrentJob {
+    pub job_id: String,
+    pub server_id: String,
+    /// `"initial_sync"` or `"delta_sync"`.
+    pub kind: String,
+    pub cancel: Arc<AtomicBool>,
+}
 
 pub struct LibraryRuntime {
     pub store: Arc<LibraryStore>,
+    /// Per-`server_id` sync session. Mutex over a `HashMap` — single
+    /// writer at a time is fine for the command surface; the
+    /// background scheduler tick reads a snapshot.
+    pub sync_sessions: Mutex<HashMap<String, SyncSession>>,
+    pub playback_hint: Mutex<PlaybackHint>,
+    /// Currently running initial / delta / manual integrity job, if
+    /// any. `library_sync_start` populates, `library_sync_cancel`
+    /// trips `cancel`; the orchestrator task clears the slot when
+    /// the job's `join` returns.
+    pub current_job: Mutex<Option<CurrentJob>>,
+    /// Top-crate scheduler tick task watches this flag; set true on
+    /// app shutdown / library index disabled.
+    pub scheduler_cancel: Arc<AtomicBool>,
 }
 
 impl LibraryRuntime {
     pub fn new(store: Arc<LibraryStore>) -> Self {
-        Self { store }
+        Self {
+            store,
+            sync_sessions: Mutex::new(HashMap::new()),
+            playback_hint: Mutex::new(PlaybackHint::default()),
+            current_job: Mutex::new(None),
+            scheduler_cancel: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn set_current_job(&self, job: CurrentJob) {
+        if let Ok(mut slot) = self.current_job.lock() {
+            // Best-effort cancel any in-flight job before we replace.
+            if let Some(prev) = slot.as_ref() {
+                prev.cancel.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+            *slot = Some(job);
+        }
+    }
+
+    pub fn current_job(&self) -> Option<CurrentJob> {
+        self.current_job.lock().ok().and_then(|s| s.clone())
+    }
+
+    pub fn clear_current_job_if_matches(&self, job_id: &str) {
+        if let Ok(mut slot) = self.current_job.lock() {
+            if slot.as_ref().is_some_and(|j| j.job_id == job_id) {
+                *slot = None;
+            }
+        }
+    }
+
+    pub fn cancel_current_job(&self) -> bool {
+        if let Ok(slot) = self.current_job.lock() {
+            if let Some(job) = slot.as_ref() {
+                job.cancel.store(true, std::sync::atomic::Ordering::SeqCst);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Snapshot all bound sessions — used by the scheduler tick task
+    /// in the top crate so it doesn't hold the mutex across an `await`.
+    pub fn snapshot_sessions(&self) -> Vec<SyncSession> {
+        self.sync_sessions
+            .lock()
+            .map(|sessions| sessions.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn get_session(&self, server_id: &str) -> Option<SyncSession> {
+        self.sync_sessions
+            .lock()
+            .ok()
+            .and_then(|s| s.get(server_id).cloned())
+    }
+
+    pub fn set_session(&self, session: SyncSession) {
+        if let Ok(mut sessions) = self.sync_sessions.lock() {
+            sessions.insert(session.server_id.clone(), session);
+        }
+    }
+
+    pub fn clear_session(&self, server_id: &str) {
+        if let Ok(mut sessions) = self.sync_sessions.lock() {
+            sessions.remove(server_id);
+        }
+    }
+
+    pub fn current_playback_hint(&self) -> PlaybackHint {
+        self.playback_hint
+            .lock()
+            .map(|h| *h)
+            .unwrap_or_default()
+    }
+
+    pub fn set_playback_hint(&self, hint: PlaybackHint) {
+        if let Ok(mut h) = self.playback_hint.lock() {
+            *h = hint;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_session(server_id: &str) -> SyncSession {
+        SyncSession {
+            server_id: server_id.into(),
+            base_url: "https://nas.example.com".into(),
+            username: "u".into(),
+            password: "p".into(),
+            navidrome_token: None,
+            library_scope: None,
+        }
+    }
+
+    #[test]
+    fn new_runtime_has_empty_sessions_and_idle_hint() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        let rt = LibraryRuntime::new(store);
+        assert!(rt.snapshot_sessions().is_empty());
+        assert_eq!(rt.current_playback_hint(), PlaybackHint::Idle);
+        assert!(!rt
+            .scheduler_cancel
+            .load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn set_and_get_session_roundtrip() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        let rt = LibraryRuntime::new(store);
+        rt.set_session(sample_session("s1"));
+        let got = rt.get_session("s1").unwrap();
+        assert_eq!(got.base_url, "https://nas.example.com");
+        assert_eq!(got.username, "u");
+    }
+
+    #[test]
+    fn clear_session_removes_one_server_only() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        let rt = LibraryRuntime::new(store);
+        rt.set_session(sample_session("s1"));
+        rt.set_session(sample_session("s2"));
+        rt.clear_session("s1");
+        assert!(rt.get_session("s1").is_none());
+        assert!(rt.get_session("s2").is_some());
+    }
+
+    #[test]
+    fn snapshot_returns_clones_so_lock_drops_after_call() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        let rt = LibraryRuntime::new(store);
+        rt.set_session(sample_session("s1"));
+        let snap = rt.snapshot_sessions();
+        // Should be free to mutate after the snapshot.
+        rt.set_session(sample_session("s2"));
+        assert_eq!(snap.len(), 1);
+        assert_eq!(rt.snapshot_sessions().len(), 2);
+    }
+
+    #[test]
+    fn playback_hint_default_is_idle_and_setter_updates() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        let rt = LibraryRuntime::new(store);
+        assert_eq!(rt.current_playback_hint(), PlaybackHint::Idle);
+        rt.set_playback_hint(PlaybackHint::Playing);
+        assert_eq!(rt.current_playback_hint(), PlaybackHint::Playing);
+        rt.set_playback_hint(PlaybackHint::PrefetchActive);
+        assert_eq!(rt.current_playback_hint(), PlaybackHint::PrefetchActive);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,14 +103,89 @@ pub fn run() {
                 app.manage(cache);
             }
 
-            // ── Library track store (psysonic-library, PR-5a) ─────────────
-            // Read-only Tauri surface only in PR-5a; the sync supervisor +
-            // background scheduler land in PR-5b.
+            // ── Library track store (psysonic-library, PR-5a + PR-5b) ─────
+            // PR-5a brought up the read-only Tauri surface + LibraryRuntime.
+            // PR-5b adds the mutating commands, sync session map, current-job
+            // tracker, and the 30-second background scheduler tick task below
+            // — which sweeps every bound session through
+            // `BackgroundScheduler::tick` while honouring the runtime's
+            // `scheduler_cancel` flag.
             {
                 let store = psysonic_library::store::LibraryStore::init(app.handle())
                     .map_err(|e| format!("library store init failed: {e}"))?;
                 let runtime = psysonic_library::LibraryRuntime::new(std::sync::Arc::new(store));
                 app.manage(runtime);
+
+                let app_for_sched = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    use std::sync::atomic::Ordering;
+                    use std::time::Duration;
+                    use tokio::time::MissedTickBehavior;
+
+                    let mut interval = tokio::time::interval(Duration::from_secs(30));
+                    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                    loop {
+                        interval.tick().await;
+                        let Some(state) = app_for_sched
+                            .try_state::<psysonic_library::LibraryRuntime>()
+                        else {
+                            break;
+                        };
+                        if state.scheduler_cancel.load(Ordering::SeqCst) {
+                            break;
+                        }
+                        let sessions = state.snapshot_sessions();
+                        if sessions.is_empty() {
+                            continue;
+                        }
+                        let hint = state.current_playback_hint();
+                        let now_ms = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_millis().min(i64::MAX as u128) as i64)
+                            .unwrap_or(0);
+                        for session in sessions {
+                            let scope = session.library_scope.clone().unwrap_or_default();
+                            let flags_bits = psysonic_library::repos::SyncStateRepository::new(
+                                &state.store,
+                            )
+                            .get_capability_flags(&session.server_id, &scope)
+                            .ok()
+                            .flatten()
+                            .unwrap_or(0);
+                            let flags = psysonic_library::sync::capability::CapabilityFlags::new(
+                                flags_bits,
+                            );
+                            let subsonic = psysonic_integration::subsonic::SubsonicClient::new(
+                                session.base_url.clone(),
+                                session.username.clone(),
+                                session.password.clone(),
+                            );
+                            let mut sched =
+                                psysonic_library::sync::scheduler::BackgroundScheduler::new(
+                                    &state.store,
+                                    &subsonic,
+                                    session.server_id.clone(),
+                                    scope.clone(),
+                                    flags,
+                                )
+                                .with_playback_hint(hint);
+                            if let Some(tok) = session.navidrome_token.clone() {
+                                sched = sched.with_navidrome_credentials(
+                                    psysonic_library::sync::capability::NavidromeProbeCredentials {
+                                        server_url: session.base_url.clone(),
+                                        bearer_token: tok,
+                                    },
+                                );
+                            }
+                            let _ = sched.tick(now_ms).await;
+                            // Background ticks stay silent in PR-5b — Tauri
+                            // emit for the scheduler path lands when the
+                            // Settings panel needs it (PR-5c). Manual
+                            // `library_sync_start` already emits via its
+                            // own orchestrator.
+                        }
+                    }
+                });
             }
 
             audio::cleanup_orphan_stream_spill_dir(app.handle());
@@ -444,6 +519,16 @@ pub fn run() {
             psysonic_library::commands::library_get_artifact,
             psysonic_library::commands::library_get_facts,
             psysonic_library::commands::library_get_offline_path,
+            psysonic_library::commands::library_sync_bind_session,
+            psysonic_library::commands::library_sync_clear_session,
+            psysonic_library::commands::library_set_playback_hint,
+            psysonic_library::commands::library_sync_start,
+            psysonic_library::commands::library_sync_cancel,
+            psysonic_library::commands::library_patch_track,
+            psysonic_library::commands::library_put_artifact,
+            psysonic_library::commands::library_put_fact,
+            psysonic_library::commands::library_purge_server,
+            psysonic_library::commands::library_delete_server_data,
             psysonic_syncfs::cache::offline::download_track_offline,
             psysonic_syncfs::cache::offline::cancel_offline_downloads,
             psysonic_syncfs::cache::offline::clear_offline_cancel,


### PR DESCRIPTION
Second sub-PR of Phase D per cucadmuh's kickoff Q1 split. Adds the
mutating side of §7.1 plus the `SyncSession` credentials store, the
`PlaybackHint` setter, the orchestrator that runs runners under a
Tauri `AppHandle` and emits `library:sync-progress` /
`library:sync-idle`, and the top-crate scheduler tick task that
sweeps every bound session through `BackgroundScheduler::tick`.

## D1 part 2 mapping

- **`LibraryRuntime` extended** per kickoff Q2 — `sync_sessions`
  map, `playback_hint`, `current_job` (cancel + identity), and
  `scheduler_cancel`. Kickoff sketch had
  `Mutex<Option<SyncSupervisor>>`; supervisor's `join` consumes
  self, so blocking `library_sync_cancel` behind a join would be a
  deadlock — `CurrentJob` carries the `Arc<AtomicBool>` cancel +
  metadata instead, orchestrator task owns supervisor / receiver /
  join.
- **Commands** (§7.1):
  `library_sync_bind_session` (caches creds + Navidrome bearer +
  probe_and_persist), `library_sync_clear_session`,
  `library_set_playback_hint`, `library_sync_start` (initial /
  delta dispatch + auto-tombstone budget), `library_sync_cancel`,
  `library_patch_track` (§6.5 sparse patch), `library_put_artifact`,
  `library_put_fact`, `library_purge_server` (transactional cascade),
  `library_delete_server_data` (purge alias for logout).
- **Top crate scheduler tick task** — 30 s `tokio::time::interval`,
  `MissedTickBehavior::Skip`, snapshots bound sessions and drives
  `BackgroundScheduler::tick(now_ms)` for each. Honours
  `scheduler_cancel` + current `PlaybackHint`.
- `psysonic-integration::navidrome` re-exports `navidrome_token` so
  the bind command primes the bearer cache without exposing the
  client module.

## Tauri boundary

- 10 new `invoke` commands; argument shapes camelCase, registered
  via `tauri::generate_handler!`. Errors flatten to `String`,
  consistent with existing crates.
- 2 new events: `library:sync-progress`
  (`LibrarySyncProgressPayload` discriminated by `kind`) and
  `library:sync-idle` (`SyncIdleAck { ok, error }`). Emit rate
  follows the supervisor's `ChannelProgress` 2 Hz gate per spec
  §7.2.
- Background scheduler ticks stay silent in PR-5b (NoopProgress);
  emit for the scheduler path follows once the Settings panel in
  PR-5c surfaces it.

## References

- PR-5 kickoff Q1 (split), Q2 (runtime shape), Q5 (creds):
  `psysonic-workdocs/internal/collaboration/tasks/2026-05-library-track-store/questions/2026-05-19-pr5-kickoff.md`
- PR-5a review §7 (post-merge): `psysonic-workdocs/internal/collaboration/handoffs/2026-05-19-pr-801-review.md`
- Spec §6.1 (probe), §6.2 (scheduler), §6.5 (patch-on-use), §6.7
  (auto tombstone), §7.1 / §7.2 (commands + events), §5.6 / §5.14
  (purge semantics)

## Out of scope

- `src/library/` TS wrappers + Settings UI + server-remove modal
  → PR-5c
- `library_advanced_search` / `library_search_cross_server` →
  PR-5d
- Background-tick Tauri emit (NoopProgress today) → PR-5c
- `analysis_cache` cross-purge wiring in `library_purge_server` →
  PR-6

## Test plan

- [x] `cargo test --workspace` — passes (171 in `psysonic-library`,
      105 in `psysonic-integration`)
- [x] `cargo clippy -p psysonic-library --all-targets -- -D warnings`
- [x] `cargo clippy -p psysonic --all-targets -- -D warnings`
- [x] `./dev.sh backend-ci` — hot-path coverage gate green