### PR TITLE
feat(library): advanced search + cross-server SQL builders (Phase D-search, PR-5d)

### DIFF
--- a/src-tauri/crates/psysonic-library/src/advanced_search.rs
+++ b/src-tauri/crates/psysonic-library/src/advanced_search.rs
@@ -1,0 +1,858 @@
+//! Advanced Search SQL builder (spec §5.13). PR-5d ships the backend only —
+//! the `AdvancedSearch.tsx` UI wiring stays PR-7 (F2). Cross-server search
+//! (§5.5B) lives in the sibling `cross_server` module.
+//!
+//! The builder turns a `LibraryAdvancedSearchRequest` into one parameterised
+//! query per requested entity (track / album / artist), each sharing a WHERE
+//! built from the `FilterFieldRegistry` resolution in `filter.rs`. Only
+//! builder-supplied column expressions ever reach the SQL string; every value
+//! is bound (§5.13.5: parameterised only).
+
+use std::collections::BTreeSet;
+
+use rusqlite::types::Value as SqlValue;
+use serde_json::Value;
+
+use crate::dto::{
+    LibraryAdvancedSearchRequest, LibraryAdvancedSearchResponse, LibraryAlbumDto, LibraryArtistDto,
+    LibraryFilterClause, LibrarySearchTotals, LibrarySortClause, LibraryTrackDto, SortDir,
+};
+use crate::filter::{self, EntityKind, FilterOp, SqlFragment};
+use crate::repos;
+use crate::search::{aliased_track_columns, fts_query, PAGE_LIMIT_MAX};
+use crate::store::LibraryStore;
+
+/// `bpm` dual-storage resolution (§5.13.4): prefer the hot `track.bpm`
+/// column, fall back to the highest-priority `track_fact(bpm)` value. The
+/// spec's `not_found = 0` guard is dropped — the live `track_fact` schema
+/// has no such column (that lives on `track_artifact`).
+const BPM_RESOLVED_EXPR: &str = "COALESCE(t.bpm, (SELECT f.value_int FROM track_fact f \
+  WHERE f.server_id = t.server_id AND f.track_id = t.id AND f.fact_kind = 'bpm' \
+  ORDER BY CASE f.source_kind WHEN 'user' THEN 0 WHEN 'server_tag' THEN 1 \
+  WHEN 'analysis' THEN 2 ELSE 3 END LIMIT 1))";
+
+const ALBUM_COLUMNS: &str = "a.server_id, a.id, a.name, a.artist, a.artist_id, \
+  a.song_count, a.duration_sec, a.year, a.genre, a.cover_art_id, a.starred_at, \
+  a.synced_at, a.raw_json";
+
+const ARTIST_COLUMNS: &str = "ar.server_id, ar.id, ar.name, ar.album_count, \
+  ar.synced_at, ar.raw_json";
+
+/// `library_advanced_search` (§5.13). Runs only the queries named in
+/// `entityTypes`; absent entities return empty + zero totals.
+pub fn run_advanced_search(
+    store: &LibraryStore,
+    req: &LibraryAdvancedSearchRequest,
+) -> Result<LibraryAdvancedSearchResponse, String> {
+    // `query` shorthand → text input; a `text` filter clause is an alias for
+    // the same thing. Everything else is a scalar filter.
+    let mut text_input: Option<String> = trimmed_nonempty(req.query.as_deref());
+    let mut scalar: Vec<&LibraryFilterClause> = Vec::new();
+    for c in &req.filters {
+        if c.field == "text" {
+            if text_input.is_none() {
+                if let Some(Value::String(s)) = &c.value {
+                    text_input = trimmed_nonempty(Some(s));
+                }
+            }
+        } else {
+            scalar.push(c);
+        }
+    }
+
+    // Up-front validation: an unknown field or an op the registry doesn't
+    // declare is an error regardless of entity routing (§5.13.5).
+    for c in &scalar {
+        let field = filter::lookup(&c.field)
+            .ok_or_else(|| filter::FilterError::UnknownField(c.field.clone()).to_string())?;
+        if !field.ops.contains(&c.op) {
+            return Err(filter::FilterError::UnsupportedOp {
+                field: c.field.clone(),
+                op: c.op.as_str(),
+            }
+            .to_string());
+        }
+    }
+
+    let limit = req.limit.clamp(1, PAGE_LIMIT_MAX);
+    let offset = req.offset;
+    let text = text_input.as_deref();
+    let want = |k: EntityKind| req.entity_types.contains(&k);
+    let mut applied: BTreeSet<String> = BTreeSet::new();
+
+    let (artists, artists_total) = if want(EntityKind::Artist) {
+        build_artist(store, req, text, &scalar, limit, offset, &mut applied)?
+    } else {
+        (Vec::new(), 0)
+    };
+    let (albums, albums_total) = if want(EntityKind::Album) {
+        build_album(store, req, text, &scalar, limit, offset, &mut applied)?
+    } else {
+        (Vec::new(), 0)
+    };
+    let (tracks, tracks_total) = if want(EntityKind::Track) {
+        build_track(store, req, text, &scalar, limit, offset, &mut applied)?
+    } else {
+        (Vec::new(), 0)
+    };
+
+    Ok(LibraryAdvancedSearchResponse {
+        artists,
+        albums,
+        tracks,
+        totals: LibrarySearchTotals {
+            artists: artists_total,
+            albums: albums_total,
+            tracks: tracks_total,
+        },
+        applied_filters: applied.into_iter().collect(),
+        source: "local".to_string(),
+    })
+}
+
+// ── per-entity builders ────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn build_track(
+    store: &LibraryStore,
+    req: &LibraryAdvancedSearchRequest,
+    text: Option<&str>,
+    scalar: &[&LibraryFilterClause],
+    limit: u32,
+    offset: u32,
+    applied: &mut BTreeSet<String>,
+) -> Result<(Vec<LibraryTrackDto>, u32), String> {
+    let mut w = WhereBuilder::new();
+    let from;
+    let default_order;
+    if let Some(q) = text.and_then(fts_query) {
+        from = "track_fts f JOIN track t ON t.rowid = f.rowid".to_string();
+        w.push_param("track_fts MATCH ?", SqlValue::Text(q));
+        default_order = "ORDER BY bm25(track_fts)".to_string();
+        applied.insert("text".to_string());
+    } else {
+        from = "track t".to_string();
+        default_order = "ORDER BY t.title COLLATE NOCASE ASC, t.id ASC".to_string();
+    }
+    w.push_raw("t.deleted = 0");
+    w.push_param("t.server_id = ?", SqlValue::Text(req.server_id.clone()));
+    if let Some(scope) = trimmed_nonempty(req.library_scope.as_deref()) {
+        w.push_param("t.library_id = ?", SqlValue::Text(scope));
+    }
+    for c in scalar {
+        if let Some(frag) = resolve_clause(c, EntityKind::Track)? {
+            applied.insert(c.field.clone());
+            w.push(frag);
+        }
+    }
+    if req.starred_only == Some(true) {
+        w.push_raw("t.starred_at IS NOT NULL");
+        applied.insert("starred".to_string());
+    }
+
+    let order = order_clause(&req.sort, EntityKind::Track).unwrap_or(default_order);
+    let cols = aliased_track_columns("t");
+    query_rows(store, &cols, &from, &w, &order, limit, offset, |r| {
+        repos::row_to_track_row(r).map(|row| LibraryTrackDto::from_row(&row))
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_album(
+    store: &LibraryStore,
+    req: &LibraryAdvancedSearchRequest,
+    text: Option<&str>,
+    scalar: &[&LibraryFilterClause],
+    limit: u32,
+    offset: u32,
+    applied: &mut BTreeSet<String>,
+) -> Result<(Vec<LibraryAlbumDto>, u32), String> {
+    // `album` has no `library_id` / `deleted` columns, so `libraryScope` is
+    // a track-only filter (P20) and does not narrow album results.
+    let mut w = WhereBuilder::new();
+    w.push_param("a.server_id = ?", SqlValue::Text(req.server_id.clone()));
+    if let Some(t) = text {
+        w.push_param("a.name LIKE ? ESCAPE '\\'", SqlValue::Text(like_contains(t)));
+        applied.insert("text".to_string());
+    }
+    for c in scalar {
+        if let Some(frag) = resolve_clause(c, EntityKind::Album)? {
+            applied.insert(c.field.clone());
+            w.push(frag);
+        }
+    }
+    if req.starred_only == Some(true) {
+        w.push_raw("a.starred_at IS NOT NULL");
+        applied.insert("starred".to_string());
+    }
+
+    let order = order_clause(&req.sort, EntityKind::Album)
+        .unwrap_or_else(|| "ORDER BY a.name COLLATE NOCASE ASC, a.id ASC".to_string());
+    query_rows(store, ALBUM_COLUMNS, "album a", &w, &order, limit, offset, map_album)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_artist(
+    store: &LibraryStore,
+    req: &LibraryAdvancedSearchRequest,
+    text: Option<&str>,
+    scalar: &[&LibraryFilterClause],
+    limit: u32,
+    offset: u32,
+    applied: &mut BTreeSet<String>,
+) -> Result<(Vec<LibraryArtistDto>, u32), String> {
+    let mut w = WhereBuilder::new();
+    w.push_param("ar.server_id = ?", SqlValue::Text(req.server_id.clone()));
+    if let Some(t) = text {
+        w.push_param("ar.name LIKE ? ESCAPE '\\'", SqlValue::Text(like_contains(t)));
+        applied.insert("text".to_string());
+    }
+    // Only `text` routes to artist with a real column; other registered
+    // fields resolve to `None` (skip). `starredOnly` has no artist column.
+    for c in scalar {
+        if let Some(frag) = resolve_clause(c, EntityKind::Artist)? {
+            applied.insert(c.field.clone());
+            w.push(frag);
+        }
+    }
+
+    let order = order_clause(&req.sort, EntityKind::Artist)
+        .unwrap_or_else(|| "ORDER BY ar.name COLLATE NOCASE ASC, ar.id ASC".to_string());
+    query_rows(store, ARTIST_COLUMNS, "artist ar", &w, &order, limit, offset, map_artist)
+}
+
+// ── clause resolution ──────────────────────────────────────────────────
+
+/// Resolve one scalar clause to a WHERE fragment for `entity`. `Ok(None)`
+/// means the field is known but doesn't route to this entity (§5.13.3 skip).
+fn resolve_clause(
+    c: &LibraryFilterClause,
+    entity: EntityKind,
+) -> Result<Option<SqlFragment>, String> {
+    let applies = filter::validate_for_entity(&c.field, c.op, entity).map_err(|e| e.to_string())?;
+    if !applies {
+        return Ok(None);
+    }
+    let col = match (c.field.as_str(), entity) {
+        ("genre", EntityKind::Track) => "t.genre",
+        ("genre", EntityKind::Album) => "a.genre",
+        ("year", EntityKind::Track) => "t.year",
+        ("year", EntityKind::Album) => "a.year",
+        ("starred", EntityKind::Track) => "t.starred_at",
+        ("starred", EntityKind::Album) => "a.starred_at",
+        // `starred` routes to artist in the registry, but the `artist`
+        // table has no `starred_at` column — skip rather than error.
+        ("starred", EntityKind::Artist) => return Ok(None),
+        ("bpm", EntityKind::Track) => BPM_RESOLVED_EXPR,
+        // `text` is handled by the entity builder (FTS / LIKE), never here.
+        ("text", _) => return Ok(None),
+        // Registered but no v1 SQL builder (user_rating / suffix / bit_rate).
+        _ => return Err(filter::FilterError::NotQueryable(c.field.clone()).to_string()),
+    };
+
+    if c.field == "genre" {
+        let v = json_to_text(&c.field, c.value.as_ref())?;
+        return Ok(Some(SqlFragment {
+            sql: format!("{col} = ? COLLATE NOCASE"),
+            params: vec![v],
+        }));
+    }
+    if c.field == "starred" {
+        return filter::compare_fragment(&c.field, col, FilterOp::IsTrue, None, None)
+            .map(Some)
+            .map_err(|e| e.to_string());
+    }
+    // Numeric fields: year / bpm.
+    let value = json_to_opt_i64(&c.field, c.value.as_ref())?;
+    let value_to = json_to_opt_i64(&c.field, c.value_to.as_ref())?;
+    filter::compare_fragment(&c.field, col, c.op, value, value_to)
+        .map(Some)
+        .map_err(|e| e.to_string())
+}
+
+// ── query execution ────────────────────────────────────────────────────
+
+/// Accumulates `AND`-joined WHERE clauses and their positional params in
+/// lockstep so anonymous `?` placeholders bind left-to-right.
+struct WhereBuilder {
+    clauses: Vec<String>,
+    params: Vec<SqlValue>,
+}
+
+impl WhereBuilder {
+    fn new() -> Self {
+        Self {
+            clauses: Vec::new(),
+            params: Vec::new(),
+        }
+    }
+    fn push(&mut self, frag: SqlFragment) {
+        self.clauses.push(frag.sql);
+        self.params.extend(frag.params);
+    }
+    fn push_raw(&mut self, sql: &str) {
+        self.clauses.push(sql.to_string());
+    }
+    fn push_param(&mut self, sql: &str, param: SqlValue) {
+        self.clauses.push(sql.to_string());
+        self.params.push(param);
+    }
+    fn where_sql(&self) -> String {
+        self.clauses.join(" AND ")
+    }
+}
+
+/// Run the COUNT (full match total) + the paged SELECT in one connection
+/// borrow. Both share `where`'s params; the page appends `LIMIT ? OFFSET ?`.
+#[allow(clippy::too_many_arguments)]
+fn query_rows<T, F>(
+    store: &LibraryStore,
+    select_cols: &str,
+    from: &str,
+    w: &WhereBuilder,
+    order_sql: &str,
+    limit: u32,
+    offset: u32,
+    map: F,
+) -> Result<(Vec<T>, u32), String>
+where
+    F: Fn(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+{
+    let where_sql = w.where_sql();
+    store.with_conn(|conn| {
+        let count_sql = format!("SELECT COUNT(*) FROM {from} WHERE {where_sql}");
+        let total: i64 = conn.query_row(
+            &count_sql,
+            rusqlite::params_from_iter(w.params.iter()),
+            |r| r.get(0),
+        )?;
+
+        let page_sql = format!(
+            "SELECT {select_cols} FROM {from} WHERE {where_sql} {order_sql} LIMIT ? OFFSET ?"
+        );
+        let mut page_params: Vec<SqlValue> = w.params.clone();
+        page_params.push(SqlValue::Integer(limit as i64));
+        page_params.push(SqlValue::Integer(offset as i64));
+        let mut stmt = conn.prepare(&page_sql)?;
+        // Bind the collected `Result` before unwrapping so the `MappedRows`
+        // borrow of `stmt` ends inside the block (rusqlite borrow quirk).
+        let collected: rusqlite::Result<Vec<T>> = stmt
+            .query_map(rusqlite::params_from_iter(page_params.iter()), |r| map(r))?
+            .collect();
+        let rows = collected?;
+        Ok((rows, total.max(0) as u32))
+    })
+}
+
+// ── row mappers ────────────────────────────────────────────────────────
+
+fn map_album(r: &rusqlite::Row<'_>) -> rusqlite::Result<LibraryAlbumDto> {
+    let raw: Option<String> = r.get(12)?;
+    Ok(LibraryAlbumDto {
+        server_id: r.get(0)?,
+        id: r.get(1)?,
+        name: r.get(2)?,
+        artist: r.get(3)?,
+        artist_id: r.get(4)?,
+        song_count: r.get(5)?,
+        duration_sec: r.get(6)?,
+        year: r.get(7)?,
+        genre: r.get(8)?,
+        cover_art_id: r.get(9)?,
+        starred_at: r.get(10)?,
+        synced_at: r.get(11)?,
+        raw_json: parse_raw_json(raw),
+    })
+}
+
+fn map_artist(r: &rusqlite::Row<'_>) -> rusqlite::Result<LibraryArtistDto> {
+    let raw: Option<String> = r.get(5)?;
+    Ok(LibraryArtistDto {
+        server_id: r.get(0)?,
+        id: r.get(1)?,
+        name: r.get(2)?,
+        album_count: r.get(3)?,
+        synced_at: r.get(4)?,
+        raw_json: parse_raw_json(raw),
+    })
+}
+
+fn parse_raw_json(raw: Option<String>) -> Value {
+    raw.and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or(Value::Null)
+}
+
+// ── small helpers ──────────────────────────────────────────────────────
+
+fn trimmed_nonempty(s: Option<&str>) -> Option<String> {
+    s.map(str::trim).filter(|s| !s.is_empty()).map(String::from)
+}
+
+/// Build a `%...%` LIKE pattern with the LIKE wildcards (`%`, `_`) and the
+/// `\` escape char escaped, for use with `LIKE ? ESCAPE '\'`.
+fn like_contains(raw: &str) -> String {
+    let escaped = raw
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    format!("%{escaped}%")
+}
+
+fn order_clause(sort: &[LibrarySortClause], entity: EntityKind) -> Option<String> {
+    let mut keys: Vec<String> = Vec::new();
+    for s in sort {
+        if let Some(col) = sort_column(&s.field, entity) {
+            let dir = match s.dir {
+                SortDir::Asc => "ASC",
+                SortDir::Desc => "DESC",
+            };
+            keys.push(format!("{col} {dir}"));
+        }
+    }
+    if keys.is_empty() {
+        None
+    } else {
+        Some(format!("ORDER BY {}", keys.join(", ")))
+    }
+}
+
+/// Allowlist of sortable fields per entity → trusted column expression.
+/// Unknown sort fields are ignored (fall back to the default order).
+fn sort_column(field: &str, entity: EntityKind) -> Option<&'static str> {
+    match (field, entity) {
+        ("title", EntityKind::Track) => Some("t.title COLLATE NOCASE"),
+        ("year", EntityKind::Track) => Some("t.year"),
+        ("duration", EntityKind::Track) => Some("t.duration_sec"),
+        ("artist", EntityKind::Track) => Some("t.artist COLLATE NOCASE"),
+        ("album", EntityKind::Track) => Some("t.album COLLATE NOCASE"),
+        ("track_number", EntityKind::Track) => Some("t.track_number"),
+        ("play_count", EntityKind::Track) => Some("t.play_count"),
+        ("name", EntityKind::Album) => Some("a.name COLLATE NOCASE"),
+        ("year", EntityKind::Album) => Some("a.year"),
+        ("artist", EntityKind::Album) => Some("a.artist COLLATE NOCASE"),
+        ("name", EntityKind::Artist) => Some("ar.name COLLATE NOCASE"),
+        _ => None,
+    }
+}
+
+fn json_to_text(field: &str, v: Option<&Value>) -> Result<SqlValue, String> {
+    match v {
+        Some(Value::String(s)) => Ok(SqlValue::Text(s.clone())),
+        _ => Err(filter::FilterError::BadValue {
+            field: field.to_string(),
+            detail: "expected a string value".to_string(),
+        }
+        .to_string()),
+    }
+}
+
+fn json_to_opt_i64(field: &str, v: Option<&Value>) -> Result<Option<SqlValue>, String> {
+    match v {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(n)) => n
+            .as_i64()
+            .map(|i| Some(SqlValue::Integer(i)))
+            .ok_or_else(|| {
+                filter::FilterError::BadValue {
+                    field: field.to_string(),
+                    detail: "expected an integer value".to_string(),
+                }
+                .to_string()
+            }),
+        _ => Err(filter::FilterError::BadValue {
+            field: field.to_string(),
+            detail: "expected a numeric value".to_string(),
+        }
+        .to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dto::SortDir;
+    use crate::repos::{TrackRepository, TrackRow};
+    use serde_json::json;
+
+    // ── fixtures ───────────────────────────────────────────────────────
+
+    fn track(server: &str, id: &str, title: &str, artist: &str, album: &str) -> TrackRow {
+        TrackRow {
+            server_id: server.into(),
+            id: id.into(),
+            title: title.into(),
+            title_sort: None,
+            artist: Some(artist.into()),
+            artist_id: Some(format!("ar_{artist}")),
+            album: album.into(),
+            album_id: Some(format!("al_{album}")),
+            album_artist: Some(artist.into()),
+            duration_sec: 200,
+            track_number: Some(1),
+            disc_number: Some(1),
+            year: None,
+            genre: None,
+            suffix: None,
+            bit_rate: None,
+            size_bytes: None,
+            cover_art_id: None,
+            starred_at: None,
+            user_rating: None,
+            play_count: None,
+            played_at: None,
+            server_path: None,
+            library_id: None,
+            isrc: None,
+            mbid_recording: None,
+            bpm: None,
+            replay_gain_track_db: None,
+            replay_gain_album_db: None,
+            content_hash: None,
+            server_updated_at: None,
+            server_created_at: None,
+            deleted: false,
+            synced_at: 1,
+            raw_json: "{}".into(),
+        }
+    }
+
+    fn insert_album(store: &LibraryStore, server: &str, id: &str, name: &str, year: Option<i64>, genre: Option<&str>) {
+        store
+            .with_conn(|c| {
+                c.execute(
+                    "INSERT INTO album (server_id, id, name, year, genre, synced_at, raw_json) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, 1, '{}')",
+                    rusqlite::params![server, id, name, year, genre],
+                )
+            })
+            .unwrap();
+    }
+
+    fn insert_artist(store: &LibraryStore, server: &str, id: &str, name: &str) {
+        store
+            .with_conn(|c| {
+                c.execute(
+                    "INSERT INTO artist (server_id, id, name, synced_at, raw_json) \
+                     VALUES (?1, ?2, ?3, 1, '{}')",
+                    rusqlite::params![server, id, name],
+                )
+            })
+            .unwrap();
+    }
+
+    fn req(server: &str, entities: &[EntityKind]) -> LibraryAdvancedSearchRequest {
+        LibraryAdvancedSearchRequest {
+            server_id: server.into(),
+            library_scope: None,
+            query: None,
+            entity_types: entities.to_vec(),
+            filters: Vec::new(),
+            starred_only: None,
+            sort: Vec::new(),
+            limit: 50,
+            offset: 0,
+        }
+    }
+
+    fn clause(field: &str, op: FilterOp, value: Option<Value>, value_to: Option<Value>) -> LibraryFilterClause {
+        LibraryFilterClause {
+            field: field.into(),
+            op,
+            value,
+            value_to,
+        }
+    }
+
+    // ── text / FTS ─────────────────────────────────────────────────────
+
+    #[test]
+    fn text_query_matches_track_via_fts() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                track("s1", "t1", "Aurora", "Anna", "Skylines"),
+                track("s1", "t2", "Sunset", "Beth", "Skylines"),
+            ])
+            .unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.query = Some("aurora".into());
+        let resp = run_advanced_search(&store, &r).unwrap();
+        assert_eq!(resp.tracks.len(), 1);
+        assert_eq!(resp.tracks[0].id, "t1");
+        assert_eq!(resp.totals.tracks, 1);
+        assert!(resp.applied_filters.contains(&"text".to_string()));
+        assert_eq!(resp.source, "local");
+    }
+
+    #[test]
+    fn text_query_matches_album_and_artist_via_like() {
+        let store = LibraryStore::open_in_memory();
+        insert_album(&store, "s1", "al1", "Aurora Nights", None, None);
+        insert_album(&store, "s1", "al2", "Other", None, None);
+        insert_artist(&store, "s1", "ar1", "Aurora Quartet");
+        let mut r = req("s1", &[EntityKind::Album, EntityKind::Artist]);
+        r.query = Some("aurora".into());
+        let resp = run_advanced_search(&store, &r).unwrap();
+        assert_eq!(resp.albums.len(), 1);
+        assert_eq!(resp.albums[0].id, "al1");
+        assert_eq!(resp.artists.len(), 1);
+        assert_eq!(resp.artists[0].id, "ar1");
+    }
+
+    #[test]
+    fn special_chars_in_query_do_not_crash_fts() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[track("s1", "t1", "Hello World", "A", "B")])
+            .unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        // Each of these is a raw FTS5 syntax error if passed unescaped; the
+        // builder must quote them into safe terms so the call returns Ok.
+        for q in ["\"", "AND", "foo*", "a OR b", "((", "near/"] {
+            r.query = Some(q.to_string());
+            assert!(
+                run_advanced_search(&store, &r).is_ok(),
+                "query `{q}` must not raise an FTS syntax error"
+            );
+        }
+    }
+
+    #[test]
+    fn quoted_token_query_still_matches_clean_terms() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[track("s1", "t1", "Hello World", "A", "B")])
+            .unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        // Multi-token query AND-s its terms — both present → one hit.
+        r.query = Some("hello world".into());
+        assert_eq!(run_advanced_search(&store, &r).unwrap().tracks.len(), 1);
+    }
+
+    // ── genre / year / starred ─────────────────────────────────────────
+
+    #[test]
+    fn genre_filter_is_case_insensitive() {
+        let store = LibraryStore::open_in_memory();
+        let mut a = track("s1", "t1", "A", "X", "Alb");
+        a.genre = Some("Ambient".into());
+        let mut b = track("s1", "t2", "B", "X", "Alb");
+        b.genre = Some("Techno".into());
+        TrackRepository::new(&store).upsert_batch(&[a, b]).unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.filters = vec![clause("genre", FilterOp::Eq, Some(json!("ambient")), None)];
+        let resp = run_advanced_search(&store, &r).unwrap();
+        assert_eq!(resp.tracks.len(), 1);
+        assert_eq!(resp.tracks[0].id, "t1");
+        assert!(resp.applied_filters.contains(&"genre".to_string()));
+    }
+
+    #[test]
+    fn year_between_is_inclusive() {
+        let store = LibraryStore::open_in_memory();
+        let mut a = track("s1", "t1", "A", "X", "Alb");
+        a.year = Some(2000);
+        let mut b = track("s1", "t2", "B", "X", "Alb");
+        b.year = Some(2010);
+        let mut c = track("s1", "t3", "C", "X", "Alb");
+        c.year = Some(2011);
+        TrackRepository::new(&store).upsert_batch(&[a, b, c]).unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.filters = vec![clause("year", FilterOp::Between, Some(json!(2000)), Some(json!(2010)))];
+        let resp = run_advanced_search(&store, &r).unwrap();
+        let ids: Vec<&str> = resp.tracks.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, vec!["t1", "t2"]);
+    }
+
+    #[test]
+    fn year_only_branch_runs_without_fts() {
+        // Genre/year-only (no query) must not require an FTS join (§5.13.7).
+        let store = LibraryStore::open_in_memory();
+        let mut a = track("s1", "t1", "A", "X", "Alb");
+        a.year = Some(1999);
+        TrackRepository::new(&store).upsert_batch(&[a]).unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.filters = vec![clause("year", FilterOp::Gte, Some(json!(1999)), None)];
+        let resp = run_advanced_search(&store, &r).unwrap();
+        assert_eq!(resp.tracks.len(), 1);
+        assert!(!resp.applied_filters.contains(&"text".to_string()));
+    }
+
+    #[test]
+    fn starred_only_filters_tracks() {
+        let store = LibraryStore::open_in_memory();
+        let mut a = track("s1", "t1", "A", "X", "Alb");
+        a.starred_at = Some(123);
+        let b = track("s1", "t2", "B", "X", "Alb");
+        TrackRepository::new(&store).upsert_batch(&[a, b]).unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.starred_only = Some(true);
+        let resp = run_advanced_search(&store, &r).unwrap();
+        assert_eq!(resp.tracks.len(), 1);
+        assert_eq!(resp.tracks[0].id, "t1");
+    }
+
+    // ── bpm dual storage ───────────────────────────────────────────────
+
+    #[test]
+    fn bpm_filter_matches_hot_column() {
+        let store = LibraryStore::open_in_memory();
+        let mut a = track("s1", "t1", "A", "X", "Alb");
+        a.bpm = Some(125);
+        let mut b = track("s1", "t2", "B", "X", "Alb");
+        b.bpm = Some(90);
+        TrackRepository::new(&store).upsert_batch(&[a, b]).unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.filters = vec![clause("bpm", FilterOp::Between, Some(json!(120)), Some(json!(130)))];
+        let resp = run_advanced_search(&store, &r).unwrap();
+        assert_eq!(resp.tracks.len(), 1);
+        assert_eq!(resp.tracks[0].id, "t1");
+    }
+
+    #[test]
+    fn bpm_filter_falls_back_to_track_fact() {
+        let store = LibraryStore::open_in_memory();
+        // No hot `bpm`; an analysis fact carries it instead.
+        TrackRepository::new(&store)
+            .upsert_batch(&[track("s1", "t1", "A", "X", "Alb")])
+            .unwrap();
+        store
+            .with_conn(|c| {
+                c.execute(
+                    "INSERT INTO track_fact \
+                     (server_id, track_id, fact_kind, value_int, source_kind, source_id, confidence, fetched_at) \
+                     VALUES ('s1', 't1', 'bpm', 128, 'analysis', 'seed', 1.0, 1)",
+                    [],
+                )
+            })
+            .unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.filters = vec![clause("bpm", FilterOp::Between, Some(json!(125)), Some(json!(130)))];
+        let resp = run_advanced_search(&store, &r).unwrap();
+        assert_eq!(resp.tracks.len(), 1, "bpm should resolve via track_fact fallback");
+    }
+
+    // ── entity routing / errors ────────────────────────────────────────
+
+    #[test]
+    fn track_only_filter_is_ignored_for_album_entity_no_error() {
+        let store = LibraryStore::open_in_memory();
+        insert_album(&store, "s1", "al1", "Some Album", Some(2001), None);
+        let mut r = req("s1", &[EntityKind::Album]);
+        // bpm is track-only; for an album query it must be skipped, not error.
+        r.filters = vec![clause("bpm", FilterOp::Between, Some(json!(120)), Some(json!(130)))];
+        let resp = run_advanced_search(&store, &r).unwrap();
+        assert_eq!(resp.albums.len(), 1);
+        assert!(!resp.applied_filters.contains(&"bpm".to_string()));
+    }
+
+    #[test]
+    fn unknown_field_is_an_error() {
+        let store = LibraryStore::open_in_memory();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.filters = vec![clause("nope", FilterOp::Eq, Some(json!("x")), None)];
+        let err = run_advanced_search(&store, &r).unwrap_err();
+        assert!(err.contains("unknown filter field"), "got: {err}");
+    }
+
+    #[test]
+    fn planned_but_unbuilt_field_is_an_error() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[track("s1", "t1", "A", "X", "Alb")])
+            .unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        // `suffix` is registered (Planned) but has no v1 SQL builder.
+        r.filters = vec![clause("suffix", FilterOp::Eq, Some(json!("flac")), None)];
+        let err = run_advanced_search(&store, &r).unwrap_err();
+        assert!(err.contains("not queryable"), "got: {err}");
+    }
+
+    #[test]
+    fn undeclared_op_for_known_field_is_an_error() {
+        let store = LibraryStore::open_in_memory();
+        let mut r = req("s1", &[EntityKind::Track]);
+        // `genre` only declares `eq`.
+        r.filters = vec![clause("genre", FilterOp::Gte, Some(json!("rock")), None)];
+        let err = run_advanced_search(&store, &r).unwrap_err();
+        assert!(err.contains("not supported"), "got: {err}");
+    }
+
+    // ── scope / pagination / totals ────────────────────────────────────
+
+    #[test]
+    fn library_scope_narrows_track_results() {
+        let store = LibraryStore::open_in_memory();
+        let mut a = track("s1", "t1", "A", "X", "Alb");
+        a.library_id = Some("lib1".into());
+        let mut b = track("s1", "t2", "B", "X", "Alb");
+        b.library_id = Some("lib2".into());
+        TrackRepository::new(&store).upsert_batch(&[a, b]).unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.library_scope = Some("lib1".into());
+        let resp = run_advanced_search(&store, &r).unwrap();
+        assert_eq!(resp.tracks.len(), 1);
+        assert_eq!(resp.tracks[0].id, "t1");
+    }
+
+    #[test]
+    fn totals_reflect_full_match_count_not_page_size() {
+        let store = LibraryStore::open_in_memory();
+        let rows: Vec<TrackRow> = (0..10)
+            .map(|i| track("s1", &format!("t{i}"), "Common Title", "X", "Alb"))
+            .collect();
+        TrackRepository::new(&store).upsert_batch(&rows).unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.query = Some("common".into());
+        r.limit = 3;
+        let resp = run_advanced_search(&store, &r).unwrap();
+        assert_eq!(resp.tracks.len(), 3, "page is capped by limit");
+        assert_eq!(resp.totals.tracks, 10, "total is the full match count");
+    }
+
+    #[test]
+    fn offset_pages_through_results() {
+        let store = LibraryStore::open_in_memory();
+        let rows: Vec<TrackRow> = (0..5)
+            .map(|i| track("s1", &format!("t{i}"), &format!("Title {i}"), "X", "Alb"))
+            .collect();
+        TrackRepository::new(&store).upsert_batch(&rows).unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.sort = vec![LibrarySortClause { field: "title".into(), dir: SortDir::Asc }];
+        r.limit = 2;
+        r.offset = 2;
+        let resp = run_advanced_search(&store, &r).unwrap();
+        let ids: Vec<&str> = resp.tracks.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, vec!["t2", "t3"]);
+        assert_eq!(resp.totals.tracks, 5);
+    }
+
+    #[test]
+    fn unrequested_entities_are_empty() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[track("s1", "t1", "A", "X", "Alb")])
+            .unwrap();
+        insert_album(&store, "s1", "al1", "Alb", None, None);
+        let resp = run_advanced_search(&store, &req("s1", &[EntityKind::Track])).unwrap();
+        assert_eq!(resp.tracks.len(), 1);
+        assert!(resp.albums.is_empty());
+        assert!(resp.artists.is_empty());
+        assert_eq!(resp.totals.albums, 0);
+    }
+
+    #[test]
+    fn sort_desc_orders_results() {
+        let store = LibraryStore::open_in_memory();
+        let mut a = track("s1", "t1", "A", "X", "Alb");
+        a.year = Some(2000);
+        let mut b = track("s1", "t2", "B", "X", "Alb");
+        b.year = Some(2020);
+        TrackRepository::new(&store).upsert_batch(&[a, b]).unwrap();
+        let mut r = req("s1", &[EntityKind::Track]);
+        r.sort = vec![LibrarySortClause { field: "year".into(), dir: SortDir::Desc }];
+        let resp = run_advanced_search(&store, &r).unwrap();
+        let ids: Vec<&str> = resp.tracks.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, vec!["t2", "t1"]);
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -13,8 +13,11 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use psysonic_integration::navidrome::navidrome_token;
 use psysonic_integration::subsonic::SubsonicClient;
 
