### PR TITLE
fix(perf): reduce idle Rust CPU and stabilize Performance Probe overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+### Performance — idle Rust CPU, probe overlay, and cover prefetch
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#939](https://github.com/Psychotoxical/psysonic/pull/939)**
+
+* **Advanced analytics coordinator:** park on `Notify` when disabled — no idle 2s poll loop; wake on configure or library sync-idle.
+* **Performance Probe:** run CPU snapshot on the blocking pool; skip `/proc` poll on Windows; fix overlay flicker and sparkline clock jumps; hold previous CPU % until the first rate sample (no 0% flash).
+* **Background polls:** Settings → Storage hot-cache poll 15s; cover registry full disk stats every 30s when idle instead of every 1.5s tick.
+* **Cover art:** restore lazy route prefetch so cached WebP paths warm `diskSrcCache` before grid cells mount.
+
+
+
 ### CI — npmDepsHash on app-v* tags
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#927](https://github.com/Psychotoxical/psysonic/pull/927)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,7 +372,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Advanced analytics coordinator:** park on `Notify` when disabled — no idle 2s poll loop; wake on configure or library sync-idle.
 * **Performance Probe:** run CPU snapshot on the blocking pool; skip `/proc` poll on Windows; fix overlay flicker and sparkline clock jumps; hold previous CPU % until the first rate sample (no 0% flash).
 * **Background polls:** Settings → Storage hot-cache poll 15s; cover registry full disk stats every 30s when idle instead of every 1.5s tick.
-* **Cover art:** restore lazy route prefetch so cached WebP paths warm `diskSrcCache` before grid cells mount.
+* **Cover art:** restore lazy route prefetch; batch disk peek before ensure so cached WebP warms `diskSrcCache` without flooding invoke slots; yield when viewport ensures are queued.
 
 
 

--- a/src-tauri/src/lib_commands/app_api/perf.rs
+++ b/src-tauri/src/lib_commands/app_api/perf.rs
@@ -503,8 +503,16 @@ mod macos {
 }
 
 #[tauri::command]
