### PR TITLE
feat(library): BPM range filter UI in Advanced Search (PR-7 F6)

### DIFF
--- a/src/locales/de/search.ts
+++ b/src/locales/de/search.ts
@@ -17,6 +17,7 @@ export const search = {
   advancedYear: 'Jahr',
   advancedYearFrom: 'von',
   advancedYearTo: 'bis',
+  advancedBpm: 'BPM',
   advancedAll: 'Alle',
   advancedSearch: 'Suchen',
   advancedEmpty: 'Suchbegriff eingeben oder Filter wählen, um zu beginnen.',

--- a/src/locales/en/search.ts
+++ b/src/locales/en/search.ts
@@ -17,6 +17,7 @@ export const search = {
   advancedYear: 'Year',
   advancedYearFrom: 'from',
   advancedYearTo: 'to',
+  advancedBpm: 'BPM',
   advancedAll: 'All',
   advancedSearch: 'Search',
   advancedEmpty: 'Enter a search term or select a filter to begin.',

--- a/src/locales/es/search.ts
+++ b/src/locales/es/search.ts
@@ -17,6 +17,7 @@ export const search = {
   advancedYear: 'Año',
   advancedYearFrom: 'desde',
   advancedYearTo: 'hasta',
+  advancedBpm: 'BPM',
   advancedAll: 'Todos',
   advancedSearch: 'Buscar',
   advancedEmpty: 'Ingresa un término de búsqueda o selecciona un filtro para comenzar.',

--- a/src/locales/fr/search.ts
+++ b/src/locales/fr/search.ts
@@ -17,6 +17,7 @@ export const search = {
   advancedYear: 'Année',
   advancedYearFrom: 'de',
   advancedYearTo: 'à',
+  advancedBpm: 'BPM',
   advancedAll: 'Tous',
   advancedSearch: 'Rechercher',
   advancedEmpty: 'Entrez un terme de recherche ou sélectionnez un filtre.',

--- a/src/locales/nb/search.ts
+++ b/src/locales/nb/search.ts
@@ -17,6 +17,7 @@ export const search = {
   advancedYear: 'År',
   advancedYearFrom: 'fra',
   advancedYearTo: 'til',
+  advancedBpm: 'BPM',
   advancedAll: 'Alle',
   advancedSearch: 'Søk',
   advancedEmpty: 'Skriv inn et søkeord eller velg ett filter for å begynne.',

--- a/src/locales/nl/search.ts
+++ b/src/locales/nl/search.ts
@@ -17,6 +17,7 @@ export const search = {
   advancedYear: 'Jaar',
   advancedYearFrom: 'van',
   advancedYearTo: 'tot',
+  advancedBpm: 'BPM',
   advancedAll: 'Alle',
   advancedSearch: 'Zoeken',
   advancedEmpty: 'Voer een zoekterm in of selecteer een filter.',

--- a/src/locales/ro/search.ts
+++ b/src/locales/ro/search.ts
@@ -17,6 +17,7 @@ export const search = {
   advancedYear: 'An',
   advancedYearFrom: 'de la',
   advancedYearTo: 'până la',
+  advancedBpm: 'BPM',
   advancedAll: 'Toate',
   advancedSearch: 'Căutare',
   advancedEmpty: 'Introdu un termen de căutare sau alege un filtru pentru a începe',

--- a/src/locales/ru/search.ts
+++ b/src/locales/ru/search.ts
@@ -17,6 +17,7 @@ export const search = {
   advancedYear: 'Год',
   advancedYearFrom: 'от',
   advancedYearTo: 'до',
+  advancedBpm: 'BPM',
   advancedAll: 'Все',
   advancedSearch: 'Найти',
   advancedEmpty: 'Введите запрос или выберите фильтр.',

--- a/src/locales/zh/search.ts
+++ b/src/locales/zh/search.ts
@@ -17,6 +17,7 @@ export const search = {
   advancedYear: '年份',
   advancedYearFrom: '从',
   advancedYearTo: '至',
+  advancedBpm: 'BPM',
   advancedAll: '全部',
   advancedSearch: '搜索',
   advancedEmpty: '请输入搜索词或选择过滤器。',

--- a/src/pages/AdvancedSearch.tsx
+++ b/src/pages/AdvancedSearch.tsx
@@ -22,6 +22,8 @@ interface SearchOpts {
   genre: string;
   yearFrom: string;
   yearTo: string;
+  bpmFrom: string;
+  bpmTo: string;
   resultType: ResultType;
 }
 
@@ -39,6 +41,8 @@ export default function AdvancedSearch() {
   const [genre, setGenre] = useState('');
   const [yearFrom, setYearFrom] = useState('');
   const [yearTo, setYearTo] = useState('');
+  const [bpmFrom, setBpmFrom] = useState('');
+  const [bpmTo, setBpmTo] = useState('');
   const [resultType, setResultType] = useState<ResultType>('all');
   const [starredOnly, setStarredOnly] = useState(false);
   const [genres, setGenres] = useState<SubsonicGenre[]>([]);
@@ -81,11 +85,15 @@ export default function AdvancedSearch() {
     g: string,
     from: number | null,
     to: number | null,
+    bpmFromN: number | null,
+    bpmToN: number | null,
   ): SubsonicSong[] => {
     let r = list;
     if (g) r = r.filter(s => s.genre?.toLowerCase() === g.toLowerCase());
     if (from !== null) r = r.filter(s => !s.year || s.year >= from);
     if (to !== null) r = r.filter(s => !s.year || s.year <= to);
+    if (bpmFromN !== null) r = r.filter(s => !s.bpm || s.bpm >= bpmFromN);
+    if (bpmToN !== null) r = r.filter(s => !s.bpm || s.bpm <= bpmToN);
     return r;
   };
 
@@ -115,9 +123,11 @@ export default function AdvancedSearch() {
     }
     setLocalMode(false);
 
-    const { query: q, genre: g, yearFrom: yf, yearTo: yt, resultType: rt } = opts;
+    const { query: q, genre: g, yearFrom: yf, yearTo: yt, bpmFrom: bf, bpmTo: bt, resultType: rt } = opts;
     const from = yf ? parseInt(yf) : null;
     const to = yt ? parseInt(yt) : null;
+    const bpmFromN = bf ? parseInt(bf) : null;
+    const bpmToN = bt ? parseInt(bt) : null;
 
     let artists: SubsonicArtist[] = [];
     let albums: SubsonicAlbum[] = [];
@@ -128,7 +138,7 @@ export default function AdvancedSearch() {
         const r = await search(q.trim(), { artistCount: 30, albumCount: 50, songCount: SONGS_INITIAL });
         artists = r.artists;
         albums = r.albums;
-        songs = applySongFilters(r.songs, g, from, to);
+        songs = applySongFilters(r.songs, g, from, to, bpmFromN, bpmToN);
 
         if (g) {
           albums = albums.filter(a => a.genre?.toLowerCase() === g.toLowerCase());
@@ -175,7 +185,7 @@ export default function AdvancedSearch() {
     getGenres().then(data =>
       setGenres(data.sort((a, b) => a.value.localeCompare(b.value)))
     ).catch(() => {});
-    if (qFromUrl) runSearch({ query: qFromUrl, genre: '', yearFrom: '', yearTo: '', resultType: 'all' });
+    if (qFromUrl) runSearch({ query: qFromUrl, genre: '', yearFrom: '', yearTo: '', bpmFrom: '', bpmTo: '', resultType: 'all' });
   }, [musicLibraryFilterVersion, qFromUrl]);
 
   const loadMoreSongs = useCallback(async () => {
@@ -205,8 +215,10 @@ export default function AdvancedSearch() {
       const g = activeSearch.genre;
       const from = activeSearch.yearFrom ? parseInt(activeSearch.yearFrom) : null;
       const to = activeSearch.yearTo ? parseInt(activeSearch.yearTo) : null;
+      const bpmFromN = activeSearch.bpmFrom ? parseInt(activeSearch.bpmFrom) : null;
+      const bpmToN = activeSearch.bpmTo ? parseInt(activeSearch.bpmTo) : null;
       const page = await searchSongsPaged(q, SONGS_PAGE_SIZE, songsServerOffset);
-      const filtered = applySongFilters(page, g, from, to);
+      const filtered = applySongFilters(page, g, from, to, bpmFromN, bpmToN);
       setResults(prev => prev ? { ...prev, songs: [...prev.songs, ...filtered] } : prev);
       setSongsServerOffset(o => o + page.length);
       // No more pages when the server returned a non-full page (regardless of how many survived filtering).
@@ -231,7 +243,7 @@ export default function AdvancedSearch() {
 
   const handleSubmit = (e?: React.FormEvent) => {
     e?.preventDefault();
-    runSearch({ query, genre, yearFrom, yearTo, resultType });
+    runSearch({ query, genre, yearFrom, yearTo, bpmFrom, bpmTo, resultType });
   };
 
   const typeOptions: { id: ResultType; label: string }[] = [
@@ -310,6 +322,29 @@ export default function AdvancedSearch() {
                 max={new Date().getFullYear()}
                 value={yearTo}
                 onChange={e => setYearTo(e.target.value)}
+                placeholder={t('search.advancedYearTo')}
+                style={{ width: 96 }}
+              />
+
+              <span style={{ fontSize: 13, color: 'var(--text-muted)', marginLeft: '0.75rem', flexShrink: 0 }}>
+                {t('search.advancedBpm')}
+              </span>
+              <input
+                className="input"
+                type="number"
+                min={0}
+                value={bpmFrom}
+                onChange={e => setBpmFrom(e.target.value)}
+                placeholder={t('search.advancedYearFrom')}
+                style={{ width: 96 }}
+              />
+              <span style={{ color: 'var(--text-muted)', fontSize: 14 }}>–</span>
+              <input
+                className="input"
+                type="number"
+                min={0}
+                value={bpmTo}
+                onChange={e => setBpmTo(e.target.value)}
                 placeholder={t('search.advancedYearTo')}
                 style={{ width: 96 }}
               />

--- a/src/utils/library/advancedSearchLocal.test.ts
+++ b/src/utils/library/advancedSearchLocal.test.ts
@@ -8,6 +8,8 @@ const opts = (over: Partial<Parameters<typeof runLocalAdvancedSearch>[1]> = {}) 
   genre: '',
   yearFrom: '',
   yearTo: '',
+  bpmFrom: '',
+  bpmTo: '',
   resultType: 'all' as const,
   ...over,
 });

--- a/src/utils/library/advancedSearchLocal.ts
+++ b/src/utils/library/advancedSearchLocal.ts
@@ -30,6 +30,8 @@ export interface LocalSearchOpts {
   genre: string;
   yearFrom: string;
   yearTo: string;
+  bpmFrom: string;
+  bpmTo: string;
   resultType: AdvancedResultType;
 }
 
@@ -68,6 +70,15 @@ function buildFilters(opts: LocalSearchOpts): LibraryFilterClause[] {
     filters.push({ field: 'year', op: 'gte', value: from });
   } else if (to !== null) {
     filters.push({ field: 'year', op: 'lte', value: to });
+  }
+  const bpmFrom = opts.bpmFrom ? parseInt(opts.bpmFrom, 10) : null;
+  const bpmTo = opts.bpmTo ? parseInt(opts.bpmTo, 10) : null;
+  if (bpmFrom !== null && bpmTo !== null) {
+    filters.push({ field: 'bpm', op: 'between', value: bpmFrom, valueTo: bpmTo });
+  } else if (bpmFrom !== null) {
+    filters.push({ field: 'bpm', op: 'gte', value: bpmFrom });
+  } else if (bpmTo !== null) {
+    filters.push({ field: 'bpm', op: 'lte', value: bpmTo });
   }
   return filters;
 }


### PR DESCRIPTION
PR-7 **F6** — optional BPM range filter UI in Advanced Search. Deferred post-v1 in R7-18; pulled forward.

## What
- BPM range (two number inputs) inline next to the Year filter in `AdvancedSearch.tsx`.
- Local index path: `buildFilters` maps BPM to the normative clause `{ field:'bpm', op:'between'|'gte'|'lte', value, valueTo }` (§5.13.2 / R7-18) — full SQL filtering via the index.
- Network fallback: client-side BPM filter mirroring the existing `year` behaviour (free-text path + pagination; not applied on the genre/year-only network path — same limitation `year` already has).
- i18n: `advancedBpm` ('BPM') in all 9 locales.

## Verify
- `npm run build` (tsc + vite): green
- `advancedSearchLocal.test.ts`: 9/9
