### PR TITLE
feat(library): route playlist song star/rating through pending-sync (F4 follow-up)

### DIFF
--- a/src/hooks/usePlaylistStarRating.ts
+++ b/src/hooks/usePlaylistStarRating.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { setRating, star, unstar } from '../api/subsonicStarRating';
+import { queueSongStar, queueSongRating } from '../store/pendingStarSync';
 import type { SubsonicSong } from '../api/subsonicTypes';
 import { usePlayerStore } from '../store/playerStore';
 
@@ -18,12 +18,11 @@ export interface PlaylistStarRatingActions {
 export function usePlaylistStarRating(deps: PlaylistStarRatingDeps): PlaylistStarRatingActions {
   const { setRatings, starredSongs, setStarredSongs } = deps;
   const starredOverrides = usePlayerStore(s => s.starredOverrides);
-  const setStarredOverride = usePlayerStore(s => s.setStarredOverride);
 
   const handleRate = (songId: string, rating: number) => {
     setRatings(prev => ({ ...prev, [songId]: rating }));
-    usePlayerStore.getState().setUserRatingOverride(songId, rating);
-    setRating(songId, rating).catch(() => {});
+    // F4: optimistic override + retried server sync via the central helper.
+    queueSongRating(songId, rating);
   };
 
   const handleToggleStar = (song: SubsonicSong, e: React.MouseEvent) => {
@@ -34,8 +33,8 @@ export function usePlaylistStarRating(deps: PlaylistStarRatingDeps): PlaylistSta
       isStarred ? next.delete(song.id) : next.add(song.id);
       return next;
     });
-    setStarredOverride(song.id, !isStarred);
-    (isStarred ? unstar(song.id, 'song') : star(song.id, 'song')).catch(() => {});
+    // F4: optimistic override + retried server sync via the central helper (no rollback).
+    queueSongStar(song.id, !isStarred);
   };
 
   return { handleRate, handleToggleStar };


### PR DESCRIPTION
Follow-up to #834. The playlist-detail `usePlaylistStarRating` hook was the last shared-store song write site still hitting the Subsonic API directly; route it through the central `queueSongStar` / `queueSongRating` helper.

- `handleRate` + `handleToggleStar` now go through the helper (optimistic override + retry, no rollback); local `ratings`/`starredSongs` view state kept.
- MiniContextMenu (separate webview) stays on its direct path — now the only direct song path; album/artist paths unchanged (v1 = songs only).

Test plan: `tsc --noEmit` clean; `vitest run pendingStarSync` passes.