-pub(crate) fn performance_cpu_snapshot(include_thread_groups: Option<bool>) -> PerformanceCpuSnapshot {
+pub(crate) async fn performance_cpu_snapshot(
+    include_thread_groups: Option<bool>,
+) -> Result<PerformanceCpuSnapshot, String> {
     let include_thread_groups = include_thread_groups.unwrap_or(false);
+    tauri::async_runtime::spawn_blocking(move || performance_cpu_snapshot_blocking(include_thread_groups))
+        .await
+        .map_err(|e| e.to_string())
+}
+
+fn performance_cpu_snapshot_blocking(include_thread_groups: bool) -> PerformanceCpuSnapshot {
     #[cfg(target_os = "linux")]
     {
         let total_jiffies = read_total_jiffies().unwrap_or(0);

--- a/src-tauri/src/library_analysis_backfill/worker.rs
+++ b/src-tauri/src/library_analysis_backfill/worker.rs
@@ -2,6 +2,9 @@
 //!
 //! Replaces the webview `while` loop: top-up HTTP/CPU seed backlog without
 //! blocking the UI on `library_analysis_backfill_batch` IPC.
+//!
+//! The coordinator task **parks** on a `Notify` until Advanced analytics is
+//! configured or library sync goes idle — no idle 2 s polling while disabled.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -25,7 +28,7 @@ use psysonic_library::repos::TrackRepository;
 use psysonic_library::LibraryRuntime;
 use serde::Deserialize;
 use tauri::{AppHandle, Listener, Manager};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 const TOP_UP_POLL_MS: u64 = 500;
 const STEADY_POLL_MS: u64 = 2000;
@@ -48,6 +51,8 @@ pub struct LibraryAnalysisBackfillSession {
 
 pub struct LibraryAnalysisBackfillWorker {
     pub enabled: AtomicBool,
+    /// Wakes the coordinator task (configure, sync-idle, disable→enable).
+    wake: Notify,
     session: Mutex<Option<LibraryAnalysisBackfillSession>>,
     cursor: Mutex<Option<String>>,
     scan_phase: Mutex<AnalysisBackfillScanPhase>,
@@ -59,12 +64,17 @@ impl LibraryAnalysisBackfillWorker {
     pub fn new() -> Self {
         Self {
             enabled: AtomicBool::new(false),
+            wake: Notify::new(),
             session: Mutex::new(None),
             cursor: Mutex::new(None),
             scan_phase: Mutex::new(AnalysisBackfillScanPhase::Candidates),
             completed_total: Mutex::new(None),
             exhausted_streak: Mutex::new(0),
         }
+    }
+
+    fn ping_coordinator(&self) {
+        self.wake.notify_waiters();
     }
 
     pub async fn set_session(&self, enabled: bool, session: Option<LibraryAnalysisBackfillSession>) {
@@ -76,6 +86,7 @@ impl LibraryAnalysisBackfillWorker {
             *self.completed_total.lock().await = None;
             *self.exhausted_streak.lock().await = 0;
         }
+        self.ping_coordinator();
     }
 }
 
@@ -107,39 +118,64 @@ fn session_matches_server(session: &LibraryAnalysisBackfillSession, server_id: &
     server_id == session.server_index_key || server_id == session.library_server_id
 }
 
-struct CoordinatorTick {
-    sleep_ms: u64,
+enum CoordinatorStep {
+    Sleep(Duration),
+    /// Park until configure or sync-idle wakes the task (no idle polling).
+    Park,
+}
+
+async fn coordinator_sleep(worker: &LibraryAnalysisBackfillWorker, duration: Duration) {
+    if duration.is_zero() {
+        return;
+    }
+    tokio::select! {
+        _ = tokio::time::sleep(duration) => {}
+        _ = worker.wake.notified() => {}
+    }
 }
 
 async fn run_coordinator_forever(app: AppHandle, worker: Arc<LibraryAnalysisBackfillWorker>) {
     loop {
-        let tick = coordinator_tick(&app, worker.as_ref()).await;
-        tokio::time::sleep(Duration::from_millis(tick.sleep_ms)).await;
+        while !worker.enabled.load(Ordering::Relaxed) {
+            worker.wake.notified().await;
+        }
+
+        loop {
+            if !worker.enabled.load(Ordering::Relaxed) {
+                break;
+            }
+            match coordinator_tick(&app, worker.as_ref()).await {
+                CoordinatorStep::Park => break,
+                CoordinatorStep::Sleep(duration) => {
+                    coordinator_sleep(worker.as_ref(), duration).await;
+                }
+            }
+        }
     }
 }
 
 async fn coordinator_tick(
     app: &AppHandle,
     worker: &LibraryAnalysisBackfillWorker,
-) -> CoordinatorTick {
+) -> CoordinatorStep {
     if !worker.enabled.load(Ordering::Relaxed) {
-        return CoordinatorTick { sleep_ms: STEADY_POLL_MS };
+        return CoordinatorStep::Park;
     }
 
     let session = worker.session.lock().await.clone();
     let Some(session) = session else {
-        return CoordinatorTick { sleep_ms: STEADY_POLL_MS };
+        return CoordinatorStep::Park;
     };
 
     if !session_still_focused(worker, &session).await {
-        return CoordinatorTick { sleep_ms: STEADY_POLL_MS };
+        return CoordinatorStep::Park;
     }
 
     analysis_set_pipeline_parallelism(session.workers as usize);
 
     let runtime = match app.try_state::<LibraryRuntime>() {
         Some(r) => r,
-        None => return CoordinatorTick { sleep_ms: READY_POLL_MS },
+        None => return CoordinatorStep::Sleep(Duration::from_millis(READY_POLL_MS)),
     };
 
     if let Some(done_total) = *worker.completed_total.lock().await {
@@ -155,9 +191,7 @@ async fn coordinator_tick(
         .and_then(|r| r.ok())
         .unwrap_or(false);
         if still_same {
-            return CoordinatorTick {
-                sleep_ms: COMPLETED_RECHECK_MS,
-            };
+            return CoordinatorStep::Sleep(Duration::from_millis(COMPLETED_RECHECK_MS));
         }
         *worker.completed_total.lock().await = None;
         *worker.cursor.lock().await = None;
@@ -167,9 +201,9 @@ async fn coordinator_tick(
 
     while sync_blocks_backfill(&runtime.store, &session.library_server_id) {
         if !worker.enabled.load(Ordering::Relaxed) {
-            return CoordinatorTick { sleep_ms: SYNC_WAIT_MS };
+            return CoordinatorStep::Park;
         }
-        tokio::time::sleep(Duration::from_millis(SYNC_WAIT_MS)).await;
+        coordinator_sleep(worker, Duration::from_millis(SYNC_WAIT_MS)).await;
     }
 
     let store = runtime.store.clone();
@@ -180,7 +214,7 @@ async fn coordinator_tick(
         .and_then(|r| r.ok())
         .unwrap_or(false);
     if !ready {
-        return CoordinatorTick { sleep_ms: READY_POLL_MS };
+        return CoordinatorStep::Sleep(Duration::from_millis(READY_POLL_MS));
     }
 
     let stats = analysis_pipeline_queue_stats();
@@ -192,12 +226,12 @@ async fn coordinator_tick(
     };
 
     if !library_backfill_needs_top_up(counts, session.workers) {
-        return CoordinatorTick { sleep_ms: STEADY_POLL_MS };
+        return CoordinatorStep::Sleep(Duration::from_millis(STEADY_POLL_MS));
     }
 
     let fetch_limit = library_backfill_top_up_limit(counts, session.workers);
     if fetch_limit == 0 {
-        return CoordinatorTick { sleep_ms: TOP_UP_POLL_MS };
+        return CoordinatorStep::Sleep(Duration::from_millis(TOP_UP_POLL_MS));
     }
 
     let cursor = worker.cursor.lock().await.clone();
@@ -223,7 +257,7 @@ async fn coordinator_tick(
         .and_then(|r| r.ok());
 
     let Some((batch, next_phase)) = batch else {
-        return CoordinatorTick { sleep_ms: TOP_UP_POLL_MS };
+        return CoordinatorStep::Sleep(Duration::from_millis(TOP_UP_POLL_MS));
     };
 
     *worker.cursor.lock().await = batch.next_cursor.clone();
@@ -279,9 +313,7 @@ async fn coordinator_tick(
                 }
                 *worker.cursor.lock().await = None;
                 *worker.scan_phase.lock().await = AnalysisBackfillScanPhase::Candidates;
-                return CoordinatorTick {
-                    sleep_ms: COMPLETED_RECHECK_MS,
-                };
+                return CoordinatorStep::Sleep(Duration::from_millis(COMPLETED_RECHECK_MS));
             }
         } else {
             *worker.exhausted_streak.lock().await = 0;
@@ -289,18 +321,14 @@ async fn coordinator_tick(
         if pending > 0 {
             *worker.cursor.lock().await = None;
             *worker.scan_phase.lock().await = AnalysisBackfillScanPhase::Candidates;
-            return CoordinatorTick {
-                sleep_ms: EXHAUSTED_PENDING_RESCAN_MS,
-            };
+            return CoordinatorStep::Sleep(Duration::from_millis(EXHAUSTED_PENDING_RESCAN_MS));
         }
         *worker.cursor.lock().await = None;
         *worker.scan_phase.lock().await = AnalysisBackfillScanPhase::Candidates;
-        return CoordinatorTick {
-            sleep_ms: EXHAUSTED_PAUSE_MS,
-        };
+        return CoordinatorStep::Sleep(Duration::from_millis(EXHAUSTED_PAUSE_MS));
     }
 
-    CoordinatorTick { sleep_ms: TOP_UP_POLL_MS }
+    CoordinatorStep::Sleep(Duration::from_millis(TOP_UP_POLL_MS))
 }
 
 #[derive(Debug, Deserialize)]
@@ -333,6 +361,7 @@ fn on_sync_idle(app: &AppHandle, payload: SyncIdlePayload) {
         *worker.cursor.lock().await = None;
         *worker.scan_phase.lock().await = AnalysisBackfillScanPhase::Candidates;
         *worker.exhausted_streak.lock().await = 0;
+        worker.ping_coordinator();
     });
 }
 

--- a/src/components/FpsOverlay.tsx
+++ b/src/components/FpsOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { analysisGetPipelineQueueStats, type AnalysisPipelineQueueStatsDto } from '../api/analysis';
 import { coverGetPipelineQueueStats, type CoverPipelineQueueStatsDto } from '../api/coverCache';
@@ -18,12 +18,10 @@ import {
   type LiveOverlayItem,
 } from '../utils/perf/formatLiveOverlayItems';
 import {
-  getPerfLiveHistoryClock,
-  syncPerfLiveHistoryFromPoll,
-  usePerfLiveHistorySamples,
+  getPerfLiveHistorySamples,
 } from '../utils/perf/perfLiveHistory';
-import { acquirePerfLivePoll, usePerfLiveSnapshot } from '../utils/perf/perfLiveStore';
-import { hasAnyLiveMetricPollNeed, usePerfLiveOverlayPins } from '../utils/perf/perfOverlayPins';
+import { usePerfLiveSnapshot } from '../utils/perf/perfLiveStore';
+import { usePerfLiveOverlayPins } from '../utils/perf/perfOverlayPins';
 import {
   perfOverlayCornerClass,
   usePerfOverlayAppearance,
@@ -41,11 +39,12 @@ const QUEUE_STATS_MS = 750;
 function LiveOverlayPinnedMetric({
   item,
   now,
+  history,
 }: {
   item: LiveOverlayItem;
   now: number;
+  history: ReturnType<typeof getPerfLiveHistorySamples>;
 }) {
-  const history = usePerfLiveHistorySamples(item.id);
   const sparklineKind = item.kind === 'memory' ? 'memory' : 'cpu';
 
   return (
@@ -70,7 +69,6 @@ export default function FpsOverlay() {
   const [queueStats, setQueueStats] = useState<AnalysisPipelineQueueStatsDto | null>(null);
   const [coverQueueLines, setCoverQueueLines] = useState<string[]>([]);
   const last = useAnalysisPerfLast();
-  const lastHistoryAt = useRef(0);
 
   const liveOverlayItems = useMemo(
     () => buildLiveOverlayItems(livePins, live),
@@ -89,23 +87,9 @@ export default function FpsOverlay() {
     showLive,
   } = visibility;
 
-  lastHistoryAt.current = overlayMode === 'pinned'
-    ? syncPerfLiveHistoryFromPoll(livePins, live, lastHistoryAt.current)
-    : lastHistoryAt.current;
-
-  const sparklineNow = useMemo(() => {
-    const clock = getPerfLiveHistoryClock(
-      liveOverlayItems.filter(item => item.sparkline).map(item => item.id),
-    );
-    return clock > 0 ? clock : Date.now();
-  }, [liveOverlayItems, live.updatedAt]);
+  const sparklineNow = Date.now();
 
   useAnalysisPerfListener(showAnalysisPerfOverlay || livePins.has('analysis:tpm') || livePins.has('analysis:last'));
-
-  useEffect(() => {
-    if (overlayMode !== 'pinned' || !hasAnyLiveMetricPollNeed()) return;
-    return acquirePerfLivePoll('overlay-pins');
-  }, [overlayMode, livePins.size]);
 
   useEffect(() => {
     if (!showAnalysisPerfOverlay) {
@@ -219,7 +203,12 @@ export default function FpsOverlay() {
         <div className="fps-overlay__block">
           <div className="fps-overlay__block-title">Live</div>
           {liveOverlayItems.map(item => (
-            <LiveOverlayPinnedMetric key={item.id} item={item} now={sparklineNow} />
+            <LiveOverlayPinnedMetric
+              key={item.id}
+              item={item}
+              now={sparklineNow}
+              history={item.sparkline ? getPerfLiveHistorySamples(item.id) : []}
+            />
           ))}
         </div>
       )}

--- a/src/components/FpsOverlay.tsx
+++ b/src/components/FpsOverlay.tsx
@@ -87,7 +87,10 @@ export default function FpsOverlay() {
     showLive,
   } = visibility;
 
-  const sparklineNow = Date.now();
+  const sparklineNow = useMemo(
+    () => (live.sampleAt > 0 ? live.sampleAt : Date.now()),
+    [live.sampleAt],
+  );
 
   useAnalysisPerfListener(showAnalysisPerfOverlay || livePins.has('analysis:tpm') || livePins.has('analysis:last'));
 

--- a/src/components/perf/PerfOverlaySparkline.tsx
+++ b/src/components/perf/PerfOverlaySparkline.tsx
@@ -74,8 +74,10 @@ function stableScale(
   peakRef: { current: number },
 ): { min: number; max: number } {
   const raw = scale(samples, kind);
-  if (kind === 'cpu') return raw;
   if (raw.max > peakRef.current) peakRef.current = raw.max;
+  if (kind === 'cpu') {
+    return { min: 0, max: Math.max(5, Math.max(peakRef.current, raw.max)) };
+  }
   return { min: 0, max: Math.max(peakRef.current, raw.max) };
 }
 

--- a/src/components/perf/PerfOverlaySparkline.tsx
+++ b/src/components/perf/PerfOverlaySparkline.tsx
@@ -62,7 +62,7 @@ function scale(samples: readonly PerfLiveSample[], kind: SparklineKind): { min: 
   const minVal = Math.min(...values);
   const maxVal = Math.max(...values);
   if (kind === 'cpu') {
-    return { min: 0, max: Math.max(100, maxVal * 1.1) };
+    return { min: 0, max: Math.max(5, maxVal * 1.25) };
   }
   const pad = Math.max((maxVal - minVal) * 0.08, maxVal * 0.02, 1);
   return { min: Math.max(0, minVal - pad), max: maxVal + pad };

--- a/src/components/settings/StorageTab.tsx
+++ b/src/components/settings/StorageTab.tsx
@@ -46,7 +46,7 @@ export function StorageTab() {
     };
     refresh();
     if (!auth.hotCacheEnabled) return;
-    const interval = window.setInterval(refresh, 2000);
+    const interval = window.setInterval(refresh, 15_000);
     return () => window.clearInterval(interval);
   }, [auth.hotCacheEnabled, auth.hotCacheDownloadDir]);
 

--- a/src/components/sidebar/perfProbe/PerfLivePollControls.tsx
+++ b/src/components/sidebar/perfProbe/PerfLivePollControls.tsx
@@ -1,3 +1,4 @@
+import { perfLiveCpuSnapshotSupported } from '../../../utils/perf/perfLiveCpuSnapshot';
 import {
   PERF_LIVE_POLL_MS_MAX,
   PERF_LIVE_POLL_MS_MIN,
@@ -11,6 +12,8 @@ import {
 export default function PerfLivePollControls() {
   const pollMs = usePerfLivePollIntervalMs();
   const includeThreadGroups = usePerfLiveIncludeThreadGroups();
+  if (!perfLiveCpuSnapshotSupported()) return null;
+
   const pollSec = (pollMs / 1000).toFixed(1);
 
   return (

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeMonitorTab.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeMonitorTab.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef } from 'react';
-import { usePerfLiveSnapshot } from '../../../utils/perf/perfLiveStore';
+import { isPerfLivePollWaitingForCpu, usePerfLiveSnapshot } from '../../../utils/perf/perfLiveStore';
 import { usePerfLiveIncludeThreadGroups } from '../../../utils/perf/perfLivePollSettings';
 import {
   togglePerfLiveOverlayPin,
@@ -26,7 +26,7 @@ export default function SidebarPerfProbeMonitorTab() {
   const coverPinned = usePipelineOverlayPinned('pipeline:cover');
   const cpu = live.cpu;
   const cpuSupported = cpu?.supported === true;
-  const collecting = live.collecting && cpu == null;
+  const collecting = isPerfLivePollWaitingForCpu();
   const includeThreadGroups = usePerfLiveIncludeThreadGroups();
   const peakMemoryKbRef = useRef(1);
   const peakThreadCpuRef = useRef(1);

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -143,6 +143,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Library browse navigation: session restore on back for Artists, Search/Tracks, New Releases, Random Albums; unified SearchBrowsePage (PR #936)',
       'Genres: local index genre browse with Subsonic fallback, aligned counts cache, scroll restore, hold-to-shuffle play (PR #937)',
       'Live Search: scoped browse on Artists, Albums, New Releases, Tracks, and Composers — header badge, ghost restore, album title FTS, session stash (PR #938)',
+      'Performance: idle Rust CPU — backfill coordinator park, probe overlay stability, throttled idle polls, lazy cover prefetch restore (PR #939)',
     ],
   },
   {

--- a/src/cover/useCoverArtPrefetch.ts
+++ b/src/cover/useCoverArtPrefetch.ts
@@ -5,10 +5,12 @@ import { useCoverStrategyStore } from '../store/coverStrategyStore';
 import { useAuthStore } from '../store/authStore';
 import { coverPrefetchDrainBatch } from './prefetchRegistry';
 import { coverTrafficBackgroundPaused } from './coverTraffic';
-import { coverEnsureQueued } from './ensureQueue';
+import { coverEnsureQueued, coverEnsureQueueStats } from './ensureQueue';
+import { getDiskSrcForGrid } from './diskSrcLookup';
 import { coverStorageKeyFromRef } from './storageKeys';
+import { warmCoverDiskSrcBatch, type CoverWarmItem } from './warmDiskPeek';
 import { resolveCoverDisplayTier } from './tiers';
-import type { CoverArtTier } from './types';
+import type { CoverArtRef, CoverArtTier } from './types';
 
 const STEADY_POLL_MS = 1500;
 /** Full cover-root disk walk — idle only, not every prefetch tick. */
@@ -21,9 +23,24 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => window.setTimeout(resolve, ms));
 }
 
+function batchWarmItems(refs: CoverArtRef[]): CoverWarmItem[] {
+  return refs.map(ref => ({
+    ref,
+    tier: DENSE_PREFETCH_TIER,
+    storageKey: coverStorageKeyFromRef(ref, DENSE_PREFETCH_TIER),
+  }));
+}
+
+/** Back off while viewport cells are waiting on high-priority ensures. */
+function prefetchShouldYieldToViewport(): boolean {
+  const { queuedHigh, inflight, maxInflight } = coverEnsureQueueStats();
+  return queuedHigh > 0 || inflight >= maxInflight - 1;
+}
+
 /**
  * Background cover warm-up — low rate; Rust HTTP only (never competes with webview grid fetches).
- * Registry drains run without `cover_cache_stats` (full disk walk); stats run rarely when idle.
+ * Registry drains: batched disk peek first (cached WebP → diskSrcCache), ensure only for misses.
+ * Stats (`cover_cache_stats` disk walk) run rarely when the registry is idle.
  */
 export function useCoverArtPrefetch(enabled = true): void {
   const activeServerId = useAuthStore(s => s.activeServerId);
@@ -44,13 +61,23 @@ export function useCoverArtPrefetch(enabled = true): void {
 
         const batch = coverPrefetchDrainBatch(BATCH_LIMIT);
         if (batch.length > 0) {
+          if (prefetchShouldYieldToViewport()) {
+            await sleep(STEADY_POLL_MS);
+            continue;
+          }
+
+          await warmCoverDiskSrcBatch(batchWarmItems(batch));
+
           if (autoDownloadEnabled) {
-            await Promise.all(
-              batch.map(ref => {
-                const key = coverStorageKeyFromRef(ref, DENSE_PREFETCH_TIER);
-                return coverEnsureQueued(key, ref, DENSE_PREFETCH_TIER, 'low');
-              }),
-            );
+            const misses = batch.filter(ref => !getDiskSrcForGrid(ref, DENSE_PREFETCH_TIER));
+            if (misses.length > 0) {
+              await Promise.all(
+                misses.map(ref => {
+                  const key = coverStorageKeyFromRef(ref, DENSE_PREFETCH_TIER);
+                  return coverEnsureQueued(key, ref, DENSE_PREFETCH_TIER, 'low');
+                }),
+              );
+            }
           }
           await sleep(STEADY_POLL_MS);
           continue;

--- a/src/cover/useCoverArtPrefetch.ts
+++ b/src/cover/useCoverArtPrefetch.ts
@@ -11,12 +11,19 @@ import { resolveCoverDisplayTier } from './tiers';
 import type { CoverArtTier } from './types';
 
 const STEADY_POLL_MS = 1500;
+/** Full cover-root disk walk — idle only, not every prefetch tick. */
+const STATS_IDLE_POLL_MS = 30_000;
 const BATCH_LIMIT = 12;
 /** Match dense card thumbs (~160 CSS px) — prefetch 128 wasted a full re-ensure for 512. */
 const DENSE_PREFETCH_TIER = resolveCoverDisplayTier(160, { surface: 'dense' }) as CoverArtTier;
 
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => window.setTimeout(resolve, ms));
+}
+
 /**
  * Background cover warm-up — low rate; Rust HTTP only (never competes with webview grid fetches).
+ * Registry drains run without `cover_cache_stats` (full disk walk); stats run rarely when idle.
  */
 export function useCoverArtPrefetch(enabled = true): void {
   const activeServerId = useAuthStore(s => s.activeServerId);
@@ -25,31 +32,38 @@ export function useCoverArtPrefetch(enabled = true): void {
   useEffect(() => {
     if (!enabled || !activeServerId || !coverStrategyAllowsRoutePrefetch(strategy)) return;
     let cancelled = false;
+    let lastStatsAt = 0;
+    let autoDownloadEnabled = true;
 
     void (async () => {
       while (!cancelled) {
         if (coverTrafficBackgroundPaused()) {
-          await new Promise(r => setTimeout(r, STEADY_POLL_MS));
-          continue;
-        }
-
-        const stats = await coverCacheStats().catch(() => null);
-        if (stats && !stats.autoDownloadEnabled) {
-          await new Promise(r => setTimeout(r, STEADY_POLL_MS * 2));
+          await sleep(STEADY_POLL_MS);
           continue;
         }
 
         const batch = coverPrefetchDrainBatch(BATCH_LIMIT);
         if (batch.length > 0) {
-          await Promise.all(
-            batch.map(ref => {
-              const key = coverStorageKeyFromRef(ref, DENSE_PREFETCH_TIER);
-              return coverEnsureQueued(key, ref, DENSE_PREFETCH_TIER, 'low');
-            }),
-          );
+          if (autoDownloadEnabled) {
+            await Promise.all(
+              batch.map(ref => {
+                const key = coverStorageKeyFromRef(ref, DENSE_PREFETCH_TIER);
+                return coverEnsureQueued(key, ref, DENSE_PREFETCH_TIER, 'low');
+              }),
+            );
+          }
+          await sleep(STEADY_POLL_MS);
+          continue;
         }
 
-        await new Promise(r => setTimeout(r, STEADY_POLL_MS));
+        const now = Date.now();
+        if (now - lastStatsAt >= STATS_IDLE_POLL_MS) {
+          const stats = await coverCacheStats().catch(() => null);
+          lastStatsAt = now;
+          autoDownloadEnabled = stats?.autoDownloadEnabled ?? true;
+        }
+
+        await sleep(STEADY_POLL_MS);
       }
     })();
 

--- a/src/utils/library/coverStrategy.ts
+++ b/src/utils/library/coverStrategy.ts
@@ -4,8 +4,8 @@ export type CoverCacheStrategy = (typeof COVER_CACHE_STRATEGIES)[number];
 
 export const DEFAULT_COVER_CACHE_STRATEGY: CoverCacheStrategy = 'lazy';
 
-export function coverStrategyAllowsRoutePrefetch(strategy: CoverCacheStrategy): boolean {
-  return strategy === 'aggressive';
+export function coverStrategyAllowsRoutePrefetch(_strategy: CoverCacheStrategy): boolean {
+  return true;
 }
 
 export function coverStrategyAllowsLibraryBackfill(strategy: CoverCacheStrategy): boolean {

--- a/src/utils/library/coverStrategy.ts
+++ b/src/utils/library/coverStrategy.ts
@@ -4,8 +4,8 @@ export type CoverCacheStrategy = (typeof COVER_CACHE_STRATEGIES)[number];
 
 export const DEFAULT_COVER_CACHE_STRATEGY: CoverCacheStrategy = 'lazy';
 
-export function coverStrategyAllowsRoutePrefetch(_strategy: CoverCacheStrategy): boolean {
-  return true;
+export function coverStrategyAllowsRoutePrefetch(strategy: CoverCacheStrategy): boolean {
+  return strategy === 'aggressive';
 }
 
 export function coverStrategyAllowsLibraryBackfill(strategy: CoverCacheStrategy): boolean {

--- a/src/utils/perf/perfLiveCpuSnapshot.ts
+++ b/src/utils/perf/perfLiveCpuSnapshot.ts
@@ -1,0 +1,6 @@
+import { IS_LINUX, IS_MACOS } from '../platform';
+
+/** Matches Rust `performance_cpu_snapshot` (Linux `/proc`, macOS sysinfo). */
+export function perfLiveCpuSnapshotSupported(): boolean {
+  return IS_LINUX || IS_MACOS;
+}

--- a/src/utils/perf/perfLiveHistory.ts
+++ b/src/utils/perf/perfLiveHistory.ts
@@ -35,7 +35,7 @@ function appendSample(id: string, value: number, at: number): boolean {
   if (!Number.isFinite(value)) return false;
   const existing = series.get(id) ?? [];
   const last = existing[existing.length - 1];
-  if (last && last.at === at && last.value === value) return false;
+  if (last && last.value === value) return false;
   const appended =
     last && last.at === at
       ? [...existing.slice(0, -1), { at, value }]
@@ -50,23 +50,20 @@ export function recordPerfLiveHistory(id: string, value: number, at = Date.now()
   if (appendSample(id, value, at)) emit();
 }
 
-/** Record pinned live samples for one poll tick; returns the new last-recorded timestamp. */
+/** Record pinned live samples for one poll tick. */
 export function syncPerfLiveHistoryFromPoll(
   pins: Iterable<string>,
   live: PerfLiveSnapshot,
-  lastRecordedAt: number,
-): number {
-  if (!live.cpu?.supported || live.updatedAt <= 0 || live.updatedAt === lastRecordedAt) {
-    return lastRecordedAt;
-  }
+  options?: { emit?: boolean },
+): void {
+  if (!live.cpu?.supported || live.updatedAt <= 0) return;
   let changed = false;
   for (const pin of pins) {
     if (!isLiveHistoryPin(pin)) continue;
     const value = liveOverlayItemValue(pin, live);
     if (value != null && appendSample(pin, value, live.updatedAt)) changed = true;
   }
-  if (changed) emit();
-  return live.updatedAt;
+  if (changed && options?.emit !== false) emit();
 }
 
 export function getPerfLiveHistoryClock(ids: Iterable<string>): number {

--- a/src/utils/perf/perfLiveHistory.ts
+++ b/src/utils/perf/perfLiveHistory.ts
@@ -56,12 +56,12 @@ export function syncPerfLiveHistoryFromPoll(
   live: PerfLiveSnapshot,
   options?: { emit?: boolean },
 ): void {
-  if (!live.cpu?.supported || live.updatedAt <= 0) return;
+  if (!live.cpu?.supported || live.sampleAt <= 0) return;
   let changed = false;
   for (const pin of pins) {
     if (!isLiveHistoryPin(pin)) continue;
     const value = liveOverlayItemValue(pin, live);
-    if (value != null && appendSample(pin, value, live.updatedAt)) changed = true;
+    if (value != null && appendSample(pin, value, live.sampleAt)) changed = true;
   }
   if (changed && options?.emit !== false) emit();
 }

--- a/src/utils/perf/perfLiveStore.ts
+++ b/src/utils/perf/perfLiveStore.ts
@@ -1,8 +1,9 @@
 import { useSyncExternalStore } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { clearPerfLiveHistory } from './perfLiveHistory';
+import { clearPerfLiveHistory, syncPerfLiveHistoryFromPoll } from './perfLiveHistory';
 import { getAnalysisTracksPerMinute } from './analysisPerfStore';
 import { perfLiveCpuSnapshotSupported } from './perfLiveCpuSnapshot';
+import { getPerfLiveOverlayPins } from './perfOverlayPins';
 import {
   buildPerfCpuSnapshotRequest,
   getPerfLivePollIntervalMs,
@@ -47,7 +48,7 @@ export type PerfLiveSnapshot = {
   diagRates: PerfDiagRates | null;
   analysis: PerfAnalysisDiag | null;
   collecting: boolean;
-  /** Wall time of the last CPU poll; shared clock for overlay sparklines. */
+  /** Wall time of the last displayed sample change; overlay sparkline clock. */
   updatedAt: number;
 };
 
@@ -85,6 +86,56 @@ function emit(): void {
 function setSnapshot(next: PerfLiveSnapshot): void {
   snapshot = next;
   emit();
+}
+
+function memoryRowsEqual(a: readonly PerfProcessMemory[], b: readonly PerfProcessMemory[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((row, index) => row.label === b[index].label && row.rss_kb === b[index].rss_kb);
+}
+
+function threadCpuEqual(a: readonly PerfThreadCpu[], b: readonly PerfThreadCpu[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((row, index) => (
+    row.label === b[index].label
+    && row.pct === b[index].pct
+    && row.threadCount === b[index].threadCount
+  ));
+}
+
+function diagRatesEqual(a: PerfDiagRates | null, b: PerfDiagRates | null): boolean {
+  if (a == null || b == null) return a === b;
+  return a.progress === b.progress && a.waveform === b.waveform && a.home === b.home;
+}
+
+function analysisEqual(a: PerfAnalysisDiag | null, b: PerfAnalysisDiag | null): boolean {
+  if (a == null || b == null) return a === b;
+  return a.tracksPerMinute === b.tracksPerMinute
+    && a.lastTotalMs === b.lastTotalMs
+    && a.lastFetchMs === b.lastFetchMs
+    && a.lastSeedMs === b.lastSeedMs
+    && a.lastBpmMs === b.lastBpmMs;
+}
+
+function cpuEqual(a: PerfLiveCpu | null, b: PerfLiveCpu | null): boolean {
+  if (a == null || b == null) return a === b;
+  return a.app === b.app
+    && a.webkit === b.webkit
+    && a.supported === b.supported
+    && memoryRowsEqual(a.memory, b.memory)
+    && threadCpuEqual(a.threadCpu, b.threadCpu);
+}
+
+function publishLiveSnapshot(next: PerfLiveSnapshot): void {
+  const cpuChanged = !cpuEqual(snapshot.cpu, next.cpu);
+  const diagChanged = !diagRatesEqual(snapshot.diagRates, next.diagRates);
+  const analysisChanged = !analysisEqual(snapshot.analysis, next.analysis);
+  if (!cpuChanged && !diagChanged && !analysisChanged && next.updatedAt === snapshot.updatedAt) {
+    return;
+  }
+  if (cpuChanged && next.cpu?.supported && next.updatedAt > 0) {
+    syncPerfLiveHistoryFromPoll(getPerfLiveOverlayPins(), next, { emit: false });
+  }
+  setSnapshot(next);
 }
 
 function readUiCounters(): { progress: number; waveform: number; home: number } {
@@ -133,7 +184,7 @@ function applyJsMetricsSnapshot(now: number): void {
   const diagRates = nextDiagRates(nextCounters, now);
   prevCounters = nextCounters;
   prevCountersAt = now;
-  setSnapshot({
+  publishLiveSnapshot({
     cpu: snapshot.cpu ?? UNSUPPORTED_CPU,
     diagRates,
     analysis: buildAnalysisDiag(),
@@ -144,11 +195,10 @@ function applyJsMetricsSnapshot(now: number): void {
 
 async function pollOnce(): Promise<void> {
   const generation = pollGeneration;
-  const now = Date.now();
 
   if (!perfLiveCpuSnapshotSupported()) {
     if (generation !== pollGeneration) return;
-    applyJsMetricsSnapshot(now);
+    applyJsMetricsSnapshot(Date.now());
     return;
   }
 
@@ -156,74 +206,94 @@ async function pollOnce(): Promise<void> {
     const snap = await invoke<ProcSnapshot>('performance_cpu_snapshot', buildPerfCpuSnapshotRequest());
     if (generation !== pollGeneration) return;
 
+    const completedAt = Date.now();
     const nextCounters = readUiCounters();
-    const diagRates = nextDiagRates(nextCounters, now);
+    const diagRates = nextDiagRates(nextCounters, completedAt);
     prevCounters = nextCounters;
-    prevCountersAt = now;
+    prevCountersAt = completedAt;
 
     if (!snap.supported) {
-      setSnapshot({
+      publishLiveSnapshot({
         cpu: UNSUPPORTED_CPU,
         diagRates,
         analysis: buildAnalysisDiag(),
         collecting: false,
-        updatedAt: now,
+        updatedAt: completedAt,
       });
       return;
     }
 
     const memory = snap.memory;
-    let cpu: PerfLiveCpu = {
-      app: snapshot.cpu?.app ?? 0,
-      webkit: snapshot.cpu?.webkit ?? 0,
-      supported: true,
-      memory,
-      threadCpu: snap.thread_cpu_groups.map(g => ({
-        label: g.label,
-        threadCount: g.thread_count,
-        pct: snapshot.cpu?.threadCpu.find(t => t.label === g.label)?.pct ?? 0,
-      })),
-    };
+    const baselineProc = prevProc;
+    const prevCpu = snapshot.cpu;
+    let app = prevCpu?.app ?? 0;
+    let webkit = prevCpu?.webkit ?? 0;
+    let threadCpu: PerfThreadCpu[] = prevCpu?.threadCpu ?? snap.thread_cpu_groups.map(g => ({
+      label: g.label,
+      threadCount: g.thread_count,
+      pct: 0,
+    }));
+    let rateSampleReady = false;
 
-    if (prevProc) {
-      const totalDelta = snap.total_jiffies - prevProc.total_jiffies;
-      const appDelta = snap.app_jiffies - prevProc.app_jiffies;
-      const webkitDelta = snap.webkit_jiffies - prevProc.webkit_jiffies;
+    if (baselineProc) {
+      const totalDelta = snap.total_jiffies - baselineProc.total_jiffies;
+      const appDelta = snap.app_jiffies - baselineProc.app_jiffies;
+      const webkitDelta = snap.webkit_jiffies - baselineProc.webkit_jiffies;
       if (totalDelta > 0) {
+        rateSampleReady = true;
         const cpuScale = Math.max(1, snap.logical_cpus || 1) * 100;
         const prevThreadByLabel = new Map(
-          prevProc.thread_cpu_groups.map(g => [g.label, g.jiffies]),
+          baselineProc.thread_cpu_groups.map(g => [g.label, g.jiffies]),
         );
-        cpu = {
-          app: clampPct((appDelta / totalDelta) * cpuScale),
-          webkit: clampPct((webkitDelta / totalDelta) * cpuScale),
-          supported: true,
-          memory,
-          threadCpu: snap.thread_cpu_groups.map(g => {
-            const prevJiffies = prevThreadByLabel.get(g.label) ?? g.jiffies;
-            const delta = g.jiffies - prevJiffies;
-            return {
-              label: g.label,
-              threadCount: g.thread_count,
-              pct: clampPct((delta / totalDelta) * cpuScale),
-            };
-          }),
-        };
+        app = clampPct((appDelta / totalDelta) * cpuScale);
+        webkit = clampPct((webkitDelta / totalDelta) * cpuScale);
+        threadCpu = snap.thread_cpu_groups.map(g => {
+          const prevJiffies = prevThreadByLabel.get(g.label) ?? g.jiffies;
+          const delta = g.jiffies - prevJiffies;
+          return {
+            label: g.label,
+            threadCount: g.thread_count,
+            pct: clampPct((delta / totalDelta) * cpuScale),
+          };
+        });
       }
     }
 
+    const memoryChanged = !memoryRowsEqual(prevCpu?.memory ?? [], memory);
+    const diagChanged = !diagRatesEqual(snapshot.diagRates, diagRates);
+    const ratesChanged = rateSampleReady && (
+      app !== (prevCpu?.app ?? 0)
+      || webkit !== (prevCpu?.webkit ?? 0)
+      || !threadCpuEqual(prevCpu?.threadCpu ?? [], threadCpu)
+    );
+
     prevProc = snap;
 
-    setSnapshot({
-      cpu,
+    if (!rateSampleReady) {
+      if (baselineProc == null) return;
+      if (!memoryChanged && !diagChanged) return;
+    }
+
+    const nextUpdatedAt = (ratesChanged || memoryChanged || diagChanged)
+      ? completedAt
+      : snapshot.updatedAt;
+
+    publishLiveSnapshot({
+      cpu: {
+        app,
+        webkit,
+        supported: true,
+        memory,
+        threadCpu,
+      },
       diagRates,
       analysis: buildAnalysisDiag(),
       collecting: false,
-      updatedAt: now,
+      updatedAt: nextUpdatedAt,
     });
   } catch {
     if (generation !== pollGeneration) return;
-    setSnapshot({
+    publishLiveSnapshot({
       ...snapshot,
       cpu: { app: 0, webkit: 0, supported: false, memory: [], threadCpu: [] },
       collecting: false,
@@ -239,8 +309,6 @@ function clampPct(value: number): number {
 
 function schedulePoll(): void {
   if (pollTimer != null) return;
-  const collecting = perfLiveCpuSnapshotSupported() && snapshot.cpu == null;
-  setSnapshot({ ...snapshot, collecting });
   const intervalMs = getPerfLivePollIntervalMs();
   const tick = () => {
     pollTimer = null;
@@ -296,16 +364,23 @@ export function acquirePerfLivePoll(_reason: string): () => void {
   };
 }
 
+/** True while the first CPU baseline sample is still pending. */
+export function isPerfLivePollWaitingForCpu(): boolean {
+  return pollRefCount > 0 && snapshot.cpu == null && perfLiveCpuSnapshotSupported();
+}
+
 export function patchPerfLiveAnalysis(partial: Partial<PerfAnalysisDiag>): void {
-  setSnapshot({
+  const nextAnalysis: PerfAnalysisDiag = {
+    tracksPerMinute: partial.tracksPerMinute ?? snapshot.analysis?.tracksPerMinute ?? 0,
+    lastTotalMs: partial.lastTotalMs ?? snapshot.analysis?.lastTotalMs ?? null,
+    lastFetchMs: partial.lastFetchMs ?? snapshot.analysis?.lastFetchMs ?? null,
+    lastSeedMs: partial.lastSeedMs ?? snapshot.analysis?.lastSeedMs ?? null,
+    lastBpmMs: partial.lastBpmMs ?? snapshot.analysis?.lastBpmMs ?? null,
+  };
+  if (analysisEqual(snapshot.analysis, nextAnalysis)) return;
+  publishLiveSnapshot({
     ...snapshot,
-    analysis: {
-      tracksPerMinute: partial.tracksPerMinute ?? snapshot.analysis?.tracksPerMinute ?? 0,
-      lastTotalMs: partial.lastTotalMs ?? snapshot.analysis?.lastTotalMs ?? null,
-      lastFetchMs: partial.lastFetchMs ?? snapshot.analysis?.lastFetchMs ?? null,
-      lastSeedMs: partial.lastSeedMs ?? snapshot.analysis?.lastSeedMs ?? null,
-      lastBpmMs: partial.lastBpmMs ?? snapshot.analysis?.lastBpmMs ?? null,
-    },
+    analysis: nextAnalysis,
   });
 }
 

--- a/src/utils/perf/perfLiveStore.ts
+++ b/src/utils/perf/perfLiveStore.ts
@@ -2,6 +2,7 @@ import { useSyncExternalStore } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { clearPerfLiveHistory } from './perfLiveHistory';
 import { getAnalysisTracksPerMinute } from './analysisPerfStore';
+import { perfLiveCpuSnapshotSupported } from './perfLiveCpuSnapshot';
 import {
   buildPerfCpuSnapshotRequest,
   getPerfLivePollIntervalMs,
@@ -119,9 +120,38 @@ function nextDiagRates(
   };
 }
 
+const UNSUPPORTED_CPU: PerfLiveCpu = {
+  app: 0,
+  webkit: 0,
+  supported: false,
+  memory: [],
+  threadCpu: [],
+};
+
+function applyJsMetricsSnapshot(now: number): void {
+  const nextCounters = readUiCounters();
+  const diagRates = nextDiagRates(nextCounters, now);
+  prevCounters = nextCounters;
+  prevCountersAt = now;
+  setSnapshot({
+    cpu: snapshot.cpu ?? UNSUPPORTED_CPU,
+    diagRates,
+    analysis: buildAnalysisDiag(),
+    collecting: false,
+    updatedAt: now,
+  });
+}
+
 async function pollOnce(): Promise<void> {
   const generation = pollGeneration;
   const now = Date.now();
+
+  if (!perfLiveCpuSnapshotSupported()) {
+    if (generation !== pollGeneration) return;
+    applyJsMetricsSnapshot(now);
+    return;
+  }
+
   try {
     const snap = await invoke<ProcSnapshot>('performance_cpu_snapshot', buildPerfCpuSnapshotRequest());
     if (generation !== pollGeneration) return;
@@ -133,7 +163,7 @@ async function pollOnce(): Promise<void> {
 
     if (!snap.supported) {
       setSnapshot({
-        cpu: { app: 0, webkit: 0, supported: false, memory: [], threadCpu: [] },
+        cpu: UNSUPPORTED_CPU,
         diagRates,
         analysis: buildAnalysisDiag(),
         collecting: false,
@@ -209,7 +239,8 @@ function clampPct(value: number): number {
 
 function schedulePoll(): void {
   if (pollTimer != null) return;
-  setSnapshot({ ...snapshot, collecting: snapshot.cpu == null });
+  const collecting = perfLiveCpuSnapshotSupported() && snapshot.cpu == null;
+  setSnapshot({ ...snapshot, collecting });
   const intervalMs = getPerfLivePollIntervalMs();
   const tick = () => {
     pollTimer = null;

--- a/src/utils/perf/perfLiveStore.ts
+++ b/src/utils/perf/perfLiveStore.ts
@@ -48,8 +48,10 @@ export type PerfLiveSnapshot = {
   diagRates: PerfDiagRates | null;
   analysis: PerfAnalysisDiag | null;
   collecting: boolean;
-  /** Wall time of the last displayed sample change; overlay sparkline clock. */
+  /** Wall time of the last displayed sample change (memory / diag / rates). */
   updatedAt: number;
+  /** Wall time of the last CPU rate sample; stable sparkline clock between polls. */
+  sampleAt: number;
 };
 
 type ProcSnapshot = {
@@ -68,6 +70,7 @@ const EMPTY: PerfLiveSnapshot = {
   analysis: null,
   collecting: false,
   updatedAt: 0,
+  sampleAt: 0,
 };
 
 let snapshot: PerfLiveSnapshot = { ...EMPTY };
@@ -132,7 +135,7 @@ function publishLiveSnapshot(next: PerfLiveSnapshot): void {
   if (!cpuChanged && !diagChanged && !analysisChanged && next.updatedAt === snapshot.updatedAt) {
     return;
   }
-  if (cpuChanged && next.cpu?.supported && next.updatedAt > 0) {
+  if (next.sampleAt > snapshot.sampleAt && next.cpu?.supported) {
     syncPerfLiveHistoryFromPoll(getPerfLiveOverlayPins(), next, { emit: false });
   }
   setSnapshot(next);
@@ -190,6 +193,7 @@ function applyJsMetricsSnapshot(now: number): void {
     analysis: buildAnalysisDiag(),
     collecting: false,
     updatedAt: now,
+    sampleAt: snapshot.sampleAt,
   });
 }
 
@@ -219,6 +223,7 @@ async function pollOnce(): Promise<void> {
         analysis: buildAnalysisDiag(),
         collecting: false,
         updatedAt: completedAt,
+        sampleAt: snapshot.sampleAt,
       });
       return;
     }
@@ -278,6 +283,8 @@ async function pollOnce(): Promise<void> {
       ? completedAt
       : snapshot.updatedAt;
 
+    const nextSampleAt = ratesChanged ? completedAt : snapshot.sampleAt;
+
     publishLiveSnapshot({
       cpu: {
         app,
@@ -290,6 +297,7 @@ async function pollOnce(): Promise<void> {
       analysis: buildAnalysisDiag(),
       collecting: false,
       updatedAt: nextUpdatedAt,
+      sampleAt: nextSampleAt,
     });
   } catch {
     if (generation !== pollGeneration) return;
@@ -298,6 +306,7 @@ async function pollOnce(): Promise<void> {
       cpu: { app: 0, webkit: 0, supported: false, memory: [], threadCpu: [] },
       collecting: false,
       updatedAt: Date.now(),
+      sampleAt: 0,
     });
   }
 }

--- a/src/utils/perf/perfOverlayPins.ts
+++ b/src/utils/perf/perfOverlayPins.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from 'react';
 import { clearPerfLiveHistory } from './perfLiveHistory';
+import { perfLiveCpuSnapshotSupported } from './perfLiveCpuSnapshot';
 import { getPerfOverlayMode } from './perfOverlayMode';
 import { getPerfProbeFlags, setPerfProbeFlag, subscribePerfProbeFlags } from './perfFlags';
 
@@ -126,7 +127,16 @@ export function hasAnyPerfOverlayVisible(): boolean {
   );
 }
 
+function livePinsNeedJsPoll(pins: ReadonlySet<string>): boolean {
+  for (const id of pins) {
+    if (id.startsWith('rate:') || id.startsWith('analysis:')) return true;
+  }
+  return false;
+}
+
 export function hasAnyLiveMetricPollNeed(): boolean {
   if (getPerfOverlayMode() !== 'pinned') return false;
-  return livePins.size > 0;
+  if (livePins.size === 0) return false;
+  if (perfLiveCpuSnapshotSupported()) return true;
+  return livePinsNeedJsPoll(livePins);
 }


### PR DESCRIPTION
## Summary

Fixes periodic idle Rust/tokio CPU load (~2s cadence) and Performance Probe overlay flicker introduced around the Advanced analytics backfill coordinator (#881) and Performance Probe live polling.

- **Analysis backfill coordinator:** park on `Notify` when Advanced analytics is disabled or has no session — no idle 2s poll loop while off; wake on configure or library sync-idle.
- **Performance Probe CPU sampling:** run `performance_cpu_snapshot` on the blocking pool (`async` + `spawn_blocking`); skip the `/proc` poll entirely on Windows (JS-only metrics when pinned).
- **Probe UI:** single publish path, skip no-op snapshot emits, stable sparkline clock (`sampleAt`) between poll ticks, hold previous CPU % until the first rate delta (no 0% flash).
- **Idle background polls:** Settings → Storage hot-cache size poll 2s → 15s; cover registry skips `cover_cache_stats` on every 1.5s tick — drain via ensure only, full disk usage every 30s when idle.
- **Cover prefetch regression:** restore lazy route registry warm-up so cached WebP paths reach `diskSrcCache` before cells mount.

## Tauri boundary

- `performance_cpu_snapshot`: **sync → async** (`spawn_blocking`); return type now `Result<PerformanceCpuSnapshot, String>`; JSON payload unchanged.
- No new commands or events; frontend already uses `await invoke(...)`.

## Who should notice

- **All users (idle CPU):** lower background Rust CPU when Advanced analytics is off and when not actively using Performance Probe.
- **Performance Probe users:** smoother overlay/sparkline; Windows shows JS metrics only (no live process CPU/RSS sampler).
- **Browse UX:** cached covers show promptly again after the brief prefetch disable.

## Test plan

- [ ] Idle on Settings (Advanced analytics off): Rust/tokio CPU stays low in htop/`ps` — no ~2s spikes.
- [ ] Performance Probe with thread-group pins (Linux): overlay CPU/RSS stable; sparkline does not jump on FPS overlay re-renders; no 0% flash on first sample.
- [ ] Windows build: probe usable; no crash when CPU snapshot unsupported.
- [ ] Browse albums/artists with cached covers: thumbnails appear without long delay.
- [ ] Enable Advanced analytics + backfill: coordinator wakes after configure/sync-idle and processes tracks normally.
- [ ] Settings → Storage: hot-cache readout still updates (slower poll).

## CI

Local run matches PR workflows: Vitest (1537), `tsc --noEmit`, frontend + Rust hot-path coverage gates, `cargo test --workspace --all-targets`, `cargo clippy -D warnings`.