### PR TITLE
fix(integration): decode OpenSubsonic isrc string-array on Song

### DIFF
--- a/src-tauri/crates/psysonic-integration/src/subsonic/types.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/types.rs
@@ -7,6 +7,36 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Deserialize a field Navidrome/OpenSubsonic may return either as a plain
+/// string or as a JSON array. OpenSubsonic types `isrc` as `string[]`;
+/// Navidrome ships `isrc: []` / `["USRC…"]`, which breaks a plain
+/// `Option<String>`. Take the first usable value; the full set survives
+/// verbatim in `track.raw_json` (ADR-7).
+fn de_string_or_seq<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(match value {
+        Some(serde_json::Value::String(s)) => Some(s),
+        Some(serde_json::Value::Array(arr)) => first_tag_value(&arr),
+        _ => None,
+    })
+}
+
+/// First usable value in a multi-valued array: a string element, or an
+/// object element's `name` (the OpenSubsonic `[{ "name": … }]` shape).
+fn first_tag_value(arr: &[serde_json::Value]) -> Option<String> {
+    arr.iter().find_map(|el| match el {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Object(map) => map
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
+        _ => None,
+    })
+}
+
 /// Envelope-level metadata returned by `#ping` (and present on every
 /// other response too). Read by the capability probe to detect the
 /// server family (Navidrome vs generic Subsonic) and the OpenSubsonic
@@ -183,7 +213,9 @@ pub struct Song {
     /// responses, generic Subsonic stays on `musicFolderId`.
     #[serde(default, alias = "libraryId", alias = "musicFolderId")]
     pub library_id: Option<String>,
-    #[serde(default)]
+    // OpenSubsonic types `isrc` as `string[]` — Navidrome returns
+    // `isrc: []` / `["USRC…"]`, which breaks a plain `Option<String>`.
+    #[serde(default, deserialize_with = "de_string_or_seq")]
     pub isrc: Option<String>,
     /// MusicBrainz recording id. Subsonic / OpenSubsonic uses the
     /// `musicBrainzId` JSON key; the schema column is `mbid_recording`
@@ -284,6 +316,21 @@ mod tests {
         assert_eq!(album.name, "Test Album");
         assert_eq!(album.song.len(), 2);
         assert_eq!(album.song[1].title, "Two");
+    }
+
+    #[test]
+    fn song_isrc_accepts_opensubsonic_string_array() {
+        // OpenSubsonic `isrc` is `string[]`. Navidrome ships `isrc: []`
+        // (the album !Brincamos! repro) or a populated array — both must
+        // decode, plus the legacy single-string form.
+        let empty: Song = serde_json::from_str(r#"{"id":"a","title":"t","isrc":[]}"#).unwrap();
+        assert!(empty.isrc.is_none());
+        let arr: Song =
+            serde_json::from_str(r#"{"id":"a","title":"t","isrc":["USRC17607839"]}"#).unwrap();
+        assert_eq!(arr.isrc.as_deref(), Some("USRC17607839"));
+        let legacy: Song =
+            serde_json::from_str(r#"{"id":"a","title":"t","isrc":"USRC17607839"}"#).unwrap();
+        assert_eq!(legacy.isrc.as_deref(), Some("USRC17607839"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `Song.isrc` now decodes the OpenSubsonic `string[]` shape — Navidrome ships `isrc: []` or `["USRC…"]`, which a plain `Option<String>` could not decode and which blocked the S1 (`search3`) and S2 (`getAlbum`) ingest paths past the first array-valued track.
- Tolerant `de_string_or_seq`: string → `Some`; non-empty array → first usable value (string element, or object `.name`); `[]`/null → `None`. Full multi-value set still kept verbatim in `track.raw_json` (ADR-7).
- Maintainer policy R7-15, checklist item 1 (workdocs `2026-05-20-large-library-ingest-client-only.md`): treat Navidrome as a black box, harden the client decode.

## Test plan
- `cargo test -p psysonic-integration` green (9/9), incl. new `song_isrc_accepts_opensubsonic_string_array` (`[]` → None, populated array, legacy single-string).
- `cargo clippy -p psysonic-integration --all-targets -- -D warnings` clean.