### PR TITLE
fix(library): resume interrupted initial sync on startup

### DIFF
--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -29,6 +29,7 @@ use crate::search::search_tracks;
 use crate::sync::bandwidth::PlaybackHint;
 use crate::sync::capability::{probe_and_persist, CapabilityFlags, NavidromeProbeCredentials};
 use crate::sync::delta::DeltaSyncRunner;
+use crate::sync::error::SyncError;
 use crate::sync::initial::InitialSyncRunner;
 use crate::sync::progress::{ChannelProgress, Progress, ProgressEvent};
 use crate::sync::tombstone::should_auto_reconcile;
@@ -425,6 +426,18 @@ pub async fn library_sync_start(
     library_sync_start_inner(app, runtime, server_id, mode, library_scope, false).await
 }
 
+/// Map a runner result for the sync-idle event. Cancellation is expected —
+/// the user cancelled, or a newer `library_sync_start` superseded this job
+/// (e.g. a server switch, or the startup resume) — and must never surface as
+/// a failure toast (error.rs: "Cancelled is silent").
+fn sync_outcome_to_result<T>(r: Result<T, SyncError>) -> Result<(), String> {
+    match r {
+        Ok(_) => Ok(()),
+        Err(SyncError::Cancelled) => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
 async fn library_sync_start_inner(
     app: AppHandle,
     runtime: State<'_, LibraryRuntime>,
@@ -502,7 +515,7 @@ async fn library_sync_start_inner(
             if let Some(creds) = navidrome_creds.clone() {
                 runner = runner.with_navidrome_credentials(creds);
             }
-            runner.run().await.map(|_| ()).map_err(|e| e.to_string())
+            sync_outcome_to_result(runner.run().await)
         } else {
             // Delta — Mode A manual integrity uses the DeltaMismatch
             // budget for tombstones when the local/server count gap
@@ -529,7 +542,7 @@ async fn library_sync_start_inner(
             if let Some(creds) = navidrome_creds.clone() {
                 runner = runner.with_navidrome_credentials(creds);
             }
-            runner.run().await.map(|_| ()).map_err(|e| e.to_string())
+            sync_outcome_to_result(runner.run().await)
         };
 
         // Closing the mpsc sender by dropping `progress` so the
@@ -1032,6 +1045,16 @@ mod tests {
     #[test]
     fn normalize_base_url_trims_whitespace() {
         assert_eq!(normalize_base_url("  nas.example.com  "), "http://nas.example.com");
+    }
+
+    #[test]
+    fn sync_outcome_treats_cancellation_as_silent_success() {
+        // Cancellation (user cancel, or a newer sync_start superseding this
+        // job) must not surface as a failure on the sync-idle event.
+        assert!(sync_outcome_to_result::<()>(Ok(())).is_ok());
+        assert!(sync_outcome_to_result::<()>(Err(SyncError::Cancelled)).is_ok());
+        let err = sync_outcome_to_result::<()>(Err(SyncError::Transport("boom".into())));
+        assert_eq!(err, Err("sync transport: boom".to_string()));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -14,7 +14,7 @@ import { useGlobalShortcutsStore } from '../store/globalShortcutsStore';
 import { initHotCachePrefetch } from '../hotCachePrefetch';
 import { initMiniPlayerBridgeOnMain } from '../utils/miniPlayerBridge';
 import { runAdvancedModeMigration } from '../utils/migrations/advancedModeMigration';
-import { ensureActiveServerSessionBound } from '../utils/library/librarySession';
+import { ensureActiveServerSessionBound, resumeInitialSyncIfIncomplete } from '../utils/library/librarySession';
 import { useScanPolling } from '../hooks/useScanPolling';
 import { IS_WINDOWS } from '../utils/platform';
 import TauriEventBridge from './TauriEventBridge';
@@ -43,7 +43,15 @@ export default function MainApp() {
   // "no bound session" after a restart.
   const activeServerId = useAuthStore(s => s.activeServerId);
   useEffect(() => {
-    void ensureActiveServerSessionBound();
+    void (async () => {
+      const bound = await ensureActiveServerSessionBound();
+      // Resume an initial sync that was interrupted by an app restart —
+      // the scheduler is delta-only, so it would otherwise sit idle until
+      // the user clicks «Sync now».
+      if (bound && activeServerId) {
+        await resumeInitialSyncIfIncomplete(activeServerId);
+      }
+    })();
   }, [activeServerId]);
 
   useScanPolling();

--- a/src/utils/library/librarySession.test.ts
+++ b/src/utils/library/librarySession.test.ts
@@ -36,6 +36,20 @@ describe('resumeInitialSyncIfIncomplete', () => {
     expect(start).not.toHaveBeenCalled();
   });
 
+  it('de-dupes concurrent calls so a second start cannot cancel the first', async () => {
+    onInvoke('library_get_status', () => status()); // incomplete
+    const start = vi.fn(() => ({ jobId: 'j1', serverId: 's1', kind: 'initial_sync' }));
+    onInvoke('library_sync_start', start);
+
+    // Two near-simultaneous calls (StrictMode double-fires the startup effect).
+    await Promise.all([
+      resumeInitialSyncIfIncomplete('s1'),
+      resumeInitialSyncIfIncomplete('s1'),
+    ]);
+
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
   it('stays silent when the status lookup fails', async () => {
     onInvoke('library_get_status', () => { throw new Error('boom'); });
     const start = vi.fn();

--- a/src/utils/library/librarySession.test.ts
+++ b/src/utils/library/librarySession.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { onInvoke } from '@/test/mocks/tauri';
+import { resumeInitialSyncIfIncomplete } from './librarySession';
+
+const status = (over: Record<string, unknown> = {}) => ({
+  serverId: 's1',
+  libraryScope: '',
+  syncPhase: 'idle',
+  capabilityFlags: 0,
+  libraryTier: 'unknown',
+  syncedAt: 0,
+  ...over,
+});
+
+describe('resumeInitialSyncIfIncomplete', () => {
+  it('starts a full sync when no full sync has completed', async () => {
+    onInvoke('library_get_status', () => status()); // no lastFullSyncAt
+    const start = vi.fn(() => ({ jobId: 'j1', serverId: 's1', kind: 'initial_sync' }));
+    onInvoke('library_sync_start', start);
+
+    await resumeInitialSyncIfIncomplete('s1');
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledWith(
+      expect.objectContaining({ serverId: 's1', mode: 'full' }),
+    );
+  });
+
+  it('does nothing when a full sync has already completed', async () => {
+    onInvoke('library_get_status', () => status({ syncPhase: 'ready', lastFullSyncAt: 1_716_000_000_000 }));
+    const start = vi.fn();
+    onInvoke('library_sync_start', start);
+
+    await resumeInitialSyncIfIncomplete('s1');
+
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the status lookup fails', async () => {
+    onInvoke('library_get_status', () => { throw new Error('boom'); });
+    const start = vi.fn();
+    onInvoke('library_sync_start', start);
+
+    await expect(resumeInitialSyncIfIncomplete('s1')).resolves.toBeUndefined();
+    expect(start).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/library/librarySession.ts
+++ b/src/utils/library/librarySession.ts
@@ -1,4 +1,4 @@
-import { librarySyncBindSession } from '../../api/library';
+import { librarySyncBindSession, libraryGetStatus, librarySyncStart } from '../../api/library';
 import { useAuthStore } from '../../store/authStore';
 import { useLibraryIndexStore } from '../../store/libraryIndexStore';
 
@@ -35,4 +35,27 @@ export async function ensureActiveServerSessionBound(): Promise<boolean> {
     /* best-effort — Settings shows the real error on explicit toggle */
   }
   return true;
+}
+
+/**
+ * Resume an interrupted initial sync on startup / server switch.
+ *
+ * The background scheduler is delta-only (PR-5b), so a full sync killed
+ * mid-run (app restart) would otherwise sit at `idle` until the user clicks
+ * «Sync now». A library that has never completed a full sync
+ * (`!lastFullSyncAt`) (re)starts one with `mode: 'full'`, which resumes from
+ * the persisted cursor rather than restarting from zero. Once a full sync has
+ * landed this is a no-op, so delta stays the scheduler's job.
+ *
+ * Best-effort: errors stay silent — Settings surfaces them on explicit action.
+ */
+export async function resumeInitialSyncIfIncomplete(serverId: string): Promise<void> {
+  try {
+    const status = await libraryGetStatus(serverId);
+    if (!status.lastFullSyncAt) {
+      await librarySyncStart({ serverId, mode: 'full' });
+    }
+  } catch {
+    /* best-effort */
+  }
 }

--- a/src/utils/library/librarySession.ts
+++ b/src/utils/library/librarySession.ts
@@ -48,8 +48,16 @@ export async function ensureActiveServerSessionBound(): Promise<boolean> {
  * landed this is a no-op, so delta stays the scheduler's job.
  *
  * Best-effort: errors stay silent — Settings surfaces them on explicit action.
+ *
+ * De-duped per server: React StrictMode (and rapid re-binds) fire the startup
+ * effect twice, and a second `library_sync_start` would cancel the first
+ * (`set_current_job` is cancel-and-replace) — harmless but wasteful and noisy.
  */
+const resumeInFlight = new Set<string>();
+
 export async function resumeInitialSyncIfIncomplete(serverId: string): Promise<void> {
+  if (resumeInFlight.has(serverId)) return;
+  resumeInFlight.add(serverId);
   try {
     const status = await libraryGetStatus(serverId);
     if (!status.lastFullSyncAt) {
@@ -57,5 +65,7 @@ export async function resumeInitialSyncIfIncomplete(serverId: string): Promise<v
     }
   } catch {
     /* best-effort */
+  } finally {
+    resumeInFlight.delete(serverId);
   }
 }


### PR DESCRIPTION
## Summary
- An initial sync killed mid-run (app restart) sat at `idle` until the user clicked «Sync now» — the background scheduler is delta-only and the auto-full-sync only fired on the index toggle (#804), not on the startup re-bind. Found in live QA on a 170k library.
- `resumeInitialSyncIfIncomplete` runs after the active server's session is re-bound (startup + server switch): when no full sync has completed (`!lastFullSyncAt`) it dispatches `library_sync_start { mode: 'full' }`, which resumes from the persisted cursor instead of restarting from zero. Once a full sync has landed it is a no-op, so delta stays the scheduler's job.
- Best-effort — errors stay silent (Settings surfaces them on explicit action). Calls existing commands only; no Tauri surface change.

## Test plan
- `npx vitest run` green (998), incl. new `librarySession.test.ts`: starts a full sync when none has completed, no-ops once a full sync has landed, stays silent when the status lookup fails.
- `tsc --noEmit` clean.
- Live: confirmed by Psychotoxical that resume works mid-run; this closes the startup-resume gap (no manual «Sync now» needed after restart).