### PR TITLE
feat(library): content_hash from playback (E2, 6d)

### DIFF
--- a/src-tauri/crates/psysonic-analysis/src/analysis_cache/compute.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_cache/compute.rs
@@ -52,19 +52,39 @@ pub fn seed_from_bytes_execute(
         );
         return Ok(SeedFromBytesOutcome::SkippedNoAnalysisCache);
     };
-    seed_from_bytes_into_cache(&cache, server_id, track_id, bytes)
+    let (outcome, md5_16kb) = seed_from_bytes_into_cache(&cache, server_id, track_id, bytes)?;
+    // E2 bridge (analysis → library content_hash): once the playback-derived
+    // md5_16kb is known — whether freshly written or already cached — record it
+    // as `track.content_hash` via the registered sink. Decoupled from
+    // psysonic-library through the psysonic-core port; a no-op when the library
+    // has no row for this (server_id, track_id). Skipped under the legacy ''
+    // scope (no server known).
+    if !server_id.is_empty()
+        && matches!(
+            outcome,
+            SeedFromBytesOutcome::Upserted | SeedFromBytesOutcome::SkippedWaveformCacheHit
+        )
+    {
+        if let Some(sink) = app.try_state::<psysonic_core::ports::ContentHashSink>() {
+            sink.record_content_hash(server_id, track_id, &md5_16kb);
+        }
+    }
+    Ok(outcome)
 }
 
 /// AppHandle-free entry point for [`seed_from_bytes_execute`]: takes the cache
 /// directly, runs the same Symphonia → waveform → EBU R128 pipeline, and
 /// upserts the rows. Called from `seed_from_bytes_execute` in production and
 /// from tests against an in-memory cache.
+/// Returns the outcome plus the computed `md5_16kb` (the content fingerprint),
+/// so the AppHandle-aware caller can bridge it to the library `content_hash`
+/// (E2) without re-reading the bytes.
 pub fn seed_from_bytes_into_cache(
     cache: &AnalysisCache,
     server_id: &str,
     track_id: &str,
     bytes: &[u8],
-) -> Result<SeedFromBytesOutcome, String> {
+) -> Result<(SeedFromBytesOutcome, String), String> {
     let started = Instant::now();
     // Write under the playback server's scope. An empty `server_id` (caller did
     // not know the server) lands under the legacy '' pool — the read path's
@@ -84,7 +104,7 @@ pub fn seed_from_bytes_into_cache(
                     existing.bins.len(),
                     started.elapsed().as_millis()
                 );
-                return Ok(SeedFromBytesOutcome::SkippedWaveformCacheHit);
+                return Ok((SeedFromBytesOutcome::SkippedWaveformCacheHit, key.md5_16kb.clone()));
             }
             crate::app_deprintln!(
                 "[analysis][waveform] waveform cache hit but loudness missing — full re-analysis track_id={} md5_16kb={}",
@@ -170,7 +190,7 @@ pub fn seed_from_bytes_into_cache(
     }
 
     match build {
-        Ok(_) => Ok(SeedFromBytesOutcome::Upserted),
+        Ok(_) => Ok((SeedFromBytesOutcome::Upserted, key.md5_16kb.clone())),
         Err(e) => Err(e),
     }
 }
@@ -746,8 +766,9 @@ mod tests {
     fn seed_from_bytes_into_cache_upserts_waveform_and_loudness_for_wav() {
         let cache = AnalysisCache::open_in_memory();
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.5), 44_100);
-        let outcome = seed_from_bytes_into_cache(&cache, "", "wav-track", &wav).unwrap();
+        let (outcome, md5) = seed_from_bytes_into_cache(&cache, "", "wav-track", &wav).unwrap();
         assert_eq!(outcome, SeedFromBytesOutcome::Upserted);
+        assert_eq!(md5, md5_first_16kb(&wav), "outcome carries the content fingerprint");
 
         // Both a waveform AND a loudness row must exist after a successful
         // PCM decode + EBU R128 analysis.
