### PR TITLE
feat(library): FactRepository with TTL + provenance (Phase E4, PR-6a)

### DIFF
--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -246,48 +246,13 @@ pub fn library_get_facts(
     track_id: String,
     fact_kinds: Option<Vec<String>>,
 ) -> Result<Vec<TrackFactDto>, String> {
-    runtime
-        .store
-        .with_conn(|conn| {
-            let kinds = fact_kinds.unwrap_or_default();
-            if kinds.is_empty() {
-                let mut stmt = conn.prepare(
-                    "SELECT server_id, track_id, fact_kind, value_real, value_int, value_text, \
-                     unit, source_kind, source_id, confidence, content_hash, fetched_at, expires_at \
-                     FROM track_fact \
-                     WHERE server_id = ?1 AND track_id = ?2 \
-                     ORDER BY fact_kind ASC, fetched_at DESC",
-                )?;
-                let rows: rusqlite::Result<Vec<TrackFactDto>> = stmt
-                    .query_map(params![server_id, track_id], row_to_fact_dto)?
-                    .collect();
-                rows
-            } else {
-                // ANY value match across the provided fact_kinds.
-                let placeholders =
-                    (0..kinds.len()).map(|i| format!("?{}", i + 3)).collect::<Vec<_>>().join(", ");
-                let sql = format!(
-                    "SELECT server_id, track_id, fact_kind, value_real, value_int, value_text, \
-                     unit, source_kind, source_id, confidence, content_hash, fetched_at, expires_at \
-                     FROM track_fact \
-                     WHERE server_id = ?1 AND track_id = ?2 AND fact_kind IN ({placeholders}) \
-                     ORDER BY fact_kind ASC, fetched_at DESC"
-                );
-                let mut stmt = conn.prepare(&sql)?;
-                let mut bound: Vec<rusqlite::types::Value> = vec![
-                    rusqlite::types::Value::Text(server_id.clone()),
-                    rusqlite::types::Value::Text(track_id.clone()),
-                ];
-                for k in &kinds {
-                    bound.push(rusqlite::types::Value::Text(k.clone()));
-                }
-                let rows: rusqlite::Result<Vec<TrackFactDto>> = stmt
-                    .query_map(rusqlite::params_from_iter(bound.iter()), row_to_fact_dto)?
-                    .collect();
-                rows
-            }
-        })
-        .map_err(|e| e.to_string())
+    // E4: typed repo owns the §5.12 lazy-expiry + provenance rules.
+    crate::repos::FactRepository::new(&runtime.store).get(
+        &server_id,
+        &track_id,
+        &fact_kinds.unwrap_or_default(),
+        now_unix_ms(),
+    )
 }
 
 #[tauri::command]
@@ -351,24 +316,6 @@ fn hydrate_refs(
         .collect();
     let rows = TrackRepository::new(&runtime.store).find_batch(&pairs)?;
     Ok(rows.iter().map(LibraryTrackDto::from_row).collect())
-}
-
-fn row_to_fact_dto(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackFactDto> {
-    Ok(TrackFactDto {
-        server_id: row.get(0)?,
-        track_id: row.get(1)?,
-        fact_kind: row.get(2)?,
-        value_real: row.get(3)?,
-        value_int: row.get(4)?,
-        value_text: row.get(5)?,
-        unit: row.get(6)?,
-        source_kind: row.get(7)?,
-        source_id: row.get(8)?,
-        confidence: row.get(9)?,
-        content_hash: row.get(10)?,
-        fetched_at: row.get(11)?,
-        expires_at: row.get(12)?,
-    })
 }
 
 #[derive(Default)]
@@ -799,45 +746,9 @@ pub fn library_put_fact(
     track_id: String,
     fact: FactInputDto,
 ) -> Result<(), String> {
-    let now = now_unix_ms();
-    runtime
-        .store
-        .with_conn(|conn| {
-            conn.execute(
-                "INSERT INTO track_fact \
-                 (server_id, track_id, fact_kind, value_real, value_int, value_text, unit, \
-                  source_kind, source_id, source_detail, confidence, content_hash, \
-                  fetched_at, expires_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, ?10, ?11, ?12, ?13) \
-                 ON CONFLICT(server_id, track_id, fact_kind, source_kind, source_id) \
-                 DO UPDATE SET \
-                   value_real = excluded.value_real, \
-                   value_int = excluded.value_int, \
-                   value_text = excluded.value_text, \
-                   unit = excluded.unit, \
-                   confidence = excluded.confidence, \
-                   content_hash = excluded.content_hash, \
-                   fetched_at = excluded.fetched_at, \
-                   expires_at = excluded.expires_at",
-                params![
-                    server_id,
-                    track_id,
-                    fact.fact_kind,
-                    fact.value_real,
-                    fact.value_int,
-                    fact.value_text,
-                    fact.unit,
-                    fact.source_kind,
-                    fact.source_id,
-                    fact.confidence,
-                    fact.content_hash,
-                    now,
-                    fact.expires_at,
-                ],
-            )?;
-            Ok(())
-        })
-        .map_err(|e| e.to_string())
+    // E4: typed repo owns the upsert + the §5.12 user-override rule
+    // (a `user` bpm fact also writes the hot `track.bpm` column).
+    crate::repos::FactRepository::new(&runtime.store).put(&server_id, &track_id, &fact, now_unix_ms())
 }
 
 #[tauri::command]

--- a/src-tauri/crates/psysonic-library/src/repos/fact.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/fact.rs
@@ -1,0 +1,279 @@
+//! E4 — `FactRepository`: typed CRUD over `track_fact` with the §5.12
+//! provenance / TTL rules.
+//!
+//! - **Lazy expiry (P34):** there's no background GC; a `get` first deletes
+//!   the track's expired facts, then returns the survivors.
+//! - **User override (R6-3.4):** a `user` BPM fact also writes `track.bpm` so
+//!   the override wins and survives a server resync.
+//!
+//! The Tauri commands (`library_get_facts` / `library_put_fact`) delegate
+//! here so there's one source of truth for the storage rules.
+
+use rusqlite::params;
+
+use crate::dto::{FactInputDto, TrackFactDto};
+use crate::store::LibraryStore;
+
+pub struct FactRepository<'a> {
+    store: &'a LibraryStore,
+}
+
+impl<'a> FactRepository<'a> {
+    pub fn new(store: &'a LibraryStore) -> Self {
+        Self { store }
+    }
+
+    /// Lazily drop the track's expired facts (§5.12 read-path GC), then
+    /// return the survivors — optionally filtered to `fact_kinds`. Ordered
+    /// `fact_kind ASC, fetched_at DESC` so the highest-priority source per
+    /// kind (caller resolves) comes first within its group.
+    pub fn get(
+        &self,
+        server_id: &str,
+        track_id: &str,
+        fact_kinds: &[String],
+        now: i64,
+    ) -> Result<Vec<TrackFactDto>, String> {
+        self.store
+            .with_conn_mut(|conn| {
+                // Lazy TTL cleanup for this track.
+                conn.execute(
+                    "DELETE FROM track_fact \
+                     WHERE server_id = ?1 AND track_id = ?2 \
+                       AND expires_at IS NOT NULL AND expires_at < ?3",
+                    params![server_id, track_id, now],
+                )?;
+
+                if fact_kinds.is_empty() {
+                    let mut stmt = conn.prepare(SELECT_FACTS)?;
+                    let rows: rusqlite::Result<Vec<TrackFactDto>> = stmt
+                        .query_map(params![server_id, track_id], row_to_fact_dto)?
+                        .collect();
+                    rows
+                } else {
+                    let placeholders = (0..fact_kinds.len())
+                        .map(|i| format!("?{}", i + 3))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let sql = format!(
+                        "{SELECT_FACTS_BASE} AND fact_kind IN ({placeholders}) \
+                         ORDER BY fact_kind ASC, fetched_at DESC"
+                    );
+                    let mut bound: Vec<rusqlite::types::Value> = vec![
+                        rusqlite::types::Value::Text(server_id.to_string()),
+                        rusqlite::types::Value::Text(track_id.to_string()),
+                    ];
+                    for k in fact_kinds {
+                        bound.push(rusqlite::types::Value::Text(k.clone()));
+                    }
+                    let mut stmt = conn.prepare(&sql)?;
+                    let rows: rusqlite::Result<Vec<TrackFactDto>> = stmt
+                        .query_map(rusqlite::params_from_iter(bound.iter()), row_to_fact_dto)?
+                        .collect();
+                    rows
+                }
+            })
+            .map_err(|e| e.to_string())
+    }
+
+    /// Upsert a fact. A `user` BPM fact also writes the hot `track.bpm`
+    /// column so the manual override beats the server tag and survives a
+    /// resync (§5.12 write path / R6-3.4).
+    pub fn put(
+        &self,
+        server_id: &str,
+        track_id: &str,
+        fact: &FactInputDto,
+        now: i64,
+    ) -> Result<(), String> {
+        self.store
+            .with_conn(|conn| {
+                conn.execute(
+                    UPSERT_FACT,
+                    params![
+                        server_id,
+                        track_id,
+                        fact.fact_kind,
+                        fact.value_real,
+                        fact.value_int,
+                        fact.value_text,
+                        fact.unit,
+                        fact.source_kind,
+                        fact.source_id,
+                        fact.confidence,
+                        fact.content_hash,
+                        now,
+                        fact.expires_at,
+                    ],
+                )?;
+                if fact.fact_kind == "bpm" && fact.source_kind == "user" {
+                    if let Some(bpm) = fact.value_int {
+                        conn.execute(
+                            "UPDATE track SET bpm = ?3 WHERE server_id = ?1 AND id = ?2",
+                            params![server_id, track_id, bpm],
+                        )?;
+                    }
+                }
+                Ok(())
+            })
+            .map_err(|e| e.to_string())
+    }
+}
+
+fn row_to_fact_dto(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackFactDto> {
+    Ok(TrackFactDto {
+        server_id: row.get(0)?,
+        track_id: row.get(1)?,
+        fact_kind: row.get(2)?,
+        value_real: row.get(3)?,
+        value_int: row.get(4)?,
+        value_text: row.get(5)?,
+        unit: row.get(6)?,
+        source_kind: row.get(7)?,
+        source_id: row.get(8)?,
+        confidence: row.get(9)?,
+        content_hash: row.get(10)?,
+        fetched_at: row.get(11)?,
+        expires_at: row.get(12)?,
+    })
+}
+
+const SELECT_FACTS_BASE: &str = "SELECT server_id, track_id, fact_kind, value_real, value_int, \
+  value_text, unit, source_kind, source_id, confidence, content_hash, fetched_at, expires_at \
+  FROM track_fact WHERE server_id = ?1 AND track_id = ?2";
+
+const SELECT_FACTS: &str = "SELECT server_id, track_id, fact_kind, value_real, value_int, \
+  value_text, unit, source_kind, source_id, confidence, content_hash, fetched_at, expires_at \
+  FROM track_fact WHERE server_id = ?1 AND track_id = ?2 \
+  ORDER BY fact_kind ASC, fetched_at DESC";
+
+const UPSERT_FACT: &str = "INSERT INTO track_fact \
+  (server_id, track_id, fact_kind, value_real, value_int, value_text, unit, \
+   source_kind, source_id, source_detail, confidence, content_hash, fetched_at, expires_at) \
+  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, ?10, ?11, ?12, ?13) \
+  ON CONFLICT(server_id, track_id, fact_kind, source_kind, source_id) DO UPDATE SET \
+    value_real = excluded.value_real, \
+    value_int = excluded.value_int, \
+    value_text = excluded.value_text, \
+    unit = excluded.unit, \
+    confidence = excluded.confidence, \
+    content_hash = excluded.content_hash, \
+    fetched_at = excluded.fetched_at, \
+    expires_at = excluded.expires_at";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fact(kind: &str, source_kind: &str, value_int: Option<i64>, expires_at: Option<i64>) -> FactInputDto {
+        FactInputDto {
+            fact_kind: kind.into(),
+            value_real: None,
+            value_int,
+            value_text: None,
+            unit: None,
+            source_kind: source_kind.into(),
+            source_id: "seed".into(),
+            confidence: 1.0,
+            content_hash: None,
+            expires_at,
+        }
+    }
+
+    fn seed_track(store: &LibraryStore, server: &str, id: &str) {
+        store
+            .with_conn(|c| {
+                c.execute(
+                    "INSERT INTO track (server_id, id, title, synced_at, raw_json) \
+                     VALUES (?1, ?2, 'T', 1, '{}')",
+                    params![server, id],
+                )
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn put_then_get_roundtrips() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1");
+        let repo = FactRepository::new(&store);
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 100).unwrap();
+        let facts = repo.get("s1", "t1", &[], 200).unwrap();
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].fact_kind, "bpm");
+        assert_eq!(facts[0].value_int, Some(120));
+    }
+
+    #[test]
+    fn get_lazily_deletes_expired_facts() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1");
+        let repo = FactRepository::new(&store);
+        // expires at t=150
+        repo.put("s1", "t1", &fact("energy", "external_api", Some(5), Some(150)), 100).unwrap();
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 100).unwrap();
+
+        // read at t=200 → energy expired, dropped + excluded; bpm survives.
+        let facts = repo.get("s1", "t1", &[], 200).unwrap();
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].fact_kind, "bpm");
+
+        // and it was actually deleted from the table (not just filtered).
+        let total: i64 = store
+            .with_conn(|c| c.query_row("SELECT COUNT(*) FROM track_fact", [], |r| r.get(0)))
+            .unwrap();
+        assert_eq!(total, 1);
+    }
+
+    #[test]
+    fn get_filters_by_kind() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1");
+        let repo = FactRepository::new(&store);
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 1).unwrap();
+        repo.put("s1", "t1", &fact("energy", "analysis", Some(7), None), 1).unwrap();
+        let facts = repo.get("s1", "t1", &["bpm".into()], 2).unwrap();
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].fact_kind, "bpm");
+    }
+
+    #[test]
+    fn user_bpm_fact_also_writes_hot_track_column() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1");
+        let repo = FactRepository::new(&store);
+        repo.put("s1", "t1", &fact("bpm", "user", Some(128), None), 1).unwrap();
+        let bpm: Option<i64> = store
+            .with_conn(|c| {
+                c.query_row("SELECT bpm FROM track WHERE server_id='s1' AND id='t1'", [], |r| r.get(0))
+            })
+            .unwrap();
+        assert_eq!(bpm, Some(128), "user bpm override must write track.bpm");
+    }
+
+    #[test]
+    fn analysis_bpm_fact_does_not_touch_hot_track_column() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1");
+        let repo = FactRepository::new(&store);
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(99), None), 1).unwrap();
+        let bpm: Option<i64> = store
+            .with_conn(|c| {
+                c.query_row("SELECT bpm FROM track WHERE server_id='s1' AND id='t1'", [], |r| r.get(0))
+            })
+            .unwrap();
+        assert_eq!(bpm, None, "only a user override writes the hot column (§5.12)");
+    }
+
+    #[test]
+    fn put_is_idempotent_on_same_source_key() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1");
+        let repo = FactRepository::new(&store);
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 1).unwrap();
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(124), None), 2).unwrap();
+        let facts = repo.get("s1", "t1", &[], 3).unwrap();
+        assert_eq!(facts.len(), 1, "same (kind, source) updates in place");
+        assert_eq!(facts[0].value_int, Some(124));
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/repos/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/mod.rs
@@ -1,7 +1,9 @@
+pub mod fact;
 pub mod sync_state;
 pub mod track;
 pub mod track_id_history;
 
+pub use fact::FactRepository;
 pub use sync_state::SyncStateRepository;
 pub use track::{RemapEntry, RemapStats, TrackRepository, TrackRow};
 pub use track_id_history::TrackIdHistoryRepository;


### PR DESCRIPTION
## Summary
- New `repos::FactRepository` centralises `track_fact` storage with the §5.12 rules: lazy read-path expiry (no background GC — `get` deletes the track's expired facts, then returns survivors) and the `user`-BPM override that also writes the hot `track.bpm` column so a manual value survives a server resync.
- `library_get_facts` / `library_put_fact` now delegate to the repo — inline SQL and the local `row_to_fact_dto` helper are removed, so there is one source of truth for the fact rules (mirrors the existing `TrackRepository` shape).

## Test plan
- 6 new unit tests in `repos/fact.rs`: put→get roundtrip, lazy delete of expired facts (and verified actually deleted, not just filtered), kind filter, user-BPM writes hot column, analysis-BPM does not, idempotent upsert on same source key.
- `cargo test --workspace` green; `cargo clippy --workspace --all-targets -- -D warnings` clean.

No Tauri surface change — the two commands keep their signatures; only their internals were refactored.