### PR TITLE
refactor(queue): wire queue UI to the track resolver (thin-state phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Queue — panel now reads through the shared track cache
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#860](https://github.com/Psychotoxical/psysonic/pull/860)**
+
+* The queue panel sources its row details through the on-demand track cache, another step toward keeping multi-thousand-track queues light on memory. No visible change.
+
+
+
 ## Fixed
 
 ### In-page browse — virtual scroll and cover-art priority

--- a/src/components/queuePanel/QueueList.tsx
+++ b/src/components/queuePanel/QueueList.tsx
@@ -36,6 +36,11 @@ interface Props {
   t: TFunction;
 }
 
+// Stable reference so the virtualizer never sees a "changed" option on re-render
+// (an inline object literal would be a new ref every render). Only used until the
+// ResizeObserver reports the real viewport height.
+const INITIAL_RECT = { width: 0, height: 600 };
+
 export function QueueList({
   queue, queueIndex, contextMenu, playTrack, activeTab, queueListRef,
   suppressNextAutoScrollRef, isQueueDrag, psyDragFromIdxRef, externalDropTarget,
@@ -60,7 +65,7 @@ export function QueueList({
     // Start with a sensible viewport height so rows render before the
     // ResizeObserver reports the real size (SSR / jsdom, where the observer
     // never fires). The real height overrides this on first measure.
-    initialRect: { width: 0, height: 600 },
+    initialRect: INITIAL_RECT,
   });
   const virtualItems = rowVirtualizer.getVirtualItems();
   const totalSize = rowVirtualizer.getTotalSize();

--- a/src/components/queuePanel/QueueList.tsx
+++ b/src/components/queuePanel/QueueList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useSyncExternalStore } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Play } from 'lucide-react';
 import type { TFunction } from 'i18next';
@@ -7,6 +7,11 @@ import { usePlayerStore } from '../../store/playerStore';
 import { useLuckyMixStore } from '../../store/luckyMixStore';
 import type { Track, PlayerState } from '../../store/playerStoreTypes';
 import { formatTrackTime } from '../../utils/format/formatDuration';
+import {
+  getCachedTrack,
+  getQueueResolverVersion,
+  subscribeQueueResolver,
+} from '../../utils/library/queueTrackResolver';
 
 type StartDrag = (
   payload: { data: string; label: string },
@@ -36,6 +41,13 @@ export function QueueList({
   suppressNextAutoScrollRef, isQueueDrag, psyDragFromIdxRef, externalDropTarget,
   startDrag, orbitAttributionLabel, luckyRolling, t,
 }: Props) {
+  // Phase 3: row data comes from the resolver (cache), falling back to the
+  // canonical queue: Track[] until phase 4 drops it. Rows show title/artist/
+  // duration only (no star/rating), so no override merge here. Subscribe once to
+  // the resolver so the list re-renders as the cache fills.
+  const serverId = usePlayerStore(s => s.queueServerId);
+  useSyncExternalStore(subscribeQueueResolver, getQueueResolverVersion);
+
   // Virtualize so a 10k+ Artist-Radio queue keeps DOM at O(visible rows).
   // Scroll element is the OverlayScrollArea viewport (`queueListRef`); rows have
   // variable height (radio/auto dividers, lucky-mix loader) so we measure them.
@@ -93,10 +105,11 @@ export function QueueList({
         <div style={{ height: totalSize, width: '100%', position: 'relative' }}>
         {virtualItems.map(vi => {
           const idx = vi.index;
-          const track = queue[idx];
+          const base = queue[idx];
+          const track = (serverId ? getCachedTrack({ serverId, trackId: base.id }) : undefined) ?? base;
           const isPlaying = idx === queueIndex;
-          const isFirstAutoAdded = track.autoAdded && (idx === 0 || !queue[idx - 1].autoAdded);
-          const isFirstRadioAdded = track.radioAdded && (idx === 0 || !queue[idx - 1].radioAdded);
+          const isFirstAutoAdded = base.autoAdded && (idx === 0 || !queue[idx - 1].autoAdded);
+          const isFirstRadioAdded = base.radioAdded && (idx === 0 || !queue[idx - 1].radioAdded);
 
           let dragStyle: React.CSSProperties = {};
           if (isQueueDrag && psyDragFromIdxRef.current === idx) {

--- a/src/hooks/useQueueTracks.test.ts
+++ b/src/hooks/useQueueTracks.test.ts
@@ -13,13 +13,28 @@ const track = (id: string, over: Partial<Track> = {}): Track =>
 describe('useQueueTracks selectors', () => {
   beforeEach(() => {
     _resetQueueResolverForTest();
-    usePlayerStore.setState({ queue: [], queueIndex: 0, queueServerId: 's1', currentTrack: null });
+    usePlayerStore.setState({
+      queue: [], queueIndex: 0, queueServerId: 's1', currentTrack: null,
+      starredOverrides: {}, userRatingOverrides: {},
+    });
   });
 
   it('useQueueTrackAt returns the track at the index, or null', () => {
     usePlayerStore.setState({ queue: [track('t1'), track('t2')] });
     expect(renderHook(() => useQueueTrackAt(1)).result.current?.id).toBe('t2');
     expect(renderHook(() => useQueueTrackAt(9)).result.current).toBeNull();
+  });
+
+  it('useQueueTrackAt merges session star/rating overrides', () => {
+    usePlayerStore.setState({
+      queue: [track('t1')],
+      queueServerId: 's1',
+      starredOverrides: { t1: true },
+      userRatingOverrides: { t1: 5 },
+    });
+    const { result } = renderHook(() => useQueueTrackAt(0));
+    expect(!!result.current?.starred).toBe(true);
+    expect(result.current?.userRating).toBe(5);
   });
 
   it('useCurrentTrack returns the current track', () => {

--- a/src/hooks/useQueueTracks.ts
+++ b/src/hooks/useQueueTracks.ts
@@ -1,18 +1,35 @@
-import { useMemo } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
 import { usePlayerStore } from '../store/playerStore';
 import type { QueueItemRef, Track } from '../store/playerStoreTypes';
 import { toQueueItemRefs } from '../utils/library/queueItemRef';
+import {
+  applyQueueOverrides,
+  getCachedTrack,
+  getQueueResolverVersion,
+  subscribeQueueResolver,
+} from '../utils/library/queueTrackResolver';
 
 /**
- * Stable queue selectors (queue thin-state). Consumers migrate onto these in
- * phase 3. Today they read the canonical `queue: Track[]`; once it's dropped
- * (phase 4) the implementations move to the resolver (`queueTrackResolver`)
- * without changing these signatures.
+ * Stable queue selectors (queue thin-state). Resolver-first: read the resolved
+ * track from the cache, falling back to the canonical `queue: Track[]` until
+ * phase 4 drops it; session star/rating overrides (F4) merged on read. Consumers
+ * migrate onto these in phase 3; the signatures stay stable through phase 4.
  */
 
 /** The track at a queue index, or null. */
 export function useQueueTrackAt(idx: number): Track | null {
-  return usePlayerStore(s => s.queue[idx] ?? null);
+  const base = usePlayerStore(s => s.queue[idx] ?? null);
+  const serverId = usePlayerStore(s => s.queueServerId);
+  const starredOverrides = usePlayerStore(s => s.starredOverrides);
+  const userRatingOverrides = usePlayerStore(s => s.userRatingOverrides);
+  const version = useSyncExternalStore(subscribeQueueResolver, getQueueResolverVersion);
+  return useMemo(() => {
+    if (!base) return null;
+    const cached = serverId ? getCachedTrack({ serverId, trackId: base.id }) : undefined;
+    return applyQueueOverrides(cached ?? base);
+  // version drives re-resolution as the cache fills; overrides drive the merge.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [base, serverId, starredOverrides, userRatingOverrides, version]);
 }
 
 /** The currently playing track, or null. */

--- a/src/store/pendingStarSync.ts
+++ b/src/store/pendingStarSync.ts
@@ -1,5 +1,6 @@
 import { setRating, star, unstar } from '../api/subsonicStarRating';
 import { usePlayerStore } from './playerStore';
+import { invalidateQueueResolver } from '../utils/library/queueTrackResolver';
 
 /**
  * F4 — pending-sync for **song** star + rating (spec §6.5 / R7-18).
@@ -94,6 +95,8 @@ function onStarSuccess(id: string, starred: boolean): void {
         s.currentTrack?.id === id ? { ...s.currentTrack, starred: starredVal } : s.currentTrack,
     };
   });
+  // Drop the resolver's cached copy so the next read reflects the synced value.
+  invalidateQueueResolver(id);
 }
 
 function onRatingSuccess(id: string): void {
@@ -104,6 +107,7 @@ function onRatingSuccess(id: string): void {
     delete next[id];
     return { userRatingOverrides: next };
   });
+  invalidateQueueResolver(id);
 }
 
 /** Optimistically (un)star a song and sync it to the server with retry. */

--- a/src/store/queueResolverBridge.ts
+++ b/src/store/queueResolverBridge.ts
@@ -13,7 +13,13 @@ const SEED_BACK = 50;
 const SEED_AHEAD = 200;
 
 usePlayerStore.subscribe((state, prev) => {
-  if (state.queue === prev.queue && state.queueServerId === prev.queueServerId) return;
+  // Re-seed when the queue, its server, or the current index changes — the
+  // prefetch window travels with the playing track.
+  if (
+    state.queue === prev.queue &&
+    state.queueServerId === prev.queueServerId &&
+    state.queueIndex === prev.queueIndex
+  ) return;
   const serverId = state.queueServerId ?? '';
   if (!serverId || state.queue.length === 0) return;
   const start = Math.max(0, state.queueIndex - SEED_BACK);

--- a/src/utils/library/queueTrackResolver.ts
+++ b/src/utils/library/queueTrackResolver.ts
@@ -48,15 +48,6 @@ export function subscribeQueueResolver(cb: () => void): () => void {
   return () => { listeners.delete(cb); };
 }
 
-function cacheTouch(key: string): Track | undefined {
-  const t = cache.get(key);
-  if (t !== undefined) {
-    cache.delete(key);
-    cache.set(key, t); // move to most-recent
-  }
-  return t;
-}
-
 function cacheSet(key: string, track: Track): void {
   if (cache.has(key)) cache.delete(key);
   cache.set(key, track);
@@ -76,7 +67,10 @@ function carryFlags(track: Track, ref: QueueItemRef | undefined): Track {
 
 /** Synchronous cache read (no fetch); undefined on miss. */
 export function getCachedTrack(ref: QueueItemRef): Track | undefined {
-  return cacheTouch(refKey(ref));
+  // Pure read — no LRU bump. Called from component render (QueueList rows), where
+  // a Map mutation (delete+set) is a render side-effect. Recency is set at write
+  // time in cacheSet instead; this cache is effectively insertion-order/FIFO.
+  return cache.get(refKey(ref));
 }
 
 /** Lightweight placeholder shown until a ref resolves. */

--- a/src/utils/library/queueTrackResolver.ts
+++ b/src/utils/library/queueTrackResolver.ts
@@ -30,9 +30,16 @@ const refKey = (r: { serverId: string; trackId: string }) => `${r.serverId}:${r.
 const cache = new Map<string, Track>();
 const inFlight = new Set<string>();
 const listeners = new Set<() => void>();
+let cacheVersion = 0;
 
 function notify(): void {
+  cacheVersion++;
   for (const l of listeners) l();
+}
+
+/** Monotonic version, bumped on every cache change (for `useSyncExternalStore`). */
+export function getQueueResolverVersion(): number {
+  return cacheVersion;
 }
 
 /** Subscribe to cache changes (for `useSyncExternalStore` selectors). */


### PR DESCRIPTION
## Summary

- Queue selectors (`useQueueTracks`) read **resolver-first** — `getCachedTrack` → `queue: Track[]` fallback (until phase 4) — with F4 star/rating overrides merged on read.
- QueueList rows source their track from the resolver (queue fallback); rows show title/artist/duration only, so no override merge there.
- `pendingStarSync` star/rating success → `invalidateQueueResolver`, so the cache reflects the synced value.
- `queueResolverBridge` re-seeds on `queueIndex` change too — the prefetch window travels with the playing track.

Phase 3 of the queue thin-state plan (cucadmuh's steps). **Additive:** `queue: Track[]` stays canonical and behaviour is unchanged (rows resolve to the same data). Phase 4 drops `queue: Track[]` and the fallbacks.

## Test plan

- [ ] Long queue: scroll → title/artist/duration correct, smooth; track change → auto-scroll + now-playing highlight
- [ ] Reorder by drag, remove a row, drop a song/album in; radio/auto dividers in place
- [ ] Star/rating a song → no stale state; `npm test` + `npx tsc --noEmit` green