### PR TITLE
chore(deps): bump rusqlite to 0.40 workspace-wide

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2815,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4611,9 +4611,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "1.47.0-dev"
 edition = "2021"
-rust-version = "1.89"
+rust-version = "1.95"
 
 [workspace.dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,7 +70,7 @@ lofty = "0.24"
 sysinfo = { version = "0.38", default-features = false, features = ["disk", "system"] }
 id3 = "1.16.4"
 symphonia-adapter-libopus = "0.2.9"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 ebur128 = "0.1"
 dasp_sample = "0.11.0"
 zip = "0.6.6"

--- a/src-tauri/crates/psysonic-analysis/Cargo.toml
+++ b/src-tauri/crates/psysonic-analysis/Cargo.toml
@@ -16,7 +16,7 @@ reqwest = { version = "0.13", default-features = false, features = ["stream", "r
 futures-util = "0.3"
 ebur128 = "0.1"
 md5 = "0.8"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 symphonia = { version = "0.5", default-features = false, features = ["flac", "mp3", "pcm", "aac", "alac", "isomp4", "vorbis", "ogg", "wav", "adpcm"] }
 symphonia-adapter-libopus = "0.2.9"
 oximedia-mir = { version = "0.1.7", default-features = false, features = ["tempo", "mood"] }

--- a/src-tauri/crates/psysonic-library/Cargo.toml
+++ b/src-tauri/crates/psysonic-library/Cargo.toml
@@ -12,7 +12,7 @@ psysonic-integration = { path = "../psysonic-integration" }
 tauri = { version = "2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "gzip", "brotli"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time"] }
 


### PR DESCRIPTION
## Summary
- Bump `rusqlite` from 0.39 to 0.40 in `src-tauri/Cargo.toml`, `psysonic-analysis`, and `psysonic-library` so the workspace resolves a single `libsqlite3-sys` (0.38).
- Supersedes Dependabot #913, which only updated two crates and failed CI with a `links = "sqlite3"` conflict.

## Test plan
- [ ] CI `rust-tests`: `cargo test --workspace --all-targets`
- [ ] CI `rust-tests`: `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] CI coverage job resolves deps cleanly
- [ ] Manual: library DB open/migrate, analysis cache, backup restore smoke (no VTab usage; API unchanged)