### PR TITLE
ci: add automated winget publish workflow

### DIFF
--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -1,0 +1,14 @@
+name: Publish to winget
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@latest
+        with:
+          identifier: Psychotoxical.Psysonic
+          installers-regex: '_x64-setup\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Token needs to be made with HTTPS://GitHub.com/settings/tokens -> classic token -> only give "public_repo" rule. By a dev with write access likely Psychotoxical make sure to name the token WINGET_TOKEN

Adds a GitHub Actions workflow that automatically submits a pull request to `microsoft/winget-pkgs` whenever a new release is published.

The workflow uses `vedantmgoyal9/winget-releaser` and only fires on non-prerelease releases, so RC builds are ignored. It targets the `_x64-setup.exe` asset specifically to avoid picking up the Linux/macOS artifacts.

The initial `Psychotoxical.Psysonic 1.46.0` package has already been submitted to winget-pkgs manually — this workflow handles all future versions automatically.