### PR TITLE
fix(waveform): repaint on Vite HMR so theme CSS var edits show live

### DIFF
--- a/src/components/WaveformSeek.tsx
+++ b/src/components/WaveformSeek.tsx
@@ -226,14 +226,18 @@ export default function WaveformSeek({ trackId }: Props) {
   // On every HMR update, drop the colour cache and repaint. `import.meta.hot` is
   // undefined in production builds, so this whole effect is stripped there.
   useEffect(() => {
-    if (!import.meta.hot) return;
+    // `import.meta.hot` is undefined in prod builds and only a partial stub in
+    // the test/SSR env (has `.on` but not `.off`), so feature-detect both before
+    // wiring — otherwise the cleanup throws under vitest.
+    const hot = import.meta.hot;
+    if (!hot || typeof hot.on !== 'function' || typeof hot.off !== 'function') return;
     const repaint = () => {
       invalidateColorCache();
       const canvas = canvasRef.current;
       if (canvas) drawSeekbar(canvas, seekbarStyle, heightsRef.current, progressRef.current, bufferedRef.current, animStateRef.current);
     };
-    import.meta.hot.on('vite:afterUpdate', repaint);
-    return () => { import.meta.hot?.off('vite:afterUpdate', repaint); };
+    hot.on('vite:afterUpdate', repaint);
+    return () => { hot.off('vite:afterUpdate', repaint); };
   }, [seekbarStyle]);
 
   const trackIdRef = useRef(trackId);

--- a/src/components/WaveformSeek.tsx
+++ b/src/components/WaveformSeek.tsx
@@ -219,6 +219,23 @@ export default function WaveformSeek({ trackId }: Props) {
     return () => observer.disconnect();
   }, [seekbarStyle]);
 
+  // Dev-only: a theme's CSS variables can change via Vite HMR without the
+  // `data-theme` attribute changing, so the observer above never fires and the
+  // cached colours + canvas keep the old palette until a manual theme switch
+  // (annoying during theme dev — issue: waveform doesn't reflect CSS var edits).
+  // On every HMR update, drop the colour cache and repaint. `import.meta.hot` is
+  // undefined in production builds, so this whole effect is stripped there.
+  useEffect(() => {
+    if (!import.meta.hot) return;
+    const repaint = () => {
+      invalidateColorCache();
+      const canvas = canvasRef.current;
+      if (canvas) drawSeekbar(canvas, seekbarStyle, heightsRef.current, progressRef.current, bufferedRef.current, animStateRef.current);
+    };
+    import.meta.hot.on('vite:afterUpdate', repaint);
+    return () => { import.meta.hot?.off('vite:afterUpdate', repaint); };
+  }, [seekbarStyle]);
+
   const trackIdRef = useRef(trackId);
   trackIdRef.current = trackId;
   const seekRef = useRef(seek);


### PR DESCRIPTION
## Summary
- During theme development, editing a theme's waveform CSS variables hot-reloads the stylesheet but the seekbar canvas keeps the old colours until you manually switch themes and back.
- Root cause: the seekbar invalidates its colour cache + repaints from a `data-theme` MutationObserver. Vite HMR changes the stylesheet without changing `data-theme`, so the observer never fires.
- Fix: a **dev-only** effect that drops the colour cache and repaints on every HMR update (`vite:afterUpdate`), mirroring the theme-switch observer. `import.meta.hot` is `undefined` in production builds, so the effect is stripped there — no runtime cost.

(Reported on Discord. Dev-experience only — no end-user-facing change, so no changelog entry.)

## Test plan
- `npm run tauri:dev`, play a track so the waveform shows, then edit `--waveform-played` (or `--accent`) in the active theme's CSS file → the waveform recolours immediately, no theme switch needed.
- `npx tsc --noEmit` and `npm run build` pass; the production bundle does not include the HMR effect.