### PR TITLE
fix(settings): restore full border on active server card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## Fixed
+
+### Servers — complete border on the active server card
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#998](https://github.com/Psychotoxical/psysonic/pull/998)**
+
+* The active server card under **Settings → Servers** now draws its border on all four sides; previously only the left and right edges showed.
+
+
+
 ## [1.47.0]
 
 > **🙏 Thank you to our amazing Discord community.** This release would not have been possible without your tireless support, quality checks, bug reports and all-round collaboration. Every report, every repro and every bit of feedback shaped what shipped here — thank you. Come join us: [discord.gg/AMnDRErm4u](https://discord.gg/AMnDRErm4u)

--- a/src/components/settings/ServersTab.tsx
+++ b/src/components/settings/ServersTab.tsx
@@ -381,8 +381,16 @@ export function ServersTab({
                   style={{
                     border: isActive ? '1px solid var(--accent)' : undefined,
                     background: isActive ? 'color-mix(in srgb, var(--accent) 10%, var(--bg-card))' : undefined,
-                    borderTop:    isBefore ? '2px solid var(--accent)' : undefined,
-                    borderBottom: isAfter  ? '2px solid var(--accent)' : undefined,
+                    // Drop-target indicator via inset shadow rather than
+                    // borderTop/borderBottom: mixing the `border` shorthand with
+                    // border-side longhands in one inline style object makes React
+                    // clear the unset sides, which drops the top/bottom border on
+                    // the active card (only left/right remain).
+                    boxShadow: isBefore
+                      ? 'inset 0 2px 0 0 var(--accent)'
+                      : isAfter
+                      ? 'inset 0 -2px 0 0 var(--accent)'
+                      : undefined,
                   }}
                 >
                   <div style={{ display: 'flex', alignItems: 'stretch', gap: '0.75rem' }}>


### PR DESCRIPTION
## Summary
- The active server card in Settings → Servers showed an accent border only on its left and right sides; the top and bottom fell back to the faint base border.
- Root cause: the inline style mixed the `border` shorthand with `borderTop`/`borderBottom` longhands, so React cleared the unset top/bottom sides on mount (theme-independent).
- The drag drop-target indicator now uses an inset `box-shadow` instead, leaving the `border` shorthand to apply on all four sides (also removes the 1px layout shift during reorder).

## Test plan
- Settings → Servers: active card shows a complete border on all four sides across themes.
- Drag a server to reorder: top/bottom drop-target line still appears at the insertion point.
- `npx tsc --noEmit` clean.