### PR TITLE
chore: add SECURITY.md and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Weekly dependency update PRs for npm (frontend) and Cargo (src-tauri workspace).
+# Review and merge like any other PR; run CI before merging.
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Open pull requests against `main`. `next` and `release` are maintainer-driven pr
 - **AUR packaging problems** — follow the AUR links in [README](README.md); those packages are maintained separately from this repository.
 - **Large features or UX overhauls** — consider discussing in chat or opening an issue early so effort aligns with product direction.
 - **Changes to the Tauri boundary** — read [The Rust ↔ frontend (Tauri) contract](#the-rust--frontend-tauri-contract) before opening a PR; reviewers will ask for a clear justification.
-- **Security issues** — please do **not** open a public issue. Reach a maintainer privately via Discord or Telegram first; we'll coordinate disclosure from there.
+- **Security issues** — please do **not** open a public issue. See [SECURITY.md](SECURITY.md) for how to report vulnerabilities privately (Discord or Telegram).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security policy
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security problems.**
+
+Report them privately so we can investigate and coordinate a fix before details are public:
+
+- [Discord](https://discord.gg/AMnDRErm4u) — reach a maintainer directly
+- [Telegram](https://t.me/+GLBx1_xeH28xYTJi) — same
+
+Include what you can: affected version, platform (Windows / macOS / Linux), steps to reproduce, and impact if known.
+
+## What to expect
+
+- We will acknowledge your report as soon as we can.
+- We will work with you on verification and timing of any public disclosure.
+- We do not offer a paid bug-bounty program; credit in the changelog or release notes is given when reporters want it and when it fits the fix.
+
+## Scope notes
+
+- **This repository** — Psysonic desktop application source.
+- **AUR packages** ([`psysonic`](https://aur.archlinux.org/packages/psysonic), [`psysonic-bin`](https://aur.archlinux.org/packages/psysonic-bin)) are maintained separately; packaging issues there should go through the AUR unless they reflect a vulnerability in the upstream app itself.
+- **Your music server** (Navidrome, Gonic, etc.) is outside this project's scope; report server-side issues to those projects.
+
+## Secure development
+
+Pull requests are reviewed on `main`. Dependency updates are tracked via Dependabot. For general contribution expectations, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with private vulnerability reporting via Discord/Telegram (no public issues).
- Add `.github/dependabot.yml` for weekly npm and Cargo dependency update PRs.
- Point `CONTRIBUTING.md` at the new security policy instead of duplicating the text.

## Test plan
- [ ] GitHub shows Security policy tab from `SECURITY.md`
- [ ] Dependabot enables on merge (first PRs may appear next Monday)
- [ ] No code or runtime behavior changes