### PR TITLE
feat(library): Advanced Search local index mode (Phase F2, PR-7a)

### DIFF
--- a/src/pages/AdvancedSearch.tsx
+++ b/src/pages/AdvancedSearch.tsx
@@ -13,6 +13,7 @@ import CustomSelect from '../components/CustomSelect';
 import StarFilterButton from '../components/StarFilterButton';
 import { useAuthStore } from '../store/authStore';
 import { usePlayerStore } from '../store/playerStore';
+import { runLocalAdvancedSearch, loadMoreLocalSongs } from '../utils/library/advancedSearchLocal';
 
 type ResultType = 'all' | 'artists' | 'albums' | 'songs';
 
@@ -60,7 +61,11 @@ export default function AdvancedSearch() {
   const [loading, setLoading] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
   const [genreNote, setGenreNote] = useState(false);
+  // True while the current results came from the local index (drives the
+  // pagination branch — local pages every result type, network only free-text).
+  const [localMode, setLocalMode] = useState(false);
   const musicLibraryFilterVersion = useAuthStore(s => s.musicLibraryFilterVersion);
+  const serverId = useAuthStore(s => s.activeServerId);
 
   // Pagination — only the free-text-query branch uses search3 with offset
   const SONGS_INITIAL = 100;
@@ -91,6 +96,25 @@ export default function AdvancedSearch() {
     setActiveSearch(opts);
     setSongsServerOffset(0);
     setSongsHasMore(false);
+
+    // Local index first (§5.13.6): when the index is ready it serves the whole
+    // query offline + instantly. On not-ready / any failure this returns null
+    // and we fall through to the unchanged network path below.
+    const localPage = await runLocalAdvancedSearch(serverId, opts, SONGS_INITIAL);
+    if (localPage) {
+      setResults({
+        artists: localPage.artists,
+        albums: localPage.albums,
+        songs: localPage.songs,
+      });
+      setSongsServerOffset(localPage.songs.length);
+      setSongsHasMore(localPage.songsTotal > localPage.songs.length);
+      setLocalMode(true);
+      setLoading(false);
+      return;
+    }
+    setLocalMode(false);
+
     const { query: q, genre: g, yearFrom: yf, yearTo: yt, resultType: rt } = opts;
     const from = yf ? parseInt(yf) : null;
     const to = yt ? parseInt(yt) : null;
@@ -155,8 +179,26 @@ export default function AdvancedSearch() {
   }, [musicLibraryFilterVersion, qFromUrl]);
 
   const loadMoreSongs = useCallback(async () => {
-    if (loadingMoreSongs || !songsHasMore) return;
-    if (!activeSearch || !activeSearch.query.trim()) return;
+    if (loadingMoreSongs || !songsHasMore || !activeSearch) return;
+
+    // Local mode pages every result type (genre/year too), not just free-text.
+    if (localMode) {
+      if (!serverId) return;
+      setLoadingMoreSongs(true);
+      try {
+        const more = await loadMoreLocalSongs(serverId, activeSearch, songsServerOffset, SONGS_PAGE_SIZE);
+        setResults(prev => (prev ? { ...prev, songs: [...prev.songs, ...more] } : prev));
+        setSongsServerOffset(o => o + more.length);
+        if (more.length < SONGS_PAGE_SIZE) setSongsHasMore(false);
+      } catch {
+        setSongsHasMore(false);
+      } finally {
+        setLoadingMoreSongs(false);
+      }
+      return;
+    }
+
+    if (!activeSearch.query.trim()) return;
     setLoadingMoreSongs(true);
     try {
       const q = activeSearch.query.trim();
@@ -174,7 +216,7 @@ export default function AdvancedSearch() {
     } finally {
       setLoadingMoreSongs(false);
     }
-  }, [loadingMoreSongs, songsHasMore, activeSearch, songsServerOffset]);
+  }, [loadingMoreSongs, songsHasMore, activeSearch, songsServerOffset, localMode, serverId]);
 
   // IntersectionObserver on the bottom sentinel — fires loadMoreSongs as it nears the viewport.
   useEffect(() => {

--- a/src/utils/library/advancedSearchLocal.test.ts
+++ b/src/utils/library/advancedSearchLocal.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { onInvoke } from '@/test/mocks/tauri';
+import { useLibraryIndexStore } from '@/store/libraryIndexStore';
+import { runLocalAdvancedSearch } from './advancedSearchLocal';
+
+const opts = (over: Partial<Parameters<typeof runLocalAdvancedSearch>[1]> = {}) => ({
+  query: '',
+  genre: '',
+  yearFrom: '',
+  yearTo: '',
+  resultType: 'all' as const,
+  ...over,
+});
+
+const ready = () =>
+  onInvoke('library_get_status', () => ({
+    serverId: 's1',
+    libraryScope: '',
+    syncPhase: 'ready',
+    capabilityFlags: 0,
+    libraryTier: 'unknown',
+    syncedAt: 0,
+  }));
+
+describe('runLocalAdvancedSearch', () => {
+  beforeEach(() => {
+    useLibraryIndexStore.getState().setIndexEnabled('s1', true);
+  });
+
+  it('returns null (→ network fallback) when the index is not ready', async () => {
+    onInvoke('library_get_status', () => ({ serverId: 's1', libraryScope: '', syncPhase: 'initial_sync' }));
+    const res = await runLocalAdvancedSearch('s1', opts({ query: 'x' }), 100);
+    expect(res).toBeNull();
+  });
+
+  it('returns null when the index is disabled for the server', async () => {
+    useLibraryIndexStore.getState().setIndexEnabled('s1', false);
+    const res = await runLocalAdvancedSearch('s1', opts({ query: 'x' }), 100);
+    expect(res).toBeNull();
+  });
+
+  it('prefers rawJson, falls back to hot columns, and reports the full total', async () => {
+    ready();
+    onInvoke('library_advanced_search', () => ({
+      artists: [],
+      albums: [],
+      tracks: [
+        {
+          serverId: 's1', id: 't1', title: 'Hot Title', album: 'Alb', albumId: 'al1',
+          durationSec: 100, syncedAt: 0,
+          // rawJson is the authoritative original song — must win.
+          rawJson: {
+            id: 't1', title: 'Raw Title', artist: 'Raw Artist', album: 'Alb', albumId: 'al1',
+            duration: 100, contributors: [{ role: 'composer', artist: { name: 'C' } }],
+          },
+        },
+        {
+          serverId: 's1', id: 't2', title: 'Only Hot', album: 'Alb2', albumId: 'al2',
+          artist: 'Hot Artist', durationSec: 200, year: 1999, genre: 'Rock',
+          starredAt: 1_700_000_000_000, syncedAt: 0,
+          rawJson: {}, // sparse → hot-column fallback
+        },
+      ],
+      totals: { artists: 0, albums: 0, tracks: 42 },
+      appliedFilters: [],
+      source: 'local',
+    }));
+
+    const res = await runLocalAdvancedSearch('s1', opts({ resultType: 'songs' }), 100);
+    expect(res).not.toBeNull();
+    expect(res!.songs).toHaveLength(2);
+
+    // rawJson wins where present + carries OpenSubsonic extras.
+    expect(res!.songs[0].title).toBe('Raw Title');
+    expect(res!.songs[0].artist).toBe('Raw Artist');
+    expect(res!.songs[0].contributors).toBeDefined();
+
+    // hot-column fallback when rawJson is sparse.
+    expect(res!.songs[1].title).toBe('Only Hot');
+    expect(res!.songs[1].artist).toBe('Hot Artist');
+    expect(res!.songs[1].year).toBe(1999);
+    expect(res!.songs[1].genre).toBe('Rock');
+    expect(res!.songs[1].starred).toBeTruthy();
+
+    // Total is the full match count, not the page size.
+    expect(res!.songsTotal).toBe(42);
+  });
+
+  it('returns null without throwing when the local query errors', async () => {
+    ready();
+    onInvoke('library_advanced_search', () => {
+      throw new Error('boom');
+    });
+    const res = await runLocalAdvancedSearch('s1', opts({ query: 'x' }), 100);
+    expect(res).toBeNull();
+  });
+});

--- a/src/utils/library/advancedSearchLocal.ts
+++ b/src/utils/library/advancedSearchLocal.ts
@@ -1,0 +1,191 @@
+/**
+ * Advanced Search against the local library index (spec §5.13 / F2).
+ *
+ * Maps the AdvancedSearch UI inputs to a `library_advanced_search` request and
+ * the response back to the Subsonic shapes the existing rows render. The sync
+ * engine stores each entity's original Subsonic JSON in `rawJson` (ADR-7), so
+ * that's preferred verbatim; the flat hot columns are a fallback when a row's
+ * `rawJson` is sparse.
+ *
+ * `runLocalAdvancedSearch` returns `null` when the index isn't ready or the
+ * query can't be served locally — the caller then falls back to the network
+ * path unchanged (§5.13.6).
+ */
+import {
+  libraryAdvancedSearch,
+  type LibraryAdvancedSearchRequest,
+  type LibraryAlbumDto,
+  type LibraryArtistDto,
+  type LibraryEntityType,
+  type LibraryFilterClause,
+  type LibraryTrackDto,
+} from '../../api/library';
+import type { SubsonicAlbum, SubsonicArtist, SubsonicSong } from '../../api/subsonicTypes';
+import { libraryIsReady } from './libraryReady';
+
+export type AdvancedResultType = 'all' | 'artists' | 'albums' | 'songs';
+
+export interface LocalSearchOpts {
+  query: string;
+  genre: string;
+  yearFrom: string;
+  yearTo: string;
+  resultType: AdvancedResultType;
+}
+
+export interface LocalAdvancedSearchPage {
+  artists: SubsonicArtist[];
+  albums: SubsonicAlbum[];
+  songs: SubsonicSong[];
+  /** Full track match count (not page size) — drives "load more". */
+  songsTotal: number;
+}
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+function entityTypesFor(rt: AdvancedResultType): LibraryEntityType[] {
+  switch (rt) {
+    case 'artists':
+      return ['artist'];
+    case 'albums':
+      return ['album'];
+    case 'songs':
+      return ['track'];
+    default:
+      return ['artist', 'album', 'track'];
+  }
+}
+
+function buildFilters(opts: LocalSearchOpts): LibraryFilterClause[] {
+  const filters: LibraryFilterClause[] = [];
+  if (opts.genre) filters.push({ field: 'genre', op: 'eq', value: opts.genre });
+  const from = opts.yearFrom ? parseInt(opts.yearFrom, 10) : null;
+  const to = opts.yearTo ? parseInt(opts.yearTo, 10) : null;
+  if (from !== null && to !== null) {
+    filters.push({ field: 'year', op: 'between', value: from, valueTo: to });
+  } else if (from !== null) {
+    filters.push({ field: 'year', op: 'gte', value: from });
+  } else if (to !== null) {
+    filters.push({ field: 'year', op: 'lte', value: to });
+  }
+  return filters;
+}
+
+function buildRequest(
+  serverId: string,
+  opts: LocalSearchOpts,
+  entityTypes: LibraryEntityType[],
+  limit: number,
+  offset: number,
+): LibraryAdvancedSearchRequest {
+  const q = opts.query.trim();
+  return {
+    serverId,
+    query: q || undefined,
+    entityTypes,
+    filters: buildFilters(opts),
+    limit,
+    offset,
+  };
+}
+
+function trackToSong(t: LibraryTrackDto): SubsonicSong {
+  const raw = isObject(t.rawJson) ? t.rawJson : {};
+  const base: SubsonicSong = {
+    id: t.id,
+    title: t.title,
+    artist: t.artist ?? '',
+    album: t.album,
+    albumId: t.albumId ?? '',
+    artistId: t.artistId ?? undefined,
+    duration: t.durationSec,
+    track: t.trackNumber ?? undefined,
+    discNumber: t.discNumber ?? undefined,
+    coverArt: t.coverArtId ?? undefined,
+    year: t.year ?? undefined,
+    genre: t.genre ?? undefined,
+    suffix: t.suffix ?? undefined,
+    bitRate: t.bitRate ?? undefined,
+    size: t.sizeBytes ?? undefined,
+    starred: t.starredAt != null ? new Date(t.starredAt).toISOString() : undefined,
+    userRating: t.userRating ?? undefined,
+    playCount: t.playCount ?? undefined,
+    bpm: t.bpm ?? undefined,
+    isrc: t.isrc ?? undefined,
+    albumArtist: t.albumArtist ?? undefined,
+  };
+  // `rawJson` is the authoritative original song — let it override the
+  // hot-column fallbacks (it carries OpenSubsonic extras too).
+  return { ...base, ...(raw as Partial<SubsonicSong>) };
+}
+
+function albumToAlbum(a: LibraryAlbumDto): SubsonicAlbum {
+  const raw = isObject(a.rawJson) ? a.rawJson : {};
+  const base: SubsonicAlbum = {
+    id: a.id,
+    name: a.name,
+    artist: a.artist ?? '',
+    artistId: a.artistId ?? '',
+    songCount: a.songCount ?? 0,
+    duration: a.durationSec ?? 0,
+    year: a.year ?? undefined,
+    genre: a.genre ?? undefined,
+    coverArt: a.coverArtId ?? undefined,
+    starred: a.starredAt != null ? new Date(a.starredAt).toISOString() : undefined,
+  };
+  return { ...base, ...(raw as Partial<SubsonicAlbum>) };
+}
+
+function artistToArtist(ar: LibraryArtistDto): SubsonicArtist {
+  const raw = isObject(ar.rawJson) ? ar.rawJson : {};
+  const base: SubsonicArtist = {
+    id: ar.id,
+    name: ar.name,
+    albumCount: ar.albumCount ?? undefined,
+  };
+  return { ...base, ...(raw as Partial<SubsonicArtist>) };
+}
+
+/**
+ * Full first-page Advanced Search against the local index. Returns `null`
+ * when the index isn't ready or the local query fails — caller falls back to
+ * the network path.
+ */
+export async function runLocalAdvancedSearch(
+  serverId: string | null | undefined,
+  opts: LocalSearchOpts,
+  songsLimit: number,
+): Promise<LocalAdvancedSearchPage | null> {
+  if (!serverId) return null;
+  if (!(await libraryIsReady(serverId))) return null;
+  try {
+    const req = buildRequest(serverId, opts, entityTypesFor(opts.resultType), songsLimit, 0);
+    const resp = await libraryAdvancedSearch(req);
+    if (resp.source !== 'local') return null;
+    return {
+      artists: resp.artists.map(artistToArtist),
+      albums: resp.albums.map(albumToAlbum),
+      songs: resp.tracks.map(trackToSong),
+      songsTotal: resp.totals.tracks,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Songs-only next page for the local path (mirrors the network
+ * `searchSongsPaged` pagination). Throws are surfaced so the caller can stop
+ * the infinite-scroll loop, matching the network branch's behaviour.
+ */
+export async function loadMoreLocalSongs(
+  serverId: string,
+  opts: LocalSearchOpts,
+  offset: number,
+  pageSize: number,
+): Promise<SubsonicSong[]> {
+  const req = buildRequest(serverId, opts, ['track'], pageSize, offset);
+  const resp = await libraryAdvancedSearch(req);
+  return resp.tracks.map(trackToSong);
+}

--- a/src/utils/library/libraryReady.ts
+++ b/src/utils/library/libraryReady.ts
@@ -1,0 +1,21 @@
+/**
+ * Is the local library index usable for `serverId` right now?
+ *
+ * Spec §5.13.6 / P8: consumers (Advanced Search, browse, …) only read from
+ * the local index when it's both enabled and fully synced (`ready`); any
+ * partial / disabled / errored state falls back to the network so results
+ * are never silently incomplete.
+ */
+import { libraryGetStatus } from '../../api/library';
+import { useLibraryIndexStore } from '../../store/libraryIndexStore';
+
+export async function libraryIsReady(serverId: string | null | undefined): Promise<boolean> {
+  if (!serverId) return false;
+  if (!useLibraryIndexStore.getState().isIndexEnabled(serverId)) return false;
+  try {
+    const status = await libraryGetStatus(serverId);
+    return status.syncPhase === 'ready';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Advanced Search now serves query / genre / year / result-type from `library_advanced_search` when the active server's index is `ready`, paging songs locally — instant and offline.
- Falls back to the existing network path unchanged on not-ready / disabled / any error (spec §5.13.6), so behaviour is identical until an index is fully synced.
- Results map from each entity's stored Subsonic `rawJson` (authoritative), with the flat hot columns as a fallback.
- New `libraryIsReady` helper (reusable by later F-phase consumers).

## Test plan
- `npx vitest run src/utils/library/advancedSearchLocal.test.ts` — 4 pass (rawJson-vs-hot-column mapping, not-ready/disabled → null fallback, error → null)
- `npm test` — 995 pass · `npx tsc --noEmit` — clean