### PR TITLE
feat(library): large-library ingest strategy — S1 over N1 (R7-15)

### DIFF
--- a/src-tauri/crates/psysonic-library/migrations/002_n1_bulk_unreliable.sql
+++ b/src-tauri/crates/psysonic-library/migrations/002_n1_bulk_unreliable.sql
@@ -1,0 +1,6 @@
+-- psysonic-library schema v2 — large-library ingest policy (R7-15).
+-- Per-server learned flag: when N1 (`/api/song`) returns HTTP 500 beyond a
+-- deep offset on a large catalog, the strategy selector stops choosing N1 for
+-- that server on future initial syncs (spec §6.3 / R7-15 Q1/Q5). Additive
+-- column, DEFAULT 0 → existing rows keep N1 eligible until they hit the wall.
+ALTER TABLE sync_state ADD COLUMN n1_bulk_unreliable INTEGER NOT NULL DEFAULT 0;

--- a/src-tauri/crates/psysonic-library/src/repos/sync_state.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/sync_state.rs
@@ -409,6 +409,47 @@ impl<'a> SyncStateRepository<'a> {
         })
     }
 
+    /// Read `n1_bulk_unreliable` — per-server learned flag (R7-15). When
+    /// set, the strategy selector stops choosing N1 for this server (the
+    /// native `/api/song` endpoint 500'd beyond a deep offset). Returns
+    /// `None` when the row doesn't exist; SQL DEFAULT is 0 so a
+    /// freshly-ensured row reads back as `Some(false)`.
+    pub fn get_n1_bulk_unreliable(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+    ) -> Result<Option<bool>, String> {
+        let raw: Option<i64> = self.store.with_conn(|conn| {
+            conn.query_row(
+                "SELECT n1_bulk_unreliable FROM sync_state \
+                 WHERE server_id = ?1 AND library_scope = ?2",
+                params![server_id, library_scope],
+                |row| row.get(0),
+            )
+            .optional()
+        })?;
+        Ok(raw.map(|v| v != 0))
+    }
+
+    /// Write `n1_bulk_unreliable`. Upsert scoped to that one column.
+    pub fn set_n1_bulk_unreliable(
+        &self,
+        server_id: &str,
+        library_scope: &str,
+        unreliable: bool,
+    ) -> Result<(), String> {
+        self.store.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO sync_state (server_id, library_scope, n1_bulk_unreliable) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(server_id, library_scope) DO UPDATE SET \
+                   n1_bulk_unreliable = excluded.n1_bulk_unreliable",
+                params![server_id, library_scope, unreliable as i64],
+            )?;
+            Ok(())
+        })
+    }
+
     /// Stamp `last_delta_sync_at = now` (epoch ms). Called by DS-9 at
     /// the end of every successful delta pass.
     pub fn set_last_delta_sync_at(
@@ -670,6 +711,33 @@ mod tests {
             })
             .unwrap();
         assert_eq!(tier, "huge");
