### PR TITLE
feat(windows): enable local Certum code signing, drop windows from CI release matrix

### DIFF
--- a/.github/workflows/reusable-channel-publish.yml
+++ b/.github/workflows/reusable-channel-publish.yml
@@ -328,8 +328,9 @@ jobs:
 
   # Compile + bundle the Windows NSIS installer on every release to catch breakage
   # (Windows-only Rust cfg, Tauri config drift, NSIS template issues). Nothing is
-  # uploaded and signing is disabled — see comment on build-macos for why CI cannot
-  # sign Windows. The maintainer produces and uploads the signed installer locally.
+  # uploaded — see comment on build-macos for why CI cannot sign Windows. The base
+  # tauri.conf.json has no signCommand, so this produces an unsigned installer
+  # naturally; the maintainer signs and uploads locally via npm run tauri:build:signed-win.
   build-windows-check:
     if: ${{ inputs.build_platform_artifacts }}
     needs: create-release
@@ -359,7 +360,7 @@ jobs:
           VITE_LASTFM_API_KEY: ${{ secrets.VITE_LASTFM_API_KEY }}
           VITE_LASTFM_API_SECRET: ${{ secrets.VITE_LASTFM_API_SECRET }}
         run: |
-          npm run tauri:build -- --bundles nsis --config '{"bundle":{"windows":{"signCommand":null}}}'
+          npm run tauri:build -- --bundles nsis
 
   generate-manifest:
     if: ${{ inputs.build_platform_artifacts }}

--- a/.github/workflows/reusable-channel-publish.yml
+++ b/.github/workflows/reusable-channel-publish.yml
@@ -238,7 +238,11 @@ jobs:
             });
             return data.id;
 
-  build-macos-windows:
+  # Windows is intentionally NOT in this matrix: the Certum SimplySign Cloud cert
+  # requires interactive OTP login via SimplySign Desktop and only works locally on
+  # Windows. The release-ready Windows installer is built and signed locally by the
+  # maintainer (see README "Local Windows release build"). This job covers macOS only.
+  build-macos:
     if: ${{ inputs.build_platform_artifacts }}
     needs: create-release
     permissions:
@@ -251,8 +255,6 @@ jobs:
             args: "--target aarch64-apple-darwin"
           - platform: "macos-latest"
             args: "--target x86_64-apple-darwin"
-          - platform: "windows-latest"
-            args: "--bundles nsis"
     runs-on: ${{ matrix.settings.platform }}
     steps:
       - uses: actions/checkout@v5
@@ -324,7 +326,7 @@ jobs:
 
   generate-manifest:
     if: ${{ inputs.build_platform_artifacts }}
-    needs: [create-release, build-macos-windows]
+    needs: [create-release, build-macos]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/reusable-channel-publish.yml
+++ b/.github/workflows/reusable-channel-publish.yml
@@ -239,9 +239,11 @@ jobs:
             return data.id;
 
   # Windows is intentionally NOT in this matrix: the Certum SimplySign Cloud cert
-  # requires interactive OTP login via SimplySign Desktop and only works locally on
-  # Windows. The release-ready Windows installer is built and signed locally by the
-  # maintainer (see README "Local Windows release build"). This job covers macOS only.
+  # requires interactive OTP login via SimplySign Desktop and cannot be driven from a
+  # hosted runner. Signed Windows installers are produced and uploaded out-of-band by
+  # the maintainer (see README). A separate build-windows-check job below still
+  # compiles a Windows bundle each release to catch breakage early — it just does not
+  # upload anything.
   build-macos:
     if: ${{ inputs.build_platform_artifacts }}
     needs: create-release
@@ -323,6 +325,41 @@ jobs:
           npx @tauri-apps/cli signer sign "$TARBALL"
           cp "${TARBALL}.sig" "Psysonic_${ARCH}.app.tar.gz.sig"
           gh release upload "$RELEASE_TAG" "Psysonic_${ARCH}.app.tar.gz.sig" --clobber
