### PR TITLE
fix(cover): stop per-song over-fetch + log failed cover downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -661,7 +661,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Worklist is now built from a single DB `GROUP BY` plus one cover-dir snapshot and diffed in memory — no per-row `stat`, no per-batch rescan loop — so increasing parallelism actually saturates the pipeline.
 * **Settings → offline & cache** caused periodic CPU spikes: the section re-walked each server's full cover directory every 15s. The per-server walk is now memoized with a short TTL and reused by the stats/progress commands; the menu recomputes on entry and via progress/cache-cleared events, with a 5-minute safety poll instead of a tight 15s loop.
 * Transient download failures (network / 5xx / 429) retry up to 3× with exponential backoff; permanent 4xx settle without re-scanning.
-* **Massive cover over-fetch on Navidrome:** the per-disc cover detection treated each track's own `mf-<id>` coverArt as "distinct disc art", so backfill warmed one cover per track (e.g. ~520k elements for ~170k tracks) and filled `album/` with `mf-*` directories. It now only treats a release as multi-disc when each disc has a single consistent cover that differs across discs; per-song ids collapse to one cover per album (≈ albums + artists). Same fix in the on-demand `albumHasDistinctDiscCovers` path.
+
+### Cover art — per-song over-fetch on Navidrome (album/mf-* explosion)
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#944](https://github.com/Psychotoxical/psysonic/pull/944)**
+
+* The per-disc cover detection treated each track's own `mf-<id>` coverArt as "distinct disc art", so backfill warmed one cover per track (e.g. ~520k cached elements for ~170k tracks) and filled the `album/` bucket with `mf-*` directories.
+* It now treats a release as multi-disc only when each disc has a single consistent cover that differs across discs (a genuine box set); per-song ids collapse to one cover per album (≈ albums + artists). Fixed on both the Rust backfill path and the on-demand TS `albumHasDistinctDiscCovers`.
 
 ## [1.46.0] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -661,6 +661,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Worklist is now built from a single DB `GROUP BY` plus one cover-dir snapshot and diffed in memory — no per-row `stat`, no per-batch rescan loop — so increasing parallelism actually saturates the pipeline.
 * **Settings → offline & cache** caused periodic CPU spikes: the section re-walked each server's full cover directory every 15s. The per-server walk is now memoized with a short TTL and reused by the stats/progress commands; the menu recomputes on entry and via progress/cache-cleared events, with a 5-minute safety poll instead of a tight 15s loop.
 * Transient download failures (network / 5xx / 429) retry up to 3× with exponential backoff; permanent 4xx settle without re-scanning.
+* **Massive cover over-fetch on Navidrome:** the per-disc cover detection treated each track's own `mf-<id>` coverArt as "distinct disc art", so backfill warmed one cover per track (e.g. ~520k elements for ~170k tracks) and filled `album/` with `mf-*` directories. It now only treats a release as multi-disc when each disc has a single consistent cover that differs across discs; per-song ids collapse to one cover per album (≈ albums + artists). Same fix in the on-demand `albumHasDistinctDiscCovers` path.
 
 ## [1.46.0] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -668,6 +668,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The per-disc cover detection treated each track's own `mf-<id>` coverArt as "distinct disc art", so backfill warmed one cover per track (e.g. ~520k cached elements for ~170k tracks) and filled the `album/` bucket with `mf-*` directories.
 * It now treats a release as multi-disc only when each disc has a single consistent cover that differs across discs (a genuine box set); per-song ids collapse to one cover per album (≈ albums + artists). Fixed on both the Rust backfill path and the on-demand TS `albumHasDistinctDiscCovers`.
+* Failed cover downloads are now logged with the album/artist name and the server error (e.g. `fetch failed for album "X" — Artist (coverArtId=…): cover HTTP 503`). Backfill failures log at the normal level; incidental on-demand misses stay at the debug level.
 
 ## [1.46.0] - 2026-05-18
 

--- a/src-tauri/crates/psysonic-library/src/cover_resolve.rs
+++ b/src-tauri/crates/psysonic-library/src/cover_resolve.rs
@@ -203,6 +203,72 @@ pub fn cover_backfill_items_for_album(
     Ok(out)
 }
 
