### PR TITLE
Fix queue handle cursor and Favorites column sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -833,6 +833,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * "Exclude audiobooks & radio plays" no longer treats **Thriller** and **Fantasy** as audiobook keywords. They matched regular music (Trance/Metal genre tags, a track titled "Thriller") because the filter scans genre, title, album and artist, so a handful of legitimate songs were dropped from each mix.
 * The exclusion's toggle area is tightened so only the checkbox and its title respond to a click — the description text and surrounding empty space no longer toggle it.
 
+### Cursors and Favorites sorting
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#974](https://github.com/Psychotoxical/psysonic/pull/974) — reported by zunoz on Discord**
+
+* The queue collapse handle now shows a hand cursor like every other button; the thin resize line beside it keeps the resize cursor.
+* On Favorites, the **Plays**, **Last Played** and **BPM** columns are now actually sortable — they showed a clickable cursor but clicking did nothing.
+
 ## [1.46.0] - 2026-05-18
 
 > **🙏 Special thanks to [@zz5zz](https://github.com/zz5zz)** for his tireless quirk-spotting and bug reports on the [Psysonic Discord](https://discord.gg/AMnDRErm4u) — several of the polish fixes in this release landed directly off the back of his messages.

--- a/src/components/favorites/FavoritesSongsTracklist.tsx
+++ b/src/components/favorites/FavoritesSongsTracklist.tsx
@@ -15,8 +15,7 @@ import { useOrbitSongRowBehavior } from '../../hooks/useOrbitSongRowBehavior';
 import { songToTrack } from '../../utils/playback/songToTrack';
 import { APP_MAIN_SCROLL_VIEWPORT_ID } from '../../constants/appScroll';
 import { useElementClientHeightById } from '../../hooks/useResizeClientHeight';
-
-const SORTABLE_COLUMNS = new Set(['title', 'artist', 'album', 'rating', 'duration', 'playCount', 'lastPlayed', 'bpm']);
+import { SORTABLE_COLUMNS } from '../../hooks/useFavoritesSongFiltering';
 
 interface Props {
   visibleSongs: SubsonicSong[];

--- a/src/hooks/useFavoritesSongFiltering.tsx
+++ b/src/hooks/useFavoritesSongFiltering.tsx
@@ -6,8 +6,11 @@ import { usePlayerStore } from '../store/playerStore';
 const CURRENT_YEAR = new Date().getFullYear();
 const MIN_YEAR = 1950;
 
-// Columns that support 3-state sorting (asc → desc → reset)
-const SORTABLE_COLUMNS = new Set(['title', 'artist', 'album', 'rating', 'duration']);
+// Columns that support 3-state sorting (asc → desc → reset).
+// Single source of truth — the tracklist header imports this to decide which
+// headers show the sortable affordance, so the cursor and the click behaviour
+// can never drift apart. Every key here is handled in the comparator below.
+export const SORTABLE_COLUMNS = new Set(['title', 'artist', 'album', 'rating', 'duration', 'playCount', 'lastPlayed', 'bpm']);
 
 export type SortDir = 'asc' | 'desc';
 

--- a/src/styles/layout/resizer-handles.css
+++ b/src/styles/layout/resizer-handles.css
@@ -27,7 +27,10 @@
   border: 1px solid var(--border-subtle);
   background: var(--bg-card);
   color: var(--text-muted);
-  cursor: col-resize;
+  /* The round handle is primarily a click-to-collapse button; the seam strip
+     (.resizer) keeps col-resize, and an actual drag sets the body cursor to
+     col-resize via useQueueResizer. */
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Queue collapse handle now shows a pointer cursor instead of `col-resize` — it is a click-to-collapse button. The seam strip keeps `col-resize`, and an actual drag still switches the body cursor to `col-resize`.
- Favorites: the **Plays**, **Last Played** and **BPM** columns are now actually sortable. The header marked them sortable (pointer) but the click handler gated on a separate, narrower column set, so clicks did nothing. The header and the comparator now share one `SORTABLE_COLUMNS` source so the affordance and behaviour can't drift apart.

## Test plan
- `npx tsc --noEmit` clean.
- Manual: queue collapse handle shows a hand; the vertical seam shows the resize cursor; on Favorites, clicking Plays / Last Played / BPM headers sorts (asc → desc → reset).
- Note: 4 pre-existing full-suite failures (Login / AddServer v2 magic-string) reproduce on clean `main` and pass in isolation — unrelated to this change.