+    }
+
+    #[test]
+    fn n1_bulk_unreliable_defaults_false_and_roundtrips() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.ensure("s1", "").unwrap();
+        // DEFAULT 0 reads back as Some(false); existing servers stay N1-eligible.
+        assert_eq!(repo.get_n1_bulk_unreliable("s1", "").unwrap(), Some(false));
+        assert_eq!(repo.get_n1_bulk_unreliable("absent", "").unwrap(), None);
+
+        repo.set_n1_bulk_unreliable("s1", "", true).unwrap();
+        assert_eq!(repo.get_n1_bulk_unreliable("s1", "").unwrap(), Some(true));
+        repo.set_n1_bulk_unreliable("s1", "", false).unwrap();
+        assert_eq!(repo.get_n1_bulk_unreliable("s1", "").unwrap(), Some(false));
+    }
+
+    #[test]
+    fn n1_bulk_unreliable_set_does_not_clobber_cursor() {
+        let store = LibraryStore::open_in_memory();
+        let repo = SyncStateRepository::new(&store);
+        repo.set_initial_sync_cursor("s1", "", &json!({"offset": 7})).unwrap();
+        repo.set_n1_bulk_unreliable("s1", "", true).unwrap();
+        assert_eq!(
+            repo.get_initial_sync_cursor("s1", "").unwrap(),
+            Some(json!({"offset": 7}))
+        );
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -6,7 +6,7 @@ use tauri::Manager;
 
 /// Current head of the embedded migrations. Bump each time a new
 /// `migrations/NNN_*.sql` is added.
-pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 1;
+pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 2;
 
 /// Lowest applied schema version the current code can advance from purely
 /// additively. If a DB carries a version below this, the breaking-bump hook
@@ -19,10 +19,12 @@ pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 1;
 pub const LIBRARY_DB_MIN_COMPATIBLE_VERSION: i64 = 1;
 
 pub(crate) const INITIAL_SQL: &str = include_str!("../migrations/001_initial.sql");
+const MIGRATION_002_N1_BULK_UNRELIABLE: &str =
+    include_str!("../migrations/002_n1_bulk_unreliable.sql");
 
 /// Embedded migrations. Ordered ascending by `version`; the runner sorts
 /// defensively before applying so the source order can stay readable.
-const MIGRATIONS: &[(i64, &str)] = &[(1, INITIAL_SQL)];
+const MIGRATIONS: &[(i64, &str)] = &[(1, INITIAL_SQL), (2, MIGRATION_002_N1_BULK_UNRELIABLE)];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MigrationOutcome {
@@ -220,7 +222,9 @@ mod tests {
                 rows
             })
             .unwrap();
-        assert_eq!(versions, vec![LIBRARY_DB_SCHEMA_VERSION]);
+        // Embedded migrations are numbered 1..=head, all applied on a fresh DB.
+        let expected: Vec<i64> = (1..=LIBRARY_DB_SCHEMA_VERSION).collect();
+        assert_eq!(versions, expected);
     }
 
     #[test]
@@ -235,7 +239,10 @@ mod tests {
                 c.query_row("SELECT COUNT(*) FROM schema_migrations", [], |r| r.get(0))
             })
             .unwrap();
-        assert_eq!(count, 1, "no duplicate schema_migrations rows");
+        assert_eq!(
+            count, LIBRARY_DB_SCHEMA_VERSION,
+            "one schema_migrations row per embedded migration, no duplicates"
+        );
     }
 
     #[test]
