### PR TITLE
fix(now-playing): hide zero-valued track metadata badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Now Playing — stray zero metadata badges
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#865](https://github.com/Psychotoxical/psysonic/pull/865)**
+
+* Hero track-info badges no longer render literal `0` when numeric metadata fields (bit depth, bitrate, sample rate, year, rating) are missing and arrive as zero from the server.
+
+
+
 ## [1.46.0] - 2026-05-18
 
 > **🙏 Special thanks to [@zz5zz](https://github.com/zz5zz)** for his tireless quirk-spotting and bug reports on the [Psysonic Discord](https://discord.gg/AMnDRErm4u) — several of the polish fixes in this release landed directly off the back of his messages.

--- a/src/components/nowPlaying/Hero.tsx
+++ b/src/components/nowPlaying/Hero.tsx
@@ -43,7 +43,7 @@ function renderStars(rating?: number) {
 const Hero = memo(function Hero({ track, genre, playCount, userRatingOverride, lfmTrack, lfmArtist, starred, lfmLoved, lfmLoveEnabled, activeLyricsTab, coverUrl, onNavigate, onToggleStar, onToggleLfmLove, onOpenLyrics }: HeroProps) {
   const { t } = useTranslation();
   const rating = userRatingOverride ?? track.userRating;
-  const hiRes  = (track.bitDepth && track.bitDepth > 16) || (track.samplingRate && track.samplingRate > 48000);
+  const hiRes  = track.bitDepth > 16 || track.samplingRate > 48000;
   const releaseAge = track.year ? new Date().getFullYear() - track.year : 0;
 
   return (
@@ -67,7 +67,7 @@ const Hero = memo(function Hero({ track, genre, playCount, userRatingOverride, l
             style={{ cursor: track.albumId ? 'pointer' : 'default' }}>
             {track.album}
           </span>
-          {track.year && <><span className="np-sep">·</span><span>{track.year}</span></>}
+          {track.year != null && track.year > 0 && <><span className="np-sep">·</span><span>{track.year}</span></>}
           {releaseAge > 0 && (
             <><span className="np-sep">·</span>
             <span className="np-dash-hero-age">
@@ -79,9 +79,9 @@ const Hero = memo(function Hero({ track, genre, playCount, userRatingOverride, l
         <div className="np-dash-hero-badges">
           {genre && <span className="np-badge">{genre}</span>}
           {track.suffix && <span className="np-badge">{track.suffix.toUpperCase()}</span>}
-          {track.bitRate && <span className="np-badge">{track.bitRate} kbps</span>}
-          {track.samplingRate && <span className="np-badge">{(track.samplingRate / 1000).toFixed(1)} kHz</span>}
-          {track.bitDepth && <span className="np-badge">{track.bitDepth}-bit</span>}
+          {track.bitRate > 0 && <span className="np-badge">{track.bitRate} kbps</span>}
+          {track.samplingRate > 0 && <span className="np-badge">{(track.samplingRate / 1000).toFixed(1)} kHz</span>}
+          {track.bitDepth > 0 && <span className="np-badge">{track.bitDepth}-bit</span>}
           {hiRes && <span className="np-badge np-badge-hires">Hi-Res</span>}
           {track.duration > 0 && <span className="np-badge">{formatTrackTime(track.duration)}</span>}
         </div>
@@ -104,7 +104,7 @@ const Hero = memo(function Hero({ track, genre, playCount, userRatingOverride, l
             style={{ color: activeLyricsTab ? 'var(--accent)' : undefined }}>
             <MicVocal size={18} />
           </button>
-          {rating && renderStars(rating)}
+          {rating != null && rating > 0 && renderStars(rating)}
         </div>
 
         {(playCount != null && playCount > 0) && (

--- a/src/components/nowPlaying/Hero.tsx
+++ b/src/components/nowPlaying/Hero.tsx
@@ -43,7 +43,7 @@ function renderStars(rating?: number) {
 const Hero = memo(function Hero({ track, genre, playCount, userRatingOverride, lfmTrack, lfmArtist, starred, lfmLoved, lfmLoveEnabled, activeLyricsTab, coverUrl, onNavigate, onToggleStar, onToggleLfmLove, onOpenLyrics }: HeroProps) {
   const { t } = useTranslation();
   const rating = userRatingOverride ?? track.userRating;
-  const hiRes  = track.bitDepth > 16 || track.samplingRate > 48000;
+  const hiRes  = (track.bitDepth ?? 0) > 16 || (track.samplingRate ?? 0) > 48000;
   const releaseAge = track.year ? new Date().getFullYear() - track.year : 0;
 
   return (
@@ -79,9 +79,9 @@ const Hero = memo(function Hero({ track, genre, playCount, userRatingOverride, l
         <div className="np-dash-hero-badges">
           {genre && <span className="np-badge">{genre}</span>}
           {track.suffix && <span className="np-badge">{track.suffix.toUpperCase()}</span>}
-          {track.bitRate > 0 && <span className="np-badge">{track.bitRate} kbps</span>}
-          {track.samplingRate > 0 && <span className="np-badge">{(track.samplingRate / 1000).toFixed(1)} kHz</span>}
-          {track.bitDepth > 0 && <span className="np-badge">{track.bitDepth}-bit</span>}
+          {(track.bitRate ?? 0) > 0 && <span className="np-badge">{track.bitRate} kbps</span>}
+          {(track.samplingRate ?? 0) > 0 && <span className="np-badge">{((track.samplingRate ?? 0) / 1000).toFixed(1)} kHz</span>}
+          {(track.bitDepth ?? 0) > 0 && <span className="np-badge">{track.bitDepth}-bit</span>}
           {hiRes && <span className="np-badge np-badge-hires">Hi-Res</span>}
           {track.duration > 0 && <span className="np-badge">{formatTrackTime(track.duration)}</span>}
         </div>

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -326,6 +326,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Interface Scale: scales the entire window — sidebar, queue, player bar, modals and the fullscreen player follow the main content (PR #781)',
       'Local library index (preview): SQLite per-server track store, background initial and delta sync, live and Advanced Search against the local index, integrity verify and auto-reconcile on count drop (PR #846)',
       'Server index-key rebuild: safe dual-DB migration flow, per-server analysis strategy controls, and playback/index scope hardening (PR #864)',
+      'Now Playing: hide zero-valued track metadata badges (PR #865)',
     ],
   },
 ] as const;

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -326,7 +326,6 @@ const CONTRIBUTOR_ENTRIES = [
       'Interface Scale: scales the entire window — sidebar, queue, player bar, modals and the fullscreen player follow the main content (PR #781)',
       'Local library index (preview): SQLite per-server track store, background initial and delta sync, live and Advanced Search against the local index, integrity verify and auto-reconcile on count drop (PR #846)',
       'Server index-key rebuild: safe dual-DB migration flow, per-server analysis strategy controls, and playback/index scope hardening (PR #864)',
-      'Now Playing: hide zero-valued track metadata badges (PR #865)',
     ],
   },
 ] as const;


### PR DESCRIPTION
## Summary
- Fix Now Playing hero badges rendering literal `0` when track metadata fields (bit depth, bitrate, sample rate, year, rating) are missing and arrive as `0` from the server.
- Replace truthy `value && <JSX>` checks with explicit `> 0` / null-safe comparisons so absent numeric fields are omitted instead of shown.

## Test plan
- [ ] Open Now Playing for an MP3 track where bit depth is `0` (e.g. missing from tags) — no stray `0` between format badges.
- [ ] Confirm badges still show for tracks with valid bitrate, sample rate, and bit depth.
- [ ] Confirm year and star rating still appear when present; hidden when absent/zero.