### PR TITLE
feat(library): analysis cache server_id wiring (E1, 6c-2)

### DIFF
--- a/src-tauri/crates/psysonic-analysis/src/analysis_cache/compute.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_cache/compute.rs
@@ -40,6 +40,7 @@ pub enum SeedFromBytesOutcome {
 /// single CPU-seed worker in `lib.rs` (`spawn_blocking`) so at most one heavy decode runs.
 pub fn seed_from_bytes_execute(
     app: &tauri::AppHandle,
+    server_id: &str,
     track_id: &str,
     bytes: &[u8],
 ) -> Result<SeedFromBytesOutcome, String> {
@@ -51,7 +52,7 @@ pub fn seed_from_bytes_execute(
         );
         return Ok(SeedFromBytesOutcome::SkippedNoAnalysisCache);
     };
-    seed_from_bytes_into_cache(&cache, track_id, bytes)
+    seed_from_bytes_into_cache(&cache, server_id, track_id, bytes)
 }
 
 /// AppHandle-free entry point for [`seed_from_bytes_execute`]: takes the cache
@@ -60,15 +61,16 @@ pub fn seed_from_bytes_execute(
 /// from tests against an in-memory cache.
 pub fn seed_from_bytes_into_cache(
     cache: &AnalysisCache,
+    server_id: &str,
     track_id: &str,
     bytes: &[u8],
 ) -> Result<SeedFromBytesOutcome, String> {
     let started = Instant::now();
-    // server_id is filled in by 6c-2 (playback/active server threaded through);
-    // until then every write lands under the legacy '' scope, behaviour-identical
-    // to the pre-002 cache.
+    // Write under the playback server's scope. An empty `server_id` (caller did
+    // not know the server) lands under the legacy '' pool — the read path's
+    // legacy fallback + lazy re-tag keeps it resolvable.
     let key = TrackKey {
-        server_id: String::new(),
+        server_id: server_id.to_string(),
         track_id: track_id.to_string(),
         md5_16kb: md5_first_16kb(bytes),
     };
@@ -744,7 +746,7 @@ mod tests {
     fn seed_from_bytes_into_cache_upserts_waveform_and_loudness_for_wav() {
         let cache = AnalysisCache::open_in_memory();
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.5), 44_100);
-        let outcome = seed_from_bytes_into_cache(&cache, "wav-track", &wav).unwrap();
+        let outcome = seed_from_bytes_into_cache(&cache, "", "wav-track", &wav).unwrap();
         assert_eq!(outcome, SeedFromBytesOutcome::Upserted);
 
         // Both a waveform AND a loudness row must exist after a successful
@@ -761,12 +763,36 @@ mod tests {
     }
 
     #[test]
+    fn seed_from_bytes_into_cache_writes_under_the_given_server_scope() {
+        let cache = AnalysisCache::open_in_memory();
+        let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.5), 44_100);
+        seed_from_bytes_into_cache(&cache, "server-x", "scoped-track", &wav).unwrap();
+
+        let md5 = md5_first_16kb(&wav);
+        let scoped = TrackKey {
+            server_id: "server-x".to_string(),
+            track_id: "scoped-track".to_string(),
+            md5_16kb: md5.clone(),
+        };
+        let legacy = TrackKey {
+            server_id: String::new(),
+            track_id: "scoped-track".to_string(),
+            md5_16kb: md5,
+        };
+        assert!(cache.get_waveform(&scoped).unwrap().is_some(), "row lands under server scope");
+        assert!(
+            cache.get_waveform(&legacy).unwrap().is_none(),
+            "nothing written under the legacy '' scope"
+        );
+    }
+
+    #[test]
     fn seed_from_bytes_into_cache_returns_skipped_on_second_call() {
         let cache = AnalysisCache::open_in_memory();
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
-        let first = seed_from_bytes_into_cache(&cache, "wav-track-2", &wav).unwrap();
+        let first = seed_from_bytes_into_cache(&cache, "", "wav-track-2", &wav).unwrap();
         assert_eq!(first, SeedFromBytesOutcome::Upserted);
-        let second = seed_from_bytes_into_cache(&cache, "wav-track-2", &wav).unwrap();
+        let second = seed_from_bytes_into_cache(&cache, "", "wav-track-2", &wav).unwrap();
         assert_eq!(
             second,
             SeedFromBytesOutcome::SkippedWaveformCacheHit,
@@ -780,7 +806,7 @@ mod tests {
         // Garbage bytes — Symphonia probe fails, the pipeline falls back to
         // `derive_waveform_bins` (no loudness row gets cached).
         let bytes = vec![0xAAu8; 8 * 1024];
-        let outcome = seed_from_bytes_into_cache(&cache, "garbage", &bytes).unwrap();
+        let outcome = seed_from_bytes_into_cache(&cache, "", "garbage", &bytes).unwrap();
         assert_eq!(outcome, SeedFromBytesOutcome::Upserted);
 
         let key = TrackKey {

--- a/src-tauri/crates/psysonic-analysis/src/analysis_cache/store.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_cache/store.rs
@@ -123,8 +123,13 @@ impl AnalysisCache {
         Self { conn: Mutex::new(conn) }
     }
 
-    /// Remove all `loudness_cache` rows for this logical track (bare id and `stream:` variant).
-    pub fn delete_loudness_for_track_id(&self, track_id: &str) -> Result<u64, String> {
+    /// Remove `loudness_cache` rows for this logical track (bare id and `stream:`
+    /// variant) **scoped to one server plus the legacy `''` pool**. A reseed on
+    /// server A must not delete server B's analysis for the same bare `track_id`;
+    /// the legacy `''` rows are cleared too so a stale pre-002 blob can't shadow
+    /// the fresh re-analysis via the read fallback (and so it isn't seen as
+    /// redundant). Pass `server_id = ""` to target only the legacy pool.
+    pub fn delete_loudness_for_track_id(&self, server_id: &str, track_id: &str) -> Result<u64, String> {
         if track_id.trim().is_empty() {
             return Ok(0);
         }
@@ -135,15 +140,20 @@ impl AnalysisCache {
         let mut total: u64 = 0;
         for tid in track_id_cache_variants(track_id) {
             let n = conn
-                .execute("DELETE FROM loudness_cache WHERE track_id = ?1", params![tid])
+                .execute(
+                    "DELETE FROM loudness_cache WHERE track_id = ?1 AND server_id IN (?2, '')",
+                    params![tid, server_id],
+                )
                 .map_err(|e| e.to_string())?;
             total = total.saturating_add(n as u64);
         }
         Ok(total)
     }
 
-    /// Remove all `waveform_cache` rows for this logical track (bare id and `stream:` variant).
-    pub fn delete_waveform_for_track_id(&self, track_id: &str) -> Result<u64, String> {
+    /// Remove `waveform_cache` rows for this logical track (bare id and `stream:`
+    /// variant) scoped to one server plus the legacy `''` pool. See
+    /// [`Self::delete_loudness_for_track_id`] for the scoping rationale.
+    pub fn delete_waveform_for_track_id(&self, server_id: &str, track_id: &str) -> Result<u64, String> {
         if track_id.trim().is_empty() {
             return Ok(0);
         }
@@ -154,7 +164,10 @@ impl AnalysisCache {
         let mut total: u64 = 0;
         for tid in track_id_cache_variants(track_id) {
             let n = conn
-                .execute("DELETE FROM waveform_cache WHERE track_id = ?1", params![tid])
+                .execute(
+                    "DELETE FROM waveform_cache WHERE track_id = ?1 AND server_id IN (?2, '')",
+                    params![tid, server_id],
+                )
                 .map_err(|e| e.to_string())?;
             total = total.saturating_add(n as u64);
         }
@@ -320,93 +333,198 @@ impl AnalysisCache {
         Ok(exists != 0)
     }
 
-    pub fn get_latest_waveform_for_track(&self, track_id: &str) -> Result<Option<WaveformEntry>, String> {
+    /// Latest waveform for `(server_id, track_id)` with legacy fallback. Tries the
+    /// server-scoped rows first (both id variants), then the legacy `server_id=''`
+    /// pool. On a legacy hit while a real `server_id` is known, the matching rows
+    /// are re-tagged under the server-scoped key (best-effort) so subsequent reads
+    /// hit the exact key and other servers can't shadow each other via `''`.
+    pub fn get_latest_waveform_for_track(
+        &self,
+        server_id: &str,
+        track_id: &str,
+    ) -> Result<Option<WaveformEntry>, String> {
         let conn = self.conn.lock().map_err(|_| "analysis_cache lock poisoned".to_string())?;
-        const SQL: &str = r#"
-            SELECT w.bins, w.bin_count, w.is_partial, w.known_until_sec, w.duration_sec, w.updated_at
-            FROM waveform_cache w
-            JOIN analysis_track a
-              ON a.server_id = w.server_id
-             AND a.track_id = w.track_id
-             AND a.md5_16kb = w.md5_16kb
-            WHERE w.track_id = ?1
-              AND a.waveform_algo_version = ?2
-            ORDER BY w.updated_at DESC
-            LIMIT 1
-            "#;
-        for tid in track_id_cache_variants(track_id) {
-            let row = conn
-                .query_row(
-                    SQL,
-                    params![tid, WAVEFORM_ALGO_VERSION],
-                    |row| {
-                        Ok(WaveformEntry {
-                            bins: row.get(0)?,
-                            bin_count: row.get(1)?,
-                            is_partial: row.get::<_, i64>(2)? != 0,
-                            known_until_sec: row.get(3)?,
-                            duration_sec: row.get(4)?,
-                            updated_at: row.get(5)?,
-                        })
-                    },
-                )
-                .optional()
-                .map_err(|e| e.to_string())?;
-            if let Some(e) = row {
-                if waveform_cache_blob_len_ok(&e.bins, e.bin_count) {
-                    return Ok(Some(e));
-                }
+        if let Some(e) = query_latest_waveform_scoped(&conn, server_id, track_id)? {
+            return Ok(Some(e));
+        }
+        if !server_id.is_empty() {
+            if let Some(e) = query_latest_waveform_scoped(&conn, "", track_id)? {
+                let _ = relabel_legacy_to_server(&conn, server_id, track_id);
+                return Ok(Some(e));
             }
         }
         Ok(None)
     }
 
-    /// Both waveform and loudness rows exist — a CPU seed from bytes/file would only
-    /// decode the file to immediately skip with `SkippedWaveformCacheHit`.
-    pub fn cpu_seed_redundant_for_track(&self, track_id: &str) -> Result<bool, String> {
+    /// Both waveform and loudness rows exist for this `(server_id, track_id)`
+    /// (including the legacy `''` fallback) — a CPU seed from bytes/file would
+    /// only decode the file to immediately skip with `SkippedWaveformCacheHit`.
+    /// A legacy hit is re-tagged onto the server scope as a side effect (see
+    /// [`Self::get_latest_waveform_for_track`]), so skipping the seed still leaves
+    /// the track resolvable under its real `server_id`.
+    pub fn cpu_seed_redundant_for_track(&self, server_id: &str, track_id: &str) -> Result<bool, String> {
         Ok(
-            self.get_latest_waveform_for_track(track_id)?.is_some()
-                && self.get_latest_loudness_for_track(track_id)?.is_some(),
+            self.get_latest_waveform_for_track(server_id, track_id)?.is_some()
+                && self.get_latest_loudness_for_track(server_id, track_id)?.is_some(),
         )
     }
 
-    pub fn get_latest_loudness_for_track(&self, track_id: &str) -> Result<Option<LoudnessSnapshot>, String> {
+    /// Latest loudness for `(server_id, track_id)` with the same legacy fallback +
+    /// lazy re-tag behaviour as [`Self::get_latest_waveform_for_track`].
+    pub fn get_latest_loudness_for_track(
+        &self,
+        server_id: &str,
+        track_id: &str,
+    ) -> Result<Option<LoudnessSnapshot>, String> {
         let conn = self.conn.lock().map_err(|_| "analysis_cache lock poisoned".to_string())?;
-        const SQL: &str = r#"
-            SELECT l.integrated_lufs, l.true_peak, l.recommended_gain_db, l.target_lufs, l.updated_at
-            FROM loudness_cache l
-            JOIN analysis_track a
-              ON a.server_id = l.server_id
-             AND a.track_id = l.track_id
-             AND a.md5_16kb = l.md5_16kb
-            WHERE l.track_id = ?1
-              AND a.loudness_algo_version = ?2
-            ORDER BY l.updated_at DESC
-            LIMIT 1
-            "#;
-        for tid in track_id_cache_variants(track_id) {
-            let row = conn
-                .query_row(
-                    SQL,
-                    params![tid, LOUDNESS_ALGO_VERSION],
-                    |row| {
-                        Ok(LoudnessSnapshot {
-                            integrated_lufs: row.get(0)?,
-                            true_peak: row.get(1)?,
-                            recommended_gain_db: row.get(2)?,
-                            target_lufs: row.get(3)?,
-                            updated_at: row.get(4)?,
-                        })
-                    },
-                )
-                .optional()
-                .map_err(|e| e.to_string())?;
-            if row.is_some() {
-                return Ok(row);
+        if let Some(s) = query_latest_loudness_scoped(&conn, server_id, track_id)? {
+            return Ok(Some(s));
+        }
+        if !server_id.is_empty() {
+            if let Some(s) = query_latest_loudness_scoped(&conn, "", track_id)? {
+                let _ = relabel_legacy_to_server(&conn, server_id, track_id);
+                return Ok(Some(s));
             }
         }
         Ok(None)
     }
+
+    /// Copy any legacy (`server_id=''`) analysis rows for `track_id` (both id
+    /// variants) onto `server_id` via `INSERT OR IGNORE` — best-effort, never
+    /// clobbers an existing server-scoped row. Exposed for the exact-key read
+    /// command, which re-tags after a legacy hit. No-op when `server_id` is empty.
+    pub fn relabel_legacy_to_server(&self, server_id: &str, track_id: &str) -> Result<(), String> {
+        if server_id.is_empty() {
+            return Ok(());
+        }
+        let conn = self.conn.lock().map_err(|_| "analysis_cache lock poisoned".to_string())?;
+        relabel_legacy_to_server(&conn, server_id, track_id).map_err(|e| e.to_string())
+    }
+}
+
+/// Server-scoped variant of the "latest waveform for this track" lookup: filters
+/// `waveform_cache` to `server_id` and tries both id variants (bare ↔ `stream:`).
+fn query_latest_waveform_scoped(
+    conn: &Connection,
+    server_id: &str,
+    track_id: &str,
+) -> Result<Option<WaveformEntry>, String> {
+    const SQL: &str = r#"
+        SELECT w.bins, w.bin_count, w.is_partial, w.known_until_sec, w.duration_sec, w.updated_at
+        FROM waveform_cache w
+        JOIN analysis_track a
+          ON a.server_id = w.server_id
+         AND a.track_id = w.track_id
+         AND a.md5_16kb = w.md5_16kb
+        WHERE w.server_id = ?1
+          AND w.track_id = ?2
+          AND a.waveform_algo_version = ?3
+        ORDER BY w.updated_at DESC
+        LIMIT 1
+        "#;
+    for tid in track_id_cache_variants(track_id) {
+        let row = conn
+            .query_row(SQL, params![server_id, tid, WAVEFORM_ALGO_VERSION], |row| {
+                Ok(WaveformEntry {
+                    bins: row.get(0)?,
+                    bin_count: row.get(1)?,
+                    is_partial: row.get::<_, i64>(2)? != 0,
+                    known_until_sec: row.get(3)?,
+                    duration_sec: row.get(4)?,
+                    updated_at: row.get(5)?,
+                })
+            })
+            .optional()
+            .map_err(|e| e.to_string())?;
+        if let Some(e) = row {
+            if waveform_cache_blob_len_ok(&e.bins, e.bin_count) {
+                return Ok(Some(e));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Server-scoped variant of the "latest loudness for this track" lookup.
+fn query_latest_loudness_scoped(
+    conn: &Connection,
+    server_id: &str,
+    track_id: &str,
+) -> Result<Option<LoudnessSnapshot>, String> {
+    const SQL: &str = r#"
+        SELECT l.integrated_lufs, l.true_peak, l.recommended_gain_db, l.target_lufs, l.updated_at
+        FROM loudness_cache l
+        JOIN analysis_track a
+          ON a.server_id = l.server_id
+         AND a.track_id = l.track_id
+         AND a.md5_16kb = l.md5_16kb
+        WHERE l.server_id = ?1
+          AND l.track_id = ?2
+          AND a.loudness_algo_version = ?3
+        ORDER BY l.updated_at DESC
+        LIMIT 1
+        "#;
+    for tid in track_id_cache_variants(track_id) {
+        let row = conn
+            .query_row(SQL, params![server_id, tid, LOUDNESS_ALGO_VERSION], |row| {
+                Ok(LoudnessSnapshot {
+                    integrated_lufs: row.get(0)?,
+                    true_peak: row.get(1)?,
+                    recommended_gain_db: row.get(2)?,
+                    target_lufs: row.get(3)?,
+                    updated_at: row.get(4)?,
+                })
+            })
+            .optional()
+            .map_err(|e| e.to_string())?;
+        if row.is_some() {
+            return Ok(row);
+        }
+    }
+    Ok(None)
+}
+
+/// Lazy re-tag: copy legacy (`server_id=''`) `analysis_track` + `waveform_cache` +
+/// `loudness_cache` rows for every id variant of `track_id` onto `server_id`.
+/// `INSERT OR IGNORE` so an already-present server-scoped row (e.g. a precise
+/// playback-derived analysis) is never overwritten. Best-effort, no transaction:
+/// the rows are individually consistent and a partial copy still leaves the
+/// legacy rows readable via fallback.
+fn relabel_legacy_to_server(
+    conn: &Connection,
+    server_id: &str,
+    track_id: &str,
+) -> rusqlite::Result<()> {
+    for tid in track_id_cache_variants(track_id) {
+        conn.execute(
+            r#"
+            INSERT OR IGNORE INTO analysis_track
+                (server_id, track_id, md5_16kb, status, waveform_algo_version, loudness_algo_version, updated_at)
+            SELECT ?1, track_id, md5_16kb, status, waveform_algo_version, loudness_algo_version, updated_at
+            FROM analysis_track WHERE server_id = '' AND track_id = ?2
+            "#,
+            params![server_id, tid],
+        )?;
+        conn.execute(
+            r#"
+            INSERT OR IGNORE INTO waveform_cache
+                (server_id, track_id, md5_16kb, bins, bin_count, is_partial, known_until_sec, duration_sec, updated_at)
+            SELECT ?1, track_id, md5_16kb, bins, bin_count, is_partial, known_until_sec, duration_sec, updated_at
+            FROM waveform_cache WHERE server_id = '' AND track_id = ?2
+            "#,
+            params![server_id, tid],
+        )?;
+        conn.execute(
+            r#"
+            INSERT OR IGNORE INTO loudness_cache
+                (server_id, track_id, md5_16kb, integrated_lufs, true_peak, recommended_gain_db, target_lufs, updated_at)
+            SELECT ?1, track_id, md5_16kb, integrated_lufs, true_peak, recommended_gain_db, target_lufs, updated_at
+            FROM loudness_cache WHERE server_id = '' AND track_id = ?2
+            "#,
+            params![server_id, tid],
+        )?;
+    }
+    Ok(())
 }
 
 fn analysis_db_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
@@ -728,7 +846,7 @@ mod tests {
         cache.touch_track_status(&k, "ok").unwrap();
         cache.upsert_waveform(&k, &waveform(4, false)).unwrap();
         // Insert under stream:abc, look up with bare abc.
-        let got = cache.get_latest_waveform_for_track("abc").unwrap();
+        let got = cache.get_latest_waveform_for_track("", "abc").unwrap();
         assert!(got.is_some(), "bare-id lookup must find stream-prefixed row");
     }
 
@@ -738,7 +856,7 @@ mod tests {
         let k = key("abc");
         cache.touch_track_status(&k, "ok").unwrap();
         cache.upsert_loudness(&k, &loudness(-14.0)).unwrap();
-        let got = cache.get_latest_loudness_for_track("stream:abc").unwrap();
+        let got = cache.get_latest_loudness_for_track("", "stream:abc").unwrap();
         assert!(got.is_some(), "stream-prefixed lookup must find bare row");
     }
 
@@ -750,16 +868,16 @@ mod tests {
         let k = key("abc");
         cache.touch_track_status(&k, "ok").unwrap();
 
-        assert!(!cache.cpu_seed_redundant_for_track("abc").unwrap());
+        assert!(!cache.cpu_seed_redundant_for_track("", "abc").unwrap());
 
         cache.upsert_waveform(&k, &waveform(4, false)).unwrap();
         assert!(
-            !cache.cpu_seed_redundant_for_track("abc").unwrap(),
+            !cache.cpu_seed_redundant_for_track("", "abc").unwrap(),
             "waveform alone is not enough"
         );
 
         cache.upsert_loudness(&k, &loudness(-14.0)).unwrap();
-        assert!(cache.cpu_seed_redundant_for_track("abc").unwrap());
+        assert!(cache.cpu_seed_redundant_for_track("", "abc").unwrap());
     }
 
     // ── deletes ───────────────────────────────────────────────────────────────
@@ -774,7 +892,7 @@ mod tests {
         cache.upsert_loudness(&bare, &loudness(-14.0)).unwrap();
         cache.upsert_loudness(&prefixed, &loudness(-14.0)).unwrap();
 
-        let deleted = cache.delete_loudness_for_track_id("abc").unwrap();
+        let deleted = cache.delete_loudness_for_track_id("", "abc").unwrap();
         assert_eq!(deleted, 2, "delete must remove both bare and stream:abc rows");
         assert!(!cache.loudness_row_exists_for_key(&bare).unwrap());
         assert!(!cache.loudness_row_exists_for_key(&prefixed).unwrap());
@@ -790,7 +908,7 @@ mod tests {
         cache.upsert_waveform(&bare, &waveform(4, false)).unwrap();
         cache.upsert_waveform(&prefixed, &waveform(4, false)).unwrap();
 
-        let deleted = cache.delete_waveform_for_track_id("abc").unwrap();
+        let deleted = cache.delete_waveform_for_track_id("", "abc").unwrap();
         assert_eq!(deleted, 2);
         assert!(cache.get_waveform(&bare).unwrap().is_none());
         assert!(cache.get_waveform(&prefixed).unwrap().is_none());
@@ -799,10 +917,102 @@ mod tests {
     #[test]
     fn delete_with_empty_or_whitespace_track_id_is_noop() {
         let cache = AnalysisCache::open_in_memory();
-        assert_eq!(cache.delete_waveform_for_track_id("").unwrap(), 0);
-        assert_eq!(cache.delete_waveform_for_track_id("   ").unwrap(), 0);
-        assert_eq!(cache.delete_loudness_for_track_id("").unwrap(), 0);
-        assert_eq!(cache.delete_loudness_for_track_id("   ").unwrap(), 0);
+        assert_eq!(cache.delete_waveform_for_track_id("", "").unwrap(), 0);
+        assert_eq!(cache.delete_waveform_for_track_id("", "   ").unwrap(), 0);
+        assert_eq!(cache.delete_loudness_for_track_id("", "").unwrap(), 0);
+        assert_eq!(cache.delete_loudness_for_track_id("", "   ").unwrap(), 0);
+    }
+
+    #[test]
+    fn delete_scoped_to_server_keeps_other_servers_rows() {
+        // A reseed on server-a must not wipe server-b's analysis for the same
+        // bare track_id; the legacy '' pool is cleared alongside server-a.
+        let cache = AnalysisCache::open_in_memory();
+        let on_a = key_on("server-a", "t");
+        let on_b = key_on("server-b", "t");
+        let legacy = key_on("", "t");
+        for k in [&on_a, &on_b, &legacy] {
+            cache.touch_track_status(k, "ok").unwrap();
+            cache.upsert_waveform(k, &waveform(4, false)).unwrap();
+            cache.upsert_loudness(k, &loudness(-14.0)).unwrap();
+        }
+
+        let deleted = cache.delete_waveform_for_track_id("server-a", "t").unwrap();
+        assert_eq!(deleted, 2, "server-a + legacy '' waveform rows removed");
+        assert!(cache.get_waveform(&on_a).unwrap().is_none());
+        assert!(cache.get_waveform(&legacy).unwrap().is_none());
+        assert!(
+            cache.get_waveform(&on_b).unwrap().is_some(),
+            "another server's waveform must survive a scoped reseed"
+        );
+
+        let deleted_l = cache.delete_loudness_for_track_id("server-a", "t").unwrap();
+        assert_eq!(deleted_l, 2);
+        assert!(cache.loudness_row_exists_for_key(&on_b).unwrap());
+    }
+
+    // ── server scope: read fallback + lazy re-tag ─────────────────────────────
+
+    #[test]
+    fn get_latest_waveform_falls_back_to_legacy_and_retags() {
+        // A pre-002 blob lives under server_id=''. A read for a real server must
+        // find it via fallback and re-tag it under the server-scoped key.
+        let cache = AnalysisCache::open_in_memory();
+        let legacy = key_on("", "t");
+        cache.touch_track_status(&legacy, "ready").unwrap();
+        cache.upsert_waveform(&legacy, &waveform(4, false)).unwrap();
+        cache.upsert_loudness(&legacy, &loudness(-14.0)).unwrap();
+
+        // server-a has no scoped row yet → fallback returns the legacy blob.
+        assert!(cache.get_waveform(&key_on("server-a", "t")).unwrap().is_none());
+        assert!(cache.get_latest_waveform_for_track("server-a", "t").unwrap().is_some());
+
+        // Re-tag side effect: the exact server-scoped key now resolves directly.
+        assert!(
+            cache.get_waveform(&key_on("server-a", "t")).unwrap().is_some(),
+            "legacy hit must be re-tagged under the server scope"
+        );
+        // Legacy row is preserved (copy, not move).
+        assert!(cache.get_waveform(&legacy).unwrap().is_some());
+    }
+
+    #[test]
+    fn retag_does_not_clobber_existing_server_scoped_row() {
+        // server-a already has a precise (playback-derived) row; a legacy hit must
+        // not overwrite it via INSERT OR IGNORE.
+        let cache = AnalysisCache::open_in_memory();
+        let legacy = key_on("", "t");
+        cache.touch_track_status(&legacy, "ready").unwrap();
+        cache.upsert_waveform(&legacy, &waveform(4, true)).unwrap();
+        cache.upsert_loudness(&legacy, &loudness(-14.0)).unwrap();
+
+        let on_a = key_on("server-a", "t");
+        cache.touch_track_status(&on_a, "ready").unwrap();
+        let precise = WaveformEntry { is_partial: false, ..waveform(4, false) };
+        cache.upsert_waveform(&on_a, &precise).unwrap();
+        cache.upsert_loudness(&on_a, &loudness(-14.0)).unwrap();
+
+        cache.relabel_legacy_to_server("server-a", "t").unwrap();
+        let got = cache.get_waveform(&on_a).unwrap().expect("server row present");
+        assert!(!got.is_partial, "precise server-scoped row must be preserved");
+    }
+
+    #[test]
+    fn get_latest_loudness_legacy_fallback_scopes_to_requested_server() {
+        let cache = AnalysisCache::open_in_memory();
+        let legacy = key_on("", "t");
+        cache.touch_track_status(&legacy, "ready").unwrap();
+        cache.upsert_loudness(&legacy, &loudness(-12.0)).unwrap();
+
+        // server-b has its own distinct loudness → exact hit, no fallback.
+        let on_b = key_on("server-b", "t");
+        cache.touch_track_status(&on_b, "ready").unwrap();
+        cache.upsert_loudness(&on_b, &loudness(-20.0)).unwrap();
+
+        let a = cache.get_latest_loudness_for_track("server-a", "t").unwrap().unwrap();
+        assert_eq!(a.target_lufs, -12.0, "server-a falls back to legacy blob");
+        let b = cache.get_latest_loudness_for_track("server-b", "t").unwrap().unwrap();
+        assert_eq!(b.target_lufs, -20.0, "server-b uses its own scoped blob, not legacy");
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
@@ -30,9 +30,14 @@ pub enum AnalysisBackfillEnqueueKind {
     RunningSkipped,
 }
 
+/// One queued HTTP-backfill job: `(track_id, url, server_id)`. Dedup is by
+/// `track_id` (a track is backfilled at most once at a time); `server_id` rides
+/// along to scope the eventual cache write and follows the latest enqueue.
+type BackfillJob = (String, String, String);
+
 #[derive(Default)]
 pub struct AnalysisBackfillQueueState {
-    pub deque: VecDeque<(String, String)>,
+    pub deque: VecDeque<BackfillJob>,
     /// Set while this `track_id` is inside `analysis_backfill_download_and_seed` (not in deque).
     pub in_progress: Option<String>,
 }
@@ -40,13 +45,13 @@ pub struct AnalysisBackfillQueueState {
 impl AnalysisBackfillQueueState {
     fn is_reserved(&self, tid: &str) -> bool {
         self.in_progress.as_deref() == Some(tid)
-            || self.deque.iter().any(|(t, _)| t.as_str() == tid)
+            || self.deque.iter().any(|(t, _, _)| t.as_str() == tid)
     }
 
-    fn try_pop_next(&mut self) -> Option<(String, String)> {
-        let (tid, url) = self.deque.pop_front()?;
-        self.in_progress = Some(tid.clone());
-        Some((tid, url))
+    fn try_pop_next(&mut self) -> Option<BackfillJob> {
+        let job = self.deque.pop_front()?;
+        self.in_progress = Some(job.0.clone());
+        Some(job)
     }
 
     fn finish_job(&mut self, tid: &str) {
@@ -57,6 +62,7 @@ impl AnalysisBackfillQueueState {
 
     pub fn enqueue(
         &mut self,
+        server_id: String,
         tid: String,
         url: String,
         high_priority: bool,
@@ -69,15 +75,15 @@ impl AnalysisBackfillQueueState {
             if self.in_progress.as_deref() == Some(tref) {
                 return AnalysisBackfillEnqueueKind::RunningSkipped;
             }
-            self.deque.retain(|(t, _)| t != &tid);
-            self.deque.push_front((tid, url));
+            self.deque.retain(|(t, _, _)| t != &tid);
+            self.deque.push_front((tid, url, server_id));
             return AnalysisBackfillEnqueueKind::ReorderedFront;
         }
         if high_priority {
-            self.deque.push_front((tid, url));
+            self.deque.push_front((tid, url, server_id));
             AnalysisBackfillEnqueueKind::NewFront
         } else {
-            self.deque.push_back((tid, url));
+            self.deque.push_back((tid, url, server_id));
             AnalysisBackfillEnqueueKind::NewBack
         }
     }
@@ -85,7 +91,7 @@ impl AnalysisBackfillQueueState {
     pub fn prune_queued_not_in(&mut self, keep_track_ids: &HashSet<&str>) -> usize {
         let before = self.deque.len();
         self.deque
-            .retain(|(track_id, _)| keep_track_ids.contains(track_id.as_str()));
+            .retain(|(track_id, _, _)| keep_track_ids.contains(track_id.as_str()));
         before.saturating_sub(self.deque.len())
     }
 }
@@ -125,17 +131,19 @@ pub fn analysis_backfill_shared(app: &tauri::AppHandle) -> Arc<AnalysisBackfillS
 /// well as fresh decode hits).
 pub async fn enqueue_analysis_seed(
     app: &tauri::AppHandle,
+    server_id: &str,
     track_id: &str,
     bytes: &[u8],
 ) -> Result<bool, String> {
     if let Some(cache) = app.try_state::<analysis_cache::AnalysisCache>() {
-        if cache.cpu_seed_redundant_for_track(track_id).unwrap_or(false) {
+        if cache.cpu_seed_redundant_for_track(server_id, track_id).unwrap_or(false) {
             return Ok(true);
         }
     }
     let high = analysis_backfill_is_current_track(app, track_id);
     let outcome = submit_analysis_cpu_seed(
         app.clone(),
+        server_id.to_string(),
         track_id.to_string(),
         bytes.to_vec(),
         high,
@@ -147,7 +155,7 @@ pub async fn enqueue_analysis_seed(
     })?;
     let has_loudness = app
         .try_state::<analysis_cache::AnalysisCache>()
-        .and_then(|cache| cache.get_latest_loudness_for_track(track_id).ok().flatten())
+        .and_then(|cache| cache.get_latest_loudness_for_track(server_id, track_id).ok().flatten())
         .is_some();
     crate::app_deprintln!(
         "[analysis] seed result track_id={} bytes={} has_loudness={} outcome={outcome:?}",
@@ -160,6 +168,7 @@ pub async fn enqueue_analysis_seed(
 
 async fn analysis_backfill_download_and_seed(
     app: &tauri::AppHandle,
+    server_id: &str,
     track_id: &str,
     url: &str,
 ) -> Result<bool, String> {
@@ -176,7 +185,7 @@ async fn analysis_backfill_download_and_seed(
     if bytes.is_empty() {
         return Err("empty response".to_string());
     }
-    enqueue_analysis_seed(app, track_id, &bytes).await
+    enqueue_analysis_seed(app, server_id, track_id, &bytes).await
 }
 
 async fn analysis_backfill_worker_loop(
@@ -188,7 +197,7 @@ async fn analysis_backfill_worker_loop(
         if wake_rx.recv().await.is_none() {
             break;
         }
-        while let Some((track_id, url)) = {
+        while let Some((track_id, url, server_id)) = {
             let mut st = shared
                 .state
                 .lock()
@@ -196,7 +205,7 @@ async fn analysis_backfill_worker_loop(
             st.try_pop_next()
         } {
             crate::app_deprintln!("[analysis] backfill worker: start track_id={}", track_id);
-            let result = analysis_backfill_download_and_seed(&app, &track_id, &url).await;
+            let result = analysis_backfill_download_and_seed(&app, &server_id, &track_id, &url).await;
             match &result {
                 Ok(has_loudness) => crate::app_deprintln!(
                     "[analysis] backfill ready: {} (has_loudness={})",
@@ -238,6 +247,9 @@ type SeedDoneSender =
 type RunningSeedJob = (String, Arc<Mutex<Vec<SeedDoneSender>>>);
 
 struct AnalysisCpuSeedJob {
+    /// Playback server scope for the write key. Empty = legacy '' (caller did not
+    /// know the server); the read path's fallback + lazy re-tag covers it.
+    server_id: String,
     track_id: String,
     bytes: Vec<u8>,
     waiters: Vec<SeedDoneSender>,
@@ -253,6 +265,7 @@ struct AnalysisCpuSeedQueueState {
 impl AnalysisCpuSeedQueueState {
     fn enqueue(
         &mut self,
+        server_id: String,
         track_id: String,
         bytes: Vec<u8>,
         high_priority: bool,
@@ -275,6 +288,8 @@ impl AnalysisCpuSeedQueueState {
 
         if let Some(pos) = self.deque.iter().position(|j| j.track_id == track_id) {
             let mut job = self.deque.remove(pos).unwrap();
+            // Latest submission wins for both bytes and server scope.
+            job.server_id = server_id;
             job.bytes = bytes;
             job.waiters.push(done_tx);
             let kind = if high_priority {
@@ -288,6 +303,7 @@ impl AnalysisCpuSeedQueueState {
         }
 
         let job = AnalysisCpuSeedJob {
+            server_id,
             track_id: track_id.clone(),
             bytes,
             waiters: vec![done_tx],
@@ -422,10 +438,11 @@ async fn analysis_cpu_seed_worker_loop(
             };
             let tid_log = job.track_id.clone();
             let app2 = app.clone();
+            let sid = job.server_id.clone();
             let tid = job.track_id.clone();
             let bytes = job.bytes;
             let outcome = tokio::task::spawn_blocking(move || {
-                analysis_cache::seed_from_bytes_execute(&app2, &tid, &bytes)
+                analysis_cache::seed_from_bytes_execute(&app2, &sid, &tid, &bytes)
             })
             .await
             .unwrap_or_else(|e| Err(format!("cpu-seed spawn_blocking: {e}")));
@@ -497,6 +514,7 @@ pub fn prune_analysis_queues(
 /// re-run loudness refresh / waveform IPC for rows that were already current.
 pub async fn submit_analysis_cpu_seed(
     app: tauri::AppHandle,
+    server_id: String,
     track_id: String,
     bytes: Vec<u8>,
     high_priority: bool,
@@ -504,7 +522,7 @@ pub async fn submit_analysis_cpu_seed(
     let shared = analysis_cpu_seed_shared(&app);
     let rx = {
         let mut st = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        let (kind, rx) = st.enqueue(track_id.clone(), bytes, high_priority);
+        let (kind, rx) = st.enqueue(server_id, track_id.clone(), bytes, high_priority);
         crate::app_deprintln!("[analysis] cpu-seed submit: kind={kind:?} high_priority={high_priority}");
         drop(st);
         shared.ping_worker();
@@ -542,7 +560,7 @@ mod tests {
     #[test]
     fn backfill_is_reserved_checks_both_deque_and_in_progress() {
         let mut s = AnalysisBackfillQueueState::default();
-        s.deque.push_back(("queued".into(), "u".into()));
+        s.deque.push_back(("queued".into(), "u".into(), String::new()));
         s.in_progress = Some("active".into());
         assert!(s.is_reserved("queued"));
         assert!(s.is_reserved("active"));
@@ -552,8 +570,8 @@ mod tests {
     #[test]
     fn backfill_try_pop_next_promotes_head_to_in_progress() {
         let mut s = AnalysisBackfillQueueState::default();
-        s.deque.push_back(("a".into(), "ua".into()));
-        s.deque.push_back(("b".into(), "ub".into()));
+        s.deque.push_back(("a".into(), "ua".into(), String::new()));
+        s.deque.push_back(("b".into(), "ub".into(), String::new()));
         let popped = s.try_pop_next().unwrap();
         assert_eq!(popped.0, "a");
         assert_eq!(s.in_progress.as_deref(), Some("a"));
@@ -582,8 +600,8 @@ mod tests {
     #[test]
     fn backfill_enqueue_low_priority_appends_to_back() {
         let mut s = AnalysisBackfillQueueState::default();
-        s.deque.push_back(("first".into(), "u".into()));
-        let kind = s.enqueue("second".into(), "u2".into(), false);
+        s.deque.push_back(("first".into(), "u".into(), String::new()));
+        let kind = s.enqueue(String::new(), "second".into(), "u2".into(), false);
         assert_eq!(kind, AnalysisBackfillEnqueueKind::NewBack);
         assert_eq!(s.deque.back().unwrap().0, "second");
     }
@@ -591,8 +609,8 @@ mod tests {
     #[test]
     fn backfill_enqueue_high_priority_pushes_to_front() {
         let mut s = AnalysisBackfillQueueState::default();
-        s.deque.push_back(("old".into(), "u".into()));
-        let kind = s.enqueue("hot".into(), "u2".into(), true);
+        s.deque.push_back(("old".into(), "u".into(), String::new()));
+        let kind = s.enqueue(String::new(), "hot".into(), "u2".into(), true);
         assert_eq!(kind, AnalysisBackfillEnqueueKind::NewFront);
         assert_eq!(s.deque.front().unwrap().0, "hot");
     }
@@ -600,8 +618,8 @@ mod tests {
     #[test]
     fn backfill_enqueue_returns_duplicate_skipped_for_low_prio_dup() {
         let mut s = AnalysisBackfillQueueState::default();
-        s.deque.push_back(("dup".into(), "u".into()));
-        let kind = s.enqueue("dup".into(), "u2".into(), false);
+        s.deque.push_back(("dup".into(), "u".into(), String::new()));
+        let kind = s.enqueue(String::new(), "dup".into(), "u2".into(), false);
         assert_eq!(kind, AnalysisBackfillEnqueueKind::DuplicateSkipped);
         assert_eq!(s.deque.len(), 1);
     }
@@ -612,32 +630,35 @@ mod tests {
             in_progress: Some("active".into()),
             ..Default::default()
         };
-        let kind = s.enqueue("active".into(), "u".into(), true);
+        let kind = s.enqueue(String::new(), "active".into(), "u".into(), true);
         assert_eq!(kind, AnalysisBackfillEnqueueKind::RunningSkipped);
     }
 
     #[test]
     fn backfill_enqueue_high_prio_dup_in_deque_reorders_to_front_with_new_url() {
         let mut s = AnalysisBackfillQueueState::default();
-        s.deque.push_back(("a".into(), "u_a".into()));
-        s.deque.push_back(("dup".into(), "old_url".into()));
-        s.deque.push_back(("c".into(), "u_c".into()));
-        let kind = s.enqueue("dup".into(), "fresh_url".into(), true);
+        s.deque.push_back(("a".into(), "u_a".into(), String::new()));
+        s.deque.push_back(("dup".into(), "old_url".into(), String::new()));
+        s.deque.push_back(("c".into(), "u_c".into(), String::new()));
+        let kind = s.enqueue("server-1".into(), "dup".into(), "fresh_url".into(), true);
         assert_eq!(kind, AnalysisBackfillEnqueueKind::ReorderedFront);
-        assert_eq!(s.deque.front().unwrap(), &("dup".to_string(), "fresh_url".to_string()));
-        assert_eq!(s.deque.iter().filter(|(t, _)| t == "dup").count(), 1, "no duplicate left behind");
+        assert_eq!(
+            s.deque.front().unwrap(),
+            &("dup".to_string(), "fresh_url".to_string(), "server-1".to_string())
+        );
+        assert_eq!(s.deque.iter().filter(|(t, _, _)| t == "dup").count(), 1, "no duplicate left behind");
     }
 
     #[test]
     fn backfill_prune_queued_not_in_drops_unkept_entries() {
         let mut s = AnalysisBackfillQueueState::default();
         for tid in ["a", "b", "c", "d"] {
-            s.deque.push_back((tid.into(), "u".into()));
+            s.deque.push_back((tid.into(), "u".into(), String::new()));
         }
         let keep: HashSet<&str> = ["a", "c"].iter().copied().collect();
         let removed = s.prune_queued_not_in(&keep);
         assert_eq!(removed, 2);
-        let remaining: Vec<&str> = s.deque.iter().map(|(t, _)| t.as_str()).collect();
+        let remaining: Vec<&str> = s.deque.iter().map(|(t, _, _)| t.as_str()).collect();
         assert_eq!(remaining, vec!["a", "c"]);
     }
 
@@ -646,7 +667,7 @@ mod tests {
     #[test]
     fn cpu_seed_enqueue_low_prio_appends_to_back() {
         let mut s = AnalysisCpuSeedQueueState::default();
-        let (kind, _rx) = s.enqueue("a".into(), vec![], false);
+        let (kind, _rx) = s.enqueue(String::new(), "a".into(), vec![], false);
         assert_eq!(kind, AnalysisCpuSeedEnqueueKind::NewBack);
         assert_eq!(s.deque.len(), 1);
     }
@@ -654,8 +675,8 @@ mod tests {
     #[test]
     fn cpu_seed_enqueue_high_prio_pushes_to_front() {
         let mut s = AnalysisCpuSeedQueueState::default();
-        let (_, _r1) = s.enqueue("first".into(), vec![], false);
-        let (kind, _r2) = s.enqueue("hot".into(), vec![], true);
+        let (_, _r1) = s.enqueue(String::new(), "first".into(), vec![], false);
+        let (kind, _r2) = s.enqueue(String::new(), "hot".into(), vec![], true);
         assert_eq!(kind, AnalysisCpuSeedEnqueueKind::NewFront);
         assert_eq!(s.deque.front().unwrap().track_id, "hot");
     }
@@ -663,20 +684,21 @@ mod tests {
     #[test]
     fn cpu_seed_enqueue_existing_low_prio_merges_at_back() {
         let mut s = AnalysisCpuSeedQueueState::default();
-        let (_, _r1) = s.enqueue("dup".into(), vec![1, 2, 3], false);
-        let (kind, _r2) = s.enqueue("dup".into(), vec![4, 5, 6], false);
+        let (_, _r1) = s.enqueue("server-a".into(), "dup".into(), vec![1, 2, 3], false);
+        let (kind, _r2) = s.enqueue("server-b".into(), "dup".into(), vec![4, 5, 6], false);
         assert_eq!(kind, AnalysisCpuSeedEnqueueKind::MergedQueued);
         assert_eq!(s.deque.len(), 1);
         assert_eq!(s.deque[0].bytes, vec![4, 5, 6], "fresh bytes overwrite");
+        assert_eq!(s.deque[0].server_id, "server-b", "latest server scope wins on merge");
         assert_eq!(s.deque[0].waiters.len(), 2, "both waiters attached");
     }
 
     #[test]
     fn cpu_seed_enqueue_existing_high_prio_reorders_to_front() {
         let mut s = AnalysisCpuSeedQueueState::default();
-        let (_, _r1) = s.enqueue("first".into(), vec![], false);
-        let (_, _r2) = s.enqueue("dup".into(), vec![], false);
-        let (kind, _r3) = s.enqueue("dup".into(), vec![], true);
+        let (_, _r1) = s.enqueue(String::new(), "first".into(), vec![], false);
+        let (_, _r2) = s.enqueue(String::new(), "dup".into(), vec![], false);
+        let (kind, _r3) = s.enqueue(String::new(), "dup".into(), vec![], true);
         assert_eq!(kind, AnalysisCpuSeedEnqueueKind::ReorderedFront);
         assert_eq!(s.deque.front().unwrap().track_id, "dup");
     }
@@ -686,7 +708,7 @@ mod tests {
         let mut s = AnalysisCpuSeedQueueState::default();
         let followers = Arc::new(Mutex::new(Vec::new()));
         s.running = Some(("active".into(), followers.clone()));
-        let (kind, _rx) = s.enqueue("active".into(), vec![], false);
+        let (kind, _rx) = s.enqueue(String::new(), "active".into(), vec![], false);
         assert_eq!(kind, AnalysisCpuSeedEnqueueKind::RunningFollower);
         assert_eq!(followers.lock().unwrap().len(), 1, "follower channel attached");
         assert_eq!(s.deque.len(), 0, "follower does not occupy a queue slot");
@@ -695,10 +717,10 @@ mod tests {
     #[test]
     fn cpu_seed_prune_returns_removed_jobs_and_waiter_count() {
         let mut s = AnalysisCpuSeedQueueState::default();
-        let (_, _r1) = s.enqueue("a".into(), vec![], false);
-        let (_, _r2) = s.enqueue("b".into(), vec![], false);
-        let (_, _r3) = s.enqueue("a".into(), vec![], false); // merged: 2 waiters on a
-        let (_, _r4) = s.enqueue("c".into(), vec![], false);
+        let (_, _r1) = s.enqueue(String::new(), "a".into(), vec![], false);
+        let (_, _r2) = s.enqueue(String::new(), "b".into(), vec![], false);
+        let (_, _r3) = s.enqueue(String::new(), "a".into(), vec![], false); // merged: 2 waiters on a
+        let (_, _r4) = s.enqueue(String::new(), "c".into(), vec![], false);
 
         let keep: HashSet<&str> = ["a"].iter().copied().collect();
         let (removed_jobs, removed_waiters) = s.prune_queued_not_in(&keep);
@@ -711,7 +733,7 @@ mod tests {
     #[test]
     fn cpu_seed_prune_sends_err_to_dropped_waiters() {
         let mut s = AnalysisCpuSeedQueueState::default();
-        let (_, rx) = s.enqueue("doomed".into(), vec![], false);
+        let (_, rx) = s.enqueue(String::new(), "doomed".into(), vec![], false);
         let keep: HashSet<&str> = HashSet::new();
         let _ = s.prune_queued_not_in(&keep);
         // After pruning, the waiter receives the cancellation Err.

--- a/src-tauri/crates/psysonic-analysis/src/commands.rs
+++ b/src-tauri/crates/psysonic-analysis/src/commands.rs
@@ -49,46 +49,63 @@ pub struct LoudnessCachePayload {
     pub updated_at: i64,
 }
 
-/// AppHandle-free helper: looks up a waveform by exact `(track_id, md5_16kb)`
-/// key and converts the `WaveformEntry` into the JSON-serialisable
-/// `WaveformCachePayload`. Pulled out of [`analysis_get_waveform`] so it can
-/// be tested with `AnalysisCache::open_in_memory()` and direct upserts.
+/// AppHandle-free helper: looks up a waveform by exact `(server_id, track_id,
+/// md5_16kb)` key, falling back to the legacy `''` scope and re-tagging it onto
+/// `server_id` on a hit (best-effort). Converts the `WaveformEntry` into the
+/// JSON-serialisable `WaveformCachePayload`. Pulled out of [`analysis_get_waveform`]
+/// so it can be tested with `AnalysisCache::open_in_memory()` and direct upserts.
 pub fn get_waveform_payload(
     cache: &analysis_cache::AnalysisCache,
+    server_id: &str,
     track_id: &str,
     md5_16kb: &str,
 ) -> Result<Option<WaveformCachePayload>, String> {
-    // server_id is added in 6c-2 (read commands gain a serverId arg + legacy
-    // fallback); 6c-1 keeps the exact-key lookup scoped to the legacy '' rows.
-    let key = analysis_cache::TrackKey {
-        server_id: String::new(),
+    let exact = analysis_cache::TrackKey {
+        server_id: server_id.to_string(),
         track_id: track_id.to_string(),
         md5_16kb: md5_16kb.to_string(),
     };
-    Ok(cache.get_waveform(&key)?.map(WaveformCachePayload::from))
+    if let Some(e) = cache.get_waveform(&exact)? {
+        return Ok(Some(WaveformCachePayload::from(e)));
+    }
+    if !server_id.is_empty() {
+        let legacy = analysis_cache::TrackKey {
+            server_id: String::new(),
+            track_id: track_id.to_string(),
+            md5_16kb: md5_16kb.to_string(),
+        };
+        if let Some(e) = cache.get_waveform(&legacy)? {
+            let _ = cache.relabel_legacy_to_server(server_id, track_id);
+            return Ok(Some(WaveformCachePayload::from(e)));
+        }
+    }
+    Ok(None)
 }
 
-/// AppHandle-free helper: looks up the latest waveform for `track_id`
-/// across all id variants (bare ↔ `stream:` prefix). See [`get_waveform_payload`].
+/// AppHandle-free helper: looks up the latest waveform for `(server_id, track_id)`
+/// across all id variants (bare ↔ `stream:` prefix) with legacy fallback + lazy
+/// re-tag. See [`get_waveform_payload`].
 pub fn get_waveform_payload_for_track(
     cache: &analysis_cache::AnalysisCache,
+    server_id: &str,
     track_id: &str,
 ) -> Result<Option<WaveformCachePayload>, String> {
     Ok(cache
-        .get_latest_waveform_for_track(track_id)?
+        .get_latest_waveform_for_track(server_id, track_id)?
         .map(WaveformCachePayload::from))
 }
 
-/// AppHandle-free helper: looks up the latest loudness row for `track_id`
-/// and recomputes `recommended_gain_db` against the optional requested target
-/// (clamped to [-30, -8]). When `target_lufs` is `None`, the cached row's own
-/// target is used.
+/// AppHandle-free helper: looks up the latest loudness row for `(server_id,
+/// track_id)` (legacy fallback + lazy re-tag) and recomputes `recommended_gain_db`
+/// against the optional requested target (clamped to [-30, -8]). When
+/// `target_lufs` is `None`, the cached row's own target is used.
 pub fn get_loudness_payload_for_track(
     cache: &analysis_cache::AnalysisCache,
+    server_id: &str,
     track_id: &str,
     target_lufs: Option<f64>,
 ) -> Result<Option<LoudnessCachePayload>, String> {
-    Ok(cache.get_latest_loudness_for_track(track_id)?.map(|v| {
+    Ok(cache.get_latest_loudness_for_track(server_id, track_id)?.map(|v| {
         let requested_target = target_lufs.unwrap_or(v.target_lufs).clamp(-30.0, -8.0);
         let recommended_gain_db = analysis_cache::recommended_gain_for_target(
             v.integrated_lufs,
@@ -109,9 +126,11 @@ pub fn get_loudness_payload_for_track(
 pub fn analysis_get_waveform(
     track_id: String,
     md5_16kb: String,
+    server_id: Option<String>,
     cache: tauri::State<'_, analysis_cache::AnalysisCache>,
 ) -> Result<Option<WaveformCachePayload>, String> {
-    let result = get_waveform_payload(cache.inner(), &track_id, &md5_16kb);
+    let server_id = server_id.unwrap_or_default();
+    let result = get_waveform_payload(cache.inner(), &server_id, &track_id, &md5_16kb);
     if let Ok(ref payload) = result {
         match payload {
             Some(v) => crate::app_deprintln!(
@@ -130,9 +149,11 @@ pub fn analysis_get_waveform(
 #[tauri::command]
 pub fn analysis_get_waveform_for_track(
     track_id: String,
+    server_id: Option<String>,
     cache: tauri::State<'_, analysis_cache::AnalysisCache>,
 ) -> Result<Option<WaveformCachePayload>, String> {
-    let result = get_waveform_payload_for_track(cache.inner(), &track_id);
+    let server_id = server_id.unwrap_or_default();
+    let result = get_waveform_payload_for_track(cache.inner(), &server_id, &track_id);
     if let Ok(ref payload) = result {
         match payload {
             Some(v) => crate::app_deprintln!(
@@ -149,25 +170,29 @@ pub fn analysis_get_waveform_for_track(
 pub fn analysis_get_loudness_for_track(
     track_id: String,
     target_lufs: Option<f64>,
+    server_id: Option<String>,
     cache: tauri::State<'_, analysis_cache::AnalysisCache>,
 ) -> Result<Option<LoudnessCachePayload>, String> {
-    get_loudness_payload_for_track(cache.inner(), &track_id, target_lufs)
+    let server_id = server_id.unwrap_or_default();
+    get_loudness_payload_for_track(cache.inner(), &server_id, &track_id, target_lufs)
 }
 
 #[tauri::command]
 pub fn analysis_delete_loudness_for_track(
     track_id: String,
+    server_id: Option<String>,
     cache: tauri::State<'_, analysis_cache::AnalysisCache>,
 ) -> Result<u64, String> {
-    cache.delete_loudness_for_track_id(&track_id)
+    cache.delete_loudness_for_track_id(&server_id.unwrap_or_default(), &track_id)
 }
 
 #[tauri::command]
 pub fn analysis_delete_waveform_for_track(
     track_id: String,
+    server_id: Option<String>,
     cache: tauri::State<'_, analysis_cache::AnalysisCache>,
 ) -> Result<u64, String> {
-    cache.delete_waveform_for_track_id(&track_id)
+    cache.delete_waveform_for_track_id(&server_id.unwrap_or_default(), &track_id)
 }
 
 #[tauri::command]
@@ -182,11 +207,13 @@ pub fn analysis_enqueue_seed_from_url(
     track_id: String,
     url: String,
     force: Option<bool>,
+    server_id: Option<String>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
     if track_id.trim().is_empty() || url.trim().is_empty() {
         return Ok(());
     }
+    let server_id = server_id.unwrap_or_default();
     let force = force.unwrap_or(false);
     if !force {
         if let Some(playback) = app.try_state::<PlaybackQueryHandle>() {
@@ -201,7 +228,7 @@ pub fn analysis_enqueue_seed_from_url(
     }
     if !force {
         if let Some(cache) = app.try_state::<analysis_cache::AnalysisCache>() {
-            if cache.get_latest_loudness_for_track(&track_id)?.is_some() {
+            if cache.get_latest_loudness_for_track(&server_id, &track_id)?.is_some() {
                 crate::app_deprintln!(
                     "[analysis] backfill skip (already cached): {}",
                     track_id
@@ -218,7 +245,7 @@ pub fn analysis_enqueue_seed_from_url(
             .state
             .lock()
             .map_err(|_| "analysis backfill lock poisoned".to_string())?;
-        st.enqueue(track_id, url, high_priority)
+        st.enqueue(server_id, track_id, url, high_priority)
     };
     match kind {
         AnalysisBackfillEnqueueKind::NewBack | AnalysisBackfillEnqueueKind::NewFront => {
@@ -346,7 +373,7 @@ mod tests {
     #[test]
     fn get_waveform_payload_returns_none_for_unknown_key() {
         let cache = AnalysisCache::open_in_memory();
-        let payload = get_waveform_payload(&cache, "missing", "deadbeef").unwrap();
+        let payload = get_waveform_payload(&cache, "", "missing", "deadbeef").unwrap();
         assert!(payload.is_none());
     }
 
@@ -355,7 +382,7 @@ mod tests {
         let cache = AnalysisCache::open_in_memory();
         let bins: Vec<u8> = (0..8u8).collect();
         upsert_waveform(&cache, "abc", "deadbeef", bins.clone());
-        let payload = get_waveform_payload(&cache, "abc", "deadbeef")
+        let payload = get_waveform_payload(&cache, "", "abc", "deadbeef")
             .unwrap()
             .expect("payload exists");
         assert_eq!(payload.bins, bins);
@@ -371,8 +398,8 @@ mod tests {
         let cache = AnalysisCache::open_in_memory();
         upsert_waveform(&cache, "abc", "aaaa", vec![0u8; 8]);
         upsert_waveform(&cache, "abc", "bbbb", vec![0xFFu8; 8]);
-        let p1 = get_waveform_payload(&cache, "abc", "aaaa").unwrap().unwrap();
-        let p2 = get_waveform_payload(&cache, "abc", "bbbb").unwrap().unwrap();
+        let p1 = get_waveform_payload(&cache, "", "abc", "aaaa").unwrap().unwrap();
+        let p2 = get_waveform_payload(&cache, "", "abc", "bbbb").unwrap().unwrap();
         assert_ne!(p1.bins, p2.bins);
     }
 
@@ -384,7 +411,7 @@ mod tests {
         // matching is the whole point of get_latest_waveform_for_track.
         let cache = AnalysisCache::open_in_memory();
         upsert_waveform(&cache, "stream:abc", "deadbeef", vec![1u8; 8]);
-        let payload = get_waveform_payload_for_track(&cache, "abc")
+        let payload = get_waveform_payload_for_track(&cache, "", "abc")
             .unwrap()
             .expect("bare-id lookup must hit the stream-prefixed row");
         assert_eq!(payload.bin_count, 4);
@@ -393,7 +420,28 @@ mod tests {
     #[test]
     fn get_waveform_for_track_returns_none_for_unknown_track() {
         let cache = AnalysisCache::open_in_memory();
-        assert!(get_waveform_payload_for_track(&cache, "phantom").unwrap().is_none());
+        assert!(get_waveform_payload_for_track(&cache, "", "phantom").unwrap().is_none());
+    }
+
+    #[test]
+    fn get_waveform_payload_exact_key_falls_back_to_legacy_and_retags() {
+        // A pre-002 row lives under server_id=''. The exact-key read for a real
+        // server must find it via fallback and re-tag it under the server scope.
+        let cache = AnalysisCache::open_in_memory();
+        upsert_waveform(&cache, "abc", "deadbeef", vec![7u8; 8]); // legacy '' row
+
+        let payload = get_waveform_payload(&cache, "server-a", "abc", "deadbeef")
+            .unwrap()
+            .expect("legacy fallback must return the blob");
+        assert_eq!(payload.bins, vec![7u8; 8]);
+
+        // Re-tag side effect: the server-scoped exact key now resolves on its own.
+        let scoped = TrackKey {
+            server_id: "server-a".to_string(),
+            track_id: "abc".to_string(),
+            md5_16kb: "deadbeef".to_string(),
+        };
+        assert!(cache.get_waveform(&scoped).unwrap().is_some());
     }
 
     // ── get_loudness_payload_for_track ────────────────────────────────────────
@@ -404,7 +452,7 @@ mod tests {
         upsert_loudness(&cache, "abc", "deadbeef", -14.0);
         // Cached row: integrated -14, target -14 → gain 0. Request target -10 →
         // recommended gain = -10 - (-14) = +4 dB (capped by true-peak guard).
-        let payload = get_loudness_payload_for_track(&cache, "abc", Some(-10.0))
+        let payload = get_loudness_payload_for_track(&cache, "", "abc", Some(-10.0))
             .unwrap()
             .expect("loudness row exists");
         assert_eq!(payload.target_lufs, -10.0);
@@ -419,7 +467,7 @@ mod tests {
     fn get_loudness_for_track_uses_cached_target_when_request_is_none() {
         let cache = AnalysisCache::open_in_memory();
         upsert_loudness(&cache, "abc", "deadbeef", -16.0);
-        let payload = get_loudness_payload_for_track(&cache, "abc", None)
+        let payload = get_loudness_payload_for_track(&cache, "", "abc", None)
             .unwrap()
             .unwrap();
         assert_eq!(payload.target_lufs, -16.0);
@@ -430,11 +478,11 @@ mod tests {
         let cache = AnalysisCache::open_in_memory();
         upsert_loudness(&cache, "abc", "deadbeef", -14.0);
         // Out-of-range target gets clamped to [-30, -8].
-        let too_high = get_loudness_payload_for_track(&cache, "abc", Some(0.0))
+        let too_high = get_loudness_payload_for_track(&cache, "", "abc", Some(0.0))
             .unwrap()
             .unwrap();
         assert_eq!(too_high.target_lufs, -8.0);
-        let too_low = get_loudness_payload_for_track(&cache, "abc", Some(-100.0))
+        let too_low = get_loudness_payload_for_track(&cache, "", "abc", Some(-100.0))
             .unwrap()
             .unwrap();
         assert_eq!(too_low.target_lufs, -30.0);
@@ -443,7 +491,7 @@ mod tests {
     #[test]
     fn get_loudness_for_track_returns_none_for_unknown_track() {
         let cache = AnalysisCache::open_in_memory();
-        assert!(get_loudness_payload_for_track(&cache, "phantom", None)
+        assert!(get_loudness_payload_for_track(&cache, "", "phantom", None)
             .unwrap()
             .is_none());
     }

--- a/src-tauri/crates/psysonic-audio/src/commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/commands.rs
@@ -29,6 +29,11 @@ use super::state::{ChainedInfo, PreloadedTrack};
 /// cache to the track when playing `psysonic-local://` (hot/offline). Optional
 /// for HTTP streams (`playback_identity` is used as fallback).
 ///
+/// `server_id`: app id of the server that owns this track (`playbackServerId ??
+/// activeServerId` on the frontend). Scopes the analysis-cache write key so a
+/// later server switch can't surface another server's waveform for the same bare
+/// `track_id`. Empty/absent falls back to the legacy `''` scope.
+///
 /// `stream_format_suffix`: Subsonic `song.suffix` (e.g. m4a); `stream.view` URLs have no
 /// file extension, so this helps pick a Symphonia `format_hint` for ranged HTTP.
 #[tauri::command]
@@ -45,6 +50,7 @@ pub async fn audio_play(
     manual: bool, // true = user-initiated skip → bypass crossfade, start immediately
     hi_res_enabled: bool, // false = safe 44.1 kHz mode; true = native rate (alpha)
     analysis_track_id: Option<String>,
+    server_id: Option<String>,
     stream_format_suffix: Option<String>,
     app: AppHandle,
     state: State<'_, AudioEngine>,
@@ -134,6 +140,11 @@ pub async fn audio_play(
         .filter(|s| !s.is_empty());
     *state.current_analysis_track_id.lock().unwrap() = logical_trim.clone();
     let cache_id_for_tasks = analysis_cache_track_id(logical_trim.as_deref(), &url);
+    // Playback server scope for the analysis-cache write key (empty → legacy '').
+    let analysis_server_id = server_id.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    // Pin it so the gain-resolution + replay-gain-update + device-resume reads
+    // scope to this server too (mirrors `current_analysis_track_id`).
+    *state.current_playback_server_id.lock().unwrap() = analysis_server_id.map(str::to_string);
 
     let format_hint = url_format_hint(&url);
 
@@ -145,6 +156,7 @@ pub async fn audio_play(
             stream_format_suffix: stream_format_suffix.as_deref(),
             format_hint: format_hint.as_deref(),
             cache_id_for_tasks: cache_id_for_tasks.as_deref(),
+            server_id: analysis_server_id,
             reuse_chained_bytes,
         },
         &state,
@@ -239,6 +251,7 @@ pub async fn audio_play(
             url: &url,
             gen,
             cache_id_for_tasks: cache_id_for_tasks.as_deref(),
+            server_id: analysis_server_id,
             url_format_hint: format_hint.as_deref(),
             stream_format_suffix: stream_format_suffix.as_deref(),
             done_flag: done_flag.clone(),

--- a/src-tauri/crates/psysonic-audio/src/device_resume.rs
+++ b/src-tauri/crates/psysonic-audio/src/device_resume.rs
@@ -143,6 +143,9 @@ pub(crate) async fn try_resume_after_device_change(
     engine.samples_played.store(0, Ordering::Relaxed);
 
     let hi_res_enabled = engine.current_sample_rate.load(Ordering::Relaxed) > 48_000;
+    // Resume re-plays the current track → scope its analysis writes to the
+    // pinned playback server (empty → legacy '').
+    let resume_server = crate::helpers::current_playback_server_id_str(&engine);
 
     let ps: PlaybackSource = match build_playback_source_with_probe_fallback(
         play_input,
@@ -150,6 +153,7 @@ pub(crate) async fn try_resume_after_device_change(
             url,
             gen,
             cache_id_for_tasks: snap.analysis_track_id.as_deref(),
+            server_id: Some(resume_server.as_str()),
             url_format_hint: format_hint.as_deref(),
             stream_format_suffix: stream_format_suffix.as_deref(),
             done_flag: done_flag.clone(),

--- a/src-tauri/crates/psysonic-audio/src/engine.rs
+++ b/src-tauri/crates/psysonic-audio/src/engine.rs
@@ -82,6 +82,11 @@ pub struct AudioEngine {
     /// Subsonic song id last passed from JS with `audio_play` (trimmed). Used
     /// for loudness/waveform cache when the URL is `psysonic-local://…`.
     pub(crate) current_analysis_track_id: Arc<Mutex<Option<String>>>,
+    /// App server id (`playbackServerId ?? activeServerId`) of the current
+    /// playback, pinned by `audio_play`. Scopes analysis-cache reads (loudness
+    /// gain, replay-gain updates, device resume) to the right server so a switch
+    /// can't surface another server's blob for the same bare `track_id`.
+    pub(crate) current_playback_server_id: Arc<Mutex<Option<String>>>,
     /// While a `RangedHttpSource` download task is filling the buffer for this
     /// `(track_id, play_generation)`, skip `analysis_enqueue_seed_from_url` for the
     /// same id — otherwise a parallel full GET + Symphonia competes with playback
@@ -381,6 +386,7 @@ pub fn create_engine() -> (AudioEngine, std::thread::JoinHandle<()>) {
         radio_state: Mutex::new(None),
         current_playback_url: Arc::new(Mutex::new(None)),
         current_analysis_track_id: Arc::new(Mutex::new(None)),
+        current_playback_server_id: Arc::new(Mutex::new(None)),
         ranged_loudness_seed_hold: Arc::new(Mutex::new(None)),
         preview_sink: Arc::new(Mutex::new(None)),
         preview_gen: Arc::new(AtomicU64::new(0)),

--- a/src-tauri/crates/psysonic-audio/src/helpers.rs
+++ b/src-tauri/crates/psysonic-audio/src/helpers.rs
@@ -326,12 +326,14 @@ pub(crate) fn resolve_loudness_gain_from_cache(
     url: &str,
     target_lufs: f32,
     logical_track_id: Option<&str>,
+    server_id: &str,
 ) -> Option<f32> {
     resolve_loudness_gain_from_cache_impl(
         app,
         url,
         target_lufs,
         logical_track_id,
+        server_id,
         ResolveLoudnessCacheOpts::default(),
     )
 }
@@ -341,6 +343,7 @@ pub(crate) fn resolve_loudness_gain_from_cache_impl(
     url: &str,
     target_lufs: f32,
     logical_track_id: Option<&str>,
+    server_id: &str,
     opts: ResolveLoudnessCacheOpts,
 ) -> Option<f32> {
     // Only a SQLite loudness row counts here. Ephemeral JS hints (`analysis:loudness-partial`)
@@ -363,7 +366,7 @@ pub(crate) fn resolve_loudness_gain_from_cache_impl(
         }
         return None;
     };
-    resolve_loudness_gain_with_cache(cache.inner(), &track_id, target_lufs, opts)
+    resolve_loudness_gain_with_cache(cache.inner(), server_id, &track_id, target_lufs, opts)
 }
 
 /// AppHandle-free core of [`resolve_loudness_gain_from_cache_impl`]. Looks up
@@ -376,15 +379,16 @@ pub(crate) fn resolve_loudness_gain_from_cache_impl(
 /// connection's row cache is warm for the next IPC tick.
 pub(crate) fn resolve_loudness_gain_with_cache(
     cache: &psysonic_analysis::analysis_cache::AnalysisCache,
+    server_id: &str,
     track_id: &str,
     target_lufs: f32,
     opts: ResolveLoudnessCacheOpts,
 ) -> Option<f32> {
     if opts.touch_waveform {
         // Bind / preload: verify waveform context exists alongside loudness lookup.
-        let _ = cache.get_latest_waveform_for_track(track_id);
+        let _ = cache.get_latest_waveform_for_track(server_id, track_id);
     }
-    match cache.get_latest_loudness_for_track(track_id) {
+    match cache.get_latest_loudness_for_track(server_id, track_id) {
         Ok(Some(row)) if row.integrated_lufs.is_finite() => {
             let recommended = psysonic_analysis::analysis_cache::recommended_gain_for_target(
                 row.integrated_lufs,
@@ -493,6 +497,17 @@ pub(crate) struct TrackGainInputs {
 /// Read engine state + resolve the loudness cache for a track that's about to
 /// start playing. JS-supplied `loudness_gain_db` is **not** consulted at bind
 /// time (only post-cache via `audio_update_replay_gain`).
+/// Current playback server scope (`current_playback_server_id`, empty when
+/// unset) for scoping analysis-cache reads on the gain-resolution path.
+pub(crate) fn current_playback_server_id_str(state: &AudioEngine) -> String {
+    state
+        .current_playback_server_id
+        .lock()
+        .ok()
+        .and_then(|g| (*g).clone())
+        .unwrap_or_default()
+}
+
 pub(crate) fn resolve_track_gain_inputs(
     state: &AudioEngine,
     app: &AppHandle,
@@ -503,7 +518,9 @@ pub(crate) fn resolve_track_gain_inputs(
     let target_lufs = f32::from_bits(state.normalization_target_lufs.load(Ordering::Relaxed));
     let norm_mode = state.normalization_engine.load(Ordering::Relaxed);
     let pre_analysis_db = loudness_pre_analysis_db_for_engine(state);
-    let cache_loudness_db = resolve_loudness_gain_from_cache(app, url, target_lufs, logical_track_id);
+    let server_id = current_playback_server_id_str(state);
+    let cache_loudness_db =
+        resolve_loudness_gain_from_cache(app, url, target_lufs, logical_track_id, &server_id);
     let effective_loudness_db = if norm_mode == 2 {
         loudness_gain_db_after_resolve(
             cache_loudness_db,
@@ -736,6 +753,7 @@ pub(crate) async fn fetch_data(
 /// loudness SQLite can fill **offline** without `analysis_enqueue_seed_from_url` HTTP.
 pub(crate) fn spawn_analysis_seed_from_in_memory_bytes(
     app: &AppHandle,
+    server_id: Option<&str>,
     cache_track_id: Option<&str>,
     gen: u64,
     gen_arc: &Arc<AtomicU64>,
@@ -748,6 +766,7 @@ pub(crate) fn spawn_analysis_seed_from_in_memory_bytes(
         return;
     }
     let track_id = track_id.to_string();
+    let server_id = server_id.unwrap_or("").to_string();
     let bytes = bytes.to_vec();
     let app = app.clone();
     let gen_arc = gen_arc.clone();
@@ -761,7 +780,7 @@ pub(crate) fn spawn_analysis_seed_from_in_memory_bytes(
         if gen_arc.load(Ordering::SeqCst) != gen {
             return;
         }
-        if let Err(e) = psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(app.clone(), track_id.clone(), bytes, high).await {
+        if let Err(e) = psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(app.clone(), server_id, track_id.clone(), bytes, high).await {
             crate::app_eprintln!(
                 "[analysis] in-memory play path seed failed for {}: {}",
                 track_id,
@@ -774,6 +793,7 @@ pub(crate) fn spawn_analysis_seed_from_in_memory_bytes(
 /// Full-track analysis for a completed ranged stream spilled to disk (> RAM promote cap).
 pub(crate) fn spawn_analysis_seed_from_spill_file(
     app: &AppHandle,
+    server_id: Option<&str>,
     track_id: &str,
     spill_path: std::path::PathBuf,
     gen: u64,
@@ -783,6 +803,7 @@ pub(crate) fn spawn_analysis_seed_from_spill_file(
     if track_id.is_empty() {
         return;
     }
+    let server_id = server_id.unwrap_or("").to_string();
     let app = app.clone();
     let gen_arc = gen_arc.clone();
     let max_bytes = crate::stream::LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES;
@@ -822,6 +843,7 @@ pub(crate) fn spawn_analysis_seed_from_spill_file(
         let high = crate::engine::analysis_seed_high_priority_for_track(&app, &track_id);
         if let Err(e) = psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(
             app,
+            server_id,
             track_id.clone(),
             bytes,
             high,
@@ -1431,6 +1453,7 @@ mod tests {
         let cache = AnalysisCache::open_in_memory();
         let g = resolve_loudness_gain_with_cache(
             &cache,
+            "",
             "no-such-track",
             -14.0,
             ResolveLoudnessCacheOpts::default(),
@@ -1445,6 +1468,7 @@ mod tests {
         upsert_loudness_row(&cache, "abc", -23.0, -14.0);
         let g = resolve_loudness_gain_with_cache(
             &cache,
+            "",
             "abc",
             -14.0,
             ResolveLoudnessCacheOpts::default(),
@@ -1469,6 +1493,7 @@ mod tests {
         upsert_loudness_row(&cache, "stream:abc", -16.0, -14.0);
         let g = resolve_loudness_gain_with_cache(
             &cache,
+            "",
             "abc",
             -14.0,
             ResolveLoudnessCacheOpts::default(),
@@ -1482,6 +1507,7 @@ mod tests {
         upsert_loudness_row(&cache, "abc", -20.0, -14.0);
         let g_quiet = resolve_loudness_gain_with_cache(
             &cache,
+            "",
             "abc",
             -20.0,
             ResolveLoudnessCacheOpts::default(),
@@ -1489,6 +1515,7 @@ mod tests {
         .unwrap();
         let g_loud = resolve_loudness_gain_with_cache(
             &cache,
+            "",
             "abc",
             -10.0,
             ResolveLoudnessCacheOpts::default(),
@@ -1509,7 +1536,7 @@ mod tests {
             touch_waveform: false,
             log_soft_misses: false,
         };
-        let g = resolve_loudness_gain_with_cache(&cache, "abc", -14.0, opts);
+        let g = resolve_loudness_gain_with_cache(&cache, "", "abc", -14.0, opts);
         assert!(g.is_some());
     }
 }

--- a/src-tauri/crates/psysonic-audio/src/mix_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/mix_commands.rs
@@ -50,12 +50,14 @@ pub fn audio_update_replay_gain(
         .filter(|s| !s.is_empty());
     // If `current_playback_url` is not pinned yet, still honour JS `loudness_gain_db`
     // for the uncached path (`effective_loudness_db` / UI gain follow from `compute_gain`).
+    let server_for_loudness = crate::helpers::current_playback_server_id_str(&state);
     let cache_loudness = url_for_loudness.as_deref().and_then(|u| {
         resolve_loudness_gain_from_cache_impl(
             &app,
             u,
             target_lufs,
             logical_for_loudness.as_deref(),
+            &server_for_loudness,
             ResolveLoudnessCacheOpts {
                 touch_waveform: false,
                 log_soft_misses: false,

--- a/src-tauri/crates/psysonic-audio/src/play_input.rs
+++ b/src-tauri/crates/psysonic-audio/src/play_input.rs
@@ -54,6 +54,9 @@ pub(super) struct PlayInputContext<'a> {
     pub stream_format_suffix: Option<&'a str>,
     pub format_hint: Option<&'a str>,
     pub cache_id_for_tasks: Option<&'a str>,
+    /// Playback server scope for the analysis-cache write key (empty/`None` →
+    /// legacy `''`). Rides alongside `cache_id_for_tasks` into every seed path.
+    pub server_id: Option<&'a str>,
     /// `Some(bytes)` when manual-skip onto a pre-chained track reuses bytes
     /// from the chained-info block.
     pub reuse_chained_bytes: Option<Vec<u8>>,
@@ -76,6 +79,7 @@ pub(super) async fn select_play_input(
     if let Some(d) = ctx.reuse_chained_bytes {
         spawn_analysis_seed_from_in_memory_bytes(
             app,
+            ctx.server_id,
             ctx.cache_id_for_tasks,
             ctx.gen,
             &state.generation,
@@ -112,6 +116,7 @@ pub(super) async fn select_play_input(
     };
     spawn_analysis_seed_from_in_memory_bytes(
         app,
+        ctx.server_id,
         ctx.cache_id_for_tasks,
         ctx.gen,
         &state.generation,
@@ -143,7 +148,10 @@ fn open_local_file_input(
     if let Some(seed_id) = ctx.cache_id_for_tasks {
         let skip_cpu_seed = app
             .try_state::<psysonic_analysis::analysis_cache::AnalysisCache>()
-            .map(|c| c.cpu_seed_redundant_for_track(seed_id).unwrap_or(false))
+            .map(|c| {
+                c.cpu_seed_redundant_for_track(ctx.server_id.unwrap_or(""), seed_id)
+                    .unwrap_or(false)
+            })
             .unwrap_or(false);
         if !skip_cpu_seed {
             let path_owned = std::path::PathBuf::from(path);
@@ -151,6 +159,7 @@ fn open_local_file_input(
             let gen_seed = ctx.gen;
             let gen_arc_seed = state.generation.clone();
             let seed_id = seed_id.to_string();
+            let seed_server = ctx.server_id.unwrap_or("").to_string();
             tokio::spawn(async move {
                 if gen_arc_seed.load(Ordering::SeqCst) != gen_seed {
                     return;
@@ -178,7 +187,7 @@ fn open_local_file_input(
                 );
                 let high = crate::engine::analysis_seed_high_priority_for_track(&app_seed, &seed_id);
                 if let Err(e) =
-                    psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(app_seed.clone(), seed_id.clone(), data, high).await
+                    psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(app_seed.clone(), seed_server.clone(), seed_id.clone(), data, high).await
                 {
                     crate::app_eprintln!(
                         "[analysis] local-file seed failed for {}: {}",
@@ -316,6 +325,7 @@ async fn open_ranged_or_streaming_input(
             state.normalization_target_lufs.clone(),
             state.loudness_pre_analysis_attenuation_db.clone(),
             ctx.cache_id_for_tasks.map(|s| s.to_string()),
+            ctx.server_id.map(|s| s.to_string()),
             loudness_hold_for_defer,
             playback_armed,
             stream_hint.clone(),
@@ -369,6 +379,7 @@ async fn open_ranged_or_streaming_input(
         state.normalization_target_lufs.clone(),
         state.loudness_pre_analysis_attenuation_db.clone(),
         ctx.cache_id_for_tasks.map(|s| s.to_string()),
+        ctx.server_id.map(|s| s.to_string()),
         playback_armed,
     ));
 
@@ -459,6 +470,7 @@ pub(crate) struct BuildSourceArgs<'a> {
     pub url: &'a str,
     pub gen: u64,
     pub cache_id_for_tasks: Option<&'a str>,
+    pub server_id: Option<&'a str>,
     pub url_format_hint: Option<&'a str>,
     pub stream_format_suffix: Option<&'a str>,
     pub done_flag: Arc<AtomicBool>,
@@ -686,6 +698,7 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
         url,
         gen,
         cache_id_for_tasks,
+        server_id,
         url_format_hint,
         stream_format_suffix,
         done_flag,
@@ -751,6 +764,7 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
             }
             spawn_analysis_seed_from_in_memory_bytes(
                 app,
+                server_id,
                 cache_id_for_tasks,
                 gen,
                 &state.generation,

--- a/src-tauri/crates/psysonic-audio/src/preload_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/preload_commands.rs
@@ -17,6 +17,7 @@ pub async fn audio_preload(
     url: String,
     duration_hint: f64,
     analysis_track_id: Option<String>,
+    server_id: Option<String>,
     app: AppHandle,
     state: State<'_, AudioEngine>,
 ) -> Result<(), String> {
@@ -56,7 +57,8 @@ pub async fn audio_preload(
             data.len() as f64 / (1024.0 * 1024.0)
         );
         let high = crate::engine::analysis_track_id_is_current_playback(&state, &track_id);
-        if let Err(e) = psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(app.clone(), track_id.clone(), data.clone(), high).await {
+        let sid = server_id.clone().unwrap_or_default();
+        if let Err(e) = psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(app.clone(), sid, track_id.clone(), data.clone(), high).await {
             crate::app_eprintln!("[analysis] preload seed failed for {}: {}", track_id, e);
         }
     }

--- a/src-tauri/crates/psysonic-audio/src/stream/ranged_http.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream/ranged_http.rs
@@ -460,6 +460,8 @@ pub(crate) async fn ranged_download_task(
     normalization_target_lufs: Arc<AtomicU32>,
     loudness_pre_analysis_attenuation_db: Arc<AtomicU32>,
     cache_track_id: Option<String>,
+    // Playback server scope for the analysis-cache write key (empty/`None` → legacy '').
+    server_id: Option<String>,
     // When `Some`, ranged playback seeds on completion — defer HTTP backfill for that
     // track; `None` for large files where ranged skips seed (needs backfill).
     loudness_seed_hold: Option<LoudnessSeedHold>,
@@ -643,7 +645,8 @@ pub(crate) async fn ranged_download_task(
             }
             if let Some(track_id) = cache_track_id {
                 let high = crate::engine::analysis_seed_high_priority_for_track(&app, &track_id);
-                if let Err(e) = psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(app.clone(), track_id.clone(), data.clone(), high).await {
+                let sid = server_id.clone().unwrap_or_default();
+                if let Err(e) = psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(app.clone(), sid, track_id.clone(), data.clone(), high).await {
                     crate::app_eprintln!("[analysis] ranged seed failed for {}: {}", track_id, e);
                 }
             }
@@ -678,6 +681,7 @@ pub(crate) async fn ranged_download_task(
                     install_stream_completed_spill(&spill_cache_slot, url, path.clone());
                     spawn_analysis_seed_from_spill_file(
                         &app,
+                        server_id.as_deref(),
                         &track_id,
                         path,
                         gen,

--- a/src-tauri/crates/psysonic-audio/src/stream/track_stream.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream/track_stream.rs
@@ -35,6 +35,8 @@ pub(crate) async fn track_download_task(
     normalization_target_lufs: Arc<AtomicU32>,
     loudness_pre_analysis_attenuation_db: Arc<AtomicU32>,
     cache_track_id: Option<String>,
+    // Playback server scope for the analysis-cache write key (empty/`None` → legacy '').
+    server_id: Option<String>,
     playback_armed: Arc<AtomicBool>,
 ) {
     let mut downloaded: u64 = 0;
@@ -166,8 +168,9 @@ pub(crate) async fn track_download_task(
                     capture.len() as f64 / (1024.0 * 1024.0)
                 );
                 let high = crate::engine::analysis_seed_high_priority_for_track(&app, &track_id);
+                let sid = server_id.clone().unwrap_or_default();
                 if let Err(e) =
-                    psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(app.clone(), track_id.clone(), capture.clone(), high).await
+                    psysonic_analysis::analysis_runtime::submit_analysis_cpu_seed(app.clone(), sid, track_id.clone(), capture.clone(), high).await
                 {
                     crate::app_eprintln!("[analysis] track seed failed for {}: {}", track_id, e);
                 }

--- a/src-tauri/crates/psysonic-audio/src/transport_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/transport_commands.rs
@@ -108,6 +108,7 @@ pub fn audio_stop(state: State<'_, AudioEngine>, app: AppHandle) {
     state.generation.fetch_add(1, Ordering::SeqCst);
     *state.current_playback_url.lock().unwrap() = None;
     *state.current_analysis_track_id.lock().unwrap() = None;
+    *state.current_playback_server_id.lock().unwrap() = None;
     *state.chained_info.lock().unwrap() = None;
     // Keep `stream_completed_cache`: natural track end often calls `audio_stop` when the
     // queue is exhausted; clearing here dropped the full ranged buffer and forced a

--- a/src-tauri/crates/psysonic-syncfs/src/cache/hot.rs
+++ b/src-tauri/crates/psysonic-syncfs/src/cache/hot.rs
@@ -40,9 +40,10 @@ pub async fn download_track_hot_cache(
         // prefetch worker runs invokes sequentially.
         let app_seed = app.clone();
         let tid = track_id.clone();
+        let sid = server_id.clone();
         let fp = file_path.clone();
         tokio::spawn(async move {
-            enqueue_analysis_seed_from_file(&app_seed, &tid, &fp).await;
+            enqueue_analysis_seed_from_file(&app_seed, &sid, &tid, &fp).await;
         });
         return Ok(HotCacheDownloadResult {
             path: path_str,
@@ -79,9 +80,10 @@ pub async fn download_track_hot_cache(
 
     let app_seed = app.clone();
     let tid = track_id.clone();
+    let sid = server_id.clone();
     let fp = file_path.clone();
     tokio::spawn(async move {
-        enqueue_analysis_seed_from_file(&app_seed, &tid, &fp).await;
+        enqueue_analysis_seed_from_file(&app_seed, &sid, &tid, &fp).await;
     });
 
     let size = tokio::fs::metadata(&file_path)
@@ -134,9 +136,10 @@ pub async fn promote_stream_cache_to_hot_cache(
         );
         let app_seed = app.clone();
         let tid = track_id.clone();
+        let sid = server_id.clone();
         let fp = file_path.clone();
         tokio::spawn(async move {
-            enqueue_analysis_seed_from_file(&app_seed, &tid, &fp).await;
+            enqueue_analysis_seed_from_file(&app_seed, &sid, &tid, &fp).await;
         });
         return Ok(Some(HotCacheDownloadResult { path: path_str, size }));
     }
@@ -151,7 +154,7 @@ pub async fn promote_stream_cache_to_hot_cache(
             .await
             .map_err(|e| e.to_string())?;
 
-        let _ = enqueue_analysis_seed(&app, &track_id, &bytes).await;
+        let _ = enqueue_analysis_seed(&app, &server_id, &track_id, &bytes).await;
 
         let size = tokio::fs::metadata(&file_path)
             .await
@@ -176,9 +179,10 @@ pub async fn promote_stream_cache_to_hot_cache(
         }
         let app_seed = app.clone();
         let tid = track_id.clone();
+        let sid = server_id.clone();
         let fp = file_path.clone();
         tokio::spawn(async move {
-            enqueue_analysis_seed_from_file(&app_seed, &tid, &fp).await;
+            enqueue_analysis_seed_from_file(&app_seed, &sid, &tid, &fp).await;
         });
         let size = tokio::fs::metadata(&file_path)
             .await

--- a/src-tauri/crates/psysonic-syncfs/src/cache/offline.rs
+++ b/src-tauri/crates/psysonic-syncfs/src/cache/offline.rs
@@ -13,15 +13,16 @@ use crate::file_transfer::{finalize_streamed_download, subsonic_http_client};
 
 pub async fn enqueue_analysis_seed_from_file(
     app: &tauri::AppHandle,
+    server_id: &str,
     track_id: &str,
     file_path: &std::path::Path,
 ) {
     let cache = app.try_state::<analysis_cache::AnalysisCache>();
     let cache_ref: Option<&analysis_cache::AnalysisCache> = cache.as_ref().map(|s| s.inner());
-    let Some(bytes) = read_seed_bytes_if_needed(cache_ref, track_id, file_path).await else {
+    let Some(bytes) = read_seed_bytes_if_needed(cache_ref, server_id, track_id, file_path).await else {
         return;
     };
-    let _ = enqueue_analysis_seed(app, track_id, &bytes).await;
+    let _ = enqueue_analysis_seed(app, server_id, track_id, &bytes).await;
 }
 
 /// AppHandle-free decision: returns the file bytes when seeding is required
@@ -32,11 +33,12 @@ pub async fn enqueue_analysis_seed_from_file(
 /// branch with `AnalysisCache::open_in_memory()` plus a `tempfile::TempDir`.
 pub(crate) async fn read_seed_bytes_if_needed(
     cache: Option<&analysis_cache::AnalysisCache>,
+    server_id: &str,
     track_id: &str,
     file_path: &std::path::Path,
 ) -> Option<Vec<u8>> {
     if let Some(cache) = cache {
-        if cache.cpu_seed_redundant_for_track(track_id).unwrap_or(false) {
+        if cache.cpu_seed_redundant_for_track(server_id, track_id).unwrap_or(false) {
             return None;
         }
     }
@@ -162,7 +164,7 @@ pub async fn download_track_offline(
     )
     .await?;
 
-    enqueue_analysis_seed_from_file(&app, &track_id, &final_path).await;
+    enqueue_analysis_seed_from_file(&app, &server_id, &track_id, &final_path).await;
 
     Ok(path_str)
 }
@@ -421,7 +423,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("track.mp3");
         std::fs::write(&file, b"audio data").unwrap();
-        let bytes = read_seed_bytes_if_needed(None, "anything", &file).await;
+        let bytes = read_seed_bytes_if_needed(None, "", "anything", &file).await;
         assert_eq!(bytes.as_deref(), Some(b"audio data".as_slice()));
     }
 
@@ -431,7 +433,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("track.flac");
         std::fs::write(&file, b"some bytes").unwrap();
-        let bytes = read_seed_bytes_if_needed(Some(&cache), "fresh-track", &file).await;
+        let bytes = read_seed_bytes_if_needed(Some(&cache), "", "fresh-track", &file).await;
         assert_eq!(bytes.as_deref(), Some(b"some bytes".as_slice()));
     }
 
@@ -444,7 +446,7 @@ mod tests {
         let file = dir.path().join("track.mp3");
         std::fs::write(&file, b"would-be-decoded bytes").unwrap();
 
-        let bytes = read_seed_bytes_if_needed(Some(&cache), "redundant-track", &file).await;
+        let bytes = read_seed_bytes_if_needed(Some(&cache), "", "redundant-track", &file).await;
         assert!(
             bytes.is_none(),
             "redundant-cache short-circuit must skip the file read entirely"
@@ -455,7 +457,7 @@ mod tests {
     async fn read_seed_bytes_returns_none_for_missing_file() {
         let dir = tempfile::tempdir().unwrap();
         let phantom = dir.path().join("never-written.mp3");
-        let bytes = read_seed_bytes_if_needed(None, "any", &phantom).await;
+        let bytes = read_seed_bytes_if_needed(None, "", "any", &phantom).await;
         assert!(bytes.is_none());
     }
 
@@ -464,7 +466,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("empty.flac");
         std::fs::write(&file, b"").unwrap();
-        let bytes = read_seed_bytes_if_needed(None, "any", &file).await;
+        let bytes = read_seed_bytes_if_needed(None, "", "any", &file).await;
         assert!(bytes.is_none(), "empty file must not trigger seeding");
     }
 

--- a/src/store/audioEventHandlers.ts
+++ b/src/store/audioEventHandlers.ts
@@ -272,6 +272,7 @@ export function handleAudioProgress(
         url: nextUrl,
         durationHint: nextTrack.duration,
         analysisTrackId: nextTrack.id,
+        serverId: serverId || null,
       }).catch(() => {});
     }
 

--- a/src/store/loudnessRefresh.ts
+++ b/src/store/loudnessRefresh.ts
@@ -1,5 +1,6 @@
 import { buildStreamUrl } from '../api/subsonicStreamUrl';
 import { invoke } from '@tauri-apps/api/core';
+import { getPlaybackServerId } from '../utils/playback/playbackServer';
 import { redactSubsonicUrlForLog } from '../utils/server/redactSubsonicUrl';
 import { useAuthStore } from './authStore';
 import { usePlayerStore } from './playerStore';
@@ -69,9 +70,11 @@ async function runRefreshLoudnessForTrack(trackId: string, syncEngine: boolean):
   usePlayerStore.setState({ normalizationDbgSource: 'refresh:start', normalizationDbgTrackId: trackId });
   try {
     const requestedTarget = useAuthStore.getState().loudnessTargetLufs;
+    const serverId = getPlaybackServerId() || null;
     const row = await invoke<LoudnessCachePayload | null>('analysis_get_loudness_for_track', {
       trackId,
       targetLufs: requestedTarget,
+      serverId,
     });
     if (useAuthStore.getState().loudnessTargetLufs !== requestedTarget) {
       emitNormalizationDebug('refresh:stale-target', { trackId, requestedTarget });
@@ -102,7 +105,7 @@ async function runRefreshLoudnessForTrack(trackId: string, syncEngine: boolean):
           url: redactSubsonicUrlForLog(url),
           attempt: attempts + 1,
         });
-        void invoke('analysis_enqueue_seed_from_url', { trackId, url })
+        void invoke('analysis_enqueue_seed_from_url', { trackId, url, serverId })
           .then(() => emitNormalizationDebug('backfill:queued', { trackId, attempt: attempts + 1 }))
           .catch((e) => emitNormalizationDebug('backfill:error', { trackId, error: String(e) }))
           .finally(() => {

--- a/src/store/loudnessReseed.test.ts
+++ b/src/store/loudnessReseed.test.ts
@@ -94,6 +94,7 @@ describe('reseedLoudnessForTrackId', () => {
       trackId: 't1',
       url: 'https://mock/stream/t1',
       force: true,
+      serverId: null,
     });
   });
 

--- a/src/store/loudnessReseed.ts
+++ b/src/store/loudnessReseed.ts
@@ -1,5 +1,6 @@
 import { buildStreamUrl } from '../api/subsonicStreamUrl';
 import { invoke } from '@tauri-apps/api/core';
+import { getPlaybackServerId } from '../utils/playback/playbackServer';
 import { useAuthStore } from './authStore';
 import { usePlayerStore } from './playerStore';
 import { bumpWaveformRefreshGen } from './waveformRefreshGen';
@@ -42,13 +43,14 @@ export async function reseedLoudnessForTrackId(trackId: string): Promise<void> {
     normalizationTargetLufs: auth.loudnessTargetLufs,
     normalizationEngineLive: 'loudness',
   });
+  const serverId = getPlaybackServerId() || null;
   try {
-    await invoke('analysis_delete_waveform_for_track', { trackId });
+    await invoke('analysis_delete_waveform_for_track', { trackId, serverId });
   } catch (e) {
     console.error('[psysonic] analysis_delete_waveform_for_track failed:', e);
   }
   try {
-    await invoke('analysis_delete_loudness_for_track', { trackId });
+    await invoke('analysis_delete_loudness_for_track', { trackId, serverId });
   } catch (e) {
     console.error('[psysonic] analysis_delete_loudness_for_track failed:', e);
   }
@@ -59,6 +61,7 @@ export async function reseedLoudnessForTrackId(trackId: string): Promise<void> {
       trackId,
       url,
       force: true,
+      serverId,
     });
   } catch (e) {
     console.error('[psysonic] analysis_enqueue_seed_from_url (reseed) failed:', e);

--- a/src/store/playTrackAction.ts
+++ b/src/store/playTrackAction.ts
@@ -298,6 +298,7 @@ export function runPlayTrack(
       manual,
       hiResEnabled: authStateNow.enableHiRes,
       analysisTrackId: track.id,
+      serverId: getPlaybackServerId() || null,
       streamFormatSuffix: track.suffix ?? null,
     })
       .then(() => {

--- a/src/store/queueUndoAudioRestore.ts
+++ b/src/store/queueUndoAudioRestore.ts
@@ -59,6 +59,7 @@ export function queueUndoRestoreAudioEngine(opts: {
     manual: false,
     hiResEnabled: authState.enableHiRes,
     analysisTrackId: track.id,
+    serverId: playbackSid || null,
     streamFormatSuffix: track.suffix ?? null,
   })
     .then(() => {

--- a/src/store/resumeAction.ts
+++ b/src/store/resumeAction.ts
@@ -169,6 +169,7 @@ export function runResume(set: SetState, get: GetState): void {
           manual: false,
           hiResEnabled: useAuthStore.getState().enableHiRes,
           analysisTrackId: trackToPlay.id,
+          serverId: coldServerId || null,
           streamFormatSuffix: trackToPlay.suffix ?? null,
         }).then(() => {
           if (getPlayGeneration() === gen && currentTime > 1) {
@@ -208,6 +209,7 @@ export function runResume(set: SetState, get: GetState): void {
           manual: false,
           hiResEnabled: useAuthStore.getState().enableHiRes,
           analysisTrackId: currentTrack.id,
+          serverId: coldServerId || null,
           streamFormatSuffix: currentTrack.suffix ?? null,
         }).catch((err: unknown) => {
           if (getPlayGeneration() !== gen) return;

--- a/src/store/waveformRefresh.ts
+++ b/src/store/waveformRefresh.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { coerceWaveformBins } from '../utils/waveform/waveformParse';
+import { getPlaybackServerId } from '../utils/playback/playbackServer';
 import { usePlayerStore } from './playerStore';
 import { getWaveformRefreshGen } from './waveformRefreshGen';
 
@@ -25,7 +26,10 @@ export async function refreshWaveformForTrack(trackId: string): Promise<void> {
   if (!trackId) return;
   const gen = getWaveformRefreshGen(trackId);
   try {
-    const row = await invoke<WaveformCachePayload | null>('analysis_get_waveform_for_track', { trackId });
+    const row = await invoke<WaveformCachePayload | null>('analysis_get_waveform_for_track', {
+      trackId,
+      serverId: getPlaybackServerId() || null,
+    });
     if (getWaveformRefreshGen(trackId) !== gen) return;
     // Never apply bins for a non-current track (e.g. gapless byte-preload fetches the neighbour).
     if (usePlayerStore.getState().currentTrack?.id !== trackId) return;


### PR DESCRIPTION
Builds on the 6c-1 schema migration (#826). Wires the playback server scope through the analysis cache so a server switch can no longer surface another server's waveform/loudness for the same bare `track_id` (R7-16 Q3, §8.2 acceptance).

## Summary
- **Write** under `playbackServerId ?? activeServerId` on every path (in-memory / ranged / legacy stream / local file / spill / preload, syncfs offline+hot, loudness backfill); empty = legacy `''`.
- **Read** exact server scope first, then legacy `''` fallback; a legacy hit is re-tagged onto the server scope (`INSERT OR IGNORE`). No bulk backfill — existing caches re-tag lazily on play and are not re-analysed wholesale. The backend gain-resolution path (loudness normalization, replay-gain updates, device resume) is scoped via a pinned `current_playback_server_id` on the audio engine.
- **Delete** `delete_*_for_track_id` scope to `(server + legacy '')`; reseed on one server no longer wipes another's analysis. `delete_all_waveforms` stays global.

## Tauri boundary
Additive optional `serverId` (absent = legacy `''`):
- args added: `audio_play`, `audio_preload`, `analysis_get_waveform`, `analysis_get_waveform_for_track`, `analysis_get_loudness_for_track`, `analysis_delete_waveform_for_track`, `analysis_delete_loudness_for_track`, `analysis_enqueue_seed_from_url`
- frontend sends `getPlaybackServerId()`; Vitest tauri mocks unaffected (optional field)
- no command/event renamed or removed

## Refs
- Review of 6c-1: `handoffs/2026-05-21-pr-826-review.md` (post-merge checklist: server_id into TrackKey, legacy read fallback, lazy re-tag, scope per-track deletes)
- Normative decisions: `tasks/2026-05-library-track-store/questions/2026-05-21-pr6-analysis-bridge-decisions.md` (Q3)

## Test plan
- `cargo test --workspace` green (new tests: server-scope isolation, legacy read fallback, lazy re-tag without clobber, scoped delete keeps other servers, server-scoped seed write)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `tsc --noEmit` clean; `vitest run` green