### PR TITLE
feat(library): VirtualSongList local browse (PR-7 F1)

### DIFF
--- a/src/components/VirtualSongList.tsx
+++ b/src/components/VirtualSongList.tsx
@@ -7,6 +7,8 @@ import { Search as SearchIcon, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ndListSongs } from '../api/navidromeBrowse';
+import { runLocalSongBrowse } from '../utils/library/advancedSearchLocal';
+import { useAuthStore } from '../store/authStore';
 import SongRow, { SongListHeader } from './SongRow';
 
 const PAGE_SIZE = 50;
@@ -15,14 +17,21 @@ const ROW_HEIGHT = 52;
 const PREFETCH_PX = 600;
 
 /**
- * Empty query → Navidrome /api/song sorted by title (no Subsonic equivalent).
+ * Browse-all (empty query): local library index when ready (F1, same title-ASC
+ * order), else Navidrome /api/song sorted by title, else Subsonic search3.
  * Non-empty → Subsonic search3 (search isn't a browse).
- * Either way, returns a SubsonicSong[]; on Navidrome failure we fall back to search3.
+ * Either way, returns a SubsonicSong[].
  */
 async function fetchSongPage(query: string, offset: number): Promise<SubsonicSong[]> {
   if (query !== '') {
     return searchSongsPaged(query, PAGE_SIZE, offset);
   }
+  const local = await runLocalSongBrowse(
+    useAuthStore.getState().activeServerId,
+    offset,
+    PAGE_SIZE,
+  );
+  if (local) return local;
   try {
     return await ndListSongs(offset, offset + PAGE_SIZE, 'title', 'ASC');
   } catch {

--- a/src/utils/library/advancedSearchLocal.test.ts
+++ b/src/utils/library/advancedSearchLocal.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { onInvoke } from '@/test/mocks/tauri';
 import { useLibraryIndexStore } from '@/store/libraryIndexStore';
-import { runLocalAdvancedSearch } from './advancedSearchLocal';
+import { runLocalAdvancedSearch, runLocalSongBrowse } from './advancedSearchLocal';
 
 const opts = (over: Partial<Parameters<typeof runLocalAdvancedSearch>[1]> = {}) => ({
   query: '',
@@ -93,5 +93,58 @@ describe('runLocalAdvancedSearch', () => {
     });
     const res = await runLocalAdvancedSearch('s1', opts({ query: 'x' }), 100);
     expect(res).toBeNull();
+  });
+});
+
+describe('runLocalSongBrowse', () => {
+  beforeEach(() => {
+    useLibraryIndexStore.getState().setIndexEnabled('s1', true);
+  });
+
+  it('returns null for a missing server id (→ network browse)', async () => {
+    expect(await runLocalSongBrowse(null, 0, 50)).toBeNull();
+  });
+
+  it('returns null (→ network browse) when the index is not ready', async () => {
+    onInvoke('library_get_status', () => ({ serverId: 's1', libraryScope: '', syncPhase: 'initial_sync' }));
+    expect(await runLocalSongBrowse('s1', 0, 50)).toBeNull();
+  });
+
+  it('returns null when the response is not local', async () => {
+    ready();
+    onInvoke('library_advanced_search', () => ({
+      artists: [], albums: [], tracks: [],
+      totals: { artists: 0, albums: 0, tracks: 0 }, appliedFilters: [], source: 'network',
+    }));
+    expect(await runLocalSongBrowse('s1', 0, 50)).toBeNull();
+  });
+
+  it('maps the local browse page to Subsonic songs (rawJson wins)', async () => {
+    ready();
+    onInvoke('library_advanced_search', () => ({
+      artists: [],
+      albums: [],
+      tracks: [
+        {
+          serverId: 's1', id: 't1', title: 'Hot', album: 'Alb', albumId: 'al1',
+          durationSec: 100, syncedAt: 0,
+          rawJson: { id: 't1', title: 'Raw', artist: 'Raw Artist', album: 'Alb', albumId: 'al1', duration: 100 },
+        },
+      ],
+      totals: { artists: 0, albums: 0, tracks: 1 }, appliedFilters: [], source: 'local',
+    }));
+    const songs = await runLocalSongBrowse('s1', 0, 50);
+    expect(songs).not.toBeNull();
+    expect(songs!).toHaveLength(1);
+    expect(songs![0].title).toBe('Raw');
+    expect(songs![0].artist).toBe('Raw Artist');
+  });
+
+  it('returns null without throwing on error', async () => {
+    ready();
+    onInvoke('library_advanced_search', () => {
+      throw new Error('boom');
+    });
+    expect(await runLocalSongBrowse('s1', 0, 50)).toBeNull();
   });
 });

--- a/src/utils/library/advancedSearchLocal.ts
+++ b/src/utils/library/advancedSearchLocal.ts
@@ -175,6 +175,37 @@ export async function runLocalAdvancedSearch(
 }
 
 /**
+ * Browse-all songs against the local index for `VirtualSongList` (F1). An empty
+ * query falls through to the Rust builder's default track order
+ * (`t.title COLLATE NOCASE ASC`) — the same alphabetical browse as the network
+ * `ndListSongs('title','ASC')` path, so paging stays coherent even if a later
+ * page falls back to the network. Returns `null` when the index isn't ready or
+ * the page can't be served locally; the caller then uses the network path
+ * unchanged. Gated per page so a readiness flip mid-scroll degrades gracefully.
+ */
+export async function runLocalSongBrowse(
+  serverId: string | null | undefined,
+  offset: number,
+  pageSize: number,
+): Promise<SubsonicSong[] | null> {
+  if (!serverId) return null;
+  if (!(await libraryIsReady(serverId))) return null;
+  try {
+    const resp = await libraryAdvancedSearch({
+      serverId,
+      query: undefined,
+      entityTypes: ['track'],
+      limit: pageSize,
+      offset,
+    });
+    if (resp.source !== 'local') return null;
+    return resp.tracks.map(trackToSong);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Songs-only next page for the local path (mirrors the network
  * `searchSongsPaged` pagination). Throws are surfaced so the caller can stop
  * the infinite-scroll loop, matching the network branch's behaviour.


### PR DESCRIPTION
The all-songs browse (VirtualSongList) reads pages from the local library index when ready, falling back to the unchanged network path otherwise (spec §9.1 F1). Mirrors the F2 (#811) Advanced Search local pattern.

## Summary
- `runLocalSongBrowse` reuses the F2 local-read adapters: empty-query browse-all via `library_advanced_search`, whose default track order (`t.title COLLATE NOCASE ASC`) matches the network `ndListSongs('title','ASC')` path — paging stays coherent across a local↔network boundary.
- Gated per page on `libraryIsReady` + `source === 'local'`; any miss / failure returns null and VirtualSongList uses the existing browse path unchanged (no regression when the index is off / not ready).
- Search (non-empty query) stays on the network path; rich search is already covered by Advanced Search (F2).

## Test plan
- `tsc --noEmit` clean; `vitest run` green (new `runLocalSongBrowse` tests: null for missing server / not ready / non-local source / error; maps local page to Subsonic songs with rawJson winning)
- Frontend-only; no Rust / schema / Tauri-boundary change.