### PR TITLE
fix(statistics): keep player stats tab visible without local index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Statistics — player stats tab without local index
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#851](https://github.com/Psychotoxical/psysonic/pull/851)**
+
+* **Statistics → Player stats** tab stays visible when the local library index is off; an info notice explains that player statistics require the index and links to **Settings → Library**.
+
+
+
 ## [1.46.0] - 2026-05-18
 
 > **🙏 Special thanks to [@zz5zz](https://github.com/zz5zz)** for his tireless quirk-spotting and bug reports on the [Psysonic Discord](https://discord.gg/AMnDRErm4u) — several of the polish fixes in this release landed directly off the back of his messages.

--- a/src/components/statistics/PlayerStatisticsPanel.tsx
+++ b/src/components/statistics/PlayerStatisticsPanel.tsx
@@ -9,7 +9,9 @@ import {
   type PlaySessionYearSummary,
 } from '../../api/library';
 import { usePlayerStatsLiveRefresh } from '../../hooks/usePlayerStatsLiveRefresh';
+import { usePlayerStatsRecordingEnabled } from '../../hooks/usePlayerStatsRecordingEnabled';
 import PlayerStatsHeatmap from './PlayerStatsHeatmap';
+import PlayerStatsIndexRequiredNotice from './PlayerStatsIndexRequiredNotice';
 import PlayerStatsPartialIndexNotice from './PlayerStatsPartialIndexNotice';
 import PlayerStatsRecentDays from './PlayerStatsRecentDays';
 import { formatPlayerStatsListeningTotal } from '../../utils/format/formatHumanDuration';
@@ -18,6 +20,7 @@ const currentCalendarYear = () => new Date().getFullYear();
 
 export default function PlayerStatisticsPanel() {
   const { t } = useTranslation();
+  const recordingEnabled = usePlayerStatsRecordingEnabled();
   const [year, setYear] = useState(currentCalendarYear);
   const [yearBounds, setYearBounds] = useState<PlaySessionYearBounds | null>(null);
   const [summary, setSummary] = useState<PlaySessionYearSummary | null>(null);
@@ -28,6 +31,13 @@ export default function PlayerStatisticsPanel() {
   const [liveRefreshKey, setLiveRefreshKey] = useState(0);
 
   useEffect(() => {
+    if (!recordingEnabled) {
+      setLoading(false);
+      setSummary(null);
+      setDayCounts(new Map());
+      setSelectedDate(null);
+      return;
+    }
     let cancelled = false;
     setLoading(true);
     setSelectedDate(null);
@@ -52,9 +62,10 @@ export default function PlayerStatisticsPanel() {
         }
       });
     return () => { cancelled = true; };
-  }, [year]);
+  }, [year, recordingEnabled]);
 
   const refreshLive = useCallback(async () => {
+    if (!recordingEnabled) return;
     try {
       const [s, heat] = await Promise.all([
         libraryGetPlayerStatsYearSummary(year),
@@ -66,9 +77,17 @@ export default function PlayerStatisticsPanel() {
     } catch {
       /* ignore transient read errors during live refresh */
     }
-  }, [year]);
+  }, [year, recordingEnabled]);
 
   usePlayerStatsLiveRefresh(refreshLive);
+
+  if (!recordingEnabled) {
+    return (
+      <div className="stats-page">
+        <PlayerStatsIndexRequiredNotice />
+      </div>
+    );
+  }
 
   const empty = !loading && (summary?.trackPlayCount ?? 0) === 0;
   const calYear = currentCalendarYear();

--- a/src/components/statistics/PlayerStatsIndexRequiredNotice.tsx
+++ b/src/components/statistics/PlayerStatsIndexRequiredNotice.tsx
@@ -1,0 +1,25 @@
+import { Info } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+export default function PlayerStatsIndexRequiredNotice() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  return (
+    <div className="settings-hint settings-hint-info player-stats-partial-index-notice" role="status">
+      <Info size={16} aria-hidden style={{ flexShrink: 0, marginTop: 2 }} />
+      <span>
+        {t('statistics.playerIndexRequired')}
+        {' '}
+        <button
+          type="button"
+          className="player-stats-partial-index-link"
+          onClick={() => navigate('/settings', { state: { tab: 'library' } })}
+        >
+          {t('statistics.playerPartialIndexSettings')}
+        </button>
+      </span>
+    </div>
+  );
+}

--- a/src/components/statistics/StatisticsTabBar.tsx
+++ b/src/components/statistics/StatisticsTabBar.tsx
@@ -1,19 +1,10 @@
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useAuthStore } from '../../store/authStore';
-import { useLibraryIndexStore } from '../../store/libraryIndexStore';
 
 export default function StatisticsTabBar() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