+use crate::advanced_search;
+use crate::cross_server;
 use crate::dto::{
-    local_tracks_max_updated_ms, ArtifactInputDto, FactInputDto, LibraryTrackDto,
+    local_tracks_max_updated_ms, ArtifactInputDto, FactInputDto, LibraryAdvancedSearchRequest,
+    LibraryAdvancedSearchResponse, LibraryCrossServerSearchResponse, LibraryTrackDto,
     LibraryTracksEnvelope, OfflinePathDto, PurgeReportDto, SyncJobDto, SyncStateDto,
     TrackArtifactDto, TrackFactDto, TrackRefDto,
 };
@@ -311,6 +314,29 @@ pub fn library_get_offline_path(
         missing: path.is_none(),
         local_path: path,
     })
+}
+
+// ──────────────────────────────────────────────────────────────────────
+//  PR-5d — Advanced Search (§5.13) + cross-server search (§5.5B)
+// ──────────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn library_advanced_search(
+    runtime: State<'_, LibraryRuntime>,
+    request: LibraryAdvancedSearchRequest,
+) -> Result<LibraryAdvancedSearchResponse, String> {
+    advanced_search::run_advanced_search(&runtime.store, &request)
+}
+
+#[tauri::command]
+pub fn library_search_cross_server(
+    runtime: State<'_, LibraryRuntime>,
+    query: String,
+    limit: Option<u32>,
+    servers: Option<Vec<String>>,
+) -> Result<LibraryCrossServerSearchResponse, String> {
+    let limit = limit.unwrap_or(100);
+    cross_server::run_cross_server_search(&runtime.store, &query, limit, servers.as_deref())
 }
 
 // ── helpers ──────────────────────────────────────────────────────────

