### PR TITLE
fix(audio): cap pipewire-alsa client latency on Linux (#862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -988,6 +988,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Show remaining time** no longer reticks the seekbar width every second — fixed-width playbar clocks stop `WaveformSeek` resize/redraw jitter; clocks sit tighter against the waveform with an inline duration toggle icon.
 
 
+### Linux — instant play/pause/seek/volume on PipeWire
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), reported by PHLAK, PR [#990](https://github.com/Psychotoxical/psysonic/pull/990)**
+
+* On some PipeWire setups, play, pause, seek and volume changes only took effect after a long delay (10+ seconds). Root cause: the PipeWire ALSA bridge negotiated a multi-second audio buffer, so changes were only heard once it drained. Psysonic now caps that buffer, so the controls respond immediately.
+
+
 ## [1.46.0] - 2026-05-18
 
 > **🙏 Special thanks to [@zz5zz](https://github.com/zz5zz)** for his tireless quirk-spotting and bug reports on the [Psysonic Discord](https://discord.gg/AMnDRErm4u) — several of the polish fixes in this release landed directly off the back of his messages.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -32,7 +32,26 @@ fn apply_linux_webkit_nvidia_quirk() {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn apply_pipewire_latency() {
+    // Linux audio output goes through the pipewire-alsa bridge, which on some
+    // setups negotiates a huge default buffer (~1M frames ≈ 10–20 s); play/pause/
+    // seek/volume then lag until it drains (issue #862). cpal's buffer-size clamp
+    // is ignored by those bridges. Setting the client-node latency via
+    // `PIPEWIRE_LATENCY` caps it — the reporter confirmed `256/48000` makes
+    // play/pause/volume instant. No-op on non-PipeWire Linux (var is ignored).
+    // A user-provided value is left untouched.
+    if std::env::var_os("PIPEWIRE_LATENCY").is_none() {
+        std::env::set_var("PIPEWIRE_LATENCY", "256/48000");
+    }
+}
+
 fn main() {
+    // Linux audio: cap the pipewire-alsa client latency so play/pause/seek/volume
+    // respond promptly (issue #862). Must run before any audio stream is opened.
+    #[cfg(target_os = "linux")]
+    apply_pipewire_latency();
+
     // Linux GTK/WebKit: `webkit2gtk-nvidia-quirk` (skipped when `PSYSONIC_WEBKIT_GPU_ACCEL` is set).
     // Forced `GDK_BACKEND=x11` uses the X11-only mitigation path — see `apply_linux_webkit_nvidia_quirk`.
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary
Fixes #862 — on some Linux setups, play/pause/seek/volume only took effect after a ~10–20 s delay. Root cause: the pipewire-alsa bridge (our Linux audio output path) negotiates a multi-second output buffer, and the change is only heard once that buffer drains. cpal's buffer-size clamp is ignored by those bridges.

- Set `PIPEWIRE_LATENCY=256/48000` before the audio stream opens, capping the client-node latency so the buffer stays small.
- Linux-only; a no-op on systems without PipeWire (the variable is ignored). A user-provided `PIPEWIRE_LATENCY` is left untouched.
- The reporter confirmed `PIPEWIRE_LATENCY=256/48000` makes play/pause/volume instant on both of their machines.

## Test plan
- `cargo check` clean (Windows variant); Linux build/clippy via CI.
- Reporter-validated on Arch + PipeWire (laptop and desktop).