+/// Human-readable label for a cover target, for failure logs:
+/// `album "Name" — Artist` / `artist "Name"`. Best-effort: returns `None` when
+/// the entity is not in the local index (e.g. a stale per-disc `mf-*` id), so
+/// the caller can fall back to the raw id.
+pub fn describe_cover_entity(
+    store: &LibraryStore,
+    library_server_id: &str,
+    cache_kind: &str,
+    cache_entity_id: &str,
+) -> Option<String> {
+    let id = cache_entity_id.trim();
+    if id.is_empty() {
+        return None;
+    }
+    store
+        .with_read_conn(|conn| {
+            let label = if cache_kind == "artist" {
+                let name = conn
+                    .query_row(
+                        "SELECT name FROM artist WHERE server_id = ?1 AND id = ?2",
+                        rusqlite::params![library_server_id, id],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()?
+                    .or(conn
+                        .query_row(
+                            "SELECT artist FROM track
+                             WHERE server_id = ?1 AND artist_id = ?2 AND deleted = 0
+                               AND NULLIF(TRIM(artist), '') IS NOT NULL
+                             LIMIT 1",
+                            rusqlite::params![library_server_id, id],
+                            |row| row.get::<_, String>(0),
+                        )
+                        .optional()?);
+                name.map(|n| format!("artist \"{n}\""))
+            } else {
+                let pair = conn
+                    .query_row(
+                        "SELECT name, artist FROM album WHERE server_id = ?1 AND id = ?2",
+                        rusqlite::params![library_server_id, id],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+                    )
+                    .optional()?
+                    .or(conn
+                        .query_row(
+                            "SELECT album, artist FROM track
+                             WHERE server_id = ?1 AND album_id = ?2 AND deleted = 0
+                               AND NULLIF(TRIM(album), '') IS NOT NULL
+                             LIMIT 1",
+                            rusqlite::params![library_server_id, id],
+                            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+                        )
+                        .optional()?);
+                pair.map(|(name, artist)| {
+                    match artist.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+                        Some(a) => format!("album \"{name}\" — {a}"),
+                        None => format!("album \"{name}\""),
+                    }
+                })
+            };
+            Ok(label)
+        })
+        .ok()
+        .flatten()
+}
+
 pub fn resolve_artist_cover_entry(
     _store: &LibraryStore,
     _library_server_id: &str,
@@ -355,6 +421,35 @@ mod tests {
         let items = cover_backfill_items_for_album(&store, "srv", "al-nav").unwrap();
         let ids: Vec<_> = items.iter().map(|i| i.cache_entity_id.as_str()).collect();
         assert_eq!(ids, vec!["al-nav"]);
+    }
+
+    #[test]
+    fn describe_entity_labels_album_and_artist() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn_mut("seed_describe", |conn| {
+                conn.execute(
+                    "INSERT INTO album (server_id, id, name, artist, synced_at, raw_json)
+                     VALUES ('srv', 'al-1', 'Discovery', 'Daft Punk', 1, '{}')",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO artist (server_id, id, name, synced_at, raw_json)
+                     VALUES ('srv', 'ar-1', 'Daft Punk', 1, '{}')",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(
+            describe_cover_entity(&store, "srv", "album", "al-1").as_deref(),
+            Some("album \"Discovery\" — Daft Punk"),
+        );
+        assert_eq!(
+            describe_cover_entity(&store, "srv", "artist", "ar-1").as_deref(),
+            Some("artist \"Daft Punk\""),
+        );
+        assert_eq!(describe_cover_entity(&store, "srv", "album", "al-missing"), None);
     }
 
     // Multi-disc, but each disc still exposes per-song ids (not a shared disc

--- a/src-tauri/crates/psysonic-library/src/cover_resolve.rs
+++ b/src-tauri/crates/psysonic-library/src/cover_resolve.rs
@@ -54,7 +54,15 @@ pub fn album_has_distinct_disc_covers(
                 row.get::<_, Option<String>>(3)?,
             ))
         })?;
