### PR TITLE
feat(library): server cluster identity DB (PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Under the hood — server cluster identity store
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1003](https://github.com/Psychotoxical/psysonic/pull/1003)**
+
+* Derived multi-server cluster identity keys (`artist+title+album`) now live in a separate attached `library-cluster.db`, rebuildable without touching the main library index (server cluster v1 groundwork).
+
+
+
 ## Changed
 
 ### Dependencies — npm and Rust refresh

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4252,6 +4252,8 @@ dependencies = [
  "serde_json",
  "tauri",
  "tokio",
+ "twox-hash",
+ "unicode-normalization",
  "wiremock",
 ]
 
@@ -6602,6 +6604,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.4",
+]
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6682,6 +6693,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/src-tauri/crates/psysonic-library/Cargo.toml
+++ b/src-tauri/crates/psysonic-library/Cargo.toml
@@ -15,6 +15,8 @@ serde_json = "1"
 rusqlite = { version = "0.40", features = ["bundled"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "gzip", "brotli"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time"] }
+twox-hash = "2"
+unicode-normalization = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "test-util"] }

--- a/src-tauri/crates/psysonic-library/src/lib.rs
+++ b/src-tauri/crates/psysonic-library/src/lib.rs
@@ -33,6 +33,7 @@ pub mod payload;
 pub mod repos;
 pub mod runtime;
 pub mod search;
+pub mod server_cluster;
 pub mod store;
 pub mod sync;
 pub(crate) mod track_fts;

