### PR TITLE
fix(perf): use mach2 for macOS Mach port APIs in perf.rs

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4064,6 +4064,7 @@ dependencies = [
  "image",
  "libc",
  "lofty",
+ "mach2",
  "md5",
  "psysonic-analysis",
  "psysonic-audio",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -80,6 +80,9 @@ webp = "0.3"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+mach2 = "0.5"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 zbus = { version = "5.15", default-features = false, features = ["blocking-api", "async-io"] }
 # Match wry/tauri’s WebKitGTK stack — used only to turn off kinetic wheel scrolling.

--- a/src-tauri/src/lib_commands/app_api/perf.rs
+++ b/src-tauri/src/lib_commands/app_api/perf.rs
@@ -369,17 +369,23 @@ mod macos {
     }
 
     fn read_host_total_cpu_ticks() -> u64 {
+        use mach2::kern_return::KERN_SUCCESS;
+        use mach2::mach_init::mach_host_self;
+        use mach2::traps::mach_task_self;
+        use mach2::vm::mach_vm_deallocate;
+        use mach2::vm_types::{mach_vm_address_t, mach_vm_size_t};
+
         let mut num_cpus: u32 = 0;
         let mut cpu_info: *mut i32 = std::ptr::null_mut();
         let mut num_cpu_info: u32 = 0;
         let ok = unsafe {
             libc::host_processor_info(
-                libc::mach_host_self(),
+                mach_host_self(),
                 libc::PROCESSOR_CPU_LOAD_INFO,
                 &mut num_cpus,
                 &mut cpu_info,
                 &mut num_cpu_info,
-            ) == libc::KERN_SUCCESS
+            ) == KERN_SUCCESS
         };
         if !ok || cpu_info.is_null() {
             return 0;
@@ -392,8 +398,11 @@ mod macos {
         };
         unsafe {
             let size = num_cpu_info as usize * mem::size_of::<i32>();
-            #[allow(deprecated)]
-            libc::vm_deallocate(libc::mach_task_self(), cpu_info as _, size);
+            mach_vm_deallocate(
+                mach_task_self(),
+                cpu_info as mach_vm_address_t,
+                size as mach_vm_size_t,
+            );
         }
         total
     }


### PR DESCRIPTION
## Summary
- Silence macOS CI warning: `libc::mach_host_self` is deprecated in favor of `mach2`.
- Use `mach2` for `mach_host_self`, `mach_task_self`, and `mach_vm_deallocate` in `read_host_total_cpu_ticks`.
- Keep `libc::host_processor_info` (no equivalent in `mach2`).

## Test plan
- [ ] macOS CI (`aarch64-apple-darwin` / `x86_64-apple-darwin`) builds without deprecation warning in `perf.rs`.
- [ ] `performance_cpu_snapshot` still returns sensible `total_jiffies` on macOS.