### PR TITLE
fix(deps): bump zip to 4.6.1 with backup API fix

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,7 +73,7 @@ symphonia-adapter-libopus = "0.2.9"
 rusqlite = { version = "0.40", features = ["bundled"] }
 ebur128 = "0.1"
 dasp_sample = "0.11.0"
-zip = "0.6.6"
+zip = "4.6.1"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 webp = "0.3"
 

--- a/src-tauri/src/lib_commands/app_api/backup.rs
+++ b/src-tauri/src/lib_commands/app_api/backup.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
-use zip::write::FileOptions;
+use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
 const LIBRARY_ARCHIVE_ENTRY: &str = "library.sqlite";
@@ -212,7 +212,8 @@ fn write_databases_archive(
 ) -> Result<(), String> {
     let file = fs::File::create(destination_archive).map_err(|e| e.to_string())?;
     let mut zip = ZipWriter::new(file);
-    let options = FileOptions::default().compression_method(CompressionMethod::Deflated);
+    let options =
+        SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
     zip.start_file(LIBRARY_ARCHIVE_ENTRY, options)
         .map_err(|e| e.to_string())?;
     let mut src = fs::File::open(library_snapshot).map_err(|e| e.to_string())?;
@@ -233,7 +234,8 @@ fn write_full_archive(
 ) -> Result<(), String> {
     let file = fs::File::create(destination_archive).map_err(|e| e.to_string())?;
     let mut zip = ZipWriter::new(file);
-    let options = FileOptions::default().compression_method(CompressionMethod::Deflated);
+    let options =
+        SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
 
     zip.start_file(FULL_ARCHIVE_SETTINGS_ENTRY, options)
         .map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary
- Bump `zip` from 0.6.6 to **4.6.1** in `src-tauri/Cargo.toml` (completes broken Dependabot #910 merge that only touched `Cargo.lock`).
- Migrate backup archive writes to `SimpleFileOptions` (zip 4.x API) in `backup.rs`.
- Stops cargo from downgrading zip and transitive deps on every `tauri dev` / `./dev.sh` start.

## Test plan
- [x] `cargo build -p psysonic` (nix develop)
- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy -p psysonic -- -D warnings`
- [ ] Manual: Settings → Backup & Restore — export/import library DB and full backup round-trip