### PR TITLE
feat(library): cache + retry Navidrome bearer, keep N1 flag on transient loss (R7-15 Q3)

### DIFF
--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -5,6 +5,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use rusqlite::params;
 use serde_json::Value;
@@ -306,6 +307,29 @@ fn normalize_base_url(raw: &str) -> String {
     with_scheme.trim_end_matches('/').to_string()
 }
 
+/// Acquire a Navidrome native-API bearer with a few retries. `/auth/login`
+/// is occasionally flaky; one transient miss must not strip N1 for the whole
+/// session (R7-15 Q3). Returns `None` only after every attempt fails — the
+/// caller falls back to a cached bearer / the Subsonic-only path. Never logs
+/// the token or credentials.
+async fn navidrome_token_with_retry(
+    base_url: &str,
+    username: &str,
+    password: &str,
+) -> Option<String> {
+    const ATTEMPTS: u32 = 3;
+    for attempt in 1..=ATTEMPTS {
+        match navidrome_token(base_url, username, password).await {
+            Ok(tok) => return Some(tok),
+            Err(_) if attempt < ATTEMPTS => {
+                tokio::time::sleep(Duration::from_millis(250 * attempt as u64)).await;
+            }
+            Err(_) => return None,
+        }
+    }
+    None
+}
+
 #[tauri::command]
 pub async fn library_sync_bind_session(
     runtime: State<'_, LibraryRuntime>,
@@ -316,12 +340,18 @@ pub async fn library_sync_bind_session(
     library_scope: Option<String>,
 ) -> Result<(), String> {
     let base_url = normalize_base_url(&base_url);
-    // Try a Navidrome native-API auth once at bind time. Spec §6.1 +
-    // PR-5 kickoff Q5: this primes the bearer cache for N1 probe /
-    // ingest without making every command pass a token. Non-Navidrome
-    // servers (Subsonic-only) fall back gracefully — failure here is
-    // not blocking, sync still works via the Subsonic salted-md5 path.
-    let navidrome_token_cached = navidrome_token(&base_url, &username, &password).await.ok();
+    // Prime the Navidrome native-API bearer at bind time (spec §6.1 + PR-5
+    // kickoff Q5) so N1 probe / ingest works without every command passing a
+    // token. `/auth/login` is flaky, so retry a few times; if it still fails,
+    // keep a bearer cached from a prior bind rather than dropping to
+    // Subsonic-only — a transient miss must not strip an N1-capable server
+    // (R7-15 Q3). Non-Navidrome servers stay `None` and sync via Subsonic.
+    let navidrome_token_cached = match navidrome_token_with_retry(&base_url, &username, &password)
+        .await
+    {
+        Some(tok) => Some(tok),
+        None => runtime.get_session(&server_id).and_then(|s| s.navidrome_token),
+    };
 
     let session = SyncSession {
         server_id: server_id.clone(),
@@ -407,7 +437,15 @@ async fn library_sync_start_inner(
         format!("no bound session for server `{server_id}` — call library_sync_bind_session first")
     })?;
     let scope = library_scope.clone().or(session.library_scope.clone()).unwrap_or_default();
-    let capability_flags = load_capability_flags(&runtime, &server_id, &scope)?;
+    let mut capability_flags = load_capability_flags(&runtime, &server_id, &scope)?;
+    // N1 needs the Navidrome bearer. Without a cached token this run is
+    // Subsonic-only even on an N1-capable server — mask the flag for *this*
+    // run's strategy selection (R7-15 Q3 "proceed as Subsonic-only"). The
+    // persisted server capability stays untouched, so a later bind that
+    // recovers the token can use N1 again.
+    if session.navidrome_token.is_none() {
+        capability_flags.remove(CapabilityFlags::NAVIDROME_NATIVE_BULK);
+    }
 
     let kind = match mode.as_str() {
         "full" => "initial_sync",
@@ -994,5 +1032,38 @@ mod tests {
     #[test]
     fn normalize_base_url_trims_whitespace() {
         assert_eq!(normalize_base_url("  nas.example.com  "), "http://nas.example.com");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn navidrome_token_with_retry_returns_token_on_success() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/auth/login"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "token": "nd-tok", "userId": "u1"
+            })))
+            .mount(&server)
+            .await;
+        let tok = navidrome_token_with_retry(&server.uri(), "user", "pw").await;
+        assert_eq!(tok.as_deref(), Some("nd-tok"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn navidrome_token_with_retry_returns_none_after_exhausting_attempts() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        // No `token` field → navidrome_token errors on every attempt; after
+        // the retries are exhausted the helper yields None (caller then falls
+        // back to a cached bearer / Subsonic-only).
+        Mock::given(method("POST"))
+            .and(path("/auth/login"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+        let tok = navidrome_token_with_retry(&server.uri(), "user", "pw").await;
+        assert!(tok.is_none());
     }
 }

--- a/src-tauri/crates/psysonic-library/src/sync/capability.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/capability.rs
@@ -102,7 +102,22 @@ pub async fn probe_and_persist(
         .set_sync_phase(server_id, library_scope, "probing")
         .map_err(psysonic_integration::subsonic::SubsonicError::Transport)?;
 
-    let result = CapabilityProbe::run(subsonic, navidrome).await?;
+    let existing_flags = sync_state
+        .get_capability_flags(server_id, library_scope)
+        .map_err(psysonic_integration::subsonic::SubsonicError::Transport)?
+        .unwrap_or(0);
+
+    let mut result = CapabilityProbe::run(subsonic, navidrome).await?;
+
+    // R7-15 Q3: a probe run without a Navidrome bearer can't test N1, so it
+    // must not drop a previously-learned NavidromeNativeBulk capability — the
+    // server still supports `/api/song`; only the token is missing this bind.
+    // Token availability gates actual N1 use per run (see library_sync_start).
+    if navidrome.is_none()
+        && existing_flags & CapabilityFlags::NAVIDROME_NATIVE_BULK != 0
+    {
+        result.flags.insert(CapabilityFlags::NAVIDROME_NATIVE_BULK);
+    }
 
     sync_state
         .set_capability_flags(server_id, library_scope, result.flags.bits())
@@ -494,6 +509,43 @@ mod tests {
         assert_eq!(
             sync_state.get_server_track_count("s1", "").unwrap(),
             Some(170_000)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_preserves_navidrome_native_bulk_when_no_token_supplied() {
+        use crate::repos::SyncStateRepository;
+        use crate::store::LibraryStore;
+
+        let store = LibraryStore::open_in_memory();
+        let sync_state = SyncStateRepository::new(&store);
+        // A prior bind (with a working bearer) already learned N1.
+        sync_state
+            .set_capability_flags("s1", "", CapabilityFlags::NAVIDROME_NATIVE_BULK)
+            .unwrap();
+
+        let server = MockServer::start().await;
+        mount_subsonic_full_navidrome(&server).await;
+
+        // Re-probe without a Navidrome token (transient /auth/login failure).
+        // R7-15 Q3: the server still supports /api/song — the flag must stay.
+        let result = super::probe_and_persist(
+            &store,
+            &test_subsonic_client(&server.uri()),
+            None,
+            "s1",
+            "",
+        )
+        .await
+        .unwrap();
+        assert!(
+            result.flags.contains(CapabilityFlags::NAVIDROME_NATIVE_BULK),
+            "result must keep the previously-learned N1 capability"
+        );
+        let persisted = sync_state.get_capability_flags("s1", "").unwrap().unwrap();
+        assert!(
+            persisted & CapabilityFlags::NAVIDROME_NATIVE_BULK != 0,
+            "persisted flags must keep N1 across a token-less probe"
         );
     }
 


### PR DESCRIPTION
## Summary
- A flaky `/auth/login` previously stripped N1 for a whole bind — the bearer was fetched once, best-effort. `bind_session` now retries (`navidrome_token_with_retry`, 3 attempts) and, if it still fails, keeps the bearer cached from a prior bind instead of overwriting it with `None`. Token/credentials are never logged.
- `probe_and_persist` preserves a previously-learned `NavidromeNativeBulk` flag when it probes without a token: the server still supports `/api/song`; only the bearer is missing this bind. The capability is a stable server property, so a token-less probe must not clear it.
- `library_sync_start_inner` masks `NavidromeNativeBulk` from *this run's* strategy selection when the session has no token, so the run proceeds Subsonic-only (S1/S2) rather than selecting N1 with no creds. The persisted capability stays intact; the in-flight cursor is already protected by the resume freeze (#820).
- Implements R7-15 checklist item 6 (bind_session / probe — do not drop the bulk flag on a transient bearer loss).

## Test plan
- `cargo test -p psysonic-library` green (254), incl. token retry yields the token on success and `None` after exhausting attempts; probe keeps a learned N1 flag across a token-less re-probe.
- `cargo clippy -p psysonic-library --all-targets -- -D warnings` clean; `cargo build -p psysonic` clean.