### PR TITLE
fix(ui): square song-rail nav buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -893,6 +893,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The minimum window size is a touch larger so the layout can no longer be shrunk past the point where it breaks.
 * On a short window the Now Playing cover scales down to fit instead of overlapping the track title.
 
+### Song rails — consistent navigation buttons
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#982](https://github.com/Psychotoxical/psysonic/pull/982)**
+
+* The song rail's previous/next and reroll buttons are now square like every other rail instead of round.
+
 ## [1.46.0] - 2026-05-18
 
 > **🙏 Special thanks to [@zz5zz](https://github.com/zz5zz)** for his tireless quirk-spotting and bug reports on the [Psysonic Discord](https://discord.gg/AMnDRErm4u) — several of the polish fixes in this release landed directly off the back of his messages.

--- a/src/styles/tracks/song-rail-mirrors-album-row-pattern.css
+++ b/src/styles/tracks/song-rail-mirrors-album-row-pattern.css
@@ -25,7 +25,9 @@
   justify-content: center;
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  /* Square to match the album/artist row nav (`.album-row-nav .nav-btn`); this
+     rail had drifted to a circle. */
+  border-radius: var(--radius-sm);
   background: var(--bg-card);
   border: 1px solid var(--border-subtle);
   color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- The song rail's prev/next (and reroll) buttons were circular while every other rail (albums, artists) and the hero arrows use the square rounded-rect nav button. Align the song rail to the square style for a consistent look.

## Test plan
- CSS-only one-liner; verified live (HMR) that the song-rail nav buttons render square like the other rails.