### PR TITLE
fix(ui): center button label text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+### Advanced Search — centered button label
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#925](https://github.com/Psychotoxical/psysonic/pull/925)**
+
+* The **Search** button's label is now centered. Buttons wider than their text (the Search button has a fixed minimum width) previously rendered the label left-aligned.
+
+
+
 ### Radio — track info in OS media controls
 
 **By [@Psychotoxical](https://github.com/Psychotoxical), reported by agriffit79 on GitHub, PR [#924](https://github.com/Psychotoxical/psysonic/pull/924)**

--- a/src/styles/themes/button-variants.css
+++ b/src/styles/themes/button-variants.css
@@ -2,6 +2,7 @@
 .btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-4);
   border-radius: var(--radius-md);


### PR DESCRIPTION
`.btn` was `inline-flex` with `align-items: center` but no `justify-content`, so any button wider than its content (`min-width` / `flex: 1`) rendered its label left-aligned — visible on the Advanced Search **Search** button (`min-width: 100`).

## Summary
- Add `justify-content: center` to the base `.btn` rule.
- No `.btn` rule anywhere sets `justify-content`, so nothing relied on the left default; content-sized buttons are unaffected.

## Test plan
- Visual: Advanced Search button label now centered (confirmed live via HMR on Linux/KDE).