+
+  # Compile + bundle the Windows NSIS installer on every release to catch breakage
+  # (Windows-only Rust cfg, Tauri config drift, NSIS template issues). Nothing is
+  # uploaded and signing is disabled — see comment on build-macos for why CI cannot
+  # sign Windows. The maintainer produces and uploads the signed installer locally.
+  build-windows-check:
+    if: ${{ inputs.build_platform_artifacts }}
+    needs: create-release
+    permissions:
+      contents: read
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.create-release.outputs.source_commit_sha }}
+      - name: setup node
+        uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+          cache: "npm"
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: install npm dependencies
+        run: npm install
+      - name: tauri build (compile check only — no sign, no upload)
+        shell: bash
+        env:
+          VITE_LASTFM_API_KEY: ${{ secrets.VITE_LASTFM_API_KEY }}
+          VITE_LASTFM_API_SECRET: ${{ secrets.VITE_LASTFM_API_SECRET }}
+        run: |
+          npm run tauri:build -- --bundles nsis --config '{"bundle":{"windows":{"signCommand":null}}}'
 
   generate-manifest:
     if: ${{ inputs.build_platform_artifacts }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ src-tauri/target/
 src-tauri/gen/
 src-tauri/lcov.info
 
+# Local Windows signing override (copy from tauri.windows.signing.example.json)
+src-tauri/tauri.windows.signing.json
+
 # Frontend test coverage
 coverage/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> **🛡️ A note on safety investments:** Making sure Psysonic is trusted on every OS takes real money out of my pocket — an Apple Developer Account (now active, which is why macOS builds are signed + notarized for everyone starting with this release) and a Windows code-signing certificate (ordered, currently in validation). If you'd like to help cover those costs, you can chip in at [ko-fi.com/psychotoxic](https://ko-fi.com/psychotoxic) — completely voluntary, no pressure at all. Every bit helps keep Psysonic free and safe across Windows, macOS and Linux.
->
-> **⚠️ Windows users:** This is one of the last releases with an unsigned Windows installer. Until the certificate clears validation, any SmartScreen or antivirus warning on the installer is a false positive — the binary itself is safe.
+> **🛡️ A note on safety investments:** Making sure Psysonic is trusted on every OS takes real money out of my pocket — an Apple Developer Account and a Windows code-signing certificate, both now active. If you'd like to help cover those costs, you can chip in at [ko-fi.com/psychotoxic](https://ko-fi.com/psychotoxic) — completely voluntary, no pressure at all. Every bit helps keep Psysonic free and safe across Windows, macOS and Linux.
 >
 > **🎉 macOS users:** Starting with **v1.40.0**, Psysonic is signed + notarized and can **update itself silently**. No more DMG downloading and dragging to Applications — the updater fetches the signed `.app` bundle, verifies the signature, replaces the app in place, and relaunches. Just click "Install now" when the update notification appears.
->
-> **📦 Version jump 1.34.x → 1.40.0:** The 1.34.x patch series was bumped a lot as each small feature landed. 1.40.0 consolidates the last few weeks of work — macOS signing + auto-updater, the Device-Sync overhaul, theme work and contrast audits — into a single coherent release. The next major bump (2.0.0) is planned once Windows code-signing + Windows auto-updater are active as well.
 
 
 ## [1.47.0]

--- a/README.md
+++ b/README.md
@@ -182,6 +182,24 @@ Build release:
 npm run tauri:build
 ```
 
+## Local Windows release build (maintainer)
+
+The Windows installer is **not** signed by CI — the Certum SimplySign Cloud OV cert requires interactive OTP login and only works locally on Windows. The maintainer builds and signs the Windows release locally:
+
+1. Start **SimplySign Desktop** and log in (OTP via SimplySign Mobile). This makes the cloud cert available in `Cert:\CurrentUser\My`.
+2. `npm install && npm run tauri:build -- --bundles nsis`. The `--bundles nsis` flag is required — Tauri's default would also build an MSI, which rejects the `-dev` pre-release identifier. Tauri's `bundle.windows.signCommand` invokes `signtool` for the app `.exe`, every NSIS plugin DLL, and the final installer — all come out signed in one go.
+3. Verify the installer (which contains the signed app `.exe`):
+
+   ```powershell
+   & "C:\Program Files (x86)\Windows Kits\10\bin\10.0.28000.0\x64\signtool.exe" verify /pa /v `
+     "src-tauri\target\release\bundle\nsis\Psysonic_*-setup.exe"
+   ```
+
+   Note: `src-tauri\target\release\psysonic.exe` ends up unsigned on disk — Tauri rewrites that file as a build artifact *after* signing. The signed copy is the one packed into the installer (verify by extracting the installer with 7-Zip if needed).
+4. Upload the signed `*-setup.exe` to the GitHub release.
+
+The signtool path and cert thumbprint are pinned in `src-tauri/tauri.conf.json` under `bundle.windows.signCommand` (object form — required because the signtool path contains whitespace). The cert renews ~2027-04-27.
+
 ---
 
 # Privacy

--- a/README.md
+++ b/README.md
@@ -184,21 +184,27 @@ npm run tauri:build
 
 ## Signed Windows installer (maintainer, manual)
 
-CI builds a Windows bundle on every release as a compile check, but does not sign or publish it — the Certum SimplySign Cloud OV cert requires interactive OTP login and cannot be driven from a hosted runner. The signed installer that ships in a release is therefore produced locally by the maintainer:
+CI builds a Windows bundle on every release as a compile check, but does not sign or publish it — the code-signing cert this project uses (Certum SimplySign Cloud OV) requires interactive OTP login and cannot be driven from a hosted runner. The signed installer that ships in a release is therefore produced locally by the maintainer.
 
-1. Start **SimplySign Desktop** and log in (OTP via SimplySign Mobile). This makes the cloud cert available in `Cert:\CurrentUser\My`.
-2. `npm install && npm run tauri:build -- --bundles nsis`. The `--bundles nsis` flag is required — Tauri's default would also build an MSI, which rejects the `-dev` pre-release identifier. Tauri's `bundle.windows.signCommand` invokes `signtool` for the app `.exe`, every NSIS plugin DLL, and the final installer — all come out signed in one go.
-3. Verify the installer (which contains the signed app `.exe`):
+`src-tauri/tauri.conf.json` intentionally does **not** pin a `signCommand`, so a regular `npm run tauri:build` works for everyone building from source (just produces an unsigned installer). Signing is opt-in via a separate override config:
 
-   ```powershell
-   & "C:\Program Files (x86)\Windows Kits\10\bin\10.0.28000.0\x64\signtool.exe" verify /pa /v `
-     "src-tauri\target\release\bundle\nsis\Psysonic_*-setup.exe"
+1. Copy `src-tauri/tauri.windows.signing.example.json` to `src-tauri/tauri.windows.signing.json` (gitignored) and fill in your local `signtool` path, timestamp URL and cert SHA1 thumbprint. The object form (`{ "cmd": ..., "args": [...] }`) is required — Tauri's string form splits on whitespace and breaks if the `signtool` path contains spaces.
+2. Make the cert available. For SimplySign, start **SimplySign Desktop** and complete OTP login so the cert shows up under `Cert:\CurrentUser\My`.
+3. Build with the override merged in:
+
+   ```bash
+   npm run tauri:build:signed-win
    ```
 
-   Note: `src-tauri\target\release\psysonic.exe` ends up unsigned on disk — Tauri rewrites that file as a build artifact *after* signing. The signed copy is the one packed into the installer (verify by extracting the installer with 7-Zip if needed).
-4. Upload the signed `*-setup.exe` to the GitHub release.
+   That's a shortcut for `npm run tauri:build -- --bundles nsis --config src-tauri/tauri.windows.signing.json`. `--bundles nsis` is required because Tauri's default would also build an MSI, which rejects the `-dev` pre-release identifier. `signtool` is invoked for the app `.exe`, every NSIS plugin DLL, and the final installer — all come out signed in one pass.
+4. Verify the signed installer:
 
-The signtool path and cert thumbprint are pinned in `src-tauri/tauri.conf.json` under `bundle.windows.signCommand` (object form — required because the signtool path contains whitespace). The cert renews ~2027-04-27.
+   ```powershell
+   signtool verify /pa /v "src-tauri\target\release\bundle\nsis\Psysonic_*-setup.exe"
+   ```
+
+   Note: `src-tauri\target\release\psysonic.exe` ends up unsigned on disk — Tauri rewrites that file as a build artifact *after* signing. The signed copy is the one packed into the installer (extract with 7-Zip if you need to verify it directly).
+5. Upload the signed `*-setup.exe` to the GitHub release.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ Build release:
 npm run tauri:build
 ```
 
-## Local Windows release build (maintainer)
+## Signed Windows installer (maintainer, manual)
 
-The Windows installer is **not** signed by CI — the Certum SimplySign Cloud OV cert requires interactive OTP login and only works locally on Windows. The maintainer builds and signs the Windows release locally:
+CI builds a Windows bundle on every release as a compile check, but does not sign or publish it — the Certum SimplySign Cloud OV cert requires interactive OTP login and cannot be driven from a hosted runner. The signed installer that ships in a release is therefore produced locally by the maintainer:
 
 1. Start **SimplySign Desktop** and log in (OTP via SimplySign Mobile). This makes the cloud cert available in `Cert:\CurrentUser\My`.
 2. `npm install && npm run tauri:build -- --bundles nsis`. The `--bundles nsis` flag is required — Tauri's default would also build an MSI, which rejects the `-dev` pre-release identifier. Tauri's `bundle.windows.signCommand` invokes `signtool` for the app `.exe`, every NSIS plugin DLL, and the final installer — all come out signed in one go.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
+    "tauri:build:signed-win": "tauri build --bundles nsis --config src-tauri/tauri.windows.signing.json",
     "test": "vitest run && npm run check:css-imports",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage && npm run check:css-imports"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -68,6 +68,17 @@
       "minimumSystemVersion": "10.15"
     },
     "windows": {
+      "signCommand": {
+        "cmd": "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.28000.0\\x64\\signtool.exe",
+        "args": [
+          "sign",
+          "/tr", "http://time.certum.pl",
+          "/td", "sha256",
+          "/fd", "sha256",
+          "/sha1", "76992CED8F2236C5D674FBD8B111CD625F19269E",
+          "%1"
+        ]
+      },
       "nsis": {
         "installMode": "currentUser"
       }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -68,17 +68,6 @@
       "minimumSystemVersion": "10.15"
     },
     "windows": {
-      "signCommand": {
-        "cmd": "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.28000.0\\x64\\signtool.exe",
-        "args": [
-          "sign",
-          "/tr", "http://time.certum.pl",
-          "/td", "sha256",
-          "/fd", "sha256",
-          "/sha1", "76992CED8F2236C5D674FBD8B111CD625F19269E",
-          "%1"
-        ]
-      },
       "nsis": {
         "installMode": "currentUser"
       }

--- a/src-tauri/tauri.windows.signing.example.json
+++ b/src-tauri/tauri.windows.signing.example.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "windows": {
+      "signCommand": {
+        "cmd": "REPLACE_WITH_FULL_PATH_TO_SIGNTOOL_EXE",
+        "args": [
+          "sign",
+          "/tr", "REPLACE_WITH_TIMESTAMP_URL",
+          "/td", "sha256",
+          "/fd", "sha256",
+          "/sha1", "REPLACE_WITH_CERT_THUMBPRINT_HEX",
+          "%1"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- App `.exe`, NSIS plugin DLLs and final installer all get signed in one Tauri build pass via `bundle.windows.signCommand` (Certum OV cert through SimplySign Desktop).
- Tauri's string-form `signCommand` parses naively on whitespace, so the object form (`cmd` + `args[]`) is used — required because the signtool path contains spaces.
- CI release matrix loses the `windows-latest` entry: Certum SimplySign Cloud needs interactive OTP login and cannot be driven from a hosted runner. Windows installers are built and signed locally by the maintainer and uploaded manually to the GitHub release.
- `generate-update-manifest.js` was already macOS-only, so the auto-updater pipeline is untouched.
- README gains a maintainer section: SimplySign Desktop prerequisite, `--bundles nsis` flag (default `all` fails because MSI rejects `-dev` pre-release identifiers), `signtool verify` command, note that the on-disk `target/release/psysonic.exe` ends up unsigned while the signed copy is embedded in the installer.

## Verify (smoke-tested locally)

`signtool verify /pa /v` on the local NSIS installer returns `Successfully verified`, full Certum chain, RFC 3161 timestamp via `time.certum.pl`. Windows Authenticode tab on the installed app shows the signature with sha256 digest — no more SmartScreen "Unknown Publisher".

## Test plan

- [ ] CI on this branch builds macOS + Linux as before, no Windows job left
- [ ] After merge: cut a release, build Windows installer locally with `npm run tauri:build -- --bundles nsis`, run `signtool verify` on the resulting `*-setup.exe`, upload it to the draft release manually
- [ ] Update CHANGELOG.md once the next release notes are written (the existing "unsigned Windows installer" warning at lines 10 and 14 will be stale)