### PR TITLE
feat(library): full-queue restore from the index (PR-7 F5)

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -15,6 +15,7 @@ import { initHotCachePrefetch } from '../hotCachePrefetch';
 import { initMiniPlayerBridgeOnMain } from '../utils/miniPlayerBridge';
 import { runAdvancedModeMigration } from '../utils/migrations/advancedModeMigration';
 import { ensureActiveServerSessionBound, resumeInitialSyncIfIncomplete } from '../utils/library/librarySession';
+import { hydrateQueueFromIndex } from '../utils/library/queueRestore';
 import { useScanPolling } from '../hooks/useScanPolling';
 import { IS_WINDOWS } from '../utils/platform';
 import TauriEventBridge from './TauriEventBridge';
@@ -51,6 +52,9 @@ export default function MainApp() {
       if (bound && activeServerId) {
         await resumeInitialSyncIfIncomplete(activeServerId);
       }
+      // F5: restore the full persisted queue from the index when ready
+      // (windowed fallback already rehydrated; this swaps in the whole queue).
+      void hydrateQueueFromIndex();
     })();
   }, [activeServerId]);
 

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -94,6 +94,12 @@ export const usePlayerStore = create<PlayerState>()(
           queue: windowedQueue,
           queueServerId: state.queueServerId,
           queueIndex: qi - start, // remap into the windowed slice
+          // F5: full ordered ref list (ids are tiny) so the *whole* queue can be
+          // rehydrated from the local index on startup. The windowed `queue`
+          // above stays as the no-index fallback (queue never empty when the
+          // index is off — the P6 default).
+          queueRefs: state.queue.map(t => t.id),
+          queueRefsIndex: qi,
           isQueueVisible: state.isQueueVisible,
           // currentTime is intentionally NOT persisted here.
           // handleAudioProgress fires every 100ms and each setState with a

--- a/src/store/playerStoreTypes.ts
+++ b/src/store/playerStoreTypes.ts
@@ -58,6 +58,12 @@ export interface PlayerState {
   /** Saved server for stream/hot-cache/offline resolution while this queue plays. */
   queueServerId: string | null;
   queueIndex: number;
+  /** F5 (transient): full ordered track-id list + index persisted alongside the
+   *  windowed `queue`. On startup, when the library index is ready, the whole
+   *  queue is rehydrated from these refs (`library_get_tracks_batch`) and they
+   *  are then cleared. Absent / index-off → the windowed `queue` is used as-is. */
+  queueRefs?: string[];
+  queueRefsIndex?: number;
   isPlaying: boolean;
   /** HTTP stream still buffering (network / demux probe) — show loading on cover art. */
   isPlaybackBuffering: boolean;

--- a/src/utils/library/advancedSearchLocal.ts
+++ b/src/utils/library/advancedSearchLocal.ts
@@ -90,7 +90,7 @@ function buildRequest(
   };
 }
 
-function trackToSong(t: LibraryTrackDto): SubsonicSong {
+export function trackToSong(t: LibraryTrackDto): SubsonicSong {
   const raw = isObject(t.rawJson) ? t.rawJson : {};
   const base: SubsonicSong = {
     id: t.id,

--- a/src/utils/library/queueRestore.test.ts
+++ b/src/utils/library/queueRestore.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { onInvoke } from '@/test/mocks/tauri';
+import { useLibraryIndexStore } from '@/store/libraryIndexStore';
+import { usePlayerStore } from '@/store/playerStore';
+import type { TrackRefDto } from '@/api/library';
+import type { Track } from '@/store/playerStoreTypes';
+import { hydrateQueueFromIndex } from './queueRestore';
+
+const ready = () =>
+  onInvoke('library_get_status', () => ({
+    serverId: 's1',
+    libraryScope: '',
+    syncPhase: 'ready',
+    capabilityFlags: 0,
+    libraryTier: 'unknown',
+    syncedAt: 0,
+  }));
+
+/** Echo each requested ref back as a minimal LibraryTrackDto (order preserved). */
+const echoBatch = () =>
+  onInvoke('library_get_tracks_batch', (args) =>
+    (args as { refs: TrackRefDto[] }).refs.map(r => ({
+      serverId: r.serverId,
+      id: r.trackId,
+      title: `T-${r.trackId}`,
+      album: 'A',
+      durationSec: 1,
+      syncedAt: 0,
+      rawJson: {},
+    })),
+  );
+
+const track = (id: string): Track => ({ id, title: id, artist: '', album: 'A', albumId: 'A', duration: 1 });
+
+function seedStore(over: Partial<ReturnType<typeof usePlayerStore.getState>> = {}) {
+  usePlayerStore.setState({
+    queue: [track('w1')],
+    queueServerId: 's1',
+    queueIndex: 0,
+    currentTrack: null,
+    queueRefs: undefined,
+    queueRefsIndex: undefined,
+    ...over,
+  });
+}
+
+describe('hydrateQueueFromIndex', () => {
+  beforeEach(() => {
+    useLibraryIndexStore.getState().setIndexEnabled('s1', true);
+    seedStore();
+  });
+
+  it('does nothing without persisted refs', async () => {
+    seedStore({ queueRefs: undefined });
+    await hydrateQueueFromIndex();
+    expect(usePlayerStore.getState().queue.map(t => t.id)).toEqual(['w1']);
+  });
+
+  it('keeps the windowed fallback when the index is not ready', async () => {
+    onInvoke('library_get_status', () => ({ serverId: 's1', libraryScope: '', syncPhase: 'initial_sync' }));
+    seedStore({ queueRefs: ['t1', 't2', 't3'], queueRefsIndex: 1 });
+    await hydrateQueueFromIndex();
+    expect(usePlayerStore.getState().queue.map(t => t.id)).toEqual(['w1']);
+    expect(usePlayerStore.getState().queueRefs).toEqual(['t1', 't2', 't3']); // not cleared
+  });
+
+  it('restores the full queue and re-locates the current track when ready', async () => {
+    ready();
+    echoBatch();
+    seedStore({
+      queueRefs: ['t1', 't2', 't3'],
+      queueRefsIndex: 1,
+      currentTrack: track('t2'),
+    });
+    await hydrateQueueFromIndex();
+    const s = usePlayerStore.getState();
+    expect(s.queue.map(t => t.id)).toEqual(['t1', 't2', 't3']);
+    expect(s.queueIndex).toBe(1); // re-located to current track t2
+    expect(s.queueRefs).toBeUndefined(); // cleared after success
+  });
+
+  it('batches refs in chunks of 100', async () => {
+    ready();
+    echoBatch();
+    const refs = Array.from({ length: 150 }, (_, i) => `t${i}`);
+    seedStore({ queueRefs: refs, queueRefsIndex: 0 });
+    await hydrateQueueFromIndex();
+    expect(usePlayerStore.getState().queue).toHaveLength(150);
+  });
+
+  it('keeps the fallback when the current track is not in the hydrated list', async () => {
+    ready();
+    echoBatch();
+    seedStore({
+      queueRefs: ['t1', 't2'],
+      currentTrack: track('gone'),
+    });
+    await hydrateQueueFromIndex();
+    expect(usePlayerStore.getState().queue.map(t => t.id)).toEqual(['w1']); // unchanged
+  });
+});

--- a/src/utils/library/queueRestore.ts
+++ b/src/utils/library/queueRestore.ts
@@ -1,0 +1,61 @@
+import { libraryGetTracksBatch, type LibraryTrackDto, type TrackRefDto } from '../../api/library';
+import { useAuthStore } from '../../store/authStore';
+import { usePlayerStore } from '../../store/playerStore';
+import type { Track } from '../../store/playerStoreTypes';
+import { songToTrack } from '../playback/songToTrack';
+import { trackToSong } from './advancedSearchLocal';
+import { libraryIsReady } from './libraryReady';
+
+/** `library_get_tracks_batch` cap (spec §8.6 — max 100 refs/call). */
+const BATCH = 100;
+
+/**
+ * F5 — full-queue restore. The player store rehydrates a *windowed* `queue`
+ * plus a full `queueRefs` id list. When the library index is ready for the
+ * queue's server, hydrate the entire queue from the index
+ * (`library_get_tracks_batch`, ≤100 refs/call) and swap it in, re-locating the
+ * current track so the playback position stays correct even if some refs were
+ * dropped (unknown to the index).
+ *
+ * Best-effort: missing refs / index not ready / any failure leave the windowed
+ * `queue` untouched — no regression when the index is off (the P6 default).
+ * Clears `queueRefs` once a full hydrate succeeds so it runs at most once.
+ */
+export async function hydrateQueueFromIndex(): Promise<void> {
+  const player = usePlayerStore.getState();
+  const refs = player.queueRefs;
+  if (!refs || refs.length === 0) return;
+
+  const serverId = player.queueServerId ?? useAuthStore.getState().activeServerId;
+  if (!serverId) {
+    usePlayerStore.setState({ queueRefs: undefined, queueRefsIndex: undefined });
+    return;
+  }
+  // Keep the windowed fallback (and the refs, for a later ready startup) when
+  // the index can't serve the queue yet.
+  if (!(await libraryIsReady(serverId))) return;
+
+  try {
+    const dtos: LibraryTrackDto[] = [];
+    for (let i = 0; i < refs.length; i += BATCH) {
+      const chunk: TrackRefDto[] = refs.slice(i, i + BATCH).map(trackId => ({ serverId, trackId }));
+      dtos.push(...(await libraryGetTracksBatch(chunk)));
+    }
+    if (dtos.length === 0) return; // index has none of them → keep fallback
+
+    const hydrated: Track[] = dtos.map(d => songToTrack(trackToSong(d)));
+    // Re-locate the current track so queueIndex stays aligned with playback.
+    const cur = usePlayerStore.getState().currentTrack;
+    const idx = cur ? hydrated.findIndex(t => t.id === cur.id) : -1;
+    if (cur && idx < 0) return; // can't align playback → keep windowed fallback
+
+    usePlayerStore.setState({
+      queue: hydrated,
+      queueIndex: idx >= 0 ? idx : 0,
+      queueRefs: undefined,
+      queueRefsIndex: undefined,
+    });
+  } catch {
+    // best-effort; the windowed fallback stays in place
+  }
+}


### PR DESCRIPTION
Restore the whole playback queue across restarts by persisting a lightweight ref list and rehydrating it from the local index on startup (R7-17 / spec §8.6) — instead of only the windowed slice that survives today.

## Summary
- Persist adds `queueRefs` (full ordered ids) + `queueRefsIndex` alongside the existing windowed `queue` (ids are tiny; the windowed objects stay as the no-index fallback).
- `hydrateQueueFromIndex` (startup, after session bind): when the index is ready for the queue's server, hydrate the full queue via `library_get_tracks_batch` (batched ≤100), map `songToTrack ∘ trackToSong`, re-locate the current track so `queueIndex` stays aligned, then clear the refs.
- Index not ready / missing rows / current track not found → keep the windowed fallback (queue never empty when the index is off, the P6 default). Old persisted shape without refs loads unchanged.

Kept the windowed-objects persist (did **not** drop the cap per R7-17's note): the index-off default needs the embedded fallback, or the queue would restore empty.

## Test plan
- `tsc --noEmit` clean; `vitest run` green (new `hydrateQueueFromIndex` tests: full restore + current-track re-location, fallback when not ready / current track missing, batching >100, no-op without refs)
- Frontend-only; no Rust / schema / Tauri-boundary change.