### PR TITLE
chore(deps): Dependabot security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
-# Weekly dependency update PRs for npm (frontend) and Cargo (src-tauri workspace).
-# Review and merge like any other PR; run CI before merging.
+# Dependabot: security updates only (no scheduled version bumps).
+#
+# Version updates are disabled via open-pull-requests-limit: 0. GitHub still opens
+# PRs when Dependabot/npm/cargo audit reports a vulnerability (and related
+# transitive fixes in the same bump). Routine minor/patch upgrades are manual.
+#
+# Requires "Dependabot security updates" enabled in repo Settings → Code security.
 
 version: 2
 updates:
@@ -8,18 +13,30 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - dependencies
+      - security
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: cargo
     directory: /src-tauri
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - dependencies
+      - security
+    groups:
+      cargo-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
     ignore:
       # Symphonia 0.6 is a coordinated migration (API break + isomp4 patch port).
       # See workdocs: internal/collaboration/tasks/2026-05-symphonia-0.6-migration/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,4 +25,4 @@ Include what you can: affected version, platform (Windows / macOS / Linux), step
 
 ## Secure development
 
-Pull requests are reviewed on `main`. Dependency updates are tracked via Dependabot. For general contribution expectations, see [CONTRIBUTING.md](CONTRIBUTING.md).
+Pull requests are reviewed on `main`. **Dependency security updates** are tracked via Dependabot (PRs only for reported vulnerabilities and their fix paths—not routine version bumps). For general contribution expectations, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- Disable scheduled **version** update PRs (`open-pull-requests-limit: 0` for npm + cargo).
- Keep **security** PRs: one grouped PR per ecosystem when GitHub/npm/cargo audit reports vulnerabilities (plus transitive fix paths in the same bump).
- Clarify policy in `SECURITY.md`. Symphonia migration ignores unchanged.

Fixes the mismatch where weekly schedule opened PRs for every outdated patch/minor (serde_json, sysinfo, lucide, etc.) instead of security-only.

## Test plan
- [ ] After merge: no new version-bump PRs on Monday
- [ ] Existing Dependabot security alert (#16) can still open a grouped security PR
- [ ] Settings → Code security → Dependabot security updates remains enabled