### PR TITLE
fix(cards): selection ring clipping on browse grids (WebKitGTK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -438,7 +438,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Browse grids — multi-select ring no longer clips (WebKitGTK)
 
-**By [@cucadmuh](https://github.com/cucadmuh), reported by zunoz on Telegram, PR [#962](https://github.com/Psychotoxical/psysonic/pull/962)**
+**By [@cucadmuh](https://github.com/cucadmuh), reported by zunoz on the Psysonic Discord, PR [#962](https://github.com/Psychotoxical/psysonic/pull/962)**
 
 * Multi-select rings on Artists, All Albums, Playlists, and related card grids use an inset `::after` overlay (same approach as card focus rings) instead of `outline` on `overflow: hidden` tiles — fixes top-row clipping and the ~1px gap vs the inner border on Wayland/WebKitGTK.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,6 +436,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Scoped search on Composers no longer replaces the Navidrome role-scoped catalog with generic artist index/search3 hits that merge split composer credits into one joined name and id — results stay split like the scroll overview.
 
 
+### Browse grids — multi-select ring no longer clips (WebKitGTK)
+
+**By [@cucadmuh](https://github.com/cucadmuh), reported by zunoz on Telegram, PR [#962](https://github.com/Psychotoxical/psysonic/pull/962)**
+
+* Multi-select rings on Artists, All Albums, Playlists, and related card grids use an inset `::after` overlay (same approach as card focus rings) instead of `outline` on `overflow: hidden` tiles — fixes top-row clipping and the ~1px gap vs the inner border on Wayland/WebKitGTK.
+
+
 ### In-page browse — virtual scroll and cover-art priority
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#783](https://github.com/Psychotoxical/psysonic/pull/783)**

--- a/src/components/artists/ArtistsGridView.tsx
+++ b/src/components/artists/ArtistsGridView.tsx
@@ -24,7 +24,7 @@ type TilePropsShared = Omit<TileProps, 'artist'>;
 function ArtistGridTile({ artist, ...rest }: TileProps) {
   return (
     <div
-      className={`artist-card${rest.selectionMode && rest.selectedIds.has(artist.id) ? ' selected' : ''}${rest.selectionMode ? ' artist-card--selectable' : ''}`}
+      className={`artist-card${rest.selectionMode ? ' artist-card--selectable' : ''}${rest.selectionMode && rest.selectedIds.has(artist.id) ? ' artist-card--selected' : ''}`}
       onClick={() => {
         if (rest.selectionMode) {
           rest.toggleSelect(artist.id);
@@ -40,11 +40,6 @@ function ArtistGridTile({ artist, ...rest }: TileProps) {
           rest.openContextMenu(e.clientX, e.clientY, artist, 'artist');
         }
       }}
-      style={rest.selectionMode && rest.selectedIds.has(artist.id) ? {
-        outline: '2px solid var(--accent)',
-        outlineOffset: '2px',
-        borderRadius: 'var(--radius-md)',
-      } : {}}
     >
       {rest.selectionMode && (
         <div className={`artist-card-select-check${rest.selectedIds.has(artist.id) ? ' artist-card-select-check--on' : ''}`}>

--- a/src/components/playlists/PlaylistCard.tsx
+++ b/src/components/playlists/PlaylistCard.tsx
@@ -43,7 +43,7 @@ export default function PlaylistCard({
 
   return (
     <div
-      className={`album-card${selectionMode && selectedIds.has(pl.id) ? ' selected' : ''}`}
+      className={`album-card${selectionMode && selectedIds.has(pl.id) ? ' album-card--selected' : ''}`}
       onClick={(e) => {
         if (selectionMode) {
           toggleSelect(pl.id, { shiftKey: e.shiftKey });
@@ -60,12 +60,6 @@ export default function PlaylistCard({
         }
       }}
       onMouseLeave={() => { if (deleteConfirmId === pl.id) setDeleteConfirmId(null); }}
-      style={selectionMode && selectedIds.has(pl.id) ? {
-        position: 'relative',
-        outline: '2px solid var(--accent)',
-        outlineOffset: '2px',
-        borderRadius: 'var(--radius-md)'
-      } : { position: 'relative' }}
     >
       {!selectionMode && (
         <div className="playlist-card-actions">

--- a/src/styles/components/album-row-container.css
+++ b/src/styles/components/album-row-container.css
@@ -346,8 +346,21 @@
 }
 
 .album-card--selected {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
+  outline: none;
+}
+
+/* Inset overlay ring — same approach as `.card:focus-visible::after` in card.css:
+   outline + overflow:hidden clips on WebKitGTK/Wayland; inset box-shadow on ::after
+   paints above the cover without growing the card box. */
+.album-card--selected::after,
+.album-card.selected::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 2px var(--accent);
+  z-index: 4;
+  pointer-events: none;
 }
 
 .album-card-select-check {
@@ -362,7 +375,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 3;
+  z-index: 5;
   pointer-events: none;
 }
 

--- a/src/styles/components/artist-card-selection-checkbox.css
+++ b/src/styles/components/artist-card-selection-checkbox.css
@@ -29,10 +29,19 @@
   cursor: pointer;
 }
 
-/* Inset ring — matches album-card--selected; positive outline-offset clipped the top/side rows. */
+/* Inset overlay ring — see `.album-card--selected::after` / `.card:focus-visible::after`. */
 .artist-card--selected {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
+  outline: none;
+}
+
+.artist-card--selected::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 2px var(--accent);
+  z-index: 4;
+  pointer-events: none;
 }
 
 /* ── Albums selection bar (portal) ── */

--- a/src/styles/components/artist-card-selection-checkbox.css
+++ b/src/styles/components/artist-card-selection-checkbox.css
@@ -25,6 +25,16 @@
   color: var(--ctp-crust);
 }
 
+.artist-card--selectable {
+  cursor: pointer;
+}
+
+/* Inset ring — matches album-card--selected; positive outline-offset clipped the top/side rows. */
+.artist-card--selected {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 /* ── Albums selection bar (portal) ── */
 .albums-selection-bar {
   position: fixed;

--- a/src/styles/components/composer-grid-text-only-compact.css
+++ b/src/styles/components/composer-grid-text-only-compact.css
@@ -34,7 +34,6 @@
 .composer-card:hover {
   border-color: var(--accent);
   background: var(--bg-hover);
-  transform: translateY(-1px);
   box-shadow: 0 4px 12px -6px rgba(0, 0, 0, 0.4);
 }
 


### PR DESCRIPTION
## Summary

- **Reported by zunoz on the Psysonic Discord** (v1.47.0-rc.3): multi-select rings on Artists grid cards were clipped on the top row and near the viewport edge; the ring sat ~1px outside the card on hover. Composers top-row hover had a similar clip.
- Same visual on **All Albums** and related card grids (Wayland / WebKitGTK): `outline` on `overflow: hidden` tiles clips and misaligns against the inset 1px card border.
- **Artists:** `artist-card--selected` uses an inset `::after` overlay (same pattern as `.card:focus-visible` in `card.css`); composer hover no longer uses `translateY(-1px)`.
- **Albums / Playlists / derivatives:** `album-card--selected` (and playlist cards) use the same inset `::after` ring instead of outline; playlist inline outline styles removed.

## Test plan

- [ ] Artists → Select → pick cards in the **top row** and left/right columns — ring not clipped, no 1px gap on hover
- [ ] Composers → hover top-row cards — top edge not sheared
- [ ] All Albums → Select → top-row + hover selected cards — ring flush with card, not cut off
- [ ] Playlists → Select — same ring treatment
- [ ] Keyboard focus ring on cards still works (unchanged `card.css` path)