### PR TITLE
feat(library): route remaining song star/rating sites through pending-sync (F4 follow-up)

### DIFF
--- a/src/hooks/useNowPlayingStarLove.ts
+++ b/src/hooks/useNowPlayingStarLove.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { star, unstar } from '../api/subsonicStarRating';
+import { queueSongStar } from '../store/pendingStarSync';
 import type { SubsonicSong } from '../api/subsonicTypes';
 import {
   lastfmLoveTrack, lastfmUnloveTrack,
@@ -29,8 +29,9 @@ export function useNowPlayingStarLove(deps: NowPlayingStarLoveDeps): NowPlayingS
   useEffect(() => { setStarred(!!songMeta?.starred); }, [songMeta]);
   const toggleStar = useCallback(async () => {
     if (!currentTrack) return;
-    if (starred) { await unstar(currentTrack.id, 'song'); setStarred(false); }
-    else         { await star(currentTrack.id,   'song'); setStarred(true);  }
+    const next = !starred;
+    setStarred(next); // local view; helper owns the override + retried server sync (no rollback)
+    queueSongStar(currentTrack.id, next);
   }, [currentTrack, starred]);
 
   // Last.fm love (seeded from track.getInfo, toggle via love/unlove)

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -1,4 +1,4 @@
-import { setRating, unstar } from '../api/subsonicStarRating';
+import { queueSongStar, queueSongRating } from '../store/pendingStarSync';
 import type { SubsonicAlbum, SubsonicArtist, SubsonicSong, InternetRadioStation } from '../api/subsonicTypes';
 import { songToTrack } from '../utils/playback/songToTrack';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -93,19 +93,18 @@ export default function Favorites() {
   const previewingId = usePreviewStore(s => s.previewingId);
   const previewAudioStarted = usePreviewStore(s => s.audioStarted);
   const starredOverrides = usePlayerStore(s => s.starredOverrides);
-  const setStarredOverride = usePlayerStore(s => s.setStarredOverride);
   const userRatingOverrides = usePlayerStore(s => s.userRatingOverrides);
   const psyDrag = useDragDrop();
 
   const handleRate = (songId: string, rating: number) => {
     setRatings(r => ({ ...r, [songId]: rating }));
-    usePlayerStore.getState().setUserRatingOverride(songId, rating);
-    setRating(songId, rating).catch(() => {});
+    // F4: optimistic override + retried server sync via the central helper.
+    queueSongRating(songId, rating);
   };
 
   function removeSong(id: string) {
-    unstar(id, 'song').catch(() => {});
-    setStarredOverride(id, false);
+    // F4: optimistic un-star + retried server sync via the central helper.
+    queueSongStar(id, false);
     setSongs(prev => prev.filter(s => s.id !== id));
   }
 

--- a/src/pages/RandomMix.tsx
+++ b/src/pages/RandomMix.tsx
@@ -1,4 +1,4 @@
-import { star, unstar } from '../api/subsonicStarRating';
+import { queueSongStar } from '../store/pendingStarSync';
 import { getGenres } from '../api/subsonicGenres';
 import type { SubsonicSong, SubsonicGenre } from '../api/subsonicTypes';
 import { songToTrack } from '../utils/playback/songToTrack';
@@ -32,7 +32,6 @@ export default function RandomMix() {
   const previewingId = usePreviewStore(s => s.previewingId);
   const previewAudioStarted = usePreviewStore(s => s.audioStarted);
   const starredOverrides = usePlayerStore(s => s.starredOverrides);
-  const setStarredOverride = usePlayerStore(s => s.setStarredOverride);
   const [contextMenuSongId, setContextMenuSongId] = useState<string | null>(null);
   const isMobile = useIsMobile();
   const [starredSongs, setStarredSongs] = useState<Set<string>>(new Set());
@@ -121,23 +120,15 @@ export default function RandomMix() {
     }
   };
 
-  const toggleSongStar = async (song: SubsonicSong, e: React.MouseEvent) => {
+  const toggleSongStar = (song: SubsonicSong, e: React.MouseEvent) => {
     e.stopPropagation();
     const currentlyStarred = song.id in starredOverrides ? starredOverrides[song.id] : starredSongs.has(song.id);
     const nextStarred = new Set(starredSongs);
     if (currentlyStarred) nextStarred.delete(song.id);
     else nextStarred.add(song.id);
     setStarredSongs(nextStarred);
-    setStarredOverride(song.id, !currentlyStarred);
-
-    try {
-      if (currentlyStarred) await unstar(song.id, 'song');
-      else await star(song.id, 'song');
-    } catch (err) {
-      console.error('Failed to toggle song star', err);
-      setStarredSongs(new Set(starredSongs));
-      setStarredOverride(song.id, currentlyStarred);
-    }
+    // F4: optimistic override + retried server sync via the central helper (no rollback).
+    queueSongStar(song.id, !currentlyStarred);
   };
 
   const loadGenreMix = async (genre: string, overrideSize?: number) => {


### PR DESCRIPTION
Follow-up to #833. Routes the three standalone song star/rating sites #833 left untouched onto the central `queueSongStar` / `queueSongRating` helper, so the whole song surface shares one optimistic-override + retry path.

- **Favorites** — `handleRate` + `removeSong` (un-star); drops inline override+API, keeps local `ratings`/list view state.
- **RandomMix** — `toggleSongStar`; drops the local try/catch rollback (no-rollback policy), keeps optimistic set update.
- **useNowPlayingStarLove** — `toggleStar`; keeps local view state, helper owns override + retried sync.
- MiniContextMenu (separate webview) and album/artist paths unchanged.

Test plan: `tsc --noEmit` clean; `vitest run` 104 files / 1016 tests pass.