### PR TITLE
docs(linux): clarify AppImage is the X11/XWayland channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#731](https://github.com/Psychotoxical/psysonic/pull/731)**
 
 * **Nix / AUR** default installs follow the session GDK backend instead of pinning `GDK_BACKEND=x11`; startup applies **`webkit2gtk-nvidia-quirk`** only (skip with **`PSYSONIC_WEBKIT_GPU_ACCEL`**). **`nix run .#psysonic-x11-legacy`** keeps the old explicit X11 launcher.
+* **AppImage stays on X11/XWayland**: unlike the `.deb` / `.rpm` / Nix packages it still pins `GDK_BACKEND=x11` (set by the bundle's AppRun hook), so it doubles as the legacy channel. Use `.deb`, `.rpm`, AUR, or the Nix default for a native-Wayland launch.
 * **NVIDIA + forced X11** on a Wayland user session no longer greys out the webview — the quirk uses the DMABUF renderer path instead of Wayland explicit-sync disable.
 * **Wayland + GPU compositing:** clearer UI text via on-demand hardware acceleration on main and mini webviews; **Settings → System** adds **Wayland text rendering** presets (Balanced / Sharp / GPU / Minimal). Opt out with **`PSYSONIC_SKIP_WAYLAND_FONT_TUNING`**.
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ curl -fsSL https://raw.githubusercontent.com/Psychotoxical/psysonic/main/scripts
 
 Linux builds are also available through GitHub Releases, AUR and Cachix/Nix.
 
+> **AppImage runs under X11/XWayland** — it pins `GDK_BACKEND=x11` for a stable WebKitGTK stack. For a native-Wayland launch, use the `.deb`, `.rpm`, AUR, or Nix packages, which follow your session's display server.
+
 ## Windows
 
 Download the latest installer from the [GitHub Releases](https://github.com/Psychotoxical/psysonic/releases/latest).


### PR DESCRIPTION
Pre-RC Linux launch-keys audit follow-up. After #731 the `.deb` / `.rpm` / Nix packages follow the session display server, but **AppImage still pins `GDK_BACKEND=x11`** via the bundle's AppRun hook (upstream Tauri/linuxdeploy behaviour). This documents the asymmetry so users know which package gives a native-Wayland launch.

- **README:** install section notes AppImage = X11/XWayland; point native-Wayland users at `.deb` / `.rpm` / AUR / Nix.
- **CHANGELOG:** the 1.47.0 #731 entry only mentioned Nix/AUR following the session — added the AppImage exception so the release block is not read as "everything follows the session now".

Scope is intentionally docs-only — the AppImage launch model itself (keep as X11/legacy channel vs. patch the gtk plugin for session-native GDK) is the open call tracked in `internal/collaboration/tasks/2026-05-appimage-launch-keys`. The historical 1.4.2 `EGL_PLATFORM=x11` entry was correct at the time and is left untouched.