### PR TITLE
fix(ui): New badge flicker on mainstage album rail hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -567,7 +567,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#986](https://github.com/Psychotoxical/psysonic/pull/986)**
 
-* Horizontal rails (Home New Releases, Discover, …) no longer flash the **New** cover badge on the first pointer hover — cover stacking matches the New Releases grid (`contain: paint`, compositor layers) so the badge stays visible during hover zoom.
+* Horizontal album rails (Home New Releases, Discover, Favorites, Statistics, search rows, …) no longer hide the **New** / offline cover badges during hover zoom — cover stacking is shared with grid pages; rails keep dim-on-`::before` for play controls.
 
 
 ### Album view — bulk add to playlist selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Album grids and song rails:** overlay `pointer-events` so the dim layer does not steal hover from the card.
 
 
+### Mainstage album rails — stable New badge on first hover
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#986](https://github.com/Psychotoxical/psysonic/pull/986)**
+
+* Horizontal rails (Home New Releases, Discover, …) no longer flash the **New** cover badge on the first pointer hover — dimming sits on a cover layer below badges instead of the play overlay.
+
 
 ### Album view — bulk add to playlist selection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -567,7 +567,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#986](https://github.com/Psychotoxical/psysonic/pull/986)**
 
-* Horizontal rails (Home New Releases, Discover, …) no longer flash the **New** cover badge on the first pointer hover — dimming sits on a cover layer below badges instead of the play overlay.
+* Horizontal rails (Home New Releases, Discover, …) no longer flash the **New** cover badge on the first pointer hover — cover stacking matches the New Releases grid (`contain: paint`, compositor layers) so the badge stays visible during hover zoom.
 
 
 ### Album view — bulk add to playlist selection

--- a/src/styles/components/album-card.css
+++ b/src/styles/components/album-card.css
@@ -29,6 +29,8 @@
   height: 100%;
   object-fit: cover;
   transform-origin: center center;
+  position: relative;
+  z-index: 0;
   transform: translateZ(0) scale(1);
   transition: opacity 0.15s ease, transform 350ms cubic-bezier(0.16, 1, 0.3, 1);
 }

--- a/src/styles/components/album-row-container.css
+++ b/src/styles/components/album-row-container.css
@@ -116,8 +116,11 @@
 }
 
 .album-grid .album-card-cover {
-  contain: layout style;
-  transform: none;
+  /* Match grid pages (New Releases): paint containment + isolate so scaled
+   * cover art stays below absolutely positioned badges during hover zoom. */
+  contain: paint;
+  isolation: isolate;
+  transform: translateZ(0);
 }
 
 /* Dim below badges/play controls — overlay background on a later sibling made
@@ -137,13 +140,16 @@
 }
 
 .album-grid .album-card-cover img {
+  position: relative;
+  z-index: 0;
   transform-origin: center center;
-  transform: scale(1);
+  transform: translateZ(0) scale(1);
   transition: opacity 0.15s ease, transform 350ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.album-grid .album-card-cover:hover img {
-  transform: scale(1.02);
+.album-grid .album-card-cover:hover img,
+.album-grid .album-card:hover .album-card-cover img {
+  transform: translateZ(0) scale(1.02);
 }
 
 .album-grid .album-card .album-card-play-overlay {
@@ -174,6 +180,7 @@
 
 .album-grid .album-card-cover-badges-tr {
   z-index: 3;
+  transform: translateZ(0);
 }
 
 .album-grid .artist-card {

--- a/src/styles/components/album-row-container.css
+++ b/src/styles/components/album-row-container.css
@@ -107,7 +107,6 @@
    no .card transition, hover pinned to cover, dim via overlay background not opacity. */
 .album-grid .album-card {
   contain: none;
-  transform: none;
   transition: none;
 }
 
@@ -115,16 +114,7 @@
   box-shadow: inset 0 0 0 1px var(--border-subtle);
 }
 