--- a/src-tauri/crates/psysonic-library/src/cross_server.rs
+++ b/src-tauri/crates/psysonic-library/src/cross_server.rs
@@ -1,0 +1,262 @@
+//! Cross-server search (spec §5.5B / §5.9 A′). PR-5d ships the primary FTS
+//! union; the fuzzy 0-hit fallback (§5.5B step C) lands additively with
+//! cross-server matching in PR-4 (H3). UI wiring stays PR-7.
+
+use std::collections::HashSet;
+
+use rusqlite::types::Value as SqlValue;
+
+use crate::dto::{LibraryCrossServerSearchResponse, LibraryTrackDto};
+use crate::repos;
+use crate::search::{aliased_track_columns, fts_query, PAGE_LIMIT_MAX};
+use crate::store::LibraryStore;
+
+/// `library_search_cross_server` (§5.5B / §5.9 A′). Primary FTS union over
+/// the requested servers (or all `ready` servers), bm25-ordered, deduped by
+/// canonical id where a `track_canonical_link` row exists.
+pub fn run_cross_server_search(
+    store: &LibraryStore,
+    query: &str,
+    limit: u32,
+    servers: Option<&[String]>,
+) -> Result<LibraryCrossServerSearchResponse, String> {
+    let limit = limit.clamp(1, PAGE_LIMIT_MAX);
+    let Some(fts) = fts_query(query) else {
+        return Ok(LibraryCrossServerSearchResponse::default());
+    };
+
+    // Explicit `servers` is an override (caller's choice); otherwise default
+    // to every server whose index is `ready` (§5.9).
+    let targets: Vec<String> = match servers {
+        Some(list) if !list.is_empty() => list.to_vec(),
+        _ => ready_servers(store)?,
+    };
+    if targets.is_empty() {
+        return Ok(LibraryCrossServerSearchResponse::default());
+    }
+
+    let placeholders = vec!["?"; targets.len()].join(", ");
+    let cols = aliased_track_columns("t");
+    let sql = format!(
+        "SELECT {cols}, l.canonical_id \
+         FROM track_fts f \
+         JOIN track t ON t.rowid = f.rowid \
+         LEFT JOIN track_canonical_link l ON l.server_id = t.server_id AND l.track_id = t.id \
+         WHERE track_fts MATCH ? AND t.deleted = 0 AND t.server_id IN ({placeholders}) \
+         ORDER BY bm25(track_fts) LIMIT ?"
+    );
+
+    let mut params: Vec<SqlValue> = Vec::with_capacity(targets.len() + 2);
+    params.push(SqlValue::Text(fts));
+    for s in &targets {
+        params.push(SqlValue::Text(s.clone()));
+    }
+    params.push(SqlValue::Integer(limit as i64));
+
+    let canonical_idx = repos::track_columns().split(',').count();
+    let rows: Vec<(LibraryTrackDto, Option<String>)> = store.with_conn(|conn| {
+        let mut stmt = conn.prepare(&sql)?;
+        // Bind the collected `Result` before unwrapping so the `MappedRows`
+        // borrow of `stmt` ends inside the block (rusqlite borrow quirk).
+        let collected: rusqlite::Result<Vec<(LibraryTrackDto, Option<String>)>> = stmt
+            .query_map(rusqlite::params_from_iter(params.iter()), |r| {
+                let track = repos::row_to_track_row(r).map(|row| LibraryTrackDto::from_row(&row))?;
+                let canonical: Option<String> = r.get(canonical_idx)?;
+                Ok((track, canonical))
+            })?
+            .collect();
+        collected
+    })?;
+
+    // Dedup by canonical id (§5.5B step 2). Rows with no canonical link are
+    // always kept — pre-PR-4 the link table is sparse, so this is a no-op
+    // for most rows.
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut hits: Vec<LibraryTrackDto> = Vec::with_capacity(rows.len());
+    for (track, canonical) in rows {
+        if let Some(cid) = canonical {
+            if !seen.insert(cid) {
+                continue;
+            }
+        }
+        hits.push(track);
+    }
+
+    Ok(LibraryCrossServerSearchResponse {
+        hits,
+        servers_searched: targets,
+    })
+}
+
+fn ready_servers(store: &LibraryStore) -> Result<Vec<String>, String> {
+    store.with_conn(|conn| {
+        let mut stmt =
+            conn.prepare("SELECT DISTINCT server_id FROM sync_state WHERE sync_phase = 'ready'")?;
+        let collected: rusqlite::Result<Vec<String>> =
+            stmt.query_map([], |r| r.get(0))?.collect();
+        collected
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repos::{TrackRepository, TrackRow};
+
+    fn track(server: &str, id: &str, title: &str, artist: &str, album: &str) -> TrackRow {
+        TrackRow {
+            server_id: server.into(),
+            id: id.into(),
+            title: title.into(),
+            title_sort: None,
+            artist: Some(artist.into()),
+            artist_id: Some(format!("ar_{artist}")),
+            album: album.into(),
+            album_id: Some(format!("al_{album}")),
+            album_artist: Some(artist.into()),
+            duration_sec: 200,
+            track_number: Some(1),
+            disc_number: Some(1),
+            year: None,
+            genre: None,
+            suffix: None,
+            bit_rate: None,
+            size_bytes: None,
+            cover_art_id: None,
+            starred_at: None,
+            user_rating: None,
+            play_count: None,
+            played_at: None,
+            server_path: None,
+            library_id: None,
+            isrc: None,
+            mbid_recording: None,
+            bpm: None,
+            replay_gain_track_db: None,
+            replay_gain_album_db: None,
+            content_hash: None,
+            server_updated_at: None,
+            server_created_at: None,
+            deleted: false,
+            synced_at: 1,
+            raw_json: "{}".into(),
+        }
+    }
+
+    fn set_phase(store: &LibraryStore, server: &str, phase: &str) {
+        store
+            .with_conn(|c| {
+                c.execute(
+                    "INSERT INTO sync_state (server_id, library_scope, sync_phase) \
+                     VALUES (?1, '', ?2) \
+                     ON CONFLICT(server_id, library_scope) DO UPDATE SET sync_phase = excluded.sync_phase",
+                    rusqlite::params![server, phase],
+                )
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn union_searches_ready_servers_only() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                track("s1", "t1", "Aurora", "Anna", "Alb"),
+                track("s2", "t2", "Aurora", "Beth", "Alb"),
+                track("s3", "t3", "Aurora", "Cara", "Alb"),
+            ])
+            .unwrap();
+        set_phase(&store, "s1", "ready");
+        set_phase(&store, "s2", "ready");
+        set_phase(&store, "s3", "idle"); // not ready → excluded
+        let resp = run_cross_server_search(&store, "aurora", 50, None).unwrap();
+        let servers: HashSet<&str> = resp.hits.iter().map(|t| t.server_id.as_str()).collect();
+        assert_eq!(servers, HashSet::from(["s1", "s2"]));
+        assert_eq!(resp.servers_searched.len(), 2);
+    }
+
+    #[test]
+    fn explicit_servers_override_ready_gate() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[track("s9", "t1", "Aurora", "Anna", "Alb")])
+            .unwrap();
+        // s9 is not marked ready, but an explicit servers list overrides.
+        let resp = run_cross_server_search(&store, "aurora", 50, Some(&["s9".to_string()])).unwrap();
+        assert_eq!(resp.hits.len(), 1);
+        assert_eq!(resp.servers_searched, vec!["s9".to_string()]);
+    }
+
+    #[test]
+    fn dedups_by_canonical_id() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                track("s1", "t1", "Aurora", "Anna", "Alb"),
+                track("s2", "t2", "Aurora", "Anna", "Alb"),
+            ])
+            .unwrap();
+        // Both tracks link to the same canonical id → one survives.
+        store
+            .with_conn(|c| {
+                c.execute(
+                    "INSERT INTO canonical_track (id, created_at, updated_at) VALUES ('can1', 1, 1)",
+                    [],
+                )?;
+                for (s, t) in [("s1", "t1"), ("s2", "t2")] {
+                    c.execute(
+                        "INSERT INTO track_canonical_link \
+                         (server_id, track_id, canonical_id, match_method, confidence, linked_at) \
+                         VALUES (?1, ?2, 'can1', 'isrc', 1.0, 1)",
+                        rusqlite::params![s, t],
+                    )?;
+                }
+                Ok(())
+            })
+            .unwrap();
+        set_phase(&store, "s1", "ready");
+        set_phase(&store, "s2", "ready");
+        let resp = run_cross_server_search(&store, "aurora", 50, None).unwrap();
+        assert_eq!(resp.hits.len(), 1, "duplicate canonical id collapses to one hit");
+    }
+
+    #[test]
+    fn unlinked_rows_are_never_deduped() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                track("s1", "t1", "Aurora", "Anna", "Alb"),
+                track("s2", "t2", "Aurora", "Beth", "Alb"),
+            ])
+            .unwrap();
+        set_phase(&store, "s1", "ready");
+        set_phase(&store, "s2", "ready");
+        // No canonical links → both kept even though titles match.
+        let resp = run_cross_server_search(&store, "aurora", 50, None).unwrap();
+        assert_eq!(resp.hits.len(), 2);
+    }
+
+    #[test]
+    fn empty_query_returns_empty() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[track("s1", "t1", "Aurora", "Anna", "Alb")])
+            .unwrap();
+        set_phase(&store, "s1", "ready");
+        let resp = run_cross_server_search(&store, "   ", 50, None).unwrap();
+        assert!(resp.hits.is_empty());
+        assert!(resp.servers_searched.is_empty());
+    }
+
+    #[test]
+    fn no_ready_servers_returns_empty() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[track("s1", "t1", "Aurora", "Anna", "Alb")])
+            .unwrap();
+        // No sync_state row marked ready, and no explicit servers given.
+        let resp = run_cross_server_search(&store, "aurora", 50, None).unwrap();
+        assert!(resp.hits.is_empty());
+        assert!(resp.servers_searched.is_empty());
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/dto.rs
+++ b/src-tauri/crates/psysonic-library/src/dto.rs
@@ -5,6 +5,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::filter::{EntityKind, FilterOp};
 use crate::repos::TrackRow;
 use crate::store::LibraryStore;
 
