### PR TITLE
fix(album): bulk "add to playlist" no longer wipes the selection (#842)

### DIFF
--- a/src/hooks/useAlbumTrackListSelection.ts
+++ b/src/hooks/useAlbumTrackListSelection.ts
@@ -20,7 +20,8 @@ interface UseAlbumTrackListSelectionResult {
 /**
  * Bulk selection + drag wiring for `AlbumTrackList`:
  *  - Clears selection whenever the song list changes (album switch or
- *    filter applied) and on mousedown outside the tracklist.
+ *    filter applied) and on mousedown outside the tracklist — but not when
+ *    the click lands on the bulk-action toolbar, which belongs to the selection.
  *  - `onToggleSelect` supports shift-click ranges anchored against the
  *    last toggled row.
  *  - `onDragStart` promotes a single-row drag into a multi-row drag when
@@ -48,9 +49,14 @@ export function useAlbumTrackListSelection({
   useEffect(() => {
     if (!inSelectMode) return;
     const handler = (e: MouseEvent) => {
-      if (tracklistRef.current && !tracklistRef.current.contains(e.target as Node)) {
-        useSelectionStore.getState().clearAll();
-      }
+      const target = e.target as HTMLElement;
+      if (!tracklistRef.current || tracklistRef.current.contains(target)) return;
+      // The bulk-action toolbar (filter, add-to-playlist picker, clear button)
+      // renders outside the tracklist DOM but belongs to the selection — a
+      // mousedown there must not wipe the selection before the button's own
+      // click handler runs (otherwise "Add to playlist" clears and never opens).
+      if (target.closest('.album-track-toolbar')) return;
+      useSelectionStore.getState().clearAll();
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);


### PR DESCRIPTION
Fixes #842 — in an album view, selecting tracks and clicking the bulk "Add to playlist" button cleared the selection and never opened the picker.

## Summary
- The selection's outside-click handler cleared on every mousedown outside `.tracklist`, and the bulk toolbar is a DOM sibling of it
- Clicking the button fired mousedown → `clearAll()` → toolbar unmounted before the `onClick` could open the picker
- Skip the clear when the mousedown lands inside `.album-track-toolbar` (filter, picker, clear button)
- Clicks elsewhere (header, empty page) still clear as before

## Test plan
- `npm run build` (tsc + bundle) clean
- Album view: select tracks → click "Add to playlist" → selection stays, picker opens, tracks add; clicking outside the toolbar still clears