### PR TITLE
fix(library): run DB read commands off the main thread (async)

### DIFF
--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -38,7 +38,7 @@ use crate::sync::tombstone::should_auto_reconcile;
 const TRACKS_BATCH_LIMIT: usize = 100;
 
 #[tauri::command]
-pub fn library_get_status(
+pub async fn library_get_status(
     runtime: State<'_, LibraryRuntime>,
     server_id: String,
     library_scope: Option<String>,
@@ -101,7 +101,7 @@ pub fn library_get_status(
 }
 
 #[tauri::command]
-pub fn library_search(
+pub async fn library_search(
     runtime: State<'_, LibraryRuntime>,
     server_id: String,
     query: String,
@@ -134,7 +134,7 @@ pub fn library_search(
 }
 
 #[tauri::command]
-pub fn library_get_track(
+pub async fn library_get_track(
     runtime: State<'_, LibraryRuntime>,
     server_id: String,
     track_id: String,
@@ -146,7 +146,7 @@ pub fn library_get_track(
 }
 
 #[tauri::command]
-pub fn library_get_tracks_batch(
+pub async fn library_get_tracks_batch(
     runtime: State<'_, LibraryRuntime>,
     refs: Vec<TrackRefDto>,
 ) -> Result<Vec<LibraryTrackDto>, String> {
@@ -161,7 +161,7 @@ pub fn library_get_tracks_batch(
 }
 
 #[tauri::command]
-pub fn library_get_tracks_by_album(
+pub async fn library_get_tracks_by_album(
     runtime: State<'_, LibraryRuntime>,
     server_id: String,
     album_id: String,
@@ -171,7 +171,7 @@ pub fn library_get_tracks_by_album(
 }
 
 #[tauri::command]
-pub fn library_get_artifact(
+pub async fn library_get_artifact(
     runtime: State<'_, LibraryRuntime>,
     server_id: String,
     track_id: String,
@@ -193,7 +193,7 @@ pub fn library_get_artifact(
 }
 
 #[tauri::command]
-pub fn library_get_facts(
+pub async fn library_get_facts(
     runtime: State<'_, LibraryRuntime>,
     server_id: String,
     track_id: String,
@@ -209,7 +209,7 @@ pub fn library_get_facts(
 }
 
 #[tauri::command]
-pub fn library_get_offline_path(
+pub async fn library_get_offline_path(
     runtime: State<'_, LibraryRuntime>,
     server_id: String,
     track_id: String,
@@ -239,7 +239,7 @@ pub fn library_get_offline_path(
 // ──────────────────────────────────────────────────────────────────────
 
 #[tauri::command]
-pub fn library_advanced_search(
+pub async fn library_advanced_search(
     runtime: State<'_, LibraryRuntime>,
     request: LibraryAdvancedSearchRequest,
 ) -> Result<LibraryAdvancedSearchResponse, String> {
@@ -247,7 +247,7 @@ pub fn library_advanced_search(
 }
 
 #[tauri::command]
-pub fn library_search_cross_server(
+pub async fn library_search_cross_server(
     runtime: State<'_, LibraryRuntime>,
     query: String,
     limit: Option<u32>,


### PR DESCRIPTION
## Summary
- The 10 library read commands were synchronous (`pub fn`). Per the Tauri v2 docs, commands without `async` run on the main thread — a blocking one freezes the UI. During an initial sync the runner holds the single `Mutex<Connection>` for a whole batch write (500 rows × per-row remap on Navidrome + upsert + FTS), and the Settings library section polls `library_get_status` on an interval, so each batch write blocked that polled read on the main thread → the window greyed out until the batch finished (worse as the DB grew). Found in live QA on a 170k library.
- Made the DB-touching read commands `async` (status, search, get_track, get_tracks_batch/by_album, get_artifact, get_facts, get_offline_path, advanced_search, search_cross_server) so they run off the main thread.
- The single connection is intentional (schema mirrors `analysis_cache`, spec §5.1) — reads still serialize behind the writer, but the wait no longer blocks the UI. State-only commands stay sync. Invoke names / payloads unchanged → frontend unaffected, no Tauri surface change.

## Test plan
- `cargo test -p psysonic-library` green (256); `cargo clippy -p psysonic-library --all-targets -- -D warnings` clean; `cargo build -p psysonic` clean (invoke_handler accepts the async commands; no direct Rust callers broke).
- Frontend untouched (`invoke` is async-agnostic) — `tsc`/vitest unaffected.
- Live re-test on 170k by Psychotoxical: window no longer freezes while the Settings library section is open during a sync.