@@ -257,7 +264,9 @@ mod tests {
 
     /// `ALTER TABLE artist ADD COLUMN bio TEXT;` — minimal additive fixture,
     /// nullable column with no default. Mirrors the §5.7 additive-first rule.
-    const FIXTURE_002_ADD_BIO: &str = "ALTER TABLE artist ADD COLUMN bio TEXT;";
+    /// Numbered above the real embedded head so it stacks on a migrated DB.
+    const FIXTURE_ADD_BIO: &str = "ALTER TABLE artist ADD COLUMN bio TEXT;";
+    const FIXTURE_ADD_BIO_VERSION: i64 = LIBRARY_DB_SCHEMA_VERSION + 1;
 
     fn no_op_hook(_c: &Connection, _from: i64, _to: i64) -> rusqlite::Result<()> {
         Ok(())
@@ -284,7 +293,7 @@ mod tests {
             .with_conn(|c| {
                 run_migrations_with(
                     c,
-                    &[(1, INITIAL_SQL), (2, FIXTURE_002_ADD_BIO)],
+                    &[(1, INITIAL_SQL), (FIXTURE_ADD_BIO_VERSION, FIXTURE_ADD_BIO)],
                     LIBRARY_DB_MIN_COMPATIBLE_VERSION,
                     always_fail_hook,
                 )
@@ -313,7 +322,10 @@ mod tests {
                 rows
             })
             .unwrap();
-        assert_eq!(versions, vec![1, 2]);
+        // Real embedded migrations (1..=head) plus the additive fixture.
+        let mut expected: Vec<i64> = (1..=LIBRARY_DB_SCHEMA_VERSION).collect();
+        expected.push(FIXTURE_ADD_BIO_VERSION);
+        assert_eq!(versions, expected);
     }
 
     #[test]
@@ -325,7 +337,7 @@ mod tests {
 
         let outcome = run_migrations_with(
             &conn,
-            &[(2, FIXTURE_002_ADD_BIO), (1, INITIAL_SQL)],
+            &[(2, FIXTURE_ADD_BIO), (1, INITIAL_SQL)],
             LIBRARY_DB_MIN_COMPATIBLE_VERSION,
             always_fail_hook,
         )
@@ -345,15 +357,15 @@ mod tests {
 
     #[test]
     fn breaking_bump_hook_fires_when_db_below_min_compatible() {
-        // Simulate a future code release where MIN_COMPATIBLE was bumped to
-        // 2 but the DB still carries only version 1.
+        // Simulate a future code release where MIN_COMPATIBLE was bumped past
+        // the version the DB currently carries (the real embedded head).
         let store = LibraryStore::open_in_memory();
         let outcome = store
             .with_conn(|c| {
                 run_migrations_with(
                     c,
-                    &[(1, INITIAL_SQL), (2, FIXTURE_002_ADD_BIO)],
-                    2, // pretend MIN_COMPATIBLE has been bumped past current applied
+                    MIGRATIONS,
+                    LIBRARY_DB_SCHEMA_VERSION + 1, // bumped past current applied
                     no_op_hook,
                 )
             })

--- a/src-tauri/crates/psysonic-library/src/sync/capability.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/capability.rs
@@ -70,6 +70,12 @@ pub struct NavidromeProbeCredentials {
 pub struct CapabilityProbeResult {
     pub flags: CapabilityFlags,
     pub server_info: ServerInfo,
+    /// Server-reported track count from `getScanStatus.count`, when the
+    /// server exposes it. `None` when `getScanStatus` is unavailable or
+    /// reports no count. Persisted as the `server_track_count` watermark so
+    /// the strategy selector can route large catalogs to S1 at IS-1 without
+    /// first hitting N1's deep-offset wall (R7-15 Q4).
+    pub server_track_count: Option<i64>,
 }
 
 /// Run `CapabilityProbe::run` and persist the resulting flags +
@@ -101,6 +107,13 @@ pub async fn probe_and_persist(
     sync_state
         .set_capability_flags(server_id, library_scope, result.flags.bits())
         .map_err(psysonic_integration::subsonic::SubsonicError::Transport)?;
+    // Refresh the track-count watermark only when the probe learned one — a
+    // missing `getScanStatus.count` must not clobber a count from a prior run.
+    if let Some(count) = result.server_track_count {
+        sync_state
+            .set_server_track_count(server_id, library_scope, count)
+            .map_err(psysonic_integration::subsonic::SubsonicError::Transport)?;
+    }
     sync_state
         .set_sync_phase(server_id, library_scope, "idle")
         .map_err(psysonic_integration::subsonic::SubsonicError::Transport)?;
@@ -143,8 +156,12 @@ impl CapabilityProbe {
             flags.insert(CapabilityFlags::SUBSONIC_SEARCH3_BULK);
         }
 
-        if subsonic.get_scan_status().await.is_ok() {
+        let mut server_track_count = None;
+        if let Ok(scan) = subsonic.get_scan_status().await {
             flags.insert(CapabilityFlags::SCAN_STATUS_AVAILABLE);
+            // Only a positive count is a usable watermark; a scan in progress
+            // can report 0, which we treat as "unknown" rather than "empty".
+            server_track_count = scan.count.filter(|&c| c > 0);
         }
 
         if subsonic.get_indexes(None, None).await.is_ok() {
@@ -163,7 +180,11 @@ impl CapabilityProbe {
             }
         }
 
-        Ok(CapabilityProbeResult { flags, server_info })
+        Ok(CapabilityProbeResult {
+            flags,
+            server_info,
+            server_track_count,
+        })
     }
 }
 
@@ -419,6 +440,85 @@ mod tests {
         assert_eq!(
             sync_state.get_sync_phase("s1", "").unwrap().as_deref(),
             Some("idle")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_captures_and_persists_scan_status_track_count() {
+        use crate::repos::SyncStateRepository;
+        use crate::store::LibraryStore;
+
+        let server = MockServer::start().await;
+        // ping + search3 + getIndexes from the shared helper, then override
+        // getScanStatus with a populated `count` (large library).
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/ping.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "version": "1.16.1", "type": "navidrome" }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_envelope(
+                "searchResult3",
+                json!({ "song": [{ "id": "x", "title": "y" }] }),
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getScanStatus.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_envelope(
+                "scanStatus",
+                json!({ "scanning": false, "count": 170_000 }),
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getIndexes.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_envelope(
+                "indexes",
+                json!({ "lastModified": 0, "ignoredArticles": "", "index": [] }),
+            )))
+            .mount(&server)
+            .await;
+
+        let store = LibraryStore::open_in_memory();
+        let result =
+            super::probe_and_persist(&store, &test_subsonic_client(&server.uri()), None, "s1", "")
+                .await
+                .unwrap();
+        assert_eq!(result.server_track_count, Some(170_000));
+
+        let sync_state = SyncStateRepository::new(&store);
+        assert_eq!(
+            sync_state.get_server_track_count("s1", "").unwrap(),
+            Some(170_000)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_does_not_clobber_track_count_when_scan_status_omits_it() {
+        use crate::repos::SyncStateRepository;
+        use crate::store::LibraryStore;
+
+        let store = LibraryStore::open_in_memory();
+        let sync_state = SyncStateRepository::new(&store);
+        // A prior run already learned the count.
+        sync_state.set_server_track_count("s1", "", 52_000).unwrap();
+
+        let server = MockServer::start().await;
+        mount_subsonic_full_navidrome(&server).await; // scanStatus has no count
+
+        let result =
+            super::probe_and_persist(&store, &test_subsonic_client(&server.uri()), None, "s1", "")
+                .await
+                .unwrap();
+        assert_eq!(result.server_track_count, None);
+        // Watermark from the prior run survives the count-less probe.
+        assert_eq!(
+            sync_state.get_server_track_count("s1", "").unwrap(),
+            Some(52_000)
         );
     }
 

--- a/src-tauri/crates/psysonic-library/src/sync/initial.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial.rs
@@ -194,7 +194,22 @@ impl<'a> InitialSyncRunner<'a> {
         let raw = sync_state
             .get_initial_sync_cursor(&self.server_id, &self.library_scope)
             .map_err(SyncError::Storage)?;
-        let strategy_from_flags = IngestStrategy::select_from_flags(self.capability_flags);
+        // R7-15 Q4: pick with the large-library policy, not just the cap
+        // flags. `server_track_count` (probe `getScanStatus` count or a prior
+        // watermark) and the learned `n1_bulk_unreliable` flag steer large
+        // catalogs onto S1 instead of N1's deep-offset wall.
+        let server_track_count = sync_state
+            .get_server_track_count(&self.server_id, &self.library_scope)
+            .map_err(SyncError::Storage)?;
+        let n1_bulk_unreliable = sync_state
+            .get_n1_bulk_unreliable(&self.server_id, &self.library_scope)
+            .map_err(SyncError::Storage)?
+            .unwrap_or(false);
+        let selected_strategy = IngestStrategy::select_initial_strategy(
+            self.capability_flags,
+            server_track_count,
+            n1_bulk_unreliable,
+        );
         if let Some(raw) = raw {
             if !is_empty_cursor(&raw) {
                 // Resume a persisted cursor only when it was written under
@@ -207,7 +222,7 @@ impl<'a> InitialSyncRunner<'a> {
                 // start fresh. Re-ingest is idempotent (upsert), and the
                 // tombstone pass reconciles any leftovers.
                 match serde_json::from_value::<InitialSyncCursor>(raw) {
-                    Ok(parsed) if parsed.strategy == strategy_from_flags.as_tag() => {
+                    Ok(parsed) if parsed.strategy == selected_strategy.as_tag() => {
                         return Ok(parsed);
                     }
                     Ok(parsed) => {
@@ -216,7 +231,7 @@ impl<'a> InitialSyncRunner<'a> {
                              was `{}`, strategy is now `{}`",
                             self.server_id,
                             parsed.strategy,
-                            strategy_from_flags.as_tag()
+                            selected_strategy.as_tag()
                         );
                     }
                     Err(e) => {
@@ -234,7 +249,7 @@ impl<'a> InitialSyncRunner<'a> {
         } else {
             Some(self.library_scope.clone())
         };
-        let fresh = InitialSyncCursor::fresh(strategy_from_flags, scope);
+        let fresh = InitialSyncCursor::fresh(selected_strategy, scope);
         self.persist_cursor(sync_state, &fresh)?;
         Ok(fresh)
     }

--- a/src-tauri/crates/psysonic-library/src/sync/strategy.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/strategy.rs
@@ -5,6 +5,12 @@
 
 use super::capability::CapabilityFlags;
 
+/// Server track count above which N1 is skipped in favour of S1 at initial
+/// sync start (R7-15 Q4). N1's native `/api/song` deep-offset 500 wall makes
+/// it unable to finish very large catalogs; S1 (`search3`) does not hit it.
+/// Tunable constant — the live wall was observed past ~50k.
+pub const LARGE_LIBRARY_THRESHOLD: i64 = 40_000;
+
 /// Spec §6.3 IS-3 strategies. Names match §6.1.1 capability bits where
 /// applicable; S2 has no flag of its own — it's the universal
 /// album-crawl fallback assumed available whenever the Subsonic ping
@@ -39,6 +45,33 @@ impl IngestStrategy {
         } else {
             Self::S2
         }
+    }
+
+    /// Pick the initial-sync strategy with the large-library policy on top
+    /// of `select_from_flags` (R7-15 Q4). A large catalog — or one already
+    /// flagged `n1_bulk_unreliable` after an N1 deep-offset 500 — must avoid
+    /// N1, which cannot finish past the wall. Prefer S1 (`search3`) and fall
+    /// back to S2 (universal album crawl) when search3 bulk is unavailable.
+    ///
+    /// `server_track_count` is best-effort at IS-1 (probe `getScanStatus`
+    /// count or a prior watermark); `None` means unknown, in which case only
+    /// the `n1_bulk_unreliable` flag forces the non-N1 path (a first run with
+    /// no count still tries the cheapest strategy and learns from a 500).
+    pub fn select_initial_strategy(
+        flags: CapabilityFlags,
+        server_track_count: Option<i64>,
+        n1_bulk_unreliable: bool,
+    ) -> Self {
+        let is_large = server_track_count
+            .map(|c| c > LARGE_LIBRARY_THRESHOLD)
+            .unwrap_or(false);
+        if n1_bulk_unreliable || is_large {
+            if flags.contains(CapabilityFlags::SUBSONIC_SEARCH3_BULK) {
+                return Self::S1;
+            }
+            return Self::S2;
+        }
+        Self::select_from_flags(flags)
     }
 
     /// String tag stored in `initial_sync_cursor_json` so the runner
@@ -100,6 +133,72 @@ mod tests {
             IngestStrategy::select_from_flags(CapabilityFlags::default()),
             IngestStrategy::S2
         );
+    }
+
+    // ── select_initial_strategy (R7-15 Q4 large-library policy) ──────────
+
+    fn navidrome_full() -> CapabilityFlags {
+        CapabilityFlags::new(
+            CapabilityFlags::NAVIDROME_NATIVE_BULK | CapabilityFlags::SUBSONIC_SEARCH3_BULK,
+        )
+    }
+
+    #[test]
+    fn initial_strategy_small_library_keeps_cheapest_n1() {
+        // Below threshold, not flagged unreliable → unchanged N1-first chain.
+        let s = IngestStrategy::select_initial_strategy(navidrome_full(), Some(1_000), false);
+        assert_eq!(s, IngestStrategy::N1);
+    }
+
+    #[test]
+    fn initial_strategy_large_library_avoids_n1_for_s1() {
+        // Over threshold → S1 even though N1 is advertised (deep-offset wall).
+        let s = IngestStrategy::select_initial_strategy(navidrome_full(), Some(170_000), false);
+        assert_eq!(s, IngestStrategy::S1);
+    }
+
+    #[test]
+    fn initial_strategy_unreliable_flag_avoids_n1_regardless_of_size() {
+        // Learned `n1_bulk_unreliable` forces the non-N1 path even when the
+        // count is small/unknown (covers R7-15 "unknown → large if N1 failed").
+        let small =
+            IngestStrategy::select_initial_strategy(navidrome_full(), Some(500), true);
+        assert_eq!(small, IngestStrategy::S1);
+        let unknown = IngestStrategy::select_initial_strategy(navidrome_full(), None, true);
+        assert_eq!(unknown, IngestStrategy::S1);
+    }
+
+    #[test]
+    fn initial_strategy_large_without_search3_falls_back_to_s2() {
+        // Avoid-N1 path but no search3 bulk → universal album crawl, not N1.
+        let flags = CapabilityFlags::new(CapabilityFlags::NAVIDROME_NATIVE_BULK);
+        let s = IngestStrategy::select_initial_strategy(flags, Some(170_000), false);
+        assert_eq!(s, IngestStrategy::S2);
+    }
+
+    #[test]
+    fn initial_strategy_unknown_count_uses_cheapest_when_not_flagged() {
+        // First run, no count yet, N1 never failed → try cheapest (N1); the
+        // mid-run N1→S1 fallback (R7-15 Q5) handles the wall if hit.
+        let s = IngestStrategy::select_initial_strategy(navidrome_full(), None, false);
+        assert_eq!(s, IngestStrategy::N1);
+    }
+
+    #[test]
+    fn initial_strategy_threshold_is_strictly_greater_than() {
+        // Exactly at the threshold is not "large"; one above is.
+        let at = IngestStrategy::select_initial_strategy(
+            navidrome_full(),
+            Some(LARGE_LIBRARY_THRESHOLD),
+            false,
+        );
+        assert_eq!(at, IngestStrategy::N1);
+        let over = IngestStrategy::select_initial_strategy(
+            navidrome_full(),
+            Some(LARGE_LIBRARY_THRESHOLD + 1),
+            false,
+        );
+        assert_eq!(over, IngestStrategy::S1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Large Navidrome catalogs no longer start initial sync on N1 (its `/api/song` 500s past a deep offset and never finishes). `IngestStrategy::select_initial_strategy` routes servers with count > `LARGE_LIBRARY_THRESHOLD` (40k) or a learned `n1_bulk_unreliable` flag to S1 — or S2 when search3 bulk is absent. Normal-size libraries keep the cheapest N1 → S1 → S2 chain.
- New per-server `n1_bulk_unreliable` flag persisted on `sync_state` via additive migration `002` (DEFAULT 0; schema head → 2, MIN_COMPATIBLE stays 1, no breaking bump). The mid-run N1→S1 fallback that *sets* it follows in a later PR.
- Probe captures `getScanStatus.count` → persists the `server_track_count` watermark, so the threshold applies from the first sync rather than only after N1 hits the wall once. A count-less probe never clobbers a prior watermark.
- Implements R7-15 checklist items 2 + 3 (combined — item 2's storage is dead weight without item 3's selector).

## Test plan
- `cargo test -p psysonic-library` green (247), incl. selector table (threshold boundary, search3-absent fallback, unreliable-flag forces non-N1), repo flag roundtrip, probe count capture + watermark preservation, migration head-version bookkeeping.
- `cargo clippy -p psysonic-library --all-targets -- -D warnings` clean.