### PR TITLE
fix(perf): show non-OS probe metrics on Windows

### DIFF
--- a/src/components/sidebar/perfProbe/SidebarPerfProbeMonitorTab.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeMonitorTab.tsx
@@ -25,6 +25,7 @@ export default function SidebarPerfProbeMonitorTab() {
   const analysisPinned = usePipelineOverlayPinned('pipeline:analysis');
   const coverPinned = usePipelineOverlayPinned('pipeline:cover');
   const cpu = live.cpu;
+  const cpuSupported = cpu?.supported === true;
   const collecting = live.collecting && cpu == null;
   const includeThreadGroups = usePerfLiveIncludeThreadGroups();
   const peakMemoryKbRef = useRef(1);
@@ -47,14 +48,6 @@ export default function SidebarPerfProbeMonitorTab() {
       <div className="perf-monitor-empty">
         <div className="spinner" style={{ width: 22, height: 22 }} />
         <span>Collecting live samples…</span>
-      </div>
-    );
-  }
-
-  if (cpu && !cpu.supported) {
-    return (
-      <div className="perf-monitor-empty">
-        Live CPU/memory monitoring is unavailable on this platform or build.
       </div>
     );
   }
@@ -94,7 +87,13 @@ export default function SidebarPerfProbeMonitorTab() {
         />
       </PerfProbeMetricSection>
 
-      {cpu && (
+      {cpu && !cpuSupported && (
+        <div className="perf-monitor-empty perf-monitor-empty--inline">
+          Live CPU and RSS sampling is unavailable on this platform. Pipeline, UI rate, and analysis metrics below still work.
+        </div>
+      )}
+
+      {cpuSupported && cpu && (
         <>
           <PerfProbeMetricSection title="CPU — processes">
             <PerfProbeMetricCard

--- a/src/utils/perf/perfLiveStore.ts
+++ b/src/utils/perf/perfLiveStore.ts
@@ -96,6 +96,29 @@ function readUiCounters(): { progress: number; waveform: number; home: number } 
   };
 }
 
+function buildAnalysisDiag(): PerfAnalysisDiag {
+  return {
+    tracksPerMinute: getAnalysisTracksPerMinute(),
+    lastTotalMs: snapshot.analysis?.lastTotalMs ?? null,
+    lastFetchMs: snapshot.analysis?.lastFetchMs ?? null,
+    lastSeedMs: snapshot.analysis?.lastSeedMs ?? null,
+    lastBpmMs: snapshot.analysis?.lastBpmMs ?? null,
+  };
+}
+
+function nextDiagRates(
+  nextCounters: { progress: number; waveform: number; home: number },
+  now: number,
+): PerfDiagRates | null {
+  if (!prevCounters || prevCountersAt <= 0) return snapshot.diagRates;
+  const dt = Math.max(0.25, (now - prevCountersAt) / 1000);
+  return {
+    progress: (nextCounters.progress - prevCounters.progress) / dt,
+    waveform: (nextCounters.waveform - prevCounters.waveform) / dt,
+    home: (nextCounters.home - prevCounters.home) / dt,
+  };
+}
+
 async function pollOnce(): Promise<void> {
   const generation = pollGeneration;
   const now = Date.now();
@@ -103,17 +126,16 @@ async function pollOnce(): Promise<void> {
     const snap = await invoke<ProcSnapshot>('performance_cpu_snapshot', buildPerfCpuSnapshotRequest());
     if (generation !== pollGeneration) return;
 
+    const nextCounters = readUiCounters();
+    const diagRates = nextDiagRates(nextCounters, now);
+    prevCounters = nextCounters;
+    prevCountersAt = now;
+
     if (!snap.supported) {
       setSnapshot({
         cpu: { app: 0, webkit: 0, supported: false, memory: [], threadCpu: [] },
-        diagRates: snapshot.diagRates,
-        analysis: {
-          tracksPerMinute: getAnalysisTracksPerMinute(),
-          lastTotalMs: snapshot.analysis?.lastTotalMs ?? null,
-          lastFetchMs: snapshot.analysis?.lastFetchMs ?? null,
-          lastSeedMs: snapshot.analysis?.lastSeedMs ?? null,
-          lastBpmMs: snapshot.analysis?.lastBpmMs ?? null,
-        },
+        diagRates,
+        analysis: buildAnalysisDiag(),
         collecting: false,
         updatedAt: now,
       });
@@ -160,30 +182,12 @@ async function pollOnce(): Promise<void> {
       }
     }
 
-    const nextCounters = readUiCounters();
-    let diagRates = snapshot.diagRates;
-    if (prevCounters && prevCountersAt > 0) {
-      const dt = Math.max(0.25, (now - prevCountersAt) / 1000);
-      diagRates = {
-        progress: (nextCounters.progress - prevCounters.progress) / dt,
-        waveform: (nextCounters.waveform - prevCounters.waveform) / dt,
-        home: (nextCounters.home - prevCounters.home) / dt,
-      };
-    }
-    prevCounters = nextCounters;
-    prevCountersAt = now;
     prevProc = snap;
 
     setSnapshot({
       cpu,
       diagRates,
-      analysis: {
-        tracksPerMinute: getAnalysisTracksPerMinute(),
-        lastTotalMs: snapshot.analysis?.lastTotalMs ?? null,
-        lastFetchMs: snapshot.analysis?.lastFetchMs ?? null,
-        lastSeedMs: snapshot.analysis?.lastSeedMs ?? null,
-        lastBpmMs: snapshot.analysis?.lastBpmMs ?? null,
-      },
+      analysis: buildAnalysisDiag(),
       collecting: false,
       updatedAt: now,
     });


### PR DESCRIPTION
## Summary
- On Windows (and other platforms without `performance_cpu_snapshot`), the Monitor tab no longer early-returns with only an “unavailable” message.
- Pipeline overlay pins, UI event rates, and analysis throughput/last-track timings stay visible.
- `perfLiveStore` now updates UI counter rates even when the CPU snapshot returns `supported: false`.

## Test plan
- [ ] Windows: open Performance Probe → Monitor shows pipeline pins, Analysis, UI event rates after ~1s polling.
- [ ] Linux/macOS: CPU/RSS/thread sections unchanged when supported.
- [ ] Linux/macOS: inline note + remaining sections if CPU snapshot ever returns unsupported.