-.album-grid .album-card-cover {
-  /* Match grid pages (New Releases): paint containment + isolate so scaled
-   * cover art stays below absolutely positioned badges during hover zoom. */
-  contain: paint;
-  isolation: isolate;
-  transform: translateZ(0);
-}
-
-/* Dim below badges/play controls — overlay background on a later sibling made
-   the New badge flicker on first cover:hover (WebKitGTK mainstage rails). */
+/* Dim below badges/play controls (all horizontal rails: Home, Favorites, Statistics, …). */
 .album-grid .album-card-cover::before {
   content: '';
   position: absolute;
@@ -137,19 +127,6 @@
 .album-grid .album-card-cover:hover::before,
 .album-grid .album-card-cover:focus-within::before {
   background: rgba(0, 0, 0, 0.4);
-}
-
-.album-grid .album-card-cover img {
-  position: relative;
-  z-index: 0;
-  transform-origin: center center;
-  transform: translateZ(0) scale(1);
-  transition: opacity 0.15s ease, transform 350ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.album-grid .album-card-cover:hover img,
-.album-grid .album-card:hover .album-card-cover img {
-  transform: translateZ(0) scale(1.02);
 }
 
 .album-grid .album-card .album-card-play-overlay {
@@ -176,11 +153,6 @@
 .album-grid .album-card-cover:focus-within .album-card-details-btn {
   opacity: 1;
   pointer-events: auto;
-}
-
-.album-grid .album-card-cover-badges-tr {
-  z-index: 3;
-  transform: translateZ(0);
 }
 
 .album-grid .artist-card {
@@ -218,7 +190,8 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 4px;
-  z-index: 2;
+  z-index: 3;
+  transform: translateZ(0);
   pointer-events: none;
 }
 
@@ -249,6 +222,7 @@
 .album-card-play-overlay {
   position: absolute;
   inset: 0;
+  z-index: 2;
   background: rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;

--- a/src/styles/components/album-row-container.css
+++ b/src/styles/components/album-row-container.css
@@ -130,7 +130,8 @@
 }
 
 .album-grid .album-card .album-card-play-overlay {
-  z-index: 2;
+  z-index: 4;
+  transform: translateZ(0);
   opacity: 1;
   background-color: transparent;
   transition: none;
@@ -190,7 +191,7 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 4px;
-  z-index: 3;
+  z-index: 5;
   transform: translateZ(0);
   pointer-events: none;
 }
@@ -223,6 +224,7 @@
   position: absolute;
   inset: 0;
   z-index: 2;
+  transform: translateZ(0);
   background: rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;

--- a/src/styles/components/album-row-container.css
+++ b/src/styles/components/album-row-container.css
@@ -120,6 +120,22 @@
   transform: none;
 }
 
+/* Dim below badges/play controls — overlay background on a later sibling made
+   the New badge flicker on first cover:hover (WebKitGTK mainstage rails). */
+.album-grid .album-card-cover::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background: transparent;
+}
+
+.album-grid .album-card-cover:hover::before,
+.album-grid .album-card-cover:focus-within::before {
+  background: rgba(0, 0, 0, 0.4);
+}
+
 .album-grid .album-card-cover img {
   transform-origin: center center;
   transform: scale(1);
@@ -131,28 +147,33 @@
 }
 
 .album-grid .album-card .album-card-play-overlay {
+  z-index: 2;
   opacity: 1;
   background-color: transparent;
   transition: none;
+  pointer-events: none;
 }
 
 .album-grid .album-card .album-card-details-btn {
-  visibility: hidden;
   opacity: 0;
+  visibility: visible;
   pointer-events: none;
   transition: none;
 }
 
 .album-grid .album-card-cover:hover .album-card-play-overlay,
 .album-grid .album-card-cover:focus-within .album-card-play-overlay {
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: transparent;
 }
 
 .album-grid .album-card-cover:hover .album-card-details-btn,
 .album-grid .album-card-cover:focus-within .album-card-details-btn {
-  visibility: visible;
   opacity: 1;
   pointer-events: auto;
+}
+
+.album-grid .album-card-cover-badges-tr {
+  z-index: 3;
 }
 
 .album-grid .artist-card {


### PR DESCRIPTION
## Summary
- Mainstage horizontal album rails (New Releases, Discover, …) dim the cover via a `::before` layer below badges instead of toggling the play-overlay background.
- Rail action buttons use opacity only (no `visibility` flip) so the New badge does not flash on first cover hover.
- Matches the stable stacking used on the full New Releases grid page.

## Test plan
- [ ] Home → New Releases rail → hover a cover with a **New** badge — badge stays stable on first hover; play/enqueue still appear
- [ ] Same on Discover rail
- [ ] `/new-releases` page — unchanged hover behavior