@@ -790,9 +811,9 @@ mod tests {
     fn seed_from_bytes_into_cache_returns_skipped_on_second_call() {
         let cache = AnalysisCache::open_in_memory();
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
-        let first = seed_from_bytes_into_cache(&cache, "", "wav-track-2", &wav).unwrap();
+        let (first, _) = seed_from_bytes_into_cache(&cache, "", "wav-track-2", &wav).unwrap();
         assert_eq!(first, SeedFromBytesOutcome::Upserted);
-        let second = seed_from_bytes_into_cache(&cache, "", "wav-track-2", &wav).unwrap();
+        let (second, _) = seed_from_bytes_into_cache(&cache, "", "wav-track-2", &wav).unwrap();
         assert_eq!(
             second,
             SeedFromBytesOutcome::SkippedWaveformCacheHit,
@@ -806,7 +827,7 @@ mod tests {
         // Garbage bytes — Symphonia probe fails, the pipeline falls back to
         // `derive_waveform_bins` (no loudness row gets cached).
         let bytes = vec![0xAAu8; 8 * 1024];
-        let outcome = seed_from_bytes_into_cache(&cache, "", "garbage", &bytes).unwrap();
+        let (outcome, _) = seed_from_bytes_into_cache(&cache, "", "garbage", &bytes).unwrap();
         assert_eq!(outcome, SeedFromBytesOutcome::Upserted);
 
         let key = TrackKey {

--- a/src-tauri/crates/psysonic-core/src/ports.rs
+++ b/src-tauri/crates/psysonic-core/src/ports.rs
@@ -49,3 +49,35 @@ impl PlaybackQueryHandle {
         (self.should_defer_backfill)(track_id)
     }
 }
+
+/// Bridge for the analysis→library back-edge (E2 content_hash): when the
+/// analysis pipeline has the playback-derived `md5_16kb` for a track, it records
+/// it as `track.content_hash` in the library DB. `psysonic-analysis` must not
+/// depend on `psysonic-library`, so the shell crate registers a closure that
+/// captures an `AppHandle` and patches the library; analysis looks this handle
+/// up via `try_state::<…>()` and fires it after a successful seed.
+///
+/// The patch is a no-op when the library has no row for `(server_id, track_id)`
+/// (index off for that server), so the sink is safe to call unconditionally.
+type RecordContentHashFn = Arc<dyn Fn(&str, &str, &str) + Send + Sync + 'static>;
+
+#[derive(Clone)]
+pub struct ContentHashSink {
+    record: RecordContentHashFn,
+}
+
+impl ContentHashSink {
+    pub fn new<F>(record: F) -> Self
+    where
+        F: Fn(&str, &str, &str) + Send + Sync + 'static,
+    {
+        Self { record: Arc::new(record) }
+    }
+
+    /// Record `md5_16kb` as the library `content_hash` for `(server_id, track_id)`.
+    /// Best-effort: the registered closure swallows errors and no-ops when the
+    /// library has no matching row.
+    pub fn record_content_hash(&self, server_id: &str, track_id: &str, md5_16kb: &str) {
+        (self.record)(server_id, track_id, md5_16kb)
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -638,6 +638,35 @@ pub fn library_sync_cancel(
     Ok(())
 }
 
+/// Record the playback-derived `md5_16kb` as `track.content_hash` for
+/// `(server_id, track_id)` (E2). A no-op when the value is empty or the library
+/// has no row for that pair (index off for the server). Shared by the
+/// analysis→library content_hash bridge (registered in the shell crate) and by
+/// [`library_patch_track`]'s `contentHash` field. The playback hash is
+/// authoritative, so this overwrites unconditionally; sync ingest preserves it
+/// via `COALESCE(NULLIF(excluded.content_hash,''), …)` in the upsert.
+pub fn patch_content_hash(
+    runtime: &LibraryRuntime,
+    server_id: &str,
+    track_id: &str,
+    md5_16kb: &str,
+) -> Result<(), String> {
+    if md5_16kb.is_empty() {
+        return Ok(());
+    }
+    runtime
+        .store
+        .with_conn(|conn| {
+            conn.execute(
+                "UPDATE track SET content_hash = ?3 \
+                 WHERE server_id = ?1 AND id = ?2",
+                params![server_id, track_id, md5_16kb],
+            )?;
+            Ok(())
+        })
+        .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 pub fn library_patch_track(
     runtime: State<'_, LibraryRuntime>,
@@ -648,11 +677,15 @@ pub fn library_patch_track(
     // Sparse JSON patch — only the fields explicitly present in
     // `patch` are applied; absent keys leave the column untouched.
     // Spec §6.5 patch-on-use: `starred_at`, `user_rating`,
-    // `play_count`, `played_at`.
+    // `play_count`, `played_at`; §8.1 E2: `content_hash`.
     let starred_at = patch.get("starredAt").and_then(|v| v.as_i64());
     let user_rating = patch.get("userRating").and_then(|v| v.as_i64());
     let play_count = patch.get("playCount").and_then(|v| v.as_i64());
     let played_at = patch.get("playedAt").and_then(|v| v.as_i64());
+    let content_hash = patch
+        .get("contentHash")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
 
     runtime
         .store
@@ -683,6 +716,13 @@ pub fn library_patch_track(
             if let Some(v) = played_at {
                 conn.execute(
                     "UPDATE track SET played_at = ?3 \
+                     WHERE server_id = ?1 AND id = ?2",
+                    params![server_id, track_id, v],
+                )?;
+            }
+            if let Some(v) = content_hash {
+                conn.execute(
+                    "UPDATE track SET content_hash = ?3 \
                      WHERE server_id = ?1 AND id = ?2",
                     params![server_id, track_id, v],
                 )?;
@@ -987,6 +1027,36 @@ mod tests {
         assert_eq!(dto.id, "tr_1");
         assert_eq!(dto.album_id.as_deref(), Some("al_1"));
         assert_eq!(dto.track_number, Some(5));
+    }
+
+    #[test]
+    fn patch_content_hash_sets_value_and_noops_on_absent_or_empty() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        TrackRepository::new(&store)
+            .upsert_batch(&[make_row("s1", "tr_1", "al_1", 1)])
+            .unwrap();
+        let rt = runtime(store.clone());
+
+        let read = |store: &LibraryStore| -> Option<String> {
+            store
+                .with_conn(|c| {
+                    c.query_row(
+                        "SELECT content_hash FROM track WHERE server_id='s1' AND id='tr_1'",
+                        [],
+                        |r| r.get(0),
+                    )
+                })
+                .unwrap()
+        };
+
+        // No-ops leave the existing value untouched: empty md5, and a row that
+        // doesn't exist (the absent-row case is how "index off" stays a no-op).
+        patch_content_hash(&rt, "s1", "tr_1", "").unwrap();
+        patch_content_hash(&rt, "s1", "missing", "deadbeef").unwrap();
+        assert_eq!(read(&store).as_deref(), Some("hash-tr_1"));
+
+        patch_content_hash(&rt, "s1", "tr_1", "md5-playback").unwrap();
+        assert_eq!(read(&store).as_deref(), Some("md5-playback"));
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/repos/track.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track.rs
@@ -426,7 +426,10 @@ ON CONFLICT(server_id, id) DO UPDATE SET
   bpm                  = excluded.bpm,
   replay_gain_track_db = excluded.replay_gain_track_db,
   replay_gain_album_db = excluded.replay_gain_album_db,
-  content_hash         = excluded.content_hash,
+  -- E2: never let a sync (which passes NULL content_hash) clobber the
+  -- playback-derived md5_16kb written via library_patch_track / the analysis
+  -- bridge. A non-empty incoming hash still wins.
+  content_hash         = COALESCE(NULLIF(excluded.content_hash, ''), track.content_hash),
   server_updated_at    = excluded.server_updated_at,
   server_created_at    = excluded.server_created_at,
   deleted              = excluded.deleted,
@@ -476,6 +479,52 @@ mod tests {
             synced_at: 1_700_000_500,
             raw_json: r#"{"id":"t1"}"#.into(),
         }
+    }
+
+    #[test]
+    fn resync_does_not_clobber_playback_content_hash() {
+        // E2 safety property: a sync (which passes content_hash = None) must
+        // never wipe the playback-derived md5 written via patch / the bridge.
+        let store = LibraryStore::open_in_memory();
+        let repo = TrackRepository::new(&store);
+
+        let mut initial = row("s1", "t1", "First");
+        initial.content_hash = None;
+        repo.upsert_batch(&[initial]).unwrap();
+
+        // Playback records the content fingerprint.
+        store
+            .with_conn(|c| {
+                c.execute(
+                    "UPDATE track SET content_hash = 'playback-md5' WHERE server_id='s1' AND id='t1'",
+                    [],
+                )
+            })
+            .unwrap();
+
+        let read = |store: &LibraryStore| -> Option<String> {
+            store
+                .with_conn(|c| {
+                    c.query_row(
+                        "SELECT content_hash FROM track WHERE server_id='s1' AND id='t1'",
+                        [],
+                        |r| r.get(0),
+                    )
+                })
+                .unwrap()
+        };
+
+        // Resync with a NULL hash preserves the playback value.
+        let mut resync = row("s1", "t1", "First (resynced)");
+        resync.content_hash = None;
+        repo.upsert_batch(&[resync]).unwrap();
+        assert_eq!(read(&store).as_deref(), Some("playback-md5"));
+
+        // A non-empty incoming hash still wins.
+        let mut with_hash = row("s1", "t1", "First");
+        with_hash.content_hash = Some("server-hash".into());
+        repo.upsert_batch(&[with_hash]).unwrap();
+        assert_eq!(read(&store).as_deref(), Some("server-hash"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -212,6 +212,28 @@ pub fn run() {
                 app.manage(handle);
             }
 
+            // ── Content-hash sink (analysis → library E2 back-edge) ───────
+            // After a seed the analysis pipeline records the playback-derived
+            // md5_16kb as `track.content_hash` so id-remap can rebind a track
+            // when the server reassigns ids. Decoupled from psysonic-library
+            // via a psysonic-core port; a no-op when the library has no row for
+            // the (server_id, track_id) — i.e. the index is off for that server.
+            {
+                let app_for_hash = app.handle().clone();
+                let sink = psysonic_core::ports::ContentHashSink::new(
+                    move |server_id: &str, track_id: &str, md5: &str| {
+                        if let Some(runtime) =
+                            app_for_hash.try_state::<psysonic_library::LibraryRuntime>()
+                        {
+                            let _ = psysonic_library::commands::patch_content_hash(
+                                &runtime, server_id, track_id, md5,
+                            );
+                        }
+                    },
+                );
+                app.manage(sink);
+            }
+
             // Periodic analysis queue sizes (debug logging mode only).
             tauri::async_runtime::spawn(psysonic_analysis::analysis_runtime::analysis_queue_snapshot_loop());
 

--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -382,6 +382,9 @@ export function libraryPatchTrack(args: {
     userRating?: number | null;
     playCount?: number | null;
     playedAt?: number | null;
+    /** E2: playback-derived `md5_16kb` content fingerprint. Normally written
+     *  by the Rust analysis bridge; exposed here for contract completeness. */
+    contentHash?: string | null;
   };
 }): Promise<void> {
   return invoke<void>('library_patch_track', args);


### PR DESCRIPTION
Bridges the playback-derived `md5_16kb` into library `track.content_hash` (R7-16 Q4), the strong secondary key for id-remap when the server reassigns ids (§6.9). Builds on the 6c analysis cache server_id wiring.

## Summary
- New `ContentHashSink` port in psysonic-core (closure handle, mirrors `PlaybackQueryHandle`) keeps `psysonic-analysis` decoupled from `psysonic-library`; the analysis seed fires it after a successful seed (fresh or cache-hit) when a real server is known, and the shell crate registers it to patch the library.
- `patch_content_hash` + a new optional `contentHash` on `library_patch_track` write it; both no-op when the library has no row for `(server_id, id)` (index off for that server) and under the legacy `''` scope.
- Sync upsert no longer clobbers it: `content_hash = COALESCE(NULLIF(excluded.content_hash,''), track.content_hash)` — a sync (passes NULL) preserves the playback hash; a non-empty incoming hash still wins.
- No schema migration — the `content_hash` column already exists.

## Tauri boundary
Additive: `library_patch_track` gains optional `contentHash` (string); TS wrapper mirrors it. No command/event renamed or removed.

## Refs
- Normative decisions: `tasks/2026-05-library-track-store/questions/2026-05-21-pr6-analysis-bridge-decisions.md` (Q4)

## Test plan
- `cargo test --workspace` green (new tests: resync with NULL hash preserves the playback hash + non-empty incoming wins; `patch_content_hash` sets value and no-ops on absent row / empty md5; seed outcome carries the md5 fingerprint)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `tsc --noEmit` clean; `vitest run` green