### PR TITLE
fix(settings): remove plaintext password reveal from server/user forms

### DIFF
--- a/src/components/settings/AddServerForm.tsx
+++ b/src/components/settings/AddServerForm.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Eye, EyeOff } from 'lucide-react';
 import type { ServerProfile } from '../../store/authStoreTypes';
 import { showToast } from '../../utils/ui/toast';
 import {
@@ -30,12 +29,10 @@ export function AddServerForm({
       : { name: '', url: '', username: '', password: '' },
   );
   const [magicString, setMagicString] = useState('');
-  const [showPass, setShowPass] = useState(false);
   const [blockPasswordReveal, setBlockPasswordReveal] = useState(false);
 
   useEffect(() => {
     if (!initialInvite) return;
-    setShowPass(false);
     setBlockPasswordReveal(true);
     setForm({
       name: (initialInvite.name && initialInvite.name.trim()) || shortHostFromServerUrl(initialInvite.url),
@@ -55,7 +52,6 @@ export function AddServerForm({
     const trimmed = v.trim();
     const decoded = decodeServerMagicString(trimmed);
     if (decoded) {
-      setShowPass(false);
       setBlockPasswordReveal(true);
       setForm({
         name: (decoded.name && decoded.name.trim()) || shortHostFromServerUrl(decoded.url),
@@ -135,23 +131,13 @@ export function AddServerForm({
               style={{ letterSpacing: '0.12em', cursor: 'default' }}
             />
           ) : (
-            <div style={{ position: 'relative' }}>
-              <input
-                className="input"
-                type={showPass ? 'text' : 'password'}
-                value={form.password}
-                onChange={update('password')}
-                placeholder="••••••••"
-                style={{ paddingRight: '2.5rem' }}
-              />
-              <button
-                type="button"
-                style={{ position: 'absolute', right: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }}
-                onClick={() => setShowPass(v => !v)}
-              >
-                {showPass ? <EyeOff size={14} /> : <Eye size={14} />}
-              </button>
-            </div>
+            <input
+              className="input"
+              type="password"
+              value={form.password}
+              onChange={update('password')}
+              placeholder="••••••••"
+            />
           )}
         </div>
       </div>

--- a/src/components/settings/UserForm.tsx
+++ b/src/components/settings/UserForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Eye, EyeOff, Shield, Wand2 } from 'lucide-react';
+import { Shield, Wand2 } from 'lucide-react';
 import { ndUpdateUser, type NdLibrary, type NdUser } from '../../api/navidromeAdmin';
 import { showToast } from '../../utils/ui/toast';
 import {
@@ -54,7 +54,6 @@ export function UserForm({
 }) {
   const { t } = useTranslation();
   const [form, setForm] = useState<UserFormState>(() => initialUserFormState(initial ?? undefined, libraries));
-  const [showPass, setShowPass] = useState(false);
   const [magicGenBusy, setMagicGenBusy] = useState(false);
   const [showNewUserRequiredErrors, setShowNewUserRequiredErrors] = useState(false);
   const isEdit = !!initial;
@@ -206,28 +205,16 @@ export function UserForm({
           {t('settings.userMgmtPassword')}
           {!isEdit && <span style={{ color: 'var(--text-muted)' }}> *</span>}
         </label>
-        <div style={{ position: 'relative' }}>
-          <input
-            className="input"
-            type={showPass ? 'text' : 'password'}
-            value={form.password}
-            onChange={e => set('password', e.target.value)}
-            placeholder="••••••••"
-            autoComplete="new-password"
-            aria-invalid={markInvalid && !form.password.trim()}
-            style={{
-              paddingRight: '2.5rem',
-              ...(markInvalid && !form.password.trim() ? { borderColor: 'var(--danger)' } : {}),
-            }}
-          />
-          <button
-            type="button"
-            style={{ position: 'absolute', right: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }}
-            onClick={() => setShowPass(v => !v)}
-          >
-            {showPass ? <EyeOff size={14} /> : <Eye size={14} />}
-          </button>
-        </div>
+        <input
+          className="input"
+          type="password"
+          value={form.password}
+          onChange={e => set('password', e.target.value)}
+          placeholder="••••••••"
+          autoComplete="new-password"
+          aria-invalid={markInvalid && !form.password.trim()}
+          style={markInvalid && !form.password.trim() ? { borderColor: 'var(--danger)' } : undefined}
+        />
         {isEdit && (
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 4 }}>
             {t('settings.userMgmtPasswordEditHint')}


### PR DESCRIPTION
Removes the show-password (eye) toggle from the server and user forms so a stored password is never revealed in plaintext.

## What
- `AddServerForm`: eye toggle removed (add + edit); password field is always `type="password"`, still editable.
- `UserForm`: eye toggle removed for consistency.
- Login is unchanged — the user types their own password there, nothing stored is revealed.

## Why
The edit-server form pre-fills the stored password (`editingServer.password`); the eye revealed that saved secret in plaintext. Flagged by cucadmuh.

## Verify
- `npm run build` (tsc + vite): green
