### PR TITLE
feat(library): typed invoke wrappers + verify_integrity (Phase D2 + part of D1, PR-5c)

### DIFF
--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -452,6 +452,17 @@ pub async fn library_sync_start(
     mode: String,
     library_scope: Option<String>,
 ) -> Result<SyncJobDto, String> {
+    library_sync_start_inner(app, runtime, server_id, mode, library_scope, false).await
+}
+
+async fn library_sync_start_inner(
+    app: AppHandle,
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    mode: String,
+    library_scope: Option<String>,
+    force_full_tombstone: bool,
+) -> Result<SyncJobDto, String> {
     let session = runtime.get_session(&server_id).ok_or_else(|| {
         format!("no bound session for server `{server_id}` — call library_sync_bind_session first")
     })?;
@@ -518,8 +529,13 @@ pub async fn library_sync_start(
             // Delta — Mode A manual integrity uses the DeltaMismatch
             // budget for tombstones when the local/server count gap
             // is over threshold; otherwise a small budget keeps the
-            // background-like pass cheap.
-            let tombstone_budget = compute_tombstone_budget(&store, &session_clone.server_id, &scope_for_task);
+            // background-like pass cheap. Manual «Verify integrity»
+            // forces the full budget regardless of threshold.
+            let tombstone_budget = if force_full_tombstone {
+                crate::sync::budget::RequestBudget::DELTA_MISMATCH_CAP
+            } else {
+                compute_tombstone_budget(&store, &session_clone.server_id, &scope_for_task)
+            };
             let mut runner = DeltaSyncRunner::new(
                 &store,
                 &subsonic,
@@ -588,6 +604,30 @@ pub async fn library_sync_start(
         server_id,
         kind: kind.to_string(),
     })
+}
+
+/// Manual «Verify library integrity» — same dispatch shape as
+/// `library_sync_start { mode: 'delta' }` but always sets the full
+/// `DELTA_MISMATCH_CAP` tombstone budget regardless of the
+/// local/server count gap. Per PR-5b review §5 note 2: spec §6.7
+/// Mode A user-initiated full reconcile bypasses the threshold
+/// check.
+#[tauri::command]
+pub async fn library_sync_verify_integrity(
+    app: AppHandle,
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+    library_scope: Option<String>,
+) -> Result<SyncJobDto, String> {
+    library_sync_start_inner(
+        app,
+        runtime,
+        server_id,
+        "delta".to_string(),
+        library_scope,
+        /* force_full_tombstone */ true,
+    )
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -523,6 +523,7 @@ pub fn run() {
             psysonic_library::commands::library_sync_clear_session,
             psysonic_library::commands::library_set_playback_hint,
             psysonic_library::commands::library_sync_start,
+            psysonic_library::commands::library_sync_verify_integrity,
             psysonic_library::commands::library_sync_cancel,
             psysonic_library::commands::library_patch_track,
             psysonic_library::commands::library_put_artifact,

--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -1,0 +1,356 @@
+/**
+ * Typed wrappers around the `library_*` Tauri commands (spec §7.1) plus
+ * subscribers for `library:sync-progress` / `library:sync-idle` events
+ * (§7.2). One thin file per cucadmuh's PR-5 kickoff Q1 — Settings UI
+ * (LibraryTab) imports from here; nothing else in the app talks to the
+ * backend library surface directly.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+// ── DTO mirrors (camelCase, matching the Rust `#[serde(rename_all = "camelCase")]`) ─
+
+export interface TrackRefDto {
+  serverId: string;
+  trackId: string;
+  contentHash?: string | null;
+}
+
+export interface LibraryTrackDto {
+  serverId: string;
+  id: string;
+  contentHash?: string | null;
+  title: string;
+  titleSort?: string | null;
+  artist?: string | null;
+  artistId?: string | null;
+  album: string;
+  albumId?: string | null;
+  albumArtist?: string | null;
+  durationSec: number;
+  trackNumber?: number | null;
+  discNumber?: number | null;
+  year?: number | null;
+  genre?: string | null;
+  suffix?: string | null;
+  bitRate?: number | null;
+  sizeBytes?: number | null;
+  coverArtId?: string | null;
+  starredAt?: number | null;
+  userRating?: number | null;
+  playCount?: number | null;
+  playedAt?: number | null;
+  serverPath?: string | null;
+  libraryId?: string | null;
+  isrc?: string | null;
+  mbidRecording?: string | null;
+  bpm?: number | null;
+  replayGainTrackDb?: number | null;
+  replayGainAlbumDb?: number | null;
+  serverUpdatedAt?: number | null;
+  serverCreatedAt?: number | null;
+  syncedAt: number;
+  rawJson: unknown;
+}
+
+export interface SyncStateDto {
+  serverId: string;
+  libraryScope: string;
+  syncPhase: string;
+  capabilityFlags: number;
+  libraryTier: string;
+  lastFullSyncAt?: number | null;
+  lastDeltaSyncAt?: number | null;
+  nextPollAt?: number | null;
+  serverLastScanIso?: string | null;
+  indexesLastModifiedMs?: number | null;
+  artistsLastModifiedMs?: number | null;
+  localTrackCount?: number | null;
+  serverTrackCount?: number | null;
+  lastError?: string | null;
+  localTracksMaxUpdatedMs?: number | null;
+}
+
+export interface LibraryTracksEnvelope {
+  tracks: LibraryTrackDto[];
+  total: number;
+}
+
+export interface TrackArtifactDto {
+  serverId: string;
+  trackId: string;
+  artifactKind: string;
+  format: string;
+  sourceKind: string;
+  sourceId: string;
+  language?: string | null;
+  contentText?: string | null;
+  contentBytes: number;
+  notFound: boolean;
+  contentHash?: string | null;
+  fetchedAt: number;
+  expiresAt?: number | null;
+}
+
+export interface ArtifactInputDto {
+  artifactKind: string;
+  format: string;
+  sourceKind: string;
+  sourceId: string;
+  language?: string | null;
+  contentText?: string | null;
+  contentBlob?: number[] | null;
+  contentBytes?: number;
+  notFound?: boolean;
+  contentHash?: string | null;
+  expiresAt?: number | null;
+}
+
+export interface TrackFactDto {
+  serverId: string;
+  trackId: string;
+  factKind: string;
+  valueReal?: number | null;
+  valueInt?: number | null;
+  valueText?: string | null;
+  unit?: string | null;
+  sourceKind: string;
+  sourceId: string;
+  confidence: number;
+  contentHash?: string | null;
+  fetchedAt: number;
+  expiresAt?: number | null;
+}
+
+export interface FactInputDto {
+  factKind: string;
+  valueReal?: number | null;
+  valueInt?: number | null;
+  valueText?: string | null;
+  unit?: string | null;
+  sourceKind: string;
+  sourceId: string;
+  confidence?: number;
+  contentHash?: string | null;
+  expiresAt?: number | null;
+}
+
+export interface OfflinePathDto {
+  serverId: string;
+  trackId: string;
+  localPath?: string | null;
+  missing: boolean;
+}
+
+export interface PurgeReportDto {
+  tracksDeleted: number;
+  albumsDeleted: number;
+  artistsDeleted: number;
+  offlineRowsDeleted: number;
+  bytesFreed: number;
+}
+
+export interface SyncJobDto {
+  jobId: string;
+  serverId: string;
+  kind: string; // 'initial_sync' | 'delta_sync'
+}
+
+// ── Read commands (PR-5a) ─────────────────────────────────────────────
+
+export function libraryGetStatus(
+  serverId: string,
+  libraryScope?: string,
+): Promise<SyncStateDto> {
+  return invoke<SyncStateDto>('library_get_status', { serverId, libraryScope });
+}
+
+export function librarySearch(
+  serverId: string,
+  query: string,
+  options?: { limit?: number; offset?: number; libraryScope?: string },
+): Promise<LibraryTracksEnvelope> {
+  return invoke<LibraryTracksEnvelope>('library_search', {
+    serverId,
+    query,
+    limit: options?.limit,
+    offset: options?.offset,
+    libraryScope: options?.libraryScope,
+  });
+}
+
+export function libraryGetTrack(
+  serverId: string,
+  trackId: string,
+): Promise<LibraryTrackDto | null> {
+  return invoke<LibraryTrackDto | null>('library_get_track', { serverId, trackId });
+}
+
+export function libraryGetTracksBatch(refs: TrackRefDto[]): Promise<LibraryTrackDto[]> {
+  return invoke<LibraryTrackDto[]>('library_get_tracks_batch', { refs });
+}
+
+export function libraryGetTracksByAlbum(
+  serverId: string,
+  albumId: string,
+): Promise<LibraryTrackDto[]> {
+  return invoke<LibraryTrackDto[]>('library_get_tracks_by_album', { serverId, albumId });
+}
+
+export function libraryGetArtifact(
+  serverId: string,
+  trackId: string,
+  artifactKind: string,
+  options?: { sourceKind?: string; sourceId?: string; format?: string },
+): Promise<TrackArtifactDto | null> {
+  return invoke<TrackArtifactDto | null>('library_get_artifact', {
+    serverId,
+    trackId,
+    artifactKind,
+    sourceKind: options?.sourceKind,
+    sourceId: options?.sourceId,
+    format: options?.format,
+  });
+}
+
+export function libraryGetFacts(
+  serverId: string,
+  trackId: string,
+  factKinds?: string[],
+): Promise<TrackFactDto[]> {
+  return invoke<TrackFactDto[]>('library_get_facts', { serverId, trackId, factKinds });
+}
+
+export function libraryGetOfflinePath(
+  serverId: string,
+  trackId: string,
+): Promise<OfflinePathDto> {
+  return invoke<OfflinePathDto>('library_get_offline_path', { serverId, trackId });
+}
+
+// ── Session + lifecycle (PR-5b) ───────────────────────────────────────
+
+export function librarySyncBindSession(args: {
+  serverId: string;
+  baseUrl: string;
+  username: string;
+  password: string;
+  libraryScope?: string;
+}): Promise<void> {
+  return invoke<void>('library_sync_bind_session', args);
+}
+
+export function librarySyncClearSession(serverId: string): Promise<void> {
+  return invoke<void>('library_sync_clear_session', { serverId });
+}
+
+export type PlaybackHint = 'idle' | 'playing' | 'prefetch_active';
+
+export function librarySetPlaybackHint(hint: PlaybackHint): Promise<void> {
+  return invoke<void>('library_set_playback_hint', { hint });
+}
+
+export type SyncMode = 'full' | 'delta';
+
+export function librarySyncStart(args: {
+  serverId: string;
+  mode: SyncMode;
+  libraryScope?: string;
+}): Promise<SyncJobDto> {
+  return invoke<SyncJobDto>('library_sync_start', args);
+}
+
+/** Forced full-budget tombstone delta — Settings → «Verify integrity». */
+export function librarySyncVerifyIntegrity(args: {
+  serverId: string;
+  libraryScope?: string;
+}): Promise<SyncJobDto> {
+  return invoke<SyncJobDto>('library_sync_verify_integrity', args);
+}
+
+export function librarySyncCancel(jobId?: string): Promise<void> {
+  return invoke<void>('library_sync_cancel', { jobId });
+}
+
+export function libraryPatchTrack(args: {
+  serverId: string;
+  trackId: string;
+  patch: {
+    starredAt?: number | null;
+    userRating?: number | null;
+    playCount?: number | null;
+    playedAt?: number | null;
+  };
+}): Promise<void> {
+  return invoke<void>('library_patch_track', args);
+}
+
+export function libraryPutArtifact(args: {
+  serverId: string;
+  trackId: string;
+  artifact: ArtifactInputDto;
+}): Promise<void> {
+  return invoke<void>('library_put_artifact', args);
+}
+
+export function libraryPutFact(args: {
+  serverId: string;
+  trackId: string;
+  fact: FactInputDto;
+}): Promise<void> {
+  return invoke<void>('library_put_fact', args);
+}
+
+export function libraryPurgeServer(args: {
+  serverId: string;
+  includeAnalysis?: boolean;
+  includeOffline?: boolean;
+}): Promise<PurgeReportDto> {
+  return invoke<PurgeReportDto>('library_purge_server', args);
+}
+
+export function libraryDeleteServerData(serverId: string): Promise<void> {
+  return invoke<void>('library_delete_server_data', { serverId });
+}
+
+// ── Event subscriptions ───────────────────────────────────────────────
+
+export interface LibrarySyncProgressPayload {
+  serverId: string;
+  libraryScope: string;
+  /** 'phase_changed' | 'ingest_page' | 'remapped' | 'tombstoned' | 'completed' | 'error' */
+  kind: string;
+  phase?: string | null;
+  ingestedTotal?: number | null;
+  batchCount?: number | null;
+  remappedCount?: number | null;
+  tombstonesChecked?: number | null;
+  tombstonesDeleted?: number | null;
+  completedKind?: string | null;
+  message?: string | null;
+}
+
+export interface LibrarySyncIdlePayload {
+  serverId: string;
+  libraryScope: string;
+  kind: string; // 'initial_sync' | 'delta_sync'
+  ok: boolean;
+  error?: string | null;
+}
+
+export function subscribeLibrarySyncProgress(
+  handler: (payload: LibrarySyncProgressPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<LibrarySyncProgressPayload>('library:sync-progress', ({ payload }) =>
+    handler(payload),
+  );
+}
+
+export function subscribeLibrarySyncIdle(
+  handler: (payload: LibrarySyncIdlePayload) => void,
+): Promise<UnlistenFn> {
+  return listen<LibrarySyncIdlePayload>('library:sync-idle', ({ payload }) =>
+    handler(payload),
+  );
+}


### PR DESCRIPTION
Frontend-facing slice of Phase D. Ships the typed `src/api/library.ts`
wrapper layer + the manual-integrity backend command PR-5b's review
§5 note 2 flagged.

## Scope cut from kickoff

Kickoff Q1 proposed PR-5c = D2 + D3 + D4 (wrappers + Settings +
server-remove modal). The full UI patch turned out thick: Settings
subsection + ServerRemoveModal + playback-hint feed + authStore
extensions + i18n in five locales. Landing them with the wrappers
mixed Tauri-surface review with Settings UX review.

Per kickoff exit clause ("Do not split 5c unless review size forces
it"):

- **PR-5c (this PR)** — D2 wrappers + `library_sync_verify_integrity`.
- **PR-5c-ui (follow-up)** — D3 Settings subsection, D4 server-remove
  modal contract, playback hint feed, authStore extensions, i18n.

## Changes

- **Backend** `library_sync_verify_integrity { serverId, libraryScope? }`
  — same shape as `library_sync_start { mode:'delta' }` but forces
  the full `DELTA_MISMATCH_CAP` tombstone budget regardless of the
  count-gap threshold. Spec §6.7 Mode A user-initiated reconcile
  bypasses the auto-tombstone gate. `library_sync_start` refactored
  to a shared `library_sync_start_inner(force_full_tombstone)` so
  both entry points walk the same runner / orchestrator / emit code.
- **Frontend `src/api/library.ts`** — typed wrapper for all 19
  `library_*` invokes + camelCase DTO mirrors
  (`SyncStateDto`, `LibraryTrackDto`, `TrackArtifactDto`,
  `TrackFactDto`, `OfflinePathDto`, `PurgeReportDto`, `SyncJobDto`,
  `TrackRefDto`, `ArtifactInputDto`, `FactInputDto`) +
  `LibrarySyncProgressPayload` / `LibrarySyncIdlePayload` +
  `subscribeLibrarySyncProgress` / `subscribeLibrarySyncIdle`
  helpers. `PlaybackHint` literal type lives here so audio listeners
  in PR-5c-ui import from one place.

## Tauri boundary

- 1 new `invoke` command added (`library_sync_verify_integrity`),
  registered via `tauri::generate_handler!`. Wire shape matches
  `library_sync_start` minus the `mode` arg.
- No new events.
- TS wrapper layer is additive — no `playerStore` /
  `VirtualSongList` touches (those belong to PR-7 F1/F3/F5).

## References

- PR-5 kickoff: `psysonic-workdocs/internal/collaboration/tasks/2026-05-library-track-store/questions/2026-05-19-pr5-kickoff.md`
- PR-5b review §5 note 2 (manual integrity command):
  `psysonic-workdocs/internal/collaboration/handoffs/2026-05-19-pr-802-review.md`
- Spec §6.7 (tombstone modes), §7.1 (commands)

## Out of scope (PR-5c-ui)

- Library Settings subsection (§7.3 controls)
- ServerRemoveModal keep-vs-delete (§5.6)
- `library_set_playback_hint` from audio listeners
- `authStore` extensions (per-server index toggle + auto-reconcile
  toggle)
- i18n keys

## Test plan

- [x] `cargo test --workspace` — passes (171 in `psysonic-library`,
      105 in `psysonic-integration`)
- [x] `cargo clippy -p psysonic-library --all-targets -- -D warnings`
- [x] `npx tsc --noEmit` — `src/api/library.ts` type-checks clean