### PR TITLE
feat(library): patch-on-use for star/rating/scrobble (PR-7 F3)

### DIFF
--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -701,14 +701,28 @@ pub fn library_patch_track(
     track_id: String,
     patch: Value,
 ) -> Result<(), String> {
-    // Sparse JSON patch — only the fields explicitly present in
-    // `patch` are applied; absent keys leave the column untouched.
-    // Spec §6.5 patch-on-use: `starred_at`, `user_rating`,
-    // `play_count`, `played_at`; §8.1 E2: `content_hash`.
-    let starred_at = patch.get("starredAt").and_then(|v| v.as_i64());
-    let user_rating = patch.get("userRating").and_then(|v| v.as_i64());
-    let play_count = patch.get("playCount").and_then(|v| v.as_i64());
-    let played_at = patch.get("playedAt").and_then(|v| v.as_i64());
+    apply_track_patch(&runtime, &server_id, &track_id, &patch)
+}
+
+/// Apply a sparse `library_patch_track` JSON patch (extracted from the command
+/// so it is unit-testable without a Tauri `State`). Only fields explicitly
+/// present in `patch` are applied; absent keys leave the column untouched. For
+/// the nullable integer fields, an explicit `null` clears the column (e.g.
+/// `unstar` → `starredAt: null`): `.map` keeps the present/absent distinction
+/// (outer `Some` = key present), `as_i64()` yields the value or `None` → bound
+/// as SQL NULL. Spec §6.5 patch-on-use: `starred_at`, `user_rating`,
+/// `play_count`, `played_at`; §8.1 E2: `content_hash`. All UPDATEs no-op when
+/// the library has no row for `(server_id, track_id)`.
+pub(crate) fn apply_track_patch(
+    runtime: &LibraryRuntime,
+    server_id: &str,
+    track_id: &str,
+    patch: &Value,
+) -> Result<(), String> {
+    let starred_at = patch.get("starredAt").map(|v| v.as_i64());
+    let user_rating = patch.get("userRating").map(|v| v.as_i64());
+    let play_count = patch.get("playCount").map(|v| v.as_i64());
+    let played_at = patch.get("playedAt").map(|v| v.as_i64());
     let content_hash = patch
         .get("contentHash")
         .and_then(|v| v.as_str())
@@ -1089,6 +1103,41 @@ mod tests {
 
         patch_content_hash(&rt, "s1", "tr_1", "md5-playback").unwrap();
         assert_eq!(read(&store).as_deref(), Some("md5-playback"));
+    }
+
+    #[test]
+    fn apply_track_patch_sets_clears_and_leaves_fields() {
+        // §6.5 patch-on-use: present value sets, explicit null clears, absent key
+        // leaves the column untouched — so `unstar` ({starredAt:null}) actually
+        // un-stars the local row.
+        let store = Arc::new(LibraryStore::open_in_memory());
+        TrackRepository::new(&store)
+            .upsert_batch(&[make_row("s1", "tr_1", "al_1", 1)])
+            .unwrap();
+        let rt = runtime(store.clone());
+        let read = |store: &LibraryStore| -> (Option<i64>, Option<i64>) {
+            store
+                .with_conn(|c| {
+                    c.query_row(
+                        "SELECT starred_at, user_rating FROM track WHERE server_id='s1' AND id='tr_1'",
+                        [],
+                        |r| Ok((r.get(0)?, r.get(1)?)),
+                    )
+                })
+                .unwrap()
+        };
+
+        apply_track_patch(&rt, "s1", "tr_1", &serde_json::json!({ "starredAt": 1700, "userRating": 4 }))
+            .unwrap();
+        assert_eq!(read(&store), (Some(1700), Some(4)));
+
+        // Explicit null clears starred_at; absent userRating stays.
+        apply_track_patch(&rt, "s1", "tr_1", &serde_json::json!({ "starredAt": null })).unwrap();
+        assert_eq!(read(&store), (None, Some(4)), "null clears, absent key untouched");
+
+        // Empty patch is a no-op.
+        apply_track_patch(&rt, "s1", "tr_1", &serde_json::json!({})).unwrap();
+        assert_eq!(read(&store), (None, Some(4)));
     }
 
     #[test]

--- a/src/api/subsonicScrobble.ts
+++ b/src/api/subsonicScrobble.ts
@@ -1,5 +1,6 @@
 import { api, apiForServer } from './subsonicClient';
 import type { SubsonicNowPlaying } from './subsonicTypes';
+import { patchLibraryTrackOnUse } from '../utils/library/patchOnUse';
 
 async function scrobbleOnServer(
   serverId: string,
@@ -16,6 +17,10 @@ export async function scrobbleSong(id: string, time: number, serverId: string): 
   if (!serverId) return;
   try {
     await scrobbleOnServer(serverId, id, true, time);
+    // Patch-on-use (§6.5 / F3): reflect the play in the local index so the
+    // "recently played" surfaces aren't stale. `play_count` is left to the next
+    // sync (the patch sets absolute values; a correct increment needs the base).
+    patchLibraryTrackOnUse(serverId, id, { playedAt: time });
   } catch {
     // best effort
   }

--- a/src/api/subsonicStarRating.ts
+++ b/src/api/subsonicStarRating.ts
@@ -1,5 +1,7 @@
 import { api, libraryFilterParams } from './subsonicClient';
 import { invalidateEntityUserRatingCaches } from './subsonicRatings';
+import { useAuthStore } from '../store/authStore';
+import { patchLibraryTrackOnUse } from '../utils/library/patchOnUse';
 import type {
   EntityRatingSupportLevel,
   StarredResults,
@@ -26,6 +28,9 @@ export async function star(id: string, type: 'song' | 'album' | 'artist' = 'albu
   if (type === 'album') params.albumId = id;
   if (type === 'artist') params.artistId = id;
   await api('star.view', params);
+  if (type === 'song') {
+    patchLibraryTrackOnUse(useAuthStore.getState().activeServerId, id, { starredAt: Date.now() });
+  }
 }
 
 export async function unstar(id: string, type: 'song' | 'album' | 'artist' = 'album'): Promise<void> {
@@ -34,10 +39,15 @@ export async function unstar(id: string, type: 'song' | 'album' | 'artist' = 'al
   if (type === 'album') params.albumId = id;
   if (type === 'artist') params.artistId = id;
   await api('unstar.view', params);
+  if (type === 'song') {
+    patchLibraryTrackOnUse(useAuthStore.getState().activeServerId, id, { starredAt: null });
+  }
 }
 
 export async function setRating(id: string, rating: number): Promise<void> {
   await api('setRating.view', { id, rating });
+  // No-op in Rust when `id` is an album/artist (no track row matches).
+  patchLibraryTrackOnUse(useAuthStore.getState().activeServerId, id, { userRating: rating });
   // Cached song lists keyed by rating (e.g. Tracks → Highly Rated rail) become
   // stale immediately. `invalidateEntityUserRatingCaches` is static-imported:
   // mix paths already pull `subsonicRatings` (e.g. mixRatingFilter), so a

--- a/src/utils/library/patchOnUse.test.ts
+++ b/src/utils/library/patchOnUse.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { onInvoke, invokeMock } from '@/test/mocks/tauri';
+import { useLibraryIndexStore } from '@/store/libraryIndexStore';
+import { patchLibraryTrackOnUse } from './patchOnUse';
+
+describe('patchLibraryTrackOnUse', () => {
+  beforeEach(() => {
+    useLibraryIndexStore.getState().setIndexEnabled('s1', true);
+    onInvoke('library_patch_track', () => undefined);
+  });
+
+  it('patches the library track when the index is enabled', async () => {
+    patchLibraryTrackOnUse('s1', 't1', { starredAt: 1700 });
+    await Promise.resolve();
+    expect(invokeMock).toHaveBeenCalledWith('library_patch_track', {
+      serverId: 's1',
+      trackId: 't1',
+      patch: { starredAt: 1700 },
+    });
+  });
+
+  it('forwards an explicit null (unstar) so the column can be cleared', async () => {
+    patchLibraryTrackOnUse('s1', 't1', { starredAt: null });
+    await Promise.resolve();
+    expect(invokeMock).toHaveBeenCalledWith('library_patch_track', {
+      serverId: 's1',
+      trackId: 't1',
+      patch: { starredAt: null },
+    });
+  });
+
+  it('is a no-op when the index is disabled for the server', async () => {
+    useLibraryIndexStore.getState().setIndexEnabled('s1', false);
+    patchLibraryTrackOnUse('s1', 't1', { userRating: 4 });
+    await Promise.resolve();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op without a server id', async () => {
+    patchLibraryTrackOnUse(null, 't1', { userRating: 4 });
+    await Promise.resolve();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the patch invoke rejects', async () => {
+    onInvoke('library_patch_track', () => {
+      throw new Error('boom');
+    });
+    expect(() => patchLibraryTrackOnUse('s1', 't1', { playedAt: 9 })).not.toThrow();
+    await Promise.resolve();
+  });
+});

--- a/src/utils/library/patchOnUse.ts
+++ b/src/utils/library/patchOnUse.ts
@@ -1,0 +1,29 @@
+import { libraryPatchTrack } from '../../api/library';
+import { useLibraryIndexStore } from '../../store/libraryIndexStore';
+
+type TrackPatch = {
+  /** ms epoch when starred, or `null` to clear (unstar). */
+  starredAt?: number | null;
+  userRating?: number | null;
+  playCount?: number | null;
+  /** ms epoch of the last play. */
+  playedAt?: number | null;
+};
+
+/**
+ * Patch-on-use (spec §6.5 / F3): after a successful star / rating / scrobble,
+ * mirror the change into the local library index so its reads (browse F1,
+ * advanced search F2) reflect the action immediately — no stale list after a
+ * rate, no full resync. Skipped when the index is off for the server; the Rust
+ * command additionally no-ops when no row exists / the id is not a track.
+ * Fire-and-forget: never throws, never blocks the originating network action.
+ */
+export function patchLibraryTrackOnUse(
+  serverId: string | null | undefined,
+  trackId: string,
+  patch: TrackPatch,
+): void {
+  if (!serverId || !trackId) return;
+  if (!useLibraryIndexStore.getState().isIndexEnabled(serverId)) return;
+  void libraryPatchTrack({ serverId, trackId, patch }).catch(() => {});
+}


### PR DESCRIPTION
After a successful star / rating / play, mirror the change into the local library index so its reads (browse F1, advanced search F2) reflect the action immediately — no stale list after a rate, no full resync (spec §6.5).

## Summary
- `patchLibraryTrackOnUse` helper: fire-and-forget, gated on the index being enabled for the server; the Rust command additionally no-ops when no row matches (album/artist id, or index off).
- Wired at the central API chokepoints: `star`/`unstar` (song only) → `starredAt`, `setRating` → `userRating`, `scrobbleSong` → `playedAt`. `play_count` is left to the next sync (the patch sets absolute values; a correct increment needs the base).
- `library_patch_track` refined: nullable integer fields now distinguish absent (leave) from explicit `null` (clear) so `unstar` actually un-stars the local row. Logic extracted into a testable `apply_track_patch`; F3 is the first caller sending null, so no existing behaviour changes.

F4 (deprecating the player-store override maps) is intentionally separate — removing them would break instant star feedback when the index is off.

## Tauri boundary
No new command/arg; `library_patch_track`'s existing nullable fields now honour explicit `null` (clear). TS contract already typed `number | null`.

## Test plan
- `cargo test --workspace` green (new `apply_track_patch` test: sets value, explicit null clears, absent key untouched)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `tsc --noEmit` clean; `vitest run` green (new `patchLibraryTrackOnUse` tests: patches when enabled, forwards null, no-op when disabled / no server, never throws)