-  const servers = useAuthStore(s => s.servers);
-  const masterEnabled = useLibraryIndexStore(s => s.masterEnabled);
-  const syncExcludedByServer = useLibraryIndexStore(s => s.syncExcludedByServer);
-
-  const showPlayerTab =
-    masterEnabled && servers.some(s => syncExcludedByServer[s.id] !== true);
-  if (!showPlayerTab) return null;
 
   const isPlayer = location.pathname === '/player-stats';
 

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -125,8 +125,6 @@ const CONTRIBUTOR_ENTRIES = [
       'Local library index: multi-server settings UI, serial sync queue, music-library-scoped local search, parallel initial ingest, i18n across 9 locales (PR #846)',
       'Library browse: local-vs-network text search race, All Albums/Artists catalog from index, DevTools browse-race logging (PR #847)',
       'Player stats: local listening history tab with heatmap, year summary, recent days, and day drill-down (PR #849)',
-      'Settings → Library: exclude/include index buttons show busy state and block repeat clicks (PR #850)',
-      'Statistics → Player stats: tab stays visible without local index; notice links to library settings (PR #851)',
     ],
   },
   {

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -126,6 +126,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Library browse: local-vs-network text search race, All Albums/Artists catalog from index, DevTools browse-race logging (PR #847)',
       'Player stats: local listening history tab with heatmap, year summary, recent days, and day drill-down (PR #849)',
       'Settings → Library: exclude/include index buttons show busy state and block repeat clicks (PR #850)',
+      'Statistics → Player stats: tab stays visible without local index; notice links to library settings (PR #851)',
     ],
   },
   {

--- a/src/hooks/usePlayerStatsRecordingEnabled.ts
+++ b/src/hooks/usePlayerStatsRecordingEnabled.ts
@@ -1,0 +1,10 @@
+import { useAuthStore } from '../store/authStore';
+import { useLibraryIndexStore } from '../store/libraryIndexStore';
+
+/** True when local play history is recorded (master index on + ≥1 server included). */
+export function usePlayerStatsRecordingEnabled(): boolean {
+  const servers = useAuthStore(s => s.servers);
+  const masterEnabled = useLibraryIndexStore(s => s.masterEnabled);
+  const syncExcludedByServer = useLibraryIndexStore(s => s.syncExcludedByServer);
+  return masterEnabled && servers.some(s => syncExcludedByServer[s.id] !== true);
+}

--- a/src/locales/de/statistics.ts
+++ b/src/locales/de/statistics.ts
@@ -74,6 +74,7 @@ export const statistics = {
   playerSummaryUniqueTracks: 'Einzigartige Titel',
   playerSummaryDays: 'Days',
   playerPartialIndexNotice: 'Einige Server sind vom lokalen Bibliotheksindex ausgeschlossen. Wiedergaben auf diesen Servern werden nicht in der Player-Statistik erfasst.',
+  playerIndexRequired: 'Player-Statistiken sind erst verfügbar, wenn der lokale Bibliotheksindex aktiviert ist.',
   playerPartialIndexSettings: 'Bibliothekseinstellungen',
   playerSummaryCompletion: 'Voll / teilweise',
   playerYearPrev: 'Vorheriges Jahr',

--- a/src/locales/en/statistics.ts
+++ b/src/locales/en/statistics.ts
@@ -74,6 +74,7 @@ export const statistics = {
   playerSummaryUniqueTracks: 'Unique tracks',
   playerSummaryDays: 'Days',
   playerPartialIndexNotice: 'Some servers are excluded from the local library index. Listening on those servers is not recorded in player statistics.',
+  playerIndexRequired: 'Player statistics are not available until you enable the local library index.',
   playerPartialIndexSettings: 'Library settings',
   playerSummaryCompletion: 'Full / partial',
   playerYearPrev: 'Previous year',

--- a/src/locales/es/statistics.ts
+++ b/src/locales/es/statistics.ts
@@ -56,6 +56,7 @@ export const statistics = {
   playerSummaryUniqueTracks: 'Pistas únicas',
   playerSummaryDays: 'Days',
   playerPartialIndexNotice: 'Algunos servidores están excluidos del índice local de biblioteca. La escucha en esos servidores no se registra en las estadísticas del reproductor.',
+  playerIndexRequired: 'Las estadísticas del reproductor no están disponibles hasta que actives el índice local de biblioteca.',
   playerPartialIndexSettings: 'Ajustes de biblioteca',
   playerSummaryCompletion: 'Completas / parciales',
   playerYearPrev: 'Año anterior',

--- a/src/locales/fr/statistics.ts
+++ b/src/locales/fr/statistics.ts
@@ -56,6 +56,7 @@ export const statistics = {
   playerSummaryUniqueTracks: 'Morceaux uniques',
   playerSummaryDays: 'Days',
   playerPartialIndexNotice: 'Certains serveurs sont exclus de l’index local de bibliothèque. L’écoute sur ces serveurs n’est pas enregistrée dans les statistiques du lecteur.',
+  playerIndexRequired: 'Les statistiques du lecteur ne sont pas disponibles tant que l’index local de bibliothèque n’est pas activé.',
   playerPartialIndexSettings: 'Paramètres bibliothèque',
   playerSummaryCompletion: 'Complets / partiels',
   playerYearPrev: 'Année précédente',

--- a/src/locales/nb/statistics.ts
+++ b/src/locales/nb/statistics.ts
@@ -56,6 +56,7 @@ export const statistics = {
   playerSummaryUniqueTracks: 'Unike spor',
   playerSummaryDays: 'Days',
   playerPartialIndexNotice: 'Noen servere er ekskludert fra det lokale biblioteksindeks. Lytting på disse serverne registreres ikke i spillerstatistikken.',
+  playerIndexRequired: 'Spillerstatistikk er ikke tilgjengelig før du aktiverer det lokale biblioteksindeks.',
   playerPartialIndexSettings: 'Bibliotekinnstillinger',
   playerSummaryCompletion: 'Full / delvis',
   playerYearPrev: 'Forrige år',

--- a/src/locales/nl/statistics.ts
+++ b/src/locales/nl/statistics.ts
@@ -56,6 +56,7 @@ export const statistics = {
   playerSummaryUniqueTracks: 'Unieke nummers',
   playerSummaryDays: 'Days',
   playerPartialIndexNotice: 'Sommige servers zijn uitgesloten van de lokale bibliotheekindex. Luisteren op die servers wordt niet vastgelegd in de playerstatistieken.',
+  playerIndexRequired: 'Playerstatistieken zijn niet beschikbaar totdat je de lokale bibliotheekindex inschakelt.',
   playerPartialIndexSettings: 'Bibliotheekinstellingen',
   playerSummaryCompletion: 'Volledig / gedeeltelijk',
   playerYearPrev: 'Vorig jaar',

--- a/src/locales/ro/statistics.ts
+++ b/src/locales/ro/statistics.ts
@@ -74,6 +74,7 @@ export const statistics = {
   playerSummaryUniqueTracks: 'Piese unice',
   playerSummaryDays: 'Days',
   playerPartialIndexNotice: 'Unele servere sunt excluse din indexul local al bibliotecii. Ascultarea pe aceste servere nu este înregistrată în statisticile playerului.',
+  playerIndexRequired: 'Statisticile playerului nu sunt disponibile până când activezi indexul local al bibliotecii.',
   playerPartialIndexSettings: 'Setări bibliotecă',
   playerSummaryCompletion: 'Complete / parțiale',
   playerYearPrev: 'Anul anterior',

--- a/src/locales/ru/statistics.ts
+++ b/src/locales/ru/statistics.ts
@@ -67,6 +67,7 @@ export const statistics = {
   playerSummaryUniqueTracks: 'Уникальные треки',
   playerSummaryDays: 'Days',
   playerPartialIndexNotice: 'Не все серверы включены в локальный индекс библиотеки. Прослушивание с выключенных серверов не попадает в эту статистику.',
+  playerIndexRequired: 'Статистика плеера недоступна, пока не включён локальный индекс библиотеки.',
   playerPartialIndexSettings: 'Настройки библиотеки',
   playerSummaryCompletion: 'Полные / частичные',
   playerYearPrev: 'Предыдущий год',

--- a/src/locales/zh/statistics.ts
+++ b/src/locales/zh/statistics.ts
@@ -56,6 +56,7 @@ export const statistics = {
   playerSummaryUniqueTracks: '独立曲目',
   playerSummaryDays: 'Days',
   playerPartialIndexNotice: '部分服务器未纳入本地库索引，在这些服务器上的收听不会计入播放器统计。',
+  playerIndexRequired: '启用本地库索引后才会显示播放器统计。',
   playerPartialIndexSettings: '库设置',
   playerSummaryCompletion: '完整 / 部分',
   playerYearPrev: '上一年',


### PR DESCRIPTION
## Summary
- Always show the **Player stats** tab on the Statistics page, even when the local library index is off or all servers are excluded from sync.
- When recording is unavailable, show an info notice with a link to **Settings → Library** instead of hiding the tab or loading empty stats.
- Extract `usePlayerStatsRecordingEnabled` so tab visibility and panel gating share the same rule.

## Test plan
- [ ] With local library index **disabled**, open Statistics → **Player stats**: tab is visible; notice explains index is required; link opens Library settings.
- [ ] Enable local index with at least one included server: heatmap and summaries load as before.
- [ ] Partial index (some servers excluded): partial-index notice still appears above stats when data is available.
- [ ] `npx tsc --noEmit` passes.