-        let mut art_by_disc: std::collections::HashMap<i64, String> = std::collections::HashMap::new();
+        // Genuine per-disc artwork = a multi-disc release where each disc has ONE
+        // consistent cover and those covers differ between discs (e.g. a box set).
+        // It must NOT be tripped by per-song cover ids: Navidrome (and other
+        // OpenSubsonic servers) give every track its own `mf-<id>` coverArt, so a
+        // disc whose tracks carry many different ids is per-song art, not per-disc
+        // art — treating it as distinct explodes the backfill into one cover per
+        // track instead of one per album.
+        let mut art_by_disc: std::collections::HashMap<i64, std::collections::HashSet<String>> =
+            std::collections::HashMap::new();
         for row in rows {
             let (track_id, disc_number, cover_art_id, row_album_id) = row?;
             let disc = disc_number.unwrap_or(1);
@@ -63,19 +71,22 @@ pub fn album_has_distinct_disc_covers(
                 .filter(|s| !s.is_empty())
                 .unwrap_or(album_id);
             let fetch = song_fetch_cover_art_id(cover_art_id.as_deref(), &track_id, al);
-            if let Some(prev) = art_by_disc.get(&disc) {
-                if prev != &fetch {
-                    return Ok(true);
-                }
-            } else {
-                art_by_disc.insert(disc, fetch);
-            }
+            art_by_disc.entry(disc).or_default().insert(fetch);
         }
         if art_by_disc.len() <= 1 {
             return Ok(false);
         }
-        let unique: std::collections::HashSet<_> = art_by_disc.values().collect();
-        Ok(unique.len() > 1)
+        let mut disc_covers: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for covers in art_by_disc.values() {
+            // Tracks within a disc disagree → per-song ids, not a shared disc cover.
+            if covers.len() != 1 {
+                return Ok(false);
+            }
+            if let Some(cover) = covers.iter().next() {
+                disc_covers.insert(cover.clone());
+            }
+        }
+        Ok(disc_covers.len() > 1)
     })
 }
 
@@ -328,5 +339,37 @@ mod tests {
         assert!(album_has_distinct_disc_covers(&store, "srv", "al-box").unwrap());
         let e = resolve_track_cover_entry(&store, "srv", "tr2").unwrap().unwrap();
         assert_eq!(e.cache_entity_id, "mf-b");
+    }
+
+    // Navidrome gives every song its own `mf-<id>` coverArt. Many tracks on a
+    // single disc must NOT count as distinct disc covers, or backfill would warm
+    // one cover per track instead of one per album.
+    #[test]
+    fn per_song_ids_within_one_disc_are_not_distinct() {
+        let store = LibraryStore::open_in_memory();
+        seed_album(&store, "srv", "al-nav", None);
+        seed_track(&store, "srv", "tr1", "al-nav", 1, Some("mf-1"));
+        seed_track(&store, "srv", "tr2", "al-nav", 1, Some("mf-2"));
+        seed_track(&store, "srv", "tr3", "al-nav", 1, Some("mf-3"));
+        assert!(!album_has_distinct_disc_covers(&store, "srv", "al-nav").unwrap());
+        let items = cover_backfill_items_for_album(&store, "srv", "al-nav").unwrap();
+        let ids: Vec<_> = items.iter().map(|i| i.cache_entity_id.as_str()).collect();
+        assert_eq!(ids, vec!["al-nav"]);
+    }
+
+    // Multi-disc, but each disc still exposes per-song ids (not a shared disc
+    // cover) → per-song art, so backfill collapses to the single album cover.
+    #[test]
+    fn per_song_ids_across_discs_are_not_distinct() {
+        let store = LibraryStore::open_in_memory();
+        seed_album(&store, "srv", "al-nav2", None);
+        seed_track(&store, "srv", "tr1", "al-nav2", 1, Some("mf-1"));
+        seed_track(&store, "srv", "tr2", "al-nav2", 1, Some("mf-2"));
+        seed_track(&store, "srv", "tr3", "al-nav2", 2, Some("mf-3"));
+        seed_track(&store, "srv", "tr4", "al-nav2", 2, Some("mf-4"));
+        assert!(!album_has_distinct_disc_covers(&store, "srv", "al-nav2").unwrap());
+        let items = cover_backfill_items_for_album(&store, "srv", "al-nav2").unwrap();
+        let ids: Vec<_> = items.iter().map(|i| i.cache_entity_id.as_str()).collect();
+        assert_eq!(ids, vec!["al-nav2"]);
     }
 }

--- a/src-tauri/src/cover_cache/backfill_worker.rs
+++ b/src-tauri/src/cover_cache/backfill_worker.rs
@@ -271,6 +271,7 @@ async fn ensure_one(
         username: session.username,
         password: session.password,
         library_bulk: true,
+        library_server_id: Some(session.library_server_id),
     };
     let _ = CoverCacheState::ensure_inner(&st, &app, &args, Some(http_sem)).await;
 }

