### PR TITLE
docs(changelog): drop removed scan triggers, add bulk add-to-playlist fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-### Servers — scan triggers + edit existing profiles
+### Servers — edit existing profiles
 
 **By [@Psychotoxical](https://github.com/Psychotoxical), PR [#780](https://github.com/Psychotoxical/psysonic/pull/780)**
 
-* Quick/Full Scan buttons on each server card and in the switcher dropdown (Full needs a two-step confirm).
 * Pencil button opens an inline edit form prefilled with the existing profile. Card actions collapse to icon-only on narrow viewports so Edit/Delete stay reachable.
 
 
@@ -71,6 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#785](https://github.com/Psychotoxical/psysonic/pull/785)**
 
 * **Lucky Mix after server switch:** starting a mix on the browsed server no longer spams cross-server enqueue errors — unpinned or foreign queues hand off cleanly before batch enqueue.
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#844](https://github.com/Psychotoxical/psysonic/pull/844)**
+
+* **Album view:** bulk "Add to playlist" no longer clears the track selection without opening the playlist picker.
 
 
 


### PR DESCRIPTION
Tidies the unreleased 1.47.0 block.

## Summary
- Drop the server-card Quick/Full scan line from #780 — those buttons were removed before release (#843); the edit-existing-profile half stays
- Add the album bulk "Add to playlist" selection fix (#844) under Fixed