### PR TITLE
feat(library): pending-sync for song star/rating (PR-7 F4)

### DIFF
--- a/src/components/FullscreenPlayer.tsx
+++ b/src/components/FullscreenPlayer.tsx
@@ -1,4 +1,4 @@
-import { star, unstar } from '../api/subsonicStarRating';
+import { queueSongStar } from '../store/pendingStarSync';
 import { usePlaybackCoverArt } from '../hooks/usePlaybackCoverArt';
 import { playbackCoverArtForId } from '../utils/playback/playbackServer';
 import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react';
@@ -34,7 +34,6 @@ export default function FullscreenPlayer({ onClose }: FullscreenPlayerProps) {
   const previous           = usePlayerStore(s => s.previous);
   const stop               = usePlayerStore(s => s.stop);
   const toggleRepeat       = usePlayerStore(s => s.toggleRepeat);
-  const setStarredOverride = usePlayerStore(s => s.setStarredOverride);
   // Derive isStarred inside the selector so we only re-render when the boolean
   // actually flips — not when any unrelated track's star status changes.
   const isStarred = usePlayerStore(s => {
@@ -43,17 +42,10 @@ export default function FullscreenPlayer({ onClose }: FullscreenPlayerProps) {
     return track.id in s.starredOverrides ? s.starredOverrides[track.id] : !!track.starred;
   });
 
-  const toggleStar = useCallback(async () => {
+  const toggleStar = useCallback(() => {
     if (!currentTrack) return;
-    const nextVal = !isStarred;
-    setStarredOverride(currentTrack.id, nextVal);
-    try {
-      if (nextVal) await star(currentTrack.id, 'song');
-      else await unstar(currentTrack.id, 'song');
-    } catch {
-      setStarredOverride(currentTrack.id, !nextVal);
-    }
-  }, [currentTrack, isStarred, setStarredOverride]);
+    queueSongStar(currentTrack.id, !isStarred);
+  }, [currentTrack, isStarred]);
 
   const duration = currentTrack?.duration ?? 0;
 

--- a/src/components/MobilePlayerView.tsx
+++ b/src/components/MobilePlayerView.tsx
@@ -1,4 +1,4 @@
-import { star, unstar } from '../api/subsonicStarRating';
+import { queueSongStar } from '../store/pendingStarSync';
 import { usePlaybackCoverArt } from '../hooks/usePlaybackCoverArt';
 import type { Track } from '../store/playerStoreTypes';
 import { getPlaybackProgressSnapshot, subscribePlaybackProgress } from '../store/playbackProgress';
@@ -182,7 +182,6 @@ export default function MobilePlayerView() {
   const toggleRepeat = usePlayerStore(s => s.toggleRepeat);
   const shuffleQueue = usePlayerStore(s => s.shuffleQueue);
   const starredOverrides = usePlayerStore(s => s.starredOverrides);
-  const setStarredOverride = usePlayerStore(s => s.setStarredOverride);
 
   const duration = currentTrack?.duration ?? 0;
 
@@ -197,17 +196,10 @@ export default function MobilePlayerView() {
     ? (currentTrack.id in starredOverrides ? starredOverrides[currentTrack.id] : !!currentTrack.starred)
     : false;
 
-  const toggleStar = useCallback(async () => {
+  const toggleStar = useCallback(() => {
     if (!currentTrack) return;
-    const nextVal = !isStarred;
-    setStarredOverride(currentTrack.id, nextVal);
-    try {
-      if (nextVal) await star(currentTrack.id, 'song');
-      else await unstar(currentTrack.id, 'song');
-    } catch {
-      setStarredOverride(currentTrack.id, !nextVal);
-    }
-  }, [currentTrack, isStarred, setStarredOverride]);
+    queueSongStar(currentTrack.id, !isStarred);
+  }, [currentTrack, isStarred]);
 
   // Scrubber touch/mouse drag
   const scrubberRef = useRef<HTMLDivElement>(null);

--- a/src/components/PlayerBar.tsx
+++ b/src/components/PlayerBar.tsx
@@ -1,4 +1,4 @@
-import { star, unstar } from '../api/subsonicStarRating';
+import { queueSongStar } from '../store/pendingStarSync';
 import { buildCoverArtUrl, coverArtCacheKey } from '../api/subsonicStreamUrl';
 import { usePlaybackCoverArt } from '../hooks/usePlaybackCoverArt';
 import type { SubsonicAlbum } from '../api/subsonicTypes';
@@ -62,8 +62,8 @@ export default function PlayerBar() {
     stop, toggleRepeat, repeatMode, toggleFullscreen,
     lastfmLoved, toggleLastfmLove,
     isQueueVisible, toggleQueue,
-    starredOverrides, setStarredOverride,
-    userRatingOverrides, setUserRatingOverride,
+    starredOverrides,
+    userRatingOverrides,
     openContextMenu,
   } = usePlayerStore(useShallow(s => ({
     currentTrack: s.currentTrack,
@@ -83,9 +83,7 @@ export default function PlayerBar() {
     isQueueVisible: s.isQueueVisible,
     toggleQueue: s.toggleQueue,
     starredOverrides: s.starredOverrides,
-    setStarredOverride: s.setStarredOverride,
     userRatingOverrides: s.userRatingOverrides,
-    setUserRatingOverride: s.setUserRatingOverride,
     openContextMenu: s.openContextMenu,
   })));
   const { lastfmSessionKey } = useAuthStore();
@@ -133,17 +131,10 @@ export default function PlayerBar() {
     ? (currentTrack.id in starredOverrides ? starredOverrides[currentTrack.id] : !!currentTrack.starred)
     : false;
 
-  const toggleStar = useCallback(async () => {
+  const toggleStar = useCallback(() => {
     if (!currentTrack) return;
-    const next = !isStarred;
-    setStarredOverride(currentTrack.id, next);
-    try {
-      if (next) await star(currentTrack.id, 'song');
-      else await unstar(currentTrack.id, 'song');
-    } catch {
-      setStarredOverride(currentTrack.id, !next);
-    }
-  }, [currentTrack, isStarred, setStarredOverride]);
+    queueSongStar(currentTrack.id, !isStarred);
+  }, [currentTrack, isStarred]);
 
   const duration = currentTrack?.duration ?? 0;
 
@@ -232,7 +223,6 @@ export default function PlayerBar() {
         lastfmLoved={lastfmLoved}
         toggleLastfmLove={toggleLastfmLove}
         userRatingOverrides={userRatingOverrides}
-        setUserRatingOverride={setUserRatingOverride}
         toggleFullscreen={toggleFullscreen}
         navigate={navigatePlaybackLibrary}
         openContextMenu={openContextMenu}

--- a/src/components/contextMenu/QueueItemContextItems.tsx
+++ b/src/components/contextMenu/QueueItemContextItems.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Play, Radio, Heart, ChevronRight, User, Disc3, ListMusic, Info, Sparkles, Star, Trash2, Share2 } from 'lucide-react';
-import { star, unstar } from '../../api/subsonicStarRating';
+import { queueSongStar } from '../../store/pendingStarSync';
 import { lastfmLoveTrack, lastfmUnloveTrack } from '../../api/lastfm';
 import type { Track } from '../../store/playerStoreTypes';
 import { useAuthStore } from '../../store/authStore';
@@ -13,7 +13,7 @@ export default function QueueItemContextItems(props: ContextMenuItemsProps) {
   const {
     type, item, queueIndex, playlistId, playlistSongIndex, shareKindOverride,
     playTrack, playNext, enqueue, removeTrack, queue, currentTrack, closeContextMenu,
-    starredOverrides, setStarredOverride, lastfmLovedCache, setLastfmLovedForSong,
+    starredOverrides, lastfmLovedCache, setLastfmLovedForSong,
     openSongInfo, userRatingOverrides, setKeyboardRating, keyboardRating,
     playlistSubmenuOpen, setPlaylistSubmenuOpen, cancelPlaylistSubmenuCloseTimer, onPlaylistSubmenuTriggerMouseLeave,
     playlistSongIds, setPlaylistSongIds,
@@ -71,9 +71,7 @@ export default function QueueItemContextItems(props: ContextMenuItemsProps) {
                 </div>
               )}
               <div className="context-menu-item" onClick={() => handleAction(() => {
-                const starred = isStarred(song.id, song.starred);
-                setStarredOverride(song.id, !starred);
-                return starred ? unstar(song.id, 'song') : star(song.id, 'song');
+                queueSongStar(song.id, !isStarred(song.id, song.starred));
               })}>
                 <Heart size={14} fill={isStarred(song.id, song.starred) ? 'currentColor' : 'none'} />
                 {isStarred(song.id, song.starred) ? t('contextMenu.unfavorite') : t('contextMenu.favorite')}

--- a/src/components/contextMenu/SongContextItems.tsx
+++ b/src/components/contextMenu/SongContextItems.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Play, ListPlus, Radio, Heart, ChevronRight, ChevronsRight, User, Disc3, ListMusic, Info, Sparkles, Star, Trash2, HeartCrack, Share2, Orbit as OrbitIcon } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { getAlbum } from '../../api/subsonicLibrary';
-import { star, unstar } from '../../api/subsonicStarRating';
+import { queueSongStar } from '../../store/pendingStarSync';
 import { lastfmLoveTrack, lastfmUnloveTrack } from '../../api/lastfm';
 import type { Track } from '../../store/playerStoreTypes';
 import { useAuthStore } from '../../store/authStore';
@@ -19,7 +19,7 @@ export default function SongContextItems(props: ContextMenuItemsProps) {
   const {
     type, item, queueIndex, playlistId, playlistSongIndex, shareKindOverride,
     playTrack, playNext, enqueue, removeTrack, queue, currentTrack, closeContextMenu,
-    starredOverrides, setStarredOverride, lastfmLovedCache, setLastfmLovedForSong,
+    starredOverrides, lastfmLovedCache, setLastfmLovedForSong,
     openSongInfo, userRatingOverrides, setKeyboardRating, keyboardRating,
     playlistSubmenuOpen, setPlaylistSubmenuOpen, cancelPlaylistSubmenuCloseTimer, onPlaylistSubmenuTriggerMouseLeave,
     playlistSongIds, setPlaylistSongIds,
@@ -119,9 +119,7 @@ export default function SongContextItems(props: ContextMenuItemsProps) {
                 </div>
               )}
               <div className="context-menu-item" onClick={() => handleAction(() => {
-                const starred = isStarred(song.id, song.starred);
-                setStarredOverride(song.id, !starred);
-                return starred ? unstar(song.id, 'song') : star(song.id, 'song');
+                queueSongStar(song.id, !isStarred(song.id, song.starred));
               })}>
                 <Heart size={14} fill={isStarred(song.id, song.starred) ? 'currentColor' : 'none'} />
                 {isStarred(song.id, song.starred) ? t('contextMenu.unfavorite') : t('contextMenu.favorite')}
@@ -303,8 +301,7 @@ export default function SongContextItems(props: ContextMenuItemsProps) {
               </div>
               <div className="context-menu-divider" />
               <div className="context-menu-item" style={{ color: 'var(--danger)' }} onClick={() => handleAction(() => {
-                setStarredOverride(song.id, false);
-                return unstar(song.id, 'song');
+                queueSongStar(song.id, false);
               })}>
                 <HeartCrack size={14} /> {t('contextMenu.unfavorite')}
               </div>

--- a/src/components/playerBar/PlayerTrackInfo.tsx
+++ b/src/components/playerBar/PlayerTrackInfo.tsx
@@ -1,6 +1,6 @@
 import { Cast, Heart, Maximize2, Music } from 'lucide-react';
 import type { TFunction } from 'i18next';
-import { setRating } from '../../api/subsonicStarRating';
+import { queueSongRating } from '../../store/pendingStarSync';
 import type { InternetRadioStation, SubsonicAlbum, SubsonicOpenArtistRef } from '../../api/subsonicTypes';
 import type { PlayerState, Track } from '../../store/playerStoreTypes';
 import type { RadioMetadata } from '../../hooks/useRadioMetadata';
@@ -39,7 +39,6 @@ interface Props {
   lastfmLoved: boolean;
   toggleLastfmLove: () => void;
   userRatingOverrides: Record<string, number>;
-  setUserRatingOverride: (id: string, r: number) => void;
   toggleFullscreen: () => void;
   navigate: (to: string) => void | Promise<void>;
   openContextMenu: PlayerState['openContextMenu'];
@@ -51,7 +50,7 @@ export function PlayerTrackInfo({
   coverSrc, coverKey, displayCoverArt, displayTitle, displayArtist, displayArtistRefs,
   showPreviewMeta, previewingTrack, isStarred, toggleStar,
   lastfmSessionKey, lastfmLoved, toggleLastfmLove,
-  userRatingOverrides, setUserRatingOverride, toggleFullscreen,
+  userRatingOverrides, toggleFullscreen,
   navigate, openContextMenu, t,
 }: Props) {
   const showBufferingOverlay = usePlayerStore(s => s.isPlaybackBuffering);
@@ -159,7 +158,7 @@ export function PlayerTrackInfo({
         {currentTrack && !isRadio && !showPreviewMeta && isLayoutVisible('starRating') && (
           <StarRating
             value={userRatingOverrides[currentTrack.id] ?? currentTrack.userRating ?? 0}
-            onChange={r => { setUserRatingOverride(currentTrack.id, r); setRating(currentTrack.id, r).catch(() => {}); }}
+            onChange={r => queueSongRating(currentTrack.id, r)}
             className="player-track-rating"
             ariaLabel={t('albumDetail.ratingLabel')}
           />

--- a/src/config/shortcutActionRegistry.ts
+++ b/src/config/shortcutActionRegistry.ts
@@ -1,4 +1,4 @@
-import { star, unstar } from '../api/subsonicStarRating';
+import { queueSongStar } from '../store/pendingStarSync';
 import { getSong } from '../api/subsonicLibrary';
 import { songToTrack } from '../utils/playback/songToTrack';
 import { invoke } from '@tauri-apps/api/core';
@@ -261,12 +261,7 @@ export const SHORTCUT_ACTION_REGISTRY = {
         showToast(i18n.t('contextMenu.cliMixNeedsTrack', { defaultValue: 'Load a track first.' }), 5000, 'error');
         return;
       }
-      star(track.id, 'song')
-        .then(() => usePlayerStore.getState().setStarredOverride(track.id, true))
-        .catch(err => {
-          console.error('Favorite current track failed', err);
-          showToast(i18n.t('contextMenu.cliStarFailed', { defaultValue: 'Could not add the track to favorites.' }), 5000, 'error');
-        });
+      queueSongStar(track.id, true);
     },
   },
   'open-help': {
@@ -314,12 +309,7 @@ export const SHORTCUT_ACTION_REGISTRY = {
         showToast(i18n.t('contextMenu.cliMixNeedsTrack'), 5000, 'error');
         return;
       }
-      star(track.id, 'song')
-        .then(() => usePlayerStore.getState().setStarredOverride(track.id, true))
-        .catch(err => {
-          console.error('CLI star failed', err);
-          showToast(i18n.t('contextMenu.cliStarFailed', { defaultValue: 'Star/unstar failed.' }), 5000, 'error');
-        });
+      queueSongStar(track.id, true);
     },
     cli: { verb: 'star', description: 'star' },
   },
@@ -332,12 +322,7 @@ export const SHORTCUT_ACTION_REGISTRY = {
         showToast(i18n.t('contextMenu.cliMixNeedsTrack'), 5000, 'error');
         return;
       }
-      unstar(track.id, 'song')
-        .then(() => usePlayerStore.getState().setStarredOverride(track.id, false))
-        .catch(err => {
-          console.error('CLI star failed', err);
-          showToast(i18n.t('contextMenu.cliStarFailed', { defaultValue: 'Star/unstar failed.' }), 5000, 'error');
-        });
+      queueSongStar(track.id, false);
     },
     cli: { verb: 'unstar', description: 'unstar' },
   },

--- a/src/config/shortcutDispatch.ts
+++ b/src/config/shortcutDispatch.ts
@@ -1,4 +1,4 @@
-import { setRating } from '../api/subsonicStarRating';
+import { queueSongRating } from '../store/pendingStarSync';
 import i18n from '../i18n';
 import { usePlayerStore } from '../store/playerStore';
 import { showToast } from '../utils/ui/toast';
@@ -90,11 +90,8 @@ export function executeCliPlayerCommand(ctx: CliContext): void | Promise<void> {
       showToast(i18n.t('contextMenu.cliMixNeedsTrack'), 5000, 'error');
       return;
     }
-    return setRating(track.id, stars)
-      .then(() => {
-        usePlayerStore.getState().setUserRatingOverride(track.id, stars);
-      })
-      .catch(err => console.error('CLI set rating failed', err));
+    queueSongRating(track.id, stars);
+    return;
   }
   // no-op for unknown command
 }

--- a/src/hooks/useContextMenuRating.ts
+++ b/src/hooks/useContextMenuRating.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { setRating } from '../api/subsonicStarRating';
+import { queueSongRating } from '../store/pendingStarSync';
 import type { SubsonicAlbum, SubsonicArtist } from '../api/subsonicTypes';
 import type { Track } from '../store/playerStoreTypes';
 import { useAuthStore } from '../store/authStore';
@@ -31,9 +32,9 @@ export function useContextMenuRating({
   const activeServerId = useAuthStore(s => s.activeServerId);
 
   const applySongRating = useCallback((songId: string, rating: number) => {
-    setUserRatingOverride(songId, rating);
-    setRating(songId, rating).catch(() => {});
-  }, [setUserRatingOverride]);
+    // F4: optimistic override + retry-with-backoff sync via the central helper.
+    queueSongRating(songId, rating);
+  }, []);
 
   const applyAlbumRating = useCallback((album: SubsonicAlbum, rating: number) => {
     setUserRatingOverride(album.id, rating);

--- a/src/pages/AlbumDetail.tsx
+++ b/src/pages/AlbumDetail.tsx
@@ -1,5 +1,6 @@
 import { buildCoverArtUrl, coverArtCacheKey, buildDownloadUrl } from '../api/subsonicStreamUrl';
 import { setRating, star, unstar } from '../api/subsonicStarRating';
+import { queueSongStar, queueSongRating } from '../store/pendingStarSync';
 import { getArtistInfo } from '../api/subsonicArtists';
 import type { SubsonicSong } from '../api/subsonicTypes';
 import { songToTrack } from '../utils/playback/songToTrack';
@@ -41,7 +42,6 @@ export default function AlbumDetail() {
   const enqueue = usePlayerStore(s => s.enqueue);
   const openContextMenu = usePlayerStore(s => s.openContextMenu);
   const starredOverrides = usePlayerStore(s => s.starredOverrides);
-  const setStarredOverride = usePlayerStore(s => s.setStarredOverride);
   const userRatingOverrides = usePlayerStore(s => s.userRatingOverrides);
   const currentTrack = usePlayerStore(s => s.currentTrack);
   const isPlaying = usePlayerStore(s => s.isPlaying);
@@ -129,10 +129,10 @@ const handleShuffleAll = () => {
 
    const handleDoubleClickSong = (song: SubsonicSong) => addTrackToOrbit(song.id);
 
-  const handleRate = async (songId: string, rating: number) => {
+  const handleRate = (songId: string, rating: number) => {
     setRatings(r => ({ ...r, [songId]: rating }));
-    usePlayerStore.getState().setUserRatingOverride(songId, rating);
-    await setRating(songId, rating);
+    // F4: optimistic override + retried server sync via the central helper.
+    queueSongRating(songId, rating);
   };
 
   const handleAlbumEntityRating = async (rating: number) => {
@@ -206,21 +206,14 @@ const handleShuffleAll = () => {
     }
   };
 
-  const toggleSongStar = async (song: SubsonicSong, e: React.MouseEvent) => {
+  const toggleSongStar = (song: SubsonicSong, e: React.MouseEvent) => {
     e.stopPropagation();
     const wasStarred = starredSongs.has(song.id);
     const next = new Set(starredSongs);
     if (wasStarred) next.delete(song.id); else next.add(song.id);
     setStarredSongs(next);
-    setStarredOverride(song.id, !wasStarred);
-    try {
-      if (wasStarred) await unstar(song.id, 'song');
-      else await star(song.id, 'song');
-    } catch (err) {
-      console.error('Failed to toggle song star', err);
-      setStarredSongs(new Set(starredSongs));
-      setStarredOverride(song.id, wasStarred);
-    }
+    // F4: optimistic override + retried server sync via the central helper.
+    queueSongStar(song.id, !wasStarred);
   };
 
   const handleCacheOffline = useCallback(async () => {

--- a/src/store/pendingStarSync.test.ts
+++ b/src/store/pendingStarSync.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const starMock = vi.fn();
+const unstarMock = vi.fn();
+const setRatingMock = vi.fn();
+vi.mock('../api/subsonicStarRating', () => ({
+  star: (...a: unknown[]) => starMock(...a),
+  unstar: (...a: unknown[]) => unstarMock(...a),
+  setRating: (...a: unknown[]) => setRatingMock(...a),
+}));
+
+import { usePlayerStore } from './playerStore';
+import type { Track } from './playerStoreTypes';
+import { queueSongStar, queueSongRating, _resetPendingStarSyncForTest } from './pendingStarSync';
+
+const track = (id: string): Track => ({
+  id, title: id, artist: '', album: 'A', albumId: 'A', duration: 1,
+});
+
+describe('pendingStarSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    starMock.mockReset().mockResolvedValue(undefined);
+    unstarMock.mockReset().mockResolvedValue(undefined);
+    setRatingMock.mockReset().mockResolvedValue(undefined);
+    _resetPendingStarSyncForTest();
+    usePlayerStore.setState({
+      currentTrack: track('t1'),
+      queue: [track('t1')],
+      starredOverrides: {},
+      userRatingOverrides: {},
+    });
+  });
+  afterEach(() => {
+    _resetPendingStarSyncForTest();
+    vi.useRealTimers();
+  });
+
+  it('stars optimistically, then clears the override + patches the track on success', async () => {
+    queueSongStar('t1', true);
+    expect(usePlayerStore.getState().starredOverrides.t1).toBe(true); // optimistic, instant
+
+    await vi.runAllTimersAsync();
+
+    expect(starMock).toHaveBeenCalledWith('t1', 'song');
+    const s = usePlayerStore.getState();
+    expect('t1' in s.starredOverrides).toBe(false); // cleared on success
+    expect(s.currentTrack?.starred).toBeTruthy(); // in-memory track patched
+    expect(s.queue[0].starred).toBeTruthy();
+  });
+
+  it('does NOT roll back on a network failure and keeps retrying', async () => {
+    starMock.mockRejectedValue(new Error('offline'));
+    queueSongStar('t1', true);
+
+    await vi.advanceTimersByTimeAsync(4000); // 0ms + 1s + 2s backoff cycles
+
+    expect(starMock.mock.calls.length).toBeGreaterThanOrEqual(2); // retried
+    expect(usePlayerStore.getState().starredOverrides.t1).toBe(true); // override survives (no rollback)
+  });
+
+  it('latest toggle wins when re-queued before sync', async () => {
+    queueSongStar('t1', true);
+    queueSongStar('t1', false); // user toggled back off
+    await vi.runAllTimersAsync();
+    expect(unstarMock).toHaveBeenCalledWith('t1', 'song');
+    expect('t1' in usePlayerStore.getState().starredOverrides).toBe(false);
+    expect(usePlayerStore.getState().currentTrack?.starred).toBeFalsy();
+  });
+
+  it('rates optimistically (track patched), clears override on success', async () => {
+    queueSongRating('t1', 4);
+    // setUserRatingOverride patches the track immediately:
+    expect(usePlayerStore.getState().currentTrack?.userRating).toBe(4);
+    expect(usePlayerStore.getState().userRatingOverrides.t1).toBe(4);
+
+    await vi.runAllTimersAsync();
+
+    expect(setRatingMock).toHaveBeenCalledWith('t1', 4);
+    const s = usePlayerStore.getState();
+    expect('t1' in s.userRatingOverrides).toBe(false); // cleared
+    expect(s.currentTrack?.userRating).toBe(4); // track stays patched
+  });
+});

--- a/src/store/pendingStarSync.ts
+++ b/src/store/pendingStarSync.ts
@@ -1,0 +1,137 @@
+import { setRating, star, unstar } from '../api/subsonicStarRating';
+import { usePlayerStore } from './playerStore';
+
+/**
+ * F4 — pending-sync for **song** star + rating (spec §6.5 / R7-18).
+ *
+ * The player-store override maps (`starredOverrides` / `userRatingOverrides`)
+ * are *session-only outbound sync state*, not a permanent second source of
+ * truth:
+ *
+ * 1. Set the override optimistically (instant UI).
+ * 2. Retry the Subsonic API (`star` / `unstar` / `setRating`) with exponential
+ *    backoff; flush immediately on `online` / window focus.
+ * 3. On success: clear the override and patch the in-memory `Track`
+ *    (`currentTrack` + `queue`) so the UI stays correct without the override.
+ *    The F3 index patch-on-use runs inside the API layer, unchanged.
+ * 4. On app restart before success: the pending change is lost — acceptable,
+ *    overrides are not persisted.
+ *
+ * **No rollback on the first network error** (this replaces the per-component
+ * star rollback). v1 routes **songs only**; album/artist stay on their existing
+ * paths.
+ */
+
+type Task =
+  | { kind: 'star'; id: string; starred: boolean }
+  | { kind: 'rating'; id: string; rating: number };
+
+const pending = new Map<string, Task>(); // key `${kind}:${id}` — latest wins
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+const attempts = new Map<string, number>();
+const MAX_BACKOFF_MS = 30_000;
+let listenersArmed = false;
+
+const keyOf = (t: Task) => `${t.kind}:${t.id}`;
+
+function armListeners(): void {
+  if (listenersArmed || typeof window === 'undefined') return;
+  listenersArmed = true;
+  const flushAll = () => {
+    for (const k of pending.keys()) schedule(k, 0);
+  };
+  window.addEventListener('online', flushAll);
+  window.addEventListener('focus', flushAll);
+}
+
+function schedule(k: string, delayMs: number): void {
+  const existing = timers.get(k);
+  if (existing) clearTimeout(existing);
+  timers.set(
+    k,
+    setTimeout(() => {
+      void run(k);
+    }, delayMs),
+  );
+}
+
+async function run(k: string): Promise<void> {
+  timers.delete(k);
+  const task = pending.get(k);
+  if (!task) return;
+  try {
+    if (task.kind === 'star') {
+      if (task.starred) await star(task.id, 'song');
+      else await unstar(task.id, 'song');
+      onStarSuccess(task.id, task.starred);
+    } else {
+      await setRating(task.id, task.rating);
+      onRatingSuccess(task.id);
+    }
+    // Only retire the entry if a newer toggle hasn't superseded it mid-flight.
+    if (pending.get(k) === task) {
+      pending.delete(k);
+      attempts.delete(k);
+    }
+  } catch {
+    if (pending.get(k) !== task) return; // superseded — the newer task self-schedules
+    const n = (attempts.get(k) ?? 0) + 1;
+    attempts.set(k, n);
+    schedule(k, Math.min(MAX_BACKOFF_MS, 1000 * 2 ** (n - 1)));
+  }
+}
+
+function onStarSuccess(id: string, starred: boolean): void {
+  const starredVal = starred ? new Date().toISOString() : undefined;
+  usePlayerStore.setState(s => {
+    if (!(id in s.starredOverrides)) return {};
+    const next = { ...s.starredOverrides };
+    delete next[id];
+    return {
+      starredOverrides: next,
+      queue: s.queue.map(t => (t.id === id ? { ...t, starred: starredVal } : t)),
+      currentTrack:
+        s.currentTrack?.id === id ? { ...s.currentTrack, starred: starredVal } : s.currentTrack,
+    };
+  });
+}
+
+function onRatingSuccess(id: string): void {
+  // `setUserRatingOverride` already patched track.userRating; just drop the override.
+  usePlayerStore.setState(s => {
+    if (!(id in s.userRatingOverrides)) return {};
+    const next = { ...s.userRatingOverrides };
+    delete next[id];
+    return { userRatingOverrides: next };
+  });
+}
+
+/** Optimistically (un)star a song and sync it to the server with retry. */
+export function queueSongStar(id: string, starred: boolean): void {
+  usePlayerStore.getState().setStarredOverride(id, starred);
+  const t: Task = { kind: 'star', id, starred };
+  const k = keyOf(t);
+  pending.set(k, t);
+  attempts.delete(k);
+  armListeners();
+  schedule(k, 0);
+}
+
+/** Optimistically rate a song and sync it to the server with retry. */
+export function queueSongRating(id: string, rating: number): void {
+  usePlayerStore.getState().setUserRatingOverride(id, rating);
+  const t: Task = { kind: 'rating', id, rating };
+  const k = keyOf(t);
+  pending.set(k, t);
+  attempts.delete(k);
+  armListeners();
+  schedule(k, 0);
+}
+
+/** Test-only: clear all pending state + timers. */
+export function _resetPendingStarSyncForTest(): void {
+  pending.clear();
+  attempts.clear();
+  for (const t of timers.values()) clearTimeout(t);
+  timers.clear();
+}

--- a/src/store/skipStarRating.test.ts
+++ b/src/store/skipStarRating.test.ts
@@ -1,37 +1,30 @@
 /**
- * Skip → 1★ helper: drive each early-return branch + the happy path through
- * the threshold-crossing flow that calls `setRating` and updates the
- * playerStore. Hoisted mocks replace `setRating`, the auth-store helper, and
- * the player-store state surface so the test can drive every input
- * independently.
+ * Skip → 1★ helper: drive each early-return branch + the happy path. The
+ * threshold-crossing case now delegates the rating to `queueSongRating`
+ * (pending-sync, F4) — its optimistic patch + retry behaviour is covered in
+ * `pendingStarSync.test.ts`, so here we only assert the delegation + guards.
  */
 import type { Track } from './playerStoreTypes';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-const { setRatingMock, recordSkipStarMock, playerSetStateMock, playerStateGet } = vi.hoisted(() => {
+const { queueSongRatingMock, recordSkipStarMock, playerStateGet } = vi.hoisted(() => {
   const playerState = {
     queue: [] as Track[],
     currentTrack: null as Track | null,
     userRatingOverrides: {} as Record<string, number>,
   };
   return {
-    setRatingMock: vi.fn(async () => undefined),
+    queueSongRatingMock: vi.fn(),
     recordSkipStarMock: vi.fn(),
-    playerSetStateMock: vi.fn((updater: (s: typeof playerState) => Partial<typeof playerState>) => {
-      Object.assign(playerState, updater(playerState));
-    }),
     playerStateGet: () => playerState,
   };
 });
 
-vi.mock('../api/subsonicStarRating', () => ({ setRating: setRatingMock }));
+vi.mock('./pendingStarSync', () => ({ queueSongRating: queueSongRatingMock }));
 vi.mock('./authStore', () => ({
   useAuthStore: { getState: () => ({ recordSkipStarManualAdvance: recordSkipStarMock }) },
 }));
 vi.mock('./playerStore', () => ({
-  usePlayerStore: {
-    getState: playerStateGet,
-    setState: playerSetStateMock,
-  },
+  usePlayerStore: { getState: playerStateGet },
 }));
 
 import { applySkipStarOnManualNext } from './skipStarRating';
@@ -43,9 +36,8 @@ function track(id: string, overrides: Partial<Track> = {}): Track {
 }
 
 beforeEach(() => {
-  setRatingMock.mockClear();
+  queueSongRatingMock.mockClear();
   recordSkipStarMock.mockReset();
-  playerSetStateMock.mockClear();
   const s = playerStateGet();
   s.queue = [];
   s.currentTrack = null;
@@ -56,7 +48,7 @@ describe('applySkipStarOnManualNext', () => {
   it('is a no-op when manual=false (gapless / natural advance)', () => {
     applySkipStarOnManualNext(track('t1'), false);
     expect(recordSkipStarMock).not.toHaveBeenCalled();
-    expect(setRatingMock).not.toHaveBeenCalled();
+    expect(queueSongRatingMock).not.toHaveBeenCalled();
   });
 
   it('is a no-op when skippedTrack is null', () => {
@@ -68,64 +60,38 @@ describe('applySkipStarOnManualNext', () => {
     recordSkipStarMock.mockReturnValueOnce({ crossedThreshold: false });
     applySkipStarOnManualNext(track('t1'), true);
     expect(recordSkipStarMock).toHaveBeenCalledWith('t1');
-    expect(setRatingMock).not.toHaveBeenCalled();
+    expect(queueSongRatingMock).not.toHaveBeenCalled();
   });
 
   it('handles a null return from recordSkipStarManualAdvance gracefully', () => {
     recordSkipStarMock.mockReturnValueOnce(null);
     expect(() => applySkipStarOnManualNext(track('t1'), true)).not.toThrow();
-    expect(setRatingMock).not.toHaveBeenCalled();
+    expect(queueSongRatingMock).not.toHaveBeenCalled();
   });
 
-  it("skips rating when the track is already rated via the override map", () => {
+  it('skips rating when the track is already rated via the override map', () => {
     recordSkipStarMock.mockReturnValueOnce({ crossedThreshold: true });
     playerStateGet().userRatingOverrides = { t1: 3 };
     applySkipStarOnManualNext(track('t1'), true);
-    expect(setRatingMock).not.toHaveBeenCalled();
+    expect(queueSongRatingMock).not.toHaveBeenCalled();
   });
 
   it('skips rating when the queue entry is already rated', () => {
     recordSkipStarMock.mockReturnValueOnce({ crossedThreshold: true });
     playerStateGet().queue = [track('t1', { userRating: 4 })];
     applySkipStarOnManualNext(track('t1'), true);
-    expect(setRatingMock).not.toHaveBeenCalled();
+    expect(queueSongRatingMock).not.toHaveBeenCalled();
   });
 
   it('skips rating when the passed track is already rated', () => {
     recordSkipStarMock.mockReturnValueOnce({ crossedThreshold: true });
     applySkipStarOnManualNext(track('t1', { userRating: 2 }), true);
-    expect(setRatingMock).not.toHaveBeenCalled();
+    expect(queueSongRatingMock).not.toHaveBeenCalled();
   });
 
-  it('calls setRating(1) when threshold crosses and the track is unrated', async () => {
+  it('delegates to queueSongRating(id, 1) when threshold crosses and the track is unrated', () => {
     recordSkipStarMock.mockReturnValueOnce({ crossedThreshold: true });
     applySkipStarOnManualNext(track('t1'), true);
-    expect(setRatingMock).toHaveBeenCalledWith('t1', 1);
-    await Promise.resolve();
-    expect(playerSetStateMock).toHaveBeenCalledTimes(1);
-    const updated = playerStateGet();
-    expect(updated.userRatingOverrides).toEqual({ t1: 1 });
-  });
-
-  it('updates queue + currentTrack when the skipped track is the current one', async () => {
-    recordSkipStarMock.mockReturnValueOnce({ crossedThreshold: true });
-    const s = playerStateGet();
-    s.queue = [track('t1'), track('t2')];
-    s.currentTrack = s.queue[0];
-    applySkipStarOnManualNext(track('t1'), true);
-    await Promise.resolve();
-    const updated = playerStateGet();
-    expect(updated.queue[0].userRating).toBe(1);
-    expect(updated.queue[1].userRating).toBeUndefined();
-    expect(updated.currentTrack?.userRating).toBe(1);
-  });
-
-  it('swallows setRating rejections silently', async () => {
-    recordSkipStarMock.mockReturnValueOnce({ crossedThreshold: true });
-    setRatingMock.mockRejectedValueOnce(new Error('network down'));
-    expect(() => applySkipStarOnManualNext(track('t1'), true)).not.toThrow();
-    // Drain the rejected microtask
-    await Promise.resolve();
-    await Promise.resolve();
+    expect(queueSongRatingMock).toHaveBeenCalledWith('t1', 1);
   });
 });

--- a/src/store/skipStarRating.ts
+++ b/src/store/skipStarRating.ts
@@ -1,7 +1,7 @@
-import { setRating } from '../api/subsonicStarRating';
 import type { Track } from './playerStoreTypes';
 import { useAuthStore } from './authStore';
 import { usePlayerStore } from './playerStore';
+import { queueSongRating } from './pendingStarSync';
 /**
  * Skip → 1★ behaviour: every user-initiated `next()` on an unrated track
  * counts in `authStore.skipStarManualSkipCountsByKey` (persisted). Once the
@@ -25,13 +25,7 @@ export function applySkipStarOnManualNext(skippedTrack: Track | null, manual: bo
     skippedTrack.userRating ??
     0;
   if (cur >= 1) return;
-  setRating(id, 1)
-    .then(() => {
-      usePlayerStore.setState(s => ({
-        queue: s.queue.map(t => (t.id === id ? { ...t, userRating: 1 } : t)),
-        currentTrack: s.currentTrack?.id === id ? { ...s.currentTrack, userRating: 1 } : s.currentTrack,
-        userRatingOverrides: { ...s.userRatingOverrides, [id]: 1 },
-      }));
-    })
-    .catch(() => {});
+  // F4: optimistic 1★ (patches queue + currentTrack + override) and retried
+  // server sync via the central helper; the override clears on success.
+  queueSongRating(id, 1);
 }


### PR DESCRIPTION
Overrides become session-only outbound sync state, routed through one central helper (R7-18 / spec §6.5) — replacing the scattered optimistic-set + API + rollback logic.

## Summary
- `queueSongStar` / `queueSongRating`: optimistic override → retry the Subsonic API with backoff (flush on `online` / focus) → on success clear the override + patch the in-memory `Track`. F3 index patch-on-use runs inside the API layer, unchanged. No rollback on first failure; latest-wins coalescing + identity guard; not persisted.
- Routed cucadmuh's named v1 surfaces through it: PlayerBar, FullscreenPlayer, MobilePlayerView, both context menus (song + queue row), both shortcut paths, the song-rating hook + player-bar stars, skip→1★, AlbumDetail (song star + rating).
- The 30+ override read sites are unchanged (`override ?? track`); the override now clears on success so reads fall through to the patched track.

## Follow-up (not this PR)
Standalone page toggles (Favorites, RandomMix, NowPlaying star) and the separate mini-player webview keep their existing path — no regression (a non-migrated override lingers as before).

## Test plan
- `tsc --noEmit` clean; `vitest run` green (new `pendingStarSync` tests: success clears override + patches track, no rollback + retry on failure, latest-wins, rating; `skipStarRating` test updated to assert delegation)
- Frontend-only; no Rust / schema / Tauri-boundary change.