--- a/src-tauri/src/cover_cache/mod.rs
+++ b/src-tauri/src/cover_cache/mod.rs
@@ -107,6 +107,10 @@ pub struct CoverCacheEnsureArgs {
     /// Library backfill: all derived tiers, no `cover:tier-ready` floods to the webview.
     #[serde(default)]
     pub library_bulk: bool,
+    /// Library server id (DB key) — set by backfill so a failed fetch can be logged
+    /// with the album/artist name. On-demand UI ensures leave it `None`.
+    #[serde(default)]
+    pub library_server_id: Option<String>,
 }
 
 fn cover_dir_for_args(root: &Path, args: &CoverCacheEnsureArgs) -> PathBuf {
@@ -266,7 +270,8 @@ impl CoverCacheState {
         } else {
             match download_cover_payload(&dir, &client, &http_sem, args).await {
                 Ok(bytes) => CoverSource::Bytes(bytes),
-                Err(_) => {
+                Err(err) => {
+                    log_cover_fetch_failure(app, args, &err);
                     let _ = std::fs::create_dir_all(&dir);
                     let _ = std::fs::write(dir.join(COVER_FETCH_FAIL_MARKER), b"1");
                     return Ok(CoverCacheEnsureResult {
@@ -356,6 +361,41 @@ impl CoverCacheState {
             path: String::new(),
             tier: requested,
         })
+    }
+}
+
+/// Log a non-200 / failed cover download with the album/artist name when known.
+/// Backfill fetches (`library_bulk`) log at the normal level — the user wants to
+/// see which covers a busy server refused; incidental on-demand UI misses stay at
+/// the debug level so they don't spam the normal log.
+fn log_cover_fetch_failure(app: &AppHandle, args: &CoverCacheEnsureArgs, err: &str) {
+    let label = args
+        .library_server_id
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .and_then(|lib_id| {
+            app.try_state::<LibraryRuntime>().and_then(|rt| {
+                psysonic_library::cover_resolve::describe_cover_entity(
+                    &rt.store,
+                    lib_id,
+                    &args.cache_kind,
+                    &args.cache_entity_id,
+                )
+            })
+        })
+        .unwrap_or_else(|| format!("{} {}", args.cache_kind, args.cache_entity_id));
+    if args.library_bulk {
+        crate::app_eprintln!(
+            "[cover-backfill] fetch failed for {label} (coverArtId={}, tier={}): {err}",
+            args.cover_art_id,
+            args.tier
+        );
+    } else {
+        crate::app_deprintln!(
+            "[cover] fetch failed for {label} (coverArtId={}, tier={}): {err}",
+            args.cover_art_id,
+            args.tier
+        );
     }
 }
 

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -145,6 +145,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Live Search: scoped browse on Artists, Albums, New Releases, Tracks, and Composers — header badge, ghost restore, album title FTS, session stash (PR #938)',
       'Performance: idle Rust CPU — backfill coordinator park, probe overlay stability, throttled idle polls, lazy cover prefetch restore (PR #939)',
       'Cover backfill: disk-free idle gate, snapshot-diff worklist, live-tunable parallelism, transient-error retries, and memoized offline & cache stats to stop idle CPU spin (PR #943)',
+      'Cover art: fix per-song cover over-fetch on Navidrome — only genuine per-disc artwork expands, collapsing ~520k per-track fetches to one cover per album (PR #944)',
     ],
   },
   {

--- a/src/cover/resolveEntry.test.ts
+++ b/src/cover/resolveEntry.test.ts
@@ -58,4 +58,25 @@ describe('albumHasDistinctDiscCovers', () => {
       ]),
     ).toBe(true);
   });
+
+  it('false for per-song ids within a single disc (Navidrome)', () => {
+    expect(
+      albumHasDistinctDiscCovers([
+        { id: 't1', albumId: 'al-1', coverArt: 'mf-1', discNumber: 1 },
+        { id: 't2', albumId: 'al-1', coverArt: 'mf-2', discNumber: 1 },
+        { id: 't3', albumId: 'al-1', coverArt: 'mf-3', discNumber: 1 },
+      ]),
+    ).toBe(false);
+  });
+
+  it('false for per-song ids across discs (no shared disc cover)', () => {
+    expect(
+      albumHasDistinctDiscCovers([
+        { id: 't1', albumId: 'al-1', coverArt: 'mf-1', discNumber: 1 },
+        { id: 't2', albumId: 'al-1', coverArt: 'mf-2', discNumber: 1 },
+        { id: 't3', albumId: 'al-1', coverArt: 'mf-3', discNumber: 2 },
+        { id: 't4', albumId: 'al-1', coverArt: 'mf-4', discNumber: 2 },
+      ]),
+    ).toBe(false);
+  });
 });

--- a/src/cover/resolveEntry.ts
+++ b/src/cover/resolveEntry.ts
@@ -33,21 +33,39 @@ export function resolveSongFetchCoverArtId(song: CoverArtResolvableSong): string
   return undefined;
 }
 