--- a/src-tauri/crates/psysonic-library/src/server_cluster/db.rs
+++ b/src-tauri/crates/psysonic-library/src/server_cluster/db.rs
@@ -1,0 +1,171 @@
+//! Attached `library-cluster.db` schema and metadata.
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+pub const CLUSTER_DB_FILENAME: &str = "library-cluster.db";
+pub const ATTACH_ALIAS: &str = "cluster";
+pub const NORM_VERSION: &str = "1";
+
+pub fn cluster_db_path(library_db_path: &Path) -> PathBuf {
+    library_db_path.with_file_name(CLUSTER_DB_FILENAME)
+}
+
+fn escape_sqlite_path(path: &str) -> String {
+    path.replace('\'', "''")
+}
+
+fn init_cluster_on_attached(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute(
+        &format!(
+            "CREATE TABLE IF NOT EXISTS {ATTACH_ALIAS}.track_cluster_key (
+               server_id    TEXT NOT NULL,
+               track_id     TEXT NOT NULL,
+               cluster_key  TEXT NOT NULL,
+               album_key    TEXT,
+               artist_key   TEXT,
+               duration_sec INTEGER,
+               PRIMARY KEY (server_id, track_id)
+             )"
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "CREATE INDEX IF NOT EXISTS {ATTACH_ALIAS}.idx_cluster_key \
+             ON track_cluster_key(cluster_key)"
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "CREATE INDEX IF NOT EXISTS {ATTACH_ALIAS}.idx_album_key \
+             ON track_cluster_key(album_key)"
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "CREATE INDEX IF NOT EXISTS {ATTACH_ALIAS}.idx_artist_key \
+             ON track_cluster_key(artist_key)"
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "CREATE TABLE IF NOT EXISTS {ATTACH_ALIAS}.cluster_meta (
+               key TEXT PRIMARY KEY,
+               value TEXT
+             )"
+        ),
+        [],
+    )?;
+    init_cluster_meta(conn)?;
+    Ok(())
+}
+
+fn init_cluster_file(cluster_path: &Path) -> rusqlite::Result<()> {
+    let cluster_conn = Connection::open(cluster_path)?;
+    cluster_conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS track_cluster_key (
+           server_id    TEXT NOT NULL,
+           track_id     TEXT NOT NULL,
+           cluster_key  TEXT NOT NULL,
+           album_key    TEXT,
+           artist_key   TEXT,
+           duration_sec INTEGER,
+           PRIMARY KEY (server_id, track_id)
+         );
+         CREATE INDEX IF NOT EXISTS idx_cluster_key ON track_cluster_key(cluster_key);
+         CREATE INDEX IF NOT EXISTS idx_album_key  ON track_cluster_key(album_key);
+         CREATE INDEX IF NOT EXISTS idx_artist_key ON track_cluster_key(artist_key);
+         CREATE TABLE IF NOT EXISTS cluster_meta (
+           key TEXT PRIMARY KEY,
+           value TEXT
+         );",
+    )?;
+    cluster_conn.execute(
+        "INSERT OR IGNORE INTO cluster_meta (key, value) VALUES ('norm_version', ?1)",
+        params![NORM_VERSION],
+    )?;
+    Ok(())
+}
+
+/// Create or migrate the cluster file, then attach it to `conn`.
+pub fn attach_cluster_database(conn: &Connection, cluster_path: &Path) -> rusqlite::Result<()> {
+    if let Some(parent) = cluster_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_IOERR),
+                Some(e.to_string()),
+            )
+        })?;
+    }
+    init_cluster_file(cluster_path)?;
+    let path_str = escape_sqlite_path(&cluster_path.to_string_lossy());
+    conn.execute_batch(&format!(
+        "ATTACH DATABASE '{path_str}' AS {ATTACH_ALIAS}"
+    ))?;
+    Ok(())
+}
+
+/// In-memory cluster DB for tests — attach then init schema on the alias.
+pub fn attach_cluster_database_uri(conn: &Connection, uri: &str) -> rusqlite::Result<()> {
+    let path_str = escape_sqlite_path(uri);
+    conn.execute_batch(&format!(
+        "ATTACH DATABASE '{path_str}' AS {ATTACH_ALIAS}"
+    ))?;
+    init_cluster_on_attached(conn)
+}
+
+pub fn ensure_cluster_schema(conn: &Connection) -> rusqlite::Result<()> {
+    init_cluster_on_attached(conn)
+}
+
+pub fn init_cluster_meta(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute(
+        &format!(
+            "INSERT OR IGNORE INTO {ATTACH_ALIAS}.cluster_meta (key, value) VALUES ('norm_version', ?1)"
+        ),
+        params![NORM_VERSION],
+    )?;
+    Ok(())
+}
+
+pub fn stored_norm_version(conn: &Connection) -> rusqlite::Result<Option<String>> {
+    conn.query_row(
+        &format!(
+            "SELECT value FROM {ATTACH_ALIAS}.cluster_meta WHERE key = 'norm_version'"
+        ),
+        [],
+        |row| row.get(0),
+    )
+    .optional()
+}
+
+pub fn needs_norm_rebuild(conn: &Connection) -> rusqlite::Result<bool> {
+    Ok(stored_norm_version(conn)?.as_deref() != Some(NORM_VERSION))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_creates_cluster_tables_on_attach() {
+        let conn = Connection::open_in_memory().unwrap();
+        attach_cluster_database_uri(&conn, "file:cluster_mem?mode=memory&cache=shared").unwrap();
+        let count: i64 = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*) FROM {ATTACH_ALIAS}.sqlite_master \
+                     WHERE type='table' AND name='track_cluster_key'"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/server_cluster/keys.rs
+++ b/src-tauri/crates/psysonic-library/src/server_cluster/keys.rs
@@ -1,0 +1,119 @@
+//! Derive `cluster_key`, `album_key`, and `artist_key` from track metadata.
+
+use std::hash::{Hash, Hasher};
+
+use twox_hash::XxHash64;
+
+use super::norm::norm_field;
+
+const FIELD_SEP: u8 = 0x1f;
+
+/// Precomputed keys for one track. `None` when any required field normalizes empty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackClusterKeys {
+    pub cluster_key: String,
+    pub album_key: String,
+    pub artist_key: String,
+}
+
+fn effective_artist<'a>(artist: Option<&'a str>, album_artist: Option<&'a str>) -> Option<&'a str> {
+    artist
+        .filter(|s| !s.is_empty())
+        .or_else(|| album_artist.filter(|s| !s.is_empty()))
+}
+
+fn effective_album_artist<'a>(
+    album_artist: Option<&'a str>,
+    artist: Option<&'a str>,
+) -> Option<&'a str> {
+    album_artist
+        .filter(|s| !s.is_empty())
+        .or_else(|| artist.filter(|s| !s.is_empty()))
+}
+
+fn hash_parts(parts: &[&str], sep: Option<u8>) -> String {
+    let mut hasher = XxHash64::with_seed(0);
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            if let Some(sep) = sep {
+                sep.hash(&mut hasher);
+            }
+        }
+        part.hash(&mut hasher);
+    }
+    format!("{:016x}", hasher.finish())
+}
+
+/// Compute cluster identity keys from raw track fields (spec §2.1–2.5).
+pub fn compute_track_cluster_keys(
+    artist: Option<&str>,
+    album_artist: Option<&str>,
+    title: &str,
+    album: &str,
+) -> Option<TrackClusterKeys> {
+    let artist_src = effective_artist(artist, album_artist)?;
+    let norm_artist = norm_field(artist_src);
+    let norm_title = norm_field(title);
+    let norm_album = norm_field(album);
+    if norm_artist.is_empty() || norm_title.is_empty() || norm_album.is_empty() {
+        return None;
+    }
+
+    let cluster_key = hash_parts(&[&norm_artist, &norm_title, &norm_album], Some(FIELD_SEP));
+
+    let album_artist_src = effective_album_artist(album_artist, artist).unwrap_or(artist_src);
+    let norm_album_artist = norm_field(album_artist_src);
+    let album_key = hash_parts(&[&norm_album_artist, &norm_album], None);
+    let artist_key = hash_parts(&[&norm_artist], None);
+
+    Some(TrackClusterKeys {
+        cluster_key,
+        album_key,
+        artist_key,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_metadata_yields_same_keys() {
+        let a = compute_track_cluster_keys(
+            Some("Artist"),
+            None,
+            "Title",
+            "Album",
+        )
+        .unwrap();
+        let b = compute_track_cluster_keys(
+            Some("artist"),
+            None,
+            "title",
+            "album",
+        )
+        .unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn artist_falls_back_to_album_artist_for_cluster_key() {
+        let with = compute_track_cluster_keys(None, Some("Band"), "Song", "LP").unwrap();
+        let direct = compute_track_cluster_keys(Some("Band"), None, "Song", "LP").unwrap();
+        assert_eq!(with.cluster_key, direct.cluster_key);
+    }
+
+    #[test]
+    fn empty_title_or_album_yields_none() {
+        assert!(compute_track_cluster_keys(Some("A"), None, "", "Album").is_none());
+        assert!(compute_track_cluster_keys(Some("A"), None, "Title", "").is_none());
+        assert!(compute_track_cluster_keys(None, None, "Title", "Album").is_none());
+    }
+
+    #[test]
+    fn punctuation_insensitive_cluster_key() {
+        let a = compute_track_cluster_keys(Some("Pink Floyd"), None, "Time", "Dark Side").unwrap();
+        let b = compute_track_cluster_keys(Some("Pink Floyd"), None, "Time!", "Dark Side.").unwrap();
+        assert_eq!(a.cluster_key, b.cluster_key);
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/server_cluster/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/server_cluster/mod.rs
@@ -1,0 +1,18 @@
+//! Server cluster identity — derived `cluster_key` / `album_key` / `artist_key`
+//! in a separate attached SQLite DB (`library-cluster.db`). Distinct from
+//! `repos/play_session/cluster.rs` (listening-session time-gap grouping).
+
+mod db;
+mod keys;
+mod norm;
+mod rebuild;
+
+pub use db::{
+    attach_cluster_database, attach_cluster_database_uri, cluster_db_path, ensure_cluster_schema,
+    init_cluster_meta, needs_norm_rebuild, ATTACH_ALIAS, CLUSTER_DB_FILENAME, NORM_VERSION,
+};
+pub use keys::{TrackClusterKeys, compute_track_cluster_keys};
+pub use norm::norm_field;
+pub use rebuild::{
+    rebuild_all_cluster_keys, rebuild_cluster_keys_for_server, rebuild_if_norm_version_stale,
+};

--- a/src-tauri/crates/psysonic-library/src/server_cluster/norm.rs
+++ b/src-tauri/crates/psysonic-library/src/server_cluster/norm.rs
@@ -1,0 +1,43 @@
+//! Cheap Unicode normalization for cluster identity keys (spec §2.2).
+
+use unicode_normalization::UnicodeNormalization;
+
+/// NFD → drop combining marks → lowercase → letters/digits only.
+pub fn norm_field(raw: &str) -> String {
+    raw.nfd()
+        .filter(|c| !unicode_normalization::char::is_combining_mark(*c))
+        .flat_map(|c| c.to_lowercase())
+        .filter(|c| c.is_alphanumeric())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_diacritics_and_punctuation() {
+        assert_eq!(norm_field("Café"), "cafe");
+        assert_eq!(norm_field("Mötley Crüe"), "motleycrue");
+        assert_eq!(norm_field("Hello, World!"), "helloworld");
+    }
+
+    #[test]
+    fn lowercases_and_removes_whitespace() {
+        assert_eq!(norm_field("  Pink   FLOYD  "), "pinkfloyd");
+        assert_eq!(norm_field("The\tBeatles\n"), "thebeatles");
+    }
+
+    #[test]
+    fn preserves_unicode_letters_and_digits() {
+        assert_eq!(norm_field("Sigur Rós"), "sigurros");
+        assert_eq!(norm_field("Track 99"), "track99");
+    }
+
+    #[test]
+    fn empty_or_non_alnum_only_becomes_empty() {
+        assert_eq!(norm_field(""), "");
+        assert_eq!(norm_field("   "), "");
+        assert_eq!(norm_field("---"), "");
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/server_cluster/rebuild.rs
+++ b/src-tauri/crates/psysonic-library/src/server_cluster/rebuild.rs
@@ -1,0 +1,362 @@
+//! Batch rebuild of `track_cluster_key` — source of truth for cluster identity.
+
+use rusqlite::{params, Transaction};
+
+use crate::store::LibraryStore;
+
+use super::db::{self, ATTACH_ALIAS, NORM_VERSION};
+use super::keys::compute_track_cluster_keys;
+
+const REBUILD_BATCH_SIZE: usize = 5_000;
+
+struct TrackRow {
+    server_id: String,
+    track_id: String,
+    artist: Option<String>,
+    album_artist: Option<String>,
+    title: String,
+    album: String,
+    duration_sec: i64,
+}
+
+fn fetch_live_tracks(
+    tx: &Transaction<'_>,
+    server_id: Option<&str>,
+) -> rusqlite::Result<Vec<TrackRow>> {
+    let (sql, bind): (&str, Option<&str>) = match server_id {
+        Some(_) => (
+            "SELECT server_id, id, artist, album_artist, title, album, duration_sec \
+             FROM track WHERE deleted = 0 AND server_id = ?1",
+            server_id,
+        ),
+        None => (
+            "SELECT server_id, id, artist, album_artist, title, album, duration_sec \
+             FROM track WHERE deleted = 0",
+            None,
+        ),
+    };
+    let mut stmt = tx.prepare(sql)?;
+    let rows = match bind {
+        Some(sid) => stmt.query_map(params![sid], map_track_row)?.collect(),
+        None => stmt.query_map([], map_track_row)?.collect(),
+    };
+    rows
+}
+
+fn map_track_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackRow> {
+    Ok(TrackRow {
+        server_id: row.get(0)?,
+        track_id: row.get(1)?,
+        artist: row.get(2)?,
+        album_artist: row.get(3)?,
+        title: row.get(4)?,
+        album: row.get(5)?,
+        duration_sec: row.get(6)?,
+    })
+}
+
+fn upsert_batch(tx: &Transaction<'_>, batch: &[(TrackRow, super::keys::TrackClusterKeys)]) -> rusqlite::Result<()> {
+    let mut stmt = tx.prepare(&format!(
+        "INSERT INTO {ATTACH_ALIAS}.track_cluster_key \
+         (server_id, track_id, cluster_key, album_key, artist_key, duration_sec) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+         ON CONFLICT(server_id, track_id) DO UPDATE SET \
+           cluster_key = excluded.cluster_key, \
+           album_key = excluded.album_key, \
+           artist_key = excluded.artist_key, \
+           duration_sec = excluded.duration_sec"
+    ))?;
+    for (row, keys) in batch {
+        stmt.execute(params![
+            row.server_id,
+            row.track_id,
+            keys.cluster_key,
+            keys.album_key,
+            keys.artist_key,
+            row.duration_sec,
+        ])?;
+    }
+    Ok(())
+}
+
+fn rebuild_in_tx(
+    tx: &Transaction<'_>,
+    server_id: Option<&str>,
+    clear_scope: bool,
+) -> rusqlite::Result<u32> {
+    if clear_scope {
+        match server_id {
+            Some(sid) => {
+                tx.execute(
+                    &format!("DELETE FROM {ATTACH_ALIAS}.track_cluster_key WHERE server_id = ?1"),
+                    params![sid],
+                )?;
+            }
+            None => {
+                tx.execute(
+                    &format!("DELETE FROM {ATTACH_ALIAS}.track_cluster_key"),
+                    [],
+                )?;
+            }
+        }
+    }
+
+    let tracks = fetch_live_tracks(tx, server_id)?;
+    let mut written = 0u32;
+    let mut batch: Vec<(TrackRow, super::keys::TrackClusterKeys)> = Vec::new();
+
+    for row in tracks {
+        let Some(keys) = compute_track_cluster_keys(
+            row.artist.as_deref(),
+            row.album_artist.as_deref(),
+            &row.title,
+            &row.album,
+        ) else {
+            continue;
+        };
+        batch.push((row, keys));
+        if batch.len() >= REBUILD_BATCH_SIZE {
+            upsert_batch(tx, &batch)?;
+            written = written.saturating_add(batch.len() as u32);
+            batch.clear();
+        }
+    }
+    if !batch.is_empty() {
+        upsert_batch(tx, &batch)?;
+        written = written.saturating_add(batch.len() as u32);
+    }
+
+    tx.execute(
+        &format!(
+            "INSERT INTO {ATTACH_ALIAS}.cluster_meta (key, value) VALUES ('norm_version', ?1) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+        ),
+        params![NORM_VERSION],
+    )?;
+
+    Ok(written)
+}
+
+/// Rebuild cluster keys for every live track in the library index.
+pub fn rebuild_all_cluster_keys(store: &LibraryStore) -> Result<u32, String> {
+    store.with_conn_mut("cluster_rebuild_all", |conn| {
+        let tx = conn.transaction()?;
+        let count = rebuild_in_tx(&tx, None, true)?;
+        tx.commit()?;
+        Ok(count)
+    })
+}
+
+/// Rebuild cluster keys for one server's live tracks (deletes stale rows first).
+pub fn rebuild_cluster_keys_for_server(
+    store: &LibraryStore,
+    server_id: &str,
+) -> Result<u32, String> {
+    store.with_conn_mut("cluster_rebuild_server", |conn| {
+        let tx = conn.transaction()?;
+        let count = rebuild_in_tx(&tx, Some(server_id), true)?;
+        tx.commit()?;
+        Ok(count)
+    })
+}
+
+/// Rebuild when `cluster_meta.norm_version` lags the compiled rules.
+pub fn rebuild_if_norm_version_stale(store: &LibraryStore) -> Result<Option<u32>, String> {
+    let stale = store.with_conn("cluster_norm_check", db::needs_norm_rebuild)?;
+    if !stale {
+        return Ok(None);
+    }
+    rebuild_all_cluster_keys(store).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::LibraryStore;
+    use rusqlite::params;
+
+    fn seed_track(
+        store: &LibraryStore,
+        server: &str,
+        id: &str,
+        artist: &str,
+        title: &str,
+        album: &str,
+        duration: i64,
+    ) {
+        store
+            .with_conn_mut("misc", |conn| {
+                conn.execute(
+                    "INSERT INTO track (server_id, id, title, artist, album, duration_sec, synced_at, raw_json) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, '{}')",
+                    params![server, id, title, artist, album, duration],
+                )
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn rebuild_is_idempotent() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1", "Artist", "Song", "Album", 200);
+        seed_track(&store, "s2", "t2", "Artist", "Song", "Album", 205);
+
+        let first = rebuild_all_cluster_keys(&store).unwrap();
+        assert_eq!(first, 2);
+
+        let count_after: i64 = store
+            .with_conn("misc", |c| {
+                c.query_row(
+                    &format!("SELECT COUNT(*) FROM {ATTACH_ALIAS}.track_cluster_key"),
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(count_after, 2);
+
+        let second = rebuild_all_cluster_keys(&store).unwrap();
+        assert_eq!(second, 2);
+        let count_again: i64 = store
+            .with_conn("misc", |c| {
+                c.query_row(
+                    &format!("SELECT COUNT(*) FROM {ATTACH_ALIAS}.track_cluster_key"),
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(count_again, 2);
+    }
+
+    #[test]
+    fn tracks_with_empty_fields_get_no_row() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1", "", "Song", "Album", 100);
+        seed_track(&store, "s1", "t2", "Artist", "Song", "Album", 100);
+
+        let written = rebuild_all_cluster_keys(&store).unwrap();
+        assert_eq!(written, 1);
+
+        let count: i64 = store
+            .with_conn("misc", |c| {
+                c.query_row(
+                    &format!("SELECT COUNT(*) FROM {ATTACH_ALIAS}.track_cluster_key"),
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn same_cluster_key_across_servers_after_rebuild() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1", "Band", "Hit", "LP", 180);
+        seed_track(&store, "s2", "t9", "Band", "Hit", "LP", 182);
+        rebuild_all_cluster_keys(&store).unwrap();
+
+        let keys: Vec<String> = store
+            .with_conn("misc", |c| {
+                let mut stmt = c.prepare(&format!(
+                    "SELECT cluster_key FROM {ATTACH_ALIAS}.track_cluster_key ORDER BY server_id"
+                ))?;
+                let rows: rusqlite::Result<Vec<String>> =
+                    stmt.query_map([], |r| r.get(0))?.collect();
+                rows
+            })
+            .unwrap();
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys[0], keys[1]);
+    }
+
+    #[test]
+    fn per_server_rebuild_replaces_stale_rows() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1", "A", "One", "X", 1);
+        seed_track(&store, "s2", "t1", "B", "Two", "Y", 2);
+        rebuild_all_cluster_keys(&store).unwrap();
+
+        store
+            .with_conn_mut("misc", |conn| {
+                conn.execute(
+                    "UPDATE track SET title = 'Updated' WHERE server_id = 's1' AND id = 't1'",
+                    [],
+                )
+            })
+            .unwrap();
+
+        rebuild_cluster_keys_for_server(&store, "s1").unwrap();
+
+        let title_norm_row: Option<String> = store
+            .with_conn("misc", |c| {
+                use rusqlite::OptionalExtension;
+                c.query_row(
+                    &format!(
+                        "SELECT k.cluster_key FROM {ATTACH_ALIAS}.track_cluster_key k \
+                         JOIN track t ON t.server_id = k.server_id AND t.id = k.track_id \
+                         WHERE k.server_id = 's1' AND k.track_id = 't1'"
+                    ),
+                    [],
+                    |r| r.get(0),
+                )
+                .optional()
+            })
+            .unwrap();
+        assert!(title_norm_row.is_some());
+
+        let s2_count: i64 = store
+            .with_conn("misc", |c| {
+                c.query_row(
+                    &format!(
+                        "SELECT COUNT(*) FROM {ATTACH_ALIAS}.track_cluster_key WHERE server_id = 's2'"
+                    ),
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(s2_count, 1);
+    }
+
+    #[test]
+    fn norm_version_bump_triggers_full_rebuild() {
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, "s1", "t1", "Artist", "Old", "Album", 1);
+        rebuild_all_cluster_keys(&store).unwrap();
+
+        store
+            .with_conn_mut("misc", |conn| {
+                conn.execute(
+                    &format!(
+                        "UPDATE {ATTACH_ALIAS}.cluster_meta SET value = '0' WHERE key = 'norm_version'"
+                    ),
+                    [],
+                )
+            })
+            .unwrap();
+
+        assert!(
+            store
+                .with_conn("misc", db::needs_norm_rebuild)
+                .unwrap()
+        );
+
+        let rebuilt = rebuild_if_norm_version_stale(&store).unwrap();
+        assert_eq!(rebuilt, Some(1));
+
+        let version: String = store
+            .with_conn("misc", |c| {
+                c.query_row(
+                    &format!(
+                        "SELECT value FROM {ATTACH_ALIAS}.cluster_meta WHERE key = 'norm_version'"
+                    ),
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(version, NORM_VERSION);
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 use rusqlite::{params, Connection, OpenFlags};
 use tauri::Manager;
 
+use crate::server_cluster::{attach_cluster_database, attach_cluster_database_uri, cluster_db_path};
+
 /// Current head of the embedded migrations. Bump each time a new
 /// `migrations/NNN_*.sql` is added.
 pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 1;
@@ -40,9 +42,17 @@ pub(crate) enum MigrationOutcome {
 /// In-memory tests share one DB across the read/write pair in a single store.
 static IN_MEMORY_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-fn in_memory_uri() -> String {
+fn in_memory_uri(prefix: &str) -> String {
     let n = IN_MEMORY_DB_COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("file:psysonic_library_mem_{n}?mode=memory&cache=shared")
+    format!("file:psysonic_{prefix}_mem_{n}?mode=memory&cache=shared")
+}
+
+fn in_memory_library_uri() -> String {
+    in_memory_uri("library")
+}
+
+fn in_memory_cluster_uri() -> String {
+    in_memory_uri("cluster")
 }
 
 pub struct LibraryStore {
@@ -67,10 +77,12 @@ impl LibraryStore {
         let write_conn = Connection::open(db_path).map_err(|e| e.to_string())?;
         configure_write_connection(&write_conn).map_err(|e| e.to_string())?;
         run_migrations(&write_conn).map_err(|e| e.to_string())?;
+        attach_cluster_file(&write_conn, db_path).map_err(|e| e.to_string())?;
         checkpoint_wal_conn(&write_conn, "open").map_err(|e| e.to_string())?;
         let read_conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
             .map_err(|e| e.to_string())?;
         configure_read_connection(&read_conn).map_err(|e| e.to_string())?;
+        attach_cluster_file(&read_conn, db_path).map_err(|e| e.to_string())?;
         Ok(Self {
             write_conn: Mutex::new(write_conn),
             read_conn: Mutex::new(read_conn),
@@ -80,12 +92,15 @@ impl LibraryStore {
 
     /// Build an in-memory DB with the production schema applied.
     pub fn open_in_memory() -> Self {
-        let uri = in_memory_uri();
+        let uri = in_memory_library_uri();
+        let cluster_uri = in_memory_cluster_uri();
         let write_conn = Connection::open(&uri).expect("in-memory write connection");
         configure_write_connection(&write_conn).expect("write pragmas");
         run_migrations(&write_conn).expect("schema migration");
+        attach_cluster_database_uri(&write_conn, &cluster_uri).expect("cluster attach write");
         let read_conn = Connection::open(&uri).expect("in-memory read connection");
         configure_read_connection(&read_conn).expect("read pragmas");
+        attach_cluster_database_uri(&read_conn, &cluster_uri).expect("cluster attach read");
         Self {
             write_conn: Mutex::new(write_conn),
             read_conn: Mutex::new(read_conn),
@@ -217,9 +232,11 @@ impl LibraryStore {
 
         let reopened_write = Connection::open(active_path).map_err(|e| e.to_string())?;
         configure_write_connection(&reopened_write).map_err(|e| e.to_string())?;
+        attach_cluster_file(&reopened_write, active_path).map_err(|e| e.to_string())?;
         let reopened_read = Connection::open_with_flags(active_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
             .map_err(|e| e.to_string())?;
         configure_read_connection(&reopened_read).map_err(|e| e.to_string())?;
+        attach_cluster_file(&reopened_read, active_path).map_err(|e| e.to_string())?;
         *write_conn = reopened_write;
         *read_conn = reopened_read;
         Ok(Some(backup))
@@ -253,9 +270,11 @@ impl LibraryStore {
 
         let reopened_write = Connection::open(active_path).map_err(|e| e.to_string())?;
         configure_write_connection(&reopened_write).map_err(|e| e.to_string())?;
+        attach_cluster_file(&reopened_write, active_path).map_err(|e| e.to_string())?;
         let reopened_read = Connection::open_with_flags(active_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
             .map_err(|e| e.to_string())?;
         configure_read_connection(&reopened_read).map_err(|e| e.to_string())?;
+        attach_cluster_file(&reopened_read, active_path).map_err(|e| e.to_string())?;
         *write_conn = reopened_write;
         *read_conn = reopened_read;
         Ok(())
@@ -283,6 +302,10 @@ fn log_write_op(op: &str, lock_wait_ms: u128, exec_ms: u128) {
     } else if lock_wait_ms >= 50 || exec_ms >= 200 {
         crate::app_eprintln!("[library-db] write op={op} lock_wait_ms={lock_wait_ms} exec_ms={exec_ms}");
     }
+}
+
+fn attach_cluster_file(conn: &Connection, library_db_path: &Path) -> rusqlite::Result<()> {
+    attach_cluster_database(conn, &cluster_db_path(library_db_path))
 }
 
 fn library_db_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
@@ -477,6 +500,39 @@ fn handle_breaking_schema_bump(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cluster_db_attached_on_open_in_memory() {
+        use crate::server_cluster::ATTACH_ALIAS;
+
+        let store = LibraryStore::open_in_memory();
+        let count: i64 = store
+            .with_conn("misc", |c| {
+                c.query_row(
+                    &format!(
+                        "SELECT COUNT(*) FROM {ATTACH_ALIAS}.sqlite_master \
+                         WHERE type='table' AND name='track_cluster_key'"
+                    ),
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let read_count: i64 = store
+            .with_read_conn(|c| {
+                c.query_row(
+                    &format!(
+                        "SELECT COUNT(*) FROM {ATTACH_ALIAS}.cluster_meta WHERE key = 'norm_version'"
+                    ),
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(read_count, 1);
+    }
 
     #[test]
     fn read_conn_sees_committed_writes_from_write_conn() {

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -152,6 +152,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Performance Probe: throughput (analysis tpm, cover cpm) measured over a trailing 5s window so the rate reacts promptly instead of coasting on minute-long inertia (PR #948)',
       'Cover backfill: follow the smart local/public endpoint switch so off-LAN clients stop fetching covers from the unreachable local address (PR #952)',
       'Audio: Symphonia 0.6 migration with libopus adapter 0.3; ranged-stream start latency fix (probe seek-gate) and a probe timeout so a stalled stream no longer hangs playback start (PR #999)',
+      'Server cluster: attached cluster identity DB and batch key rebuild (PR #1003)',
     ],
   },
   {


### PR DESCRIPTION
## Summary

Server Cluster v1 — **PR-1 of 10** (spec: `psysonic-workdocs/internal/collaboration/tasks/2026-06-server-cluster/`).

- Adds a separate attached SQLite file `library-cluster.db` (`ATTACH … AS cluster`) on both library store connections (write + read-only); excluded from library backup/restore paths.
- Schema: `track_cluster_key` (server_id, track_id, cluster_key, album_key, artist_key, duration_sec) + indexes; `cluster_meta` (norm version).
- Normalization: NFD → drop diacritics → lowercase → letters/digits only; artist falls back to album_artist; empty artist/title/album ⇒ no key row.
- Batch rebuild (`rebuild_all_cluster_keys`, `rebuild_cluster_keys_for_server`, `rebuild_if_norm_version_stale`) in 5k-row transactions.
- Unit tests: norm edge cases, empty-field policy, idempotent rebuild, norm-version bump.

## Tauri boundary

**None** — no new commands, no frontend/mocks changes in this PR.

## Test plan

- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`