### PR TITLE
feat(library): enrichment summary on library_get_track (E3, 6e)

### DIFF
--- a/src-tauri/crates/psysonic-core/src/ports.rs
+++ b/src-tauri/crates/psysonic-core/src/ports.rs
@@ -81,3 +81,31 @@ impl ContentHashSink {
         (self.record)(server_id, track_id, md5_16kb)
     }
 }
+
+/// Library→analysis readiness probe (E3 enrichment): given `(server_id,
+/// track_id, md5_16kb)`, returns `(waveform_ready, loudness_ready)` from the
+/// analysis cache. `psysonic-library` must not depend on `psysonic-analysis`, so
+/// the shell crate registers a closure that captures an `AppHandle`, looks up the
+/// `AnalysisCache`, and probes the exact key with a legacy `''` fallback —
+/// **read-only, no lazy re-tag**. Library looks this handle up via
+/// `try_state::<…>()`; absent handle ⇒ `(false, false)`.
+type QueryReadinessFn = Arc<dyn Fn(&str, &str, &str) -> (bool, bool) + Send + Sync + 'static>;
+
+#[derive(Clone)]
+pub struct AnalysisReadinessQuery {
+    query: QueryReadinessFn,
+}
+
+impl AnalysisReadinessQuery {
+    pub fn new<F>(query: F) -> Self
+    where
+        F: Fn(&str, &str, &str) -> (bool, bool) + Send + Sync + 'static,
+    {
+        Self { query: Arc::new(query) }
+    }
+
+    /// `(waveform_ready, loudness_ready)` for `(server_id, track_id, md5_16kb)`.
+    pub fn readiness(&self, server_id: &str, track_id: &str, md5_16kb: &str) -> (bool, bool) {
+        (self.query)(server_id, track_id, md5_16kb)
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -136,13 +136,40 @@ pub async fn library_search(
 #[tauri::command]
 pub async fn library_get_track(
     runtime: State<'_, LibraryRuntime>,
+    app: AppHandle,
     server_id: String,
     track_id: String,
 ) -> Result<Option<LibraryTrackDto>, String> {
     let repo = TrackRepository::new(&runtime.store);
-    Ok(repo
-        .find_one(&server_id, &track_id)?
-        .map(|row| LibraryTrackDto::from_row(&row)))
+    let Some(row) = repo.find_one(&server_id, &track_id)? else {
+        return Ok(None);
+    };
+    let mut dto = LibraryTrackDto::from_row(&row);
+
+    // E3 enrichment (read-only, per-server, best-effort — never blocks on the
+    // network). Only the single-track read pays for this; list/batch projections
+    // leave `enrichment = None`.
+    let now = now_unix_ms();
+    let lyrics_cached = crate::repos::ArtifactRepository::new(&runtime.store)
+        .lyrics_cached(&server_id, &track_id, now)
+        .unwrap_or(false);
+    // waveform/loudness readiness is gated on a known content_hash (md5_16kb,
+    // populated by E2) and probed via the analysis-readiness port — exact key
+    // then legacy '' fallback, no re-tag. Absent port or hash ⇒ not ready.
+    let (waveform_ready, loudness_ready) =
+        match row.content_hash.as_deref().filter(|s| !s.is_empty()) {
+            Some(md5) => app
+                .try_state::<psysonic_core::ports::AnalysisReadinessQuery>()
+                .map(|q| q.readiness(&server_id, &track_id, md5))
+                .unwrap_or((false, false)),
+            None => (false, false),
+        };
+    dto.enrichment = Some(crate::dto::TrackEnrichmentDto {
+        waveform_ready,
+        loudness_ready,
+        lyrics_cached,
+    });
+    Ok(Some(dto))
 }
 
 #[tauri::command]
@@ -767,7 +794,12 @@ pub fn library_purge_server(
     include_analysis: Option<bool>,
     include_offline: Option<bool>,
 ) -> Result<PurgeReportDto, String> {
-    let _ = include_analysis; // analysis_cache cross-purge wires in PR-6.
+    // R7-16 Q7: `includeAnalysis` is a deliberate v1 no-op — analysis blobs are
+    // expensive to rebuild (full-file decode) and the same host may return under
+    // a new login / app server_id with identical file content, so a purge or
+    // server-remove never deletes waveform/loudness rows. Kept on the surface for
+    // forward compat; explicit cleanup stays Settings → Storage + queue reseed.
+    let _ = include_analysis;
     let include_offline = include_offline.unwrap_or(false);
 
     let mut report = PurgeReportDto::default();

--- a/src-tauri/crates/psysonic-library/src/dto.rs
+++ b/src-tauri/crates/psysonic-library/src/dto.rs
@@ -36,6 +36,17 @@ pub struct SyncStateDto {
     pub local_tracks_max_updated_ms: Option<i64>,
 }
 
+/// E3 readiness summary attached to a single-track `library_get_track` read.
+/// Per-server, read-only, best-effort — never blocks on the network. Omitted
+/// from list/batch reads (would be one analysis probe per row).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackEnrichmentDto {
+    pub waveform_ready: bool,
+    pub loudness_ready: bool,
+    pub lyrics_cached: bool,
+}
+
 /// `library_get_track` / `library_search` row shape — flat projection
 /// over `track`'s hot columns plus the raw JSON sub-tree. Frontend
 /// re-assembles its own `LibraryTrack` shape from this.
@@ -80,6 +91,11 @@ pub struct LibraryTrackDto {
     pub server_created_at: Option<i64>,
     pub synced_at: i64,
 
+    /// E3 readiness summary. Only populated by `library_get_track`; `None`
+    /// (omitted on the wire) for list/batch projections via `from_row`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enrichment: Option<TrackEnrichmentDto>,
+
     /// Original Subsonic / Navidrome song JSON the sync engine stored.
     /// Frontend parses this lazily when it needs OpenSubsonic extras
     /// (contributors, replayGain detail, …).
@@ -123,6 +139,7 @@ impl LibraryTrackDto {
             server_updated_at: row.server_updated_at,
             server_created_at: row.server_created_at,
             synced_at: row.synced_at,
+            enrichment: None,
             raw_json,
         }
     }

--- a/src-tauri/crates/psysonic-library/src/repos/artifact.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/artifact.rs
@@ -95,6 +95,28 @@ impl<'a> ArtifactRepository<'a> {
             .map_err(|e| e.to_string())
     }
 
+    /// E3 readiness: is there a valid (non-expired, non-`not_found`) lyrics
+    /// artifact for `(server_id, track_id)`? Pure read — no lazy GC, no writes —
+    /// so the `library_get_track` enrichment summary stays read-only.
+    pub fn lyrics_cached(&self, server_id: &str, track_id: &str, now: i64) -> Result<bool, String> {
+        self.store
+            .with_conn(|conn| {
+                let exists: i64 = conn.query_row(
+                    "SELECT EXISTS ( \
+                       SELECT 1 FROM track_artifact \
+                       WHERE server_id = ?1 AND track_id = ?2 \
+                         AND artifact_kind = 'lyrics' \
+                         AND not_found = 0 \
+                         AND (expires_at IS NULL OR expires_at >= ?3) \
+                     )",
+                    params![server_id, track_id, now],
+                    |r| r.get(0),
+                )?;
+                Ok(exists != 0)
+            })
+            .map_err(|e| e.to_string())
+    }
+
     /// Upsert an artifact. Rejects content over [`MAX_ARTIFACT_BYTES`] unless
     /// it is a user import (§5.12). A negative-cache row (`not_found`) carries
     /// no content, so it always fits.
@@ -263,6 +285,42 @@ mod tests {
             .unwrap()
             .expect("negative-cache row still live");
         assert!(got.not_found, "caller sees the cached miss instead of refetching");
+    }
+
+    #[test]
+    fn lyrics_cached_only_for_live_found_row() {
+        // Live lyrics row → cached; nothing / negative-cache / expired → not.
+        let live = LibraryStore::open_in_memory();
+        seed_track(&live, "s1", "t1");
+        let repo = ArtifactRepository::new(&live);
+        assert!(!repo.lyrics_cached("s1", "t1", 200).unwrap(), "no row → not cached");
+        repo.put("s1", "t1", &artifact("lyrics", "plain", "lrclib", "lrclib"), 100)
+            .unwrap();
+        assert!(repo.lyrics_cached("s1", "t1", 200).unwrap(), "live row → cached");
+
+        let neg = LibraryStore::open_in_memory();
+        seed_track(&neg, "s1", "t1");
+        let repo_neg = ArtifactRepository::new(&neg);
+        let mut miss = artifact("lyrics", "plain", "lrclib", "lrclib");
+        miss.content_text = None;
+        miss.not_found = true;
+        miss.expires_at = Some(1000);
+        repo_neg.put("s1", "t1", &miss, 100).unwrap();
+        assert!(
+            !repo_neg.lyrics_cached("s1", "t1", 500).unwrap(),
+            "negative-cache row is not 'cached'"
+        );
+
+        let exp = LibraryStore::open_in_memory();
+        seed_track(&exp, "s1", "t1");
+        let repo_exp = ArtifactRepository::new(&exp);
+        let mut expired = artifact("lyrics", "plain", "lrclib", "lrclib");
+        expired.expires_at = Some(150);
+        repo_exp.put("s1", "t1", &expired, 100).unwrap();
+        assert!(
+            !repo_exp.lyrics_cached("s1", "t1", 200).unwrap(),
+            "expired lyrics not cached"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -234,6 +234,40 @@ pub fn run() {
                 app.manage(sink);
             }
 
+            // ── Analysis-readiness query (library → analysis E3 back-edge) ──
+            // `library_get_track` enrichment asks whether waveform/loudness are
+            // cached for (server_id, track_id, content_hash). Read-only probe:
+            // exact key then legacy '' fallback, no re-tag. Decoupled from
+            // psysonic-analysis via a psysonic-core port.
+            {
+                let app_for_readiness = app.handle().clone();
+                let query = psysonic_core::ports::AnalysisReadinessQuery::new(
+                    move |server_id: &str, track_id: &str, md5: &str| {
+                        let Some(cache) = app_for_readiness
+                            .try_state::<analysis_cache::AnalysisCache>()
+                        else {
+                            return (false, false);
+                        };
+                        let probe = |sid: &str| {
+                            let key = analysis_cache::TrackKey {
+                                server_id: sid.to_string(),
+                                track_id: track_id.to_string(),
+                                md5_16kb: md5.to_string(),
+                            };
+                            let wf = cache.get_waveform(&key).ok().flatten().is_some();
+                            let ld = cache.loudness_row_exists_for_key(&key).unwrap_or(false);
+                            (wf, ld)
+                        };
+                        let (wf, ld) = probe(server_id);
+                        // Legacy '' fallback for rows analysed before E1 wiring.
+                        let wf = wf || (!server_id.is_empty() && probe("").0);
+                        let ld = ld || (!server_id.is_empty() && probe("").1);
+                        (wf, ld)
+                    },
+                );
+                app.manage(query);
+            }
+
             // Periodic analysis queue sizes (debug logging mode only).
             tauri::async_runtime::spawn(psysonic_analysis::analysis_runtime::analysis_queue_snapshot_loop());
 

--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -17,6 +17,13 @@ export interface TrackRefDto {
   contentHash?: string | null;
 }
 
+/** E3 readiness summary — present only on single-track `libraryGetTrack` reads. */
+export interface TrackEnrichmentDto {
+  waveformReady: boolean;
+  loudnessReady: boolean;
+  lyricsCached: boolean;
+}
+
 export interface LibraryTrackDto {
   serverId: string;
   id: string;
@@ -51,6 +58,8 @@ export interface LibraryTrackDto {
   serverUpdatedAt?: number | null;
   serverCreatedAt?: number | null;
   syncedAt: number;
+  /** E3: populated only by `libraryGetTrack` (omitted on list/batch reads). */
+  enrichment?: TrackEnrichmentDto | null;
   rawJson: unknown;
 }
 


### PR DESCRIPTION
Closes the analysis-bridge data layer (E1–E3). Adds an optional `enrichment` summary to the single-track `library_get_track` read (R7-16 Q5). Builds on 6c (server_id) + 6d (content_hash).

## Summary
- `LibraryTrackDto` gains optional `enrichment { waveformReady, loudnessReady, lyricsCached }`, populated only by `library_get_track` — read-only, per-server, no network. List/batch projections leave it unset (no per-row probe).
- New `AnalysisReadinessQuery` port in psysonic-core (mirrors `ContentHashSink`) keeps `psysonic-library` decoupled from `psysonic-analysis`; the shell crate probes the analysis cache by exact `(server_id, track_id, content_hash)` with legacy `''` fallback — read-only, no re-tag. waveform/loudness readiness is gated on a known `content_hash` (from E2).
- `lyricsCached` via a new pure-read `ArtifactRepository::lyrics_cached` (valid, non-expired, non-`not_found` lyrics row).
- `library_purge_server`'s `includeAnalysis` documented as a deliberate v1 no-op (Q7): analysis is never deleted on purge / server remove.

## Tauri boundary
Additive: `LibraryTrackDto` gains optional `enrichment`; TS mirror added. No command/event renamed or removed; no schema migration.

## Refs
- Normative decisions: `tasks/2026-05-library-track-store/questions/2026-05-21-pr6-analysis-bridge-decisions.md` (Q5 enrichment, Q7 purge no-op)

## Test plan
- `cargo test --workspace` green (new test: `lyrics_cached` true only for a live found row; false for none / negative-cache / expired)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `tsc --noEmit` clean; `vitest run` green