### PR TITLE
fix(ci): refresh npmDepsHash before app-v* tag

### DIFF
--- a/.github/workflows/reusable-channel-publish.yml
+++ b/.github/workflows/reusable-channel-publish.yml
@@ -35,7 +35,70 @@ on:
         type: boolean
 
 jobs:
+  # Refresh npmDepsHash + flake.lock on the channel branch *before* tagging.
+  # Promote workflows push with GITHUB_TOKEN (no downstream workflow runs), and the
+  # old post-tag verify-nix PR landed after app-v* tags were already cut.
+  prepare-nix-sources:
+    if: ${{ inputs.verify_nix }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    outputs:
+      source_commit_sha: ${{ steps.final-sha.outputs.value }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.target_branch }}
+      - name: install Nix
+        uses: DeterminateSystems/nix-installer-action@v15
+      - name: configure Cachix (managed signing)
+        uses: cachix/cachix-action@v15
+        with:
+          name: psysonic
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: compute npmDepsHash from package-lock.json
+        id: npm-hash
+        run: |
+          set -euo pipefail
+          HASH="$(nix run nixpkgs/nixos-unstable#prefetch-npm-deps -- package-lock.json)"
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "Computed npmDepsHash: $HASH"
+      - name: write npmDepsHash into nix/upstream-sources.json
+        run: |
+          set -euo pipefail
+          HASH='${{ steps.npm-hash.outputs.hash }}'
+          jq --arg h "$HASH" '.npmDepsHash = $h' nix/upstream-sources.json > nix/upstream-sources.json.new
+          mv nix/upstream-sources.json.new nix/upstream-sources.json
+      - name: refresh flake.lock (nixpkgs pin)
+        run: nix flake update --accept-flake-config
+      - name: verify nix build + push to Cachix
+        run: |
+          set -euo pipefail
+          nix build .#psysonic --accept-flake-config --no-link --print-build-logs
+          nix path-info --recursive .#psysonic | cachix push psysonic
+      - name: commit and push refreshed lock and hash (if changed)
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add flake.lock nix/upstream-sources.json
+          if git diff --cached --quiet; then
+            echo "flake.lock / nix/upstream-sources.json unchanged — nothing to commit."
+            exit 0
+          fi
+          VERSION="$(node -p 'require("./package.json").version')"
+          git commit -m "chore(nix): refresh lock + npmDepsHash for v${VERSION}"
+          git push origin "HEAD:${{ inputs.target_branch }}"
+      - name: capture source commit sha
+        id: final-sha
+        run: |
+          set -euo pipefail
+          echo "value=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   create-release:
+    needs: prepare-nix-sources
+    if: ${{ !cancelled() && !failure() && (needs.prepare-nix-sources.result == 'success' || needs.prepare-nix-sources.result == 'skipped') }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -47,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ inputs.verify_nix && needs.prepare-nix-sources.outputs.source_commit_sha || inputs.source_ref }}
       - name: setup node
         uses: actions/setup-node@v5
         with:
@@ -194,7 +257,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.create-release.outputs.source_commit_sha }}
       - name: setup node
         uses: actions/setup-node@v5
         with:
@@ -268,7 +331,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.create-release.outputs.source_commit_sha }}
       - name: generate latest.json
         env:
           VERSION: ${{ needs.create-release.outputs.package_version }}
@@ -290,7 +353,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.create-release.outputs.source_commit_sha }}
       - name: install dependencies
         run: |
           sudo apt-get update