-/** True when 2+ discs use different cover art ids. */
+/**
+ * True only for genuine per-disc artwork: a multi-disc release where each disc
+ * has ONE consistent cover and those covers differ between discs (e.g. a box
+ * set). It must NOT be tripped by per-song cover ids — Navidrome (and other
+ * OpenSubsonic servers) give every track its own `mf-<id>` coverArt, so a disc
+ * whose tracks carry many different ids is per-song art, not per-disc art, and
+ * treating it as distinct would warm one cover per track instead of per album.
+ *
+ * Mirrors `album_has_distinct_disc_covers` in `psysonic-library/cover_resolve.rs`.
+ */
 export function albumHasDistinctDiscCovers(
   songs: ReadonlyArray<Pick<SubsonicSong, 'discNumber' | 'coverArt' | 'id' | 'albumId'>>,
 ): boolean {
-  const artByDisc = new Map<number, string>();
+  const artByDisc = new Map<number, Set<string>>();
   for (const song of songs) {
     const disc = song.discNumber ?? 1;
     const artId = resolveSongFetchCoverArtId(song);
     if (!artId) continue;
-    const prev = artByDisc.get(disc);
-    if (prev !== undefined && prev !== artId) return true;
-    artByDisc.set(disc, artId);
+    let set = artByDisc.get(disc);
+    if (!set) {
+      set = new Set<string>();
+      artByDisc.set(disc, set);
+    }
+    set.add(artId);
   }
   if (artByDisc.size <= 1) return false;
-  return new Set(artByDisc.values()).size > 1;
+  const discCovers = new Set<string>();
+  for (const covers of artByDisc.values()) {
+    // Tracks within a disc disagree → per-song ids, not a shared disc cover.
+    if (covers.size !== 1) return false;
+    for (const cover of covers) discCovers.add(cover);
+  }
+  return discCovers.size > 1;
 }
 
 /** Album entity — one cache slot per album unless `distinctDiscCovers`. */


### PR DESCRIPTION
## Summary

Two related cover-backfill improvements (follow-up to #943).

### 1. Stop per-song cover over-fetch (album/mf-* explosion)
On large Navidrome libraries the backfill warmed roughly **one cover per track** instead of one per album — e.g. ~520k cached elements for ~170k tracks — and filled the `album/` bucket with `mf-*` directories.

Root cause: `album_has_distinct_disc_covers` returned `true` as soon as two tracks on the **same disc** had different cover ids. Navidrome (and other OpenSubsonic servers) give every song its own `mf-<id>` coverArt, so almost every album was flagged "distinct disc covers" and each track's `mf-*` became its own `album/mf-*` slot.

Fix: treat a release as multi-disc only when each disc has a single consistent cover that differs across discs (genuine box set). Per-song ids collapse to one cover per album (≈ albums + artists). Mirrored on both the Rust backfill (`cover_resolve.rs`) and the on-demand TS path (`resolveEntry.ts`).

### 2. Log failed cover downloads with the album/artist name
A non-200 / network-failed `getCoverArt` was swallowed silently. Now it is logged with the resolved album/artist name and the server error, e.g.:

```
[cover-backfill] fetch failed for album "Discovery" — Daft Punk (coverArtId=al-1, tier=800): cover HTTP 503
```

- `cover_resolve::describe_cover_entity` resolves a human label from the local index (best-effort, id fallback).
- `log_cover_fetch_failure` in `ensure_inner` logs on the download-error path; an optional `library_server_id` is threaded through `CoverCacheEnsureArgs` so the name lookup only runs on failure. Backfill failures log at the normal level; incidental on-demand UI misses at the debug level.

## Notes
- Caches populated before fix #1 still contain stale `album/mf-*` dirs. They are no longer fetched/referenced; a **Clear cover cache** + re-run rebuilds the bucket at the correct ~albums+artists size.

## Test plan
- [ ] `cargo test -p psysonic-library cover` green (incl. per-song + `describe_cover_entity` tests).
- [ ] `vitest run src/cover/resolveEntry.test.ts src/cover/ref.test.ts` green.
- [ ] Navidrome: clear cover cache, run aggressive backfill → cached count ≈ albums + artists; no new `album/mf-*` dirs.
- [ ] Genuine multi-disc box set with per-disc artwork still warms per-disc covers.
- [ ] Point at a server that 5xx/429s some covers → log lines name the album/artist and the HTTP status.