@@ -268,6 +269,134 @@ pub struct SyncJobDto {
     pub server_id: String,
     /// `"initial_sync"` or `"delta_sync"`.
     pub kind: String,
+}
+
+// ──────────────────────────────────────────────────────────────────────
+//  PR-5d — Advanced Search (§5.13) + cross-server search (§5.5B)
+// ──────────────────────────────────────────────────────────────────────
+
+/// `library_advanced_search` row shape for an album. Flat projection over
+/// the `album` hot columns plus the raw JSON sub-tree (mirrors
+/// `LibraryTrackDto`'s lazy-parse contract).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibraryAlbumDto {
+    pub server_id: String,
+    pub id: String,
+    pub name: String,
+    pub artist: Option<String>,
+    pub artist_id: Option<String>,
+    pub song_count: Option<i64>,
+    pub duration_sec: Option<i64>,
+    pub year: Option<i64>,
+    pub genre: Option<String>,
+    pub cover_art_id: Option<String>,
+    pub starred_at: Option<i64>,
+    pub synced_at: i64,
+    pub raw_json: Value,
+}
+
+/// `library_advanced_search` row shape for an artist.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibraryArtistDto {
+    pub server_id: String,
+    pub id: String,
+    pub name: String,
+    pub album_count: Option<i64>,
+    pub synced_at: i64,
+    pub raw_json: Value,
+}
+
+/// One filter predicate. `field` is a `FilterFieldRegistry` id (§5.13.3),
+/// `op` the comparison, `value` / `valueTo` the operands. `between` uses
+/// both bounds (inclusive); scalar ops use `value` only; `isTrue` ignores
+/// the value side.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibraryFilterClause {
+    pub field: String,
+    pub op: FilterOp,
+    #[serde(default)]
+    pub value: Option<Value>,
+    #[serde(default)]
+    pub value_to: Option<Value>,
+}
+
+/// One sort key. `field` is a registry id; `dir` is `asc` / `desc`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibrarySortClause {
+    pub field: String,
+    pub dir: SortDir,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SortDir {
+    Asc,
+    Desc,
+}
+
+/// `library_advanced_search` request (§5.13.2). `query` is shorthand for an
+/// `fts` clause on the text fields; `entityTypes` controls which of the
+/// three queries run; `filters` are combined with AND.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibraryAdvancedSearchRequest {
+    pub server_id: String,
+    #[serde(default)]
+    pub library_scope: Option<String>,
+    #[serde(default)]
+    pub query: Option<String>,
+    pub entity_types: Vec<EntityKind>,
+    #[serde(default)]
+    pub filters: Vec<LibraryFilterClause>,
+    #[serde(default)]
+    pub starred_only: Option<bool>,
+    #[serde(default)]
+    pub sort: Vec<LibrarySortClause>,
+    pub limit: u32,
+    #[serde(default)]
+    pub offset: u32,
+}
+
+/// Per-entity result counts (full match count, not page size).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibrarySearchTotals {
+    pub artists: u32,
+    pub albums: u32,
+    pub tracks: u32,
+}
+
+/// `library_advanced_search` response (§5.13.2).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibraryAdvancedSearchResponse {
+    pub artists: Vec<LibraryArtistDto>,
+    pub albums: Vec<LibraryAlbumDto>,
+    pub tracks: Vec<LibraryTrackDto>,
+    pub totals: LibrarySearchTotals,
+    /// Distinct registry field ids that were actually applied — UI chips /
+    /// debug. Includes `starred` when `starredOnly` is set.
+    pub applied_filters: Vec<String>,
+    /// Always `"local"` from this command (it queries the local index); the
+    /// frontend's fallback decides local vs network (§5.13.6).
+    pub source: String,
+}
+
+/// `library_search_cross_server` response (§5.5B). PR-5d ships the primary
+/// FTS-union (`hits`, deduped by canonical id where a link exists); the
+/// fuzzy 0-hit fallback (§5.5B step C) lands with cross-server matching in
+/// PR-4 (H3) as an additive `fuzzy` field.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LibraryCrossServerSearchResponse {
+    pub hits: Vec<LibraryTrackDto>,
+    /// The server ids that were actually searched (resolved from the
+    /// request's `servers` or all `ready` servers).
+    pub servers_searched: Vec<String>,
 }
 
 /// Read `MAX(server_updated_at)` for non-deleted tracks on this server