@@ -324,68 +387,6 @@ jobs:
           find src-tauri/target/release/bundle \
             \( -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" \) \
             | xargs gh release upload "$RELEASE_TAG" --clobber
-
-  verify-nix:
-    if: ${{ inputs.verify_nix }}
-    needs: create-release
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.target_branch }}
-      - name: install Nix
-        uses: DeterminateSystems/nix-installer-action@v15
-      - name: configure Cachix (managed signing)
-        uses: cachix/cachix-action@v15
-        with:
-          name: psysonic
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: compute npmDepsHash from package-lock.json
-        id: npm-hash
-        run: |
-          set -euo pipefail
-          HASH="$(nix run nixpkgs/nixos-unstable#prefetch-npm-deps -- package-lock.json)"
-          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
-          echo "Computed npmDepsHash: $HASH"
-      - name: write npmDepsHash into nix/upstream-sources.json
-        run: |
-          set -euo pipefail
-          HASH='${{ steps.npm-hash.outputs.hash }}'
-          jq --arg h "$HASH" '.npmDepsHash = $h' nix/upstream-sources.json > nix/upstream-sources.json.new
-          mv nix/upstream-sources.json.new nix/upstream-sources.json
-      - name: refresh flake.lock (nixpkgs pin)
-        run: nix flake update --accept-flake-config
-      - name: verify nix build + push to Cachix
-        run: |
-          set -euo pipefail
-          nix build .#psysonic --accept-flake-config --no-link --print-build-logs
-          nix path-info --recursive .#psysonic | cachix push psysonic
-      - name: open + auto-merge PR with refreshed lock and hash (if changed)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add flake.lock nix/upstream-sources.json
-          if git diff --cached --quiet; then
-            echo "flake.lock / nix/upstream-sources.json unchanged — nothing to commit."
-            exit 0
-          fi
-          VERSION="${{ needs.create-release.outputs.package_version }}"
-          BRANCH="chore/nix-lock-refresh-${{ inputs.target_branch }}-v${VERSION}"
-          git checkout -b "$BRANCH"
-          git commit -m "chore(nix): refresh lock + npmDepsHash for v${VERSION}"
-          git push origin "$BRANCH"
-          gh pr create \
-            --base "${{ inputs.target_branch }}" \
-            --head "$BRANCH" \
-            --title "chore(nix): refresh lock + npmDepsHash for v${VERSION}" \
-            --body "Auto-generated for the \`${{ inputs.channel }}\` channel after v${VERSION}: refreshes \`flake.lock\` and \`nix/upstream-sources.json\`."
 
   bump-main-to-next-dev:
     if: ${{ inputs.channel == 'release' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,6 +332,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+### CI — npmDepsHash on app-v* tags
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#927](https://github.com/Psychotoxical/psysonic/pull/927)**
+
+* Channel publish now refreshes `nix/upstream-sources.json` and `flake.lock` on the channel branch **before** cutting `app-v*` tags, so Nix builds from release tags no longer fail with stale `npmDepsHash` (e.g. after promote finalizes `package-lock.json` version).
+
 ### Advanced Search — centered button label
 
 **By [@Psychotoxical](https://github.com/Psychotoxical), PR [#925](https://github.com/Psychotoxical/psysonic/pull/925)**


### PR DESCRIPTION
## Summary

- **Root cause:** `promote-next-to-release` / `promote-main-to-next` push with `GITHUB_TOKEN`, which does not trigger downstream workflows — so `nix-npm-deps-hash-sync.yml` never ran on the finalize/RC bump commit. `verify-nix` ran *after* `create-release` and only opened a PR; the `app-v*` tag was already cut at the stale commit (e.g. `app-v1.45.0` still had rc.6 hash while `package-lock.json` needed `sha256-WXfc5…`).
- **Fix:** new `prepare-nix-sources` job runs before `create-release`: prefetch npm hash, refresh `flake.lock`, verify `nix build`, commit+push directly to the channel branch, then tag/build from that SHA.
- **Also:** platform build jobs now checkout `source_commit_sha` from `create-release` so artifacts match the tagged tree.

## Affected tags (already shipped — need manual retag or use `release` branch)

| Tag | Tag hash in `upstream-sources.json` | Required for `package-lock.json` |
|-----|-------------------------------------|----------------------------------|
| `app-v1.45.0` | `sha256-+lM9a3…` (rc.6) | `sha256-WXfc5WsypV2HdUTaZLDzPN9OdgLq18/hcJVvKCn3LTU=` |
| `app-v1.46.0` | `sha256-zcd6mu…` | `sha256-4q+d3lfR8S6abAbw0Z//pvJCHwO3AqR+lNOTWdSZp4Q=` |

The `release` branch already has the correct hashes (from merged verify-nix PRs #457 / #776).

## Test plan

- [ ] Merge and run `Promote next to release` (or `Next Channel` on a test RC) with `verify_nix` enabled
- [ ] Confirm `prepare-nix-sources` commits hash refresh **before** `create-release` tags
- [ ] Confirm `app-v*` tag commit contains matching `nix/upstream-sources.json` and `nix build .#psysonic` succeeds
- [ ] Optionally retag `app-v1.45.0` / `app-v1.46.0` to the merge commits from PR #457 / #776 for Nix consumers pinning tags