### PR TITLE
Fix Random Mix audiobook exclusion: click area and false matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -826,6 +826,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * A pass of UI/CSS fixes: keyboard focus rings now sit inside the focused element, so they're no longer clipped at the edge of cards, rails, the player bar, queue tabs or search fields; the page, Help and Settings search fields share one consistent shape and focus highlight; the column-visibility dropdown on track tables no longer gets cut off on short lists (e.g. a single favorited song); and the Theme settings list rounds its corners to match its section.
 
+### Random Mix — audiobook exclusion no longer drops normal music
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#973](https://github.com/Psychotoxical/psysonic/pull/973) — reported by zunoz on Discord**
+
+* "Exclude audiobooks & radio plays" no longer treats **Thriller** and **Fantasy** as audiobook keywords. They matched regular music (Trance/Metal genre tags, a track titled "Thriller") because the filter scans genre, title, album and artist, so a handful of legitimate songs were dropped from each mix.
+* The exclusion's toggle area is tightened so only the checkbox and its title respond to a click — the description text and surrounding empty space no longer toggle it.
+
 ## [1.46.0] - 2026-05-18
 
 > **🙏 Special thanks to [@zz5zz](https://github.com/zz5zz)** for his tireless quirk-spotting and bug reports on the [Psysonic Discord](https://discord.gg/AMnDRErm4u) — several of the polish fixes in this release landed directly off the back of his messages.

--- a/src/components/randomMix/RandomMixFiltersPanel.tsx
+++ b/src/components/randomMix/RandomMixFiltersPanel.tsx
@@ -92,18 +92,24 @@ export default function RandomMixFiltersPanel({
             {t('randomMix.filterPanelDesc')}
           </p>
 
-          <label style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', cursor: 'pointer', fontSize: 13, marginBottom: '0.6rem' }}>
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', fontSize: 13, marginBottom: '0.6rem' }}>
             <input
+              id="random-mix-exclude-audiobooks"
               type="checkbox"
               checked={excludeAudiobooks}
               onChange={e => setExcludeAudiobooks(e.target.checked)}
-              style={{ marginTop: 2 }}
+              style={{ marginTop: 2, flexShrink: 0, cursor: 'pointer' }}
             />
             <div>
-              <div style={{ fontWeight: 500, color: 'var(--text-primary)' }}>{t('randomMix.excludeAudiobooks')}</div>
+              <label
+                htmlFor="random-mix-exclude-audiobooks"
+                style={{ fontWeight: 500, color: 'var(--text-primary)', cursor: 'pointer', display: 'inline-block' }}
+              >
+                {t('randomMix.excludeAudiobooks')}
+              </label>
               <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 2 }}>{t('randomMix.excludeAudiobooksDesc')}</div>
             </div>
-          </label>
+          </div>
 
           <button
             className="btn btn-ghost"

--- a/src/utils/componentHelpers/randomMixHelpers.ts
+++ b/src/utils/componentHelpers/randomMixHelpers.ts
@@ -4,8 +4,8 @@ import { passesMixMinRatings, type MixMinRatingsConfig } from '../mix/mixRatingF
 export const AUDIOBOOK_GENRES = [
   'hörbuch', 'hoerbuch', 'hörspiel', 'hoerspiel',
   'audiobook', 'audio book', 'spoken word', 'spokenword',
-  'podcast', 'kapitel', 'thriller', 'krimi', 'speech',
-  'fantasy', 'comedy', 'literature',
+  'podcast', 'kapitel', 'krimi', 'speech',
+  'comedy', 'literature',
 ];
 
 export function formatRandomMixDuration(seconds: number): string {


### PR DESCRIPTION
## Summary
- Random Mix exclusion toggle: only the checkbox and its title are clickable now — clicking the description or empty space no longer toggles it.
- Drop `Thriller` and `Fantasy` from the audiobook/radio exclusion keyword list. They match regular music (Trance/Metal genre tags, a track titled "Thriller") because the filter checks genre, title, album and artist by substring, so a few legit songs were dropped per mix.

## Test plan
- `npx tsc --noEmit` clean; `npx vitest run` — 1611/1611 green.
- Manual: in Random Mix, the exclusion row toggles only via checkbox/title; with the exclusion on, music tagged or titled Thriller/Fantasy stays in the mix.