--- a/src-tauri/crates/psysonic-library/src/filter.rs
+++ b/src-tauri/crates/psysonic-library/src/filter.rs
@@ -3,14 +3,18 @@
 //! §5.13.5) and the Tauri command surface (§5.13.6) come later; PR-1a
 //! ships the registry shape + the v1 fields + the entity-routing rule.
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum EntityKind {
     Track,
     Album,
     Artist,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum FilterOp {
     /// FTS5 MATCH (`track_fts`). Only valid on the `text` field in v1.
     Fts,
@@ -24,11 +28,45 @@ pub enum FilterOp {
     IsTrue,
 }
 
+impl FilterOp {
+    /// Wire spelling — matches the TypeScript `FilterOperator` union and the
+    /// `FilterOp::from_wire` parser. Used in error messages too.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FilterOp::Fts => "fts",
+            FilterOp::Eq => "eq",
+            FilterOp::In => "in",
+            FilterOp::Gte => "gte",
+            FilterOp::Lte => "lte",
+            FilterOp::Between => "between",
+            FilterOp::IsTrue => "is_true",
+        }
+    }
+
+    /// Parse the wire operator. Spec §5.13.2 lists a few operators
+    /// (`neq` / `contains` / `is_false`) the v1 builder doesn't implement
+    /// yet — those return `None` so the caller can raise a clear error
+    /// rather than silently dropping the clause.
+    pub fn from_wire(wire: &str) -> Option<FilterOp> {
+        match wire {
+            "fts" => Some(FilterOp::Fts),
+            "eq" => Some(FilterOp::Eq),
+            "in" => Some(FilterOp::In),
+            "gte" => Some(FilterOp::Gte),
+            "lte" => Some(FilterOp::Lte),
+            "between" => Some(FilterOp::Between),
+            "is_true" => Some(FilterOp::IsTrue),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FilterStatus {
     /// v1: built into the SQL builder and exercised by parity tests.
     V1,
-    /// Schema present, builder hook to come post-v1.
+    /// Schema + SQL builder present (the request and registry accept it),
+    /// but hidden from the v1 UI — see §5.13.4 (`bpm` dual-storage).
     SchemaV1UiLater,
     /// Reserved column / planned-but-not-built.
     Planned,
@@ -110,6 +148,135 @@ pub fn applies_to(field: &FilterField, entity: EntityKind) -> bool {
     field.entities.contains(&entity)
 }
 
+// ── SQL fragment resolution (§5.13.5) ─────────────────────────────────
+
+/// A resolved WHERE-clause snippet plus the values it binds. The builder
+/// appends fragments in order and binds their params left-to-right against
+/// anonymous `?` placeholders (`params_from_iter`), so a fragment must keep
+/// its `sql` placeholders and `params` in the same order.
+///
+/// `sql` only ever contains builder-supplied column expressions and literal
+/// operators — never user input (spec §5.13.5: parameterised only).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SqlFragment {
+    pub sql: String,
+    pub params: Vec<rusqlite::types::Value>,
+}
+
+/// Why a `LibraryFilterClause` could not be turned into SQL. Surfaced to the
+/// command as a human-readable string; `UnknownField` carries the known-field
+/// list for dev builds (§5.13.5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterError {
+    /// `field` is not in the registry at all (typo / wrong client).
+    UnknownField(String),
+    /// `field` is registered but has no v1 SQL builder yet (`user_rating`,
+    /// `suffix`, `bit_rate`, …). Distinct from `UnknownField` so the caller
+    /// can tell a typo from a planned-but-unbuilt field.
+    NotQueryable(String),
+    /// `op` is not declared for `field` in the registry.
+    UnsupportedOp { field: String, op: &'static str },
+    /// The value side was missing or the wrong type for the operator.
+    BadValue { field: String, detail: String },
+}
+
+impl std::fmt::Display for FilterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FilterError::UnknownField(field) => {
+                let known = FILTER_FIELD_REGISTRY
+                    .iter()
+                    .map(|x| x.id)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "unknown filter field `{field}` (known: {known})")
+            }
+            FilterError::NotQueryable(field) => {
+                write!(f, "filter field `{field}` is registered but not queryable in v1")
+            }
+            FilterError::UnsupportedOp { field, op } => {
+                write!(f, "operator `{op}` is not supported for filter field `{field}`")
+            }
+            FilterError::BadValue { field, detail } => {
+                write!(f, "bad value for filter field `{field}`: {detail}")
+            }
+        }
+    }
+}
+
+/// Validate that `field` exists, applies to `entity`, and declares `op`.
+///
+/// Returns `Ok(true)` when the clause is applicable, `Ok(false)` when the
+/// field is known but doesn't route to this entity (§5.13.3: skip, don't
+/// error), and `Err` when the field is unknown or the op is undeclared.
+pub fn validate_for_entity(
+    field_id: &str,
+    op: FilterOp,
+    entity: EntityKind,
+) -> Result<bool, FilterError> {
+    let field = lookup(field_id).ok_or_else(|| FilterError::UnknownField(field_id.to_string()))?;
+    if !field.ops.contains(&op) {
+        return Err(FilterError::UnsupportedOp {
+            field: field_id.to_string(),
+            op: op.as_str(),
+        });
+    }
+    Ok(applies_to(field, entity))
+}
+
+/// Build a comparison fragment for a builder-supplied column expression.
+/// `col` is trusted SQL (never user input); only the bound values come from
+/// the request. `eq`/`gte`/`lte`/`between` parameterise their operands;
+/// `is_true` ignores the value and tests `IS NOT NULL`. `between` is
+/// inclusive on both ends (matches the year UI — §5.13.5).
+pub fn compare_fragment(
+    field: &str,
+    col: &str,
+    op: FilterOp,
+    value: Option<rusqlite::types::Value>,
+    value_to: Option<rusqlite::types::Value>,
+) -> Result<SqlFragment, FilterError> {
+    let need_value = |v: Option<rusqlite::types::Value>| {
+        v.ok_or_else(|| FilterError::BadValue {
+            field: field.to_string(),
+            detail: format!("operator `{}` requires a value", op.as_str()),
+        })
+    };
+    match op {
+        FilterOp::Eq => Ok(SqlFragment {
+            sql: format!("{col} = ?"),
+            params: vec![need_value(value)?],
+        }),
+        FilterOp::Gte => Ok(SqlFragment {
+            sql: format!("{col} >= ?"),
+            params: vec![need_value(value)?],
+        }),
+        FilterOp::Lte => Ok(SqlFragment {
+            sql: format!("{col} <= ?"),
+            params: vec![need_value(value)?],
+        }),
+        FilterOp::Between => {
+            let lo = need_value(value)?;
+            let hi = value_to.ok_or_else(|| FilterError::BadValue {
+                field: field.to_string(),
+                detail: "operator `between` requires `valueTo`".to_string(),
+            })?;
+            Ok(SqlFragment {
+                sql: format!("{col} BETWEEN ? AND ?"),
+                params: vec![lo, hi],
+            })
+        }
+        FilterOp::IsTrue => Ok(SqlFragment {
+            sql: format!("{col} IS NOT NULL"),
+            params: vec![],
+        }),
+        FilterOp::Fts | FilterOp::In => Err(FilterError::UnsupportedOp {
+            field: field.to_string(),
+            op: op.as_str(),
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -157,5 +324,92 @@ mod tests {
         let len_before = ids.len();
         ids.dedup();
         assert_eq!(ids.len(), len_before, "duplicate filter field id detected");
+    }
+
+    // ── SQL fragment resolution ───────────────────────────────────────
+
+    #[test]
+    fn op_wire_roundtrips() {
+        for op in [
+            FilterOp::Fts,
+            FilterOp::Eq,
+            FilterOp::In,
+            FilterOp::Gte,
+            FilterOp::Lte,
+            FilterOp::Between,
+            FilterOp::IsTrue,
+        ] {
+            assert_eq!(FilterOp::from_wire(op.as_str()), Some(op));
+        }
+    }
+
+    #[test]
+    fn op_from_wire_rejects_unbuilt_operators() {
+        // Spec §5.13.2 lists these but the v1 builder doesn't implement them.
+        for wire in ["neq", "contains", "is_false", "nope"] {
+            assert!(FilterOp::from_wire(wire).is_none(), "`{wire}` must not parse");
+        }
+    }
+
+    #[test]
+    fn validate_unknown_field_errors() {
+        let err = validate_for_entity("nope", FilterOp::Eq, EntityKind::Track).unwrap_err();
+        assert!(matches!(err, FilterError::UnknownField(f) if f == "nope"));
+    }
+
+    #[test]
+    fn validate_undeclared_op_errors() {
+        // `genre` only declares `eq` in v1.
+        let err = validate_for_entity("genre", FilterOp::Gte, EntityKind::Track).unwrap_err();
+        assert!(matches!(err, FilterError::UnsupportedOp { .. }));
+    }
+
+    #[test]
+    fn validate_known_field_off_entity_is_skip_not_error() {
+        // `bpm` is track-only — for an album query it routes to "skip".
+        assert_eq!(
+            validate_for_entity("bpm", FilterOp::Between, EntityKind::Album),
+            Ok(false)
+        );
+        assert_eq!(
+            validate_for_entity("bpm", FilterOp::Between, EntityKind::Track),
+            Ok(true)
+        );
+    }
+
+    #[test]
+    fn compare_fragment_between_is_inclusive_both_ends() {
+        use rusqlite::types::Value;
+        let frag = compare_fragment(
+            "year",
+            "t.year",
+            FilterOp::Between,
+            Some(Value::Integer(2000)),
+            Some(Value::Integer(2010)),
+        )
+        .unwrap();
+        assert_eq!(frag.sql, "t.year BETWEEN ? AND ?");
+        assert_eq!(frag.params, vec![Value::Integer(2000), Value::Integer(2010)]);
+    }
+
+    #[test]
+    fn compare_fragment_between_without_value_to_errors() {
+        use rusqlite::types::Value;
+        let err = compare_fragment(
+            "year",
+            "t.year",
+            FilterOp::Between,
+            Some(Value::Integer(2000)),
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, FilterError::BadValue { .. }));
+    }
+
+    #[test]
+    fn compare_fragment_is_true_ignores_value() {
+        let frag = compare_fragment("starred", "t.starred_at", FilterOp::IsTrue, None, None).unwrap();
+        assert_eq!(frag.sql, "t.starred_at IS NOT NULL");
+        assert!(frag.params.is_empty());
     }
 }

--- a/src-tauri/crates/psysonic-library/src/lib.rs
+++ b/src-tauri/crates/psysonic-library/src/lib.rs
@@ -7,7 +7,9 @@
 //! - `filter` — `FilterFieldRegistry` (Rust source of truth for Advanced Search)
 //! - `sync`   — capability probe + orchestrator (PR-3*)
 
+pub mod advanced_search;
 pub mod commands;
+pub mod cross_server;
 pub mod dto;
 pub mod filter;
 pub mod payload;

--- a/src-tauri/crates/psysonic-library/src/repos/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/mod.rs
@@ -5,3 +5,7 @@ pub mod track_id_history;
 pub use sync_state::SyncStateRepository;
 pub use track::{RemapEntry, RemapStats, TrackRepository, TrackRow};
 pub use track_id_history::TrackIdHistoryRepository;
+
+// Shared row-mapper + column list so the Advanced Search builder can project
+// the same hot columns as the repositories without re-declaring them.
+pub(crate) use track::{row_to_track_row, track_columns};

--- a/src-tauri/crates/psysonic-library/src/repos/track.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track.rs
@@ -329,12 +329,11 @@ const SELECT_TRACKS_BY_ALBUM: &str = "SELECT server_id, id, title, title_sort, a
   FROM track WHERE server_id = ?1 AND album_id = ?2 AND deleted = 0 \
   ORDER BY disc_number ASC NULLS LAST, track_number ASC NULLS LAST, id ASC";
 
-#[allow(dead_code)]
 pub(crate) fn track_columns() -> &'static str {
     TRACK_COLUMNS
 }
 
-fn row_to_track_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackRow> {
+pub(crate) fn row_to_track_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackRow> {
     Ok(TrackRow {
         server_id: row.get(0)?,
         id: row.get(1)?,

--- a/src-tauri/crates/psysonic-library/src/search.rs
+++ b/src-tauri/crates/psysonic-library/src/search.rs
@@ -52,6 +52,38 @@ pub fn search_tracks(
     })
 }
 
+// ── shared search SQL helpers (Advanced Search §5.13 + cross-server §5.5B) ──
+
+/// Hard ceiling on a single search page — keeps the FTS5 p95 budget (§5.9).
+/// Callers clamp their requested `limit` into `1..=PAGE_LIMIT_MAX`.
+pub(crate) const PAGE_LIMIT_MAX: u32 = 500;
+
+/// Build a safe FTS5 MATCH string: each whitespace token is quoted (and its
+/// internal `"` doubled) so arbitrary user input can't trip FTS5 query
+/// syntax. Tokens are implicitly AND-ed. `None` when the input has no tokens.
+pub(crate) fn fts_query(raw: &str) -> Option<String> {
+    let tokens: Vec<String> = raw
+        .split_whitespace()
+        .map(|t| format!("\"{}\"", t.replace('"', "\"\"")))
+        .collect();
+    if tokens.is_empty() {
+        None
+    } else {
+        Some(tokens.join(" "))
+    }
+}
+
+/// Project the `track` hot columns prefixed with `alias` (e.g. `t.title`),
+/// in `repos::row_to_track_row`'s positional order so the Advanced Search /
+/// cross-server builders can reuse the shared row mapper.
+pub(crate) fn aliased_track_columns(alias: &str) -> String {
+    crate::repos::track_columns()
+        .split(',')
+        .map(|c| format!("{alias}.{}", c.trim()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -136,5 +168,26 @@ mod tests {
         repo.upsert_batch(&[gone]).unwrap();
         let hits = search_tracks(&store, "s1", "aurora", 10).unwrap();
         assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn fts_query_quotes_tokens_and_doubles_inner_quotes() {
+        assert_eq!(fts_query("hello world").as_deref(), Some("\"hello\" \"world\""));
+        assert_eq!(fts_query("a\"b").as_deref(), Some("\"a\"\"b\""));
+    }
+
+    #[test]
+    fn fts_query_is_none_for_blank_input() {
+        assert!(fts_query("").is_none());
+        assert!(fts_query("   ").is_none());
+    }
+
+    #[test]
+    fn aliased_track_columns_prefixes_every_column() {
+        let cols = aliased_track_columns("t");
+        assert!(cols.starts_with("t.server_id, t.id, t.title"));
+        assert!(cols.ends_with("t.raw_json"));
+        // One alias per column — count matches the shared column list.
+        assert_eq!(cols.matches("t.").count(), crate::repos::track_columns().split(',').count());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -513,6 +513,8 @@ pub fn run() {
             psysonic_analysis::commands::analysis_prune_pending_to_track_ids,
             psysonic_library::commands::library_get_status,
             psysonic_library::commands::library_search,
+            psysonic_library::commands::library_advanced_search,
+            psysonic_library::commands::library_search_cross_server,
             psysonic_library::commands::library_get_track,
             psysonic_library::commands::library_get_tracks_batch,
             psysonic_library::commands::library_get_tracks_by_album,

--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -157,6 +157,85 @@ export interface SyncJobDto {
   kind: string; // 'initial_sync' | 'delta_sync'
 }
 
+// ── Advanced Search (PR-5d, §5.13 / §5.5B) ────────────────────────────
+
+export type LibraryEntityType = 'artist' | 'album' | 'track';
+
+/** v1 operator set the Rust `FilterFieldRegistry` accepts (§5.13.2). */
+export type FilterOperator = 'eq' | 'gte' | 'lte' | 'between' | 'fts' | 'is_true' | 'in';
+
+export type SortDir = 'asc' | 'desc';
+
+export interface LibraryFilterClause {
+  field: string; // registry id, e.g. 'genre' | 'year' | 'bpm'
+  op: FilterOperator;
+  value?: string | number | boolean | null;
+  valueTo?: number | null; // between: inclusive upper bound
+}
+
+export interface LibrarySortClause {
+  field: string;
+  dir: SortDir;
+}
+
+export interface LibraryAdvancedSearchRequest {
+  serverId: string;
+  libraryScope?: string | null;
+  query?: string | null; // shorthand → fts clause on text fields
+  entityTypes: LibraryEntityType[];
+  filters?: LibraryFilterClause[];
+  starredOnly?: boolean | null;
+  sort?: LibrarySortClause[];
+  limit: number;
+  offset?: number;
+}
+
+export interface LibraryAlbumDto {
+  serverId: string;
+  id: string;
+  name: string;
+  artist?: string | null;
+  artistId?: string | null;
+  songCount?: number | null;
+  durationSec?: number | null;
+  year?: number | null;
+  genre?: string | null;
+  coverArtId?: string | null;
+  starredAt?: number | null;
+  syncedAt: number;
+  rawJson: unknown;
+}
+
+export interface LibraryArtistDto {
+  serverId: string;
+  id: string;
+  name: string;
+  albumCount?: number | null;
+  syncedAt: number;
+  rawJson: unknown;
+}
+
+export interface LibrarySearchTotals {
+  artists: number;
+  albums: number;
+  tracks: number;
+}
+
+export interface LibraryAdvancedSearchResponse {
+  artists: LibraryArtistDto[];
+  albums: LibraryAlbumDto[];
+  tracks: LibraryTrackDto[];
+  totals: LibrarySearchTotals;
+  /** Registry field ids actually applied — UI chips / debug. */
+  appliedFilters: string[];
+  source: 'local' | 'network' | 'mixed';
+}
+
+export interface LibraryCrossServerSearchResponse {
+  hits: LibraryTrackDto[];
+  serversSearched: string[];
+}
+
 // ── Read commands (PR-5a) ─────────────────────────────────────────────
 
 export function libraryGetStatus(
@@ -178,6 +257,26 @@ export function librarySearch(
     offset: options?.offset,
     libraryScope: options?.libraryScope,
   });
+}
+
+/**
+ * Advanced Search against the local index (§5.13). The frontend fallback
+ * (PR-7 F2) decides local vs network and maps the same `LibraryFilterClause`
+ * shape onto the network path; this wrapper only talks to the local builder.
+ */
+export function libraryAdvancedSearch(
+  request: LibraryAdvancedSearchRequest,
+): Promise<LibraryAdvancedSearchResponse> {
+  return invoke<LibraryAdvancedSearchResponse>('library_advanced_search', { request });
+}
+
+/** Cross-server FTS union over the given servers, or all `ready` ones (§5.5B). */
+export function librarySearchCrossServer(args: {
+  query: string;
+  limit?: number;
+  servers?: string[];
+}): Promise<LibraryCrossServerSearchResponse> {
+  return invoke<LibraryCrossServerSearchResponse>('library_search_cross_server', args);
 }
 
 export function libraryGetTrack(


### PR DESCRIPTION
## Summary
- Advanced Search SQL builder (§5.13): `library_advanced_search` runs per-entity track/album/artist queries from a `FilterFieldRegistry`-validated AST — text (FTS) / genre / year / starred / bpm (dual-storage §5.13.4), `libraryScope`, sort, full-match totals.
- Cross-server FTS union (§5.5B / §5.9 A′): `library_search_cross_server` searches the given servers (or all `ready` ones), bm25-ordered, deduped by canonical id.
- Typed wrappers in `src/api/library.ts` (`libraryAdvancedSearch` / `librarySearchCrossServer`) + mirror DTOs.
- Backend only — `AdvancedSearch.tsx` parity stays PR-7 (F2); cross-server fuzzy fallback (§5.5B-C) stays PR-4 (H3).

## Tauri boundary
Adds two read-only commands (`library_advanced_search`, `library_search_cross_server`). No events, no breaking changes; camelCase DTOs mirror the serde shapes.

## Test plan
- `cargo test -p psysonic-library` — 210 pass (builder, filters, bpm fallback, entity routing, error cases, scope, totals, cross-server union/dedup)
- `cargo clippy -p psysonic-library --all-targets -- -D warnings` — clean
- `npx tsc --noEmit` — clean
- `./dev.sh check` — green (frontend test/tsc/coverage/gate/build + backend workspace test + clippy)