### PR TITLE
feat(psylab): Connections tab, AudioMuse OpenSubsonic probe, admin role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### PsyLab — Connections tab and Navidrome admin role
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1032](https://github.com/Psychotoxical/psysonic/pull/1032)**
+
+* New **Connections** tab: session/endpoint status, active-server capability readout (OpenSubsonic, AudioMuse plugin probe, legacy similar probe, AudioMuse mode), and queue-playback server when it differs from the active profile.
+* Navidrome **admin vs standard user** badge via native login probe — useful when diagnosing plugin/settings visibility.
+
+
+
+### Servers — AudioMuse plugin probe via OpenSubsonic (Navidrome ≥ 0.62)
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1032](https://github.com/Psychotoxical/psysonic/pull/1032)**
+
+* Navidrome **0.62+**: detect the AudioMuse-AI plugin from `getOpenSubsonicExtensions` when `sonicSimilarity` is advertised — the first reliable signal; the per-server AudioMuse toggle in Settings appears only when the extension is present.
+* Older Navidrome keeps the legacy `getSimilarSongs` Instant Mix probe path.
+
+
+
 ## Fixed
 
 ### Servers — complete border on the active server card
@@ -194,6 +212,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#1031](https://github.com/Psychotoxical/psysonic/pull/1031)**
 
 * Play on **Top Tracks** rows no longer silently does nothing when the artist page has top songs but no albums loaded (e.g. lossless artist view); playback starts from the clicked track and continues into the catalog when albums are available.
+
+
+
+### PsyLab — tab bar no longer collapses on the Logs tab
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1032](https://github.com/Psychotoxical/psysonic/pull/1032)**
+
+* The PsyLab tab row keeps its height when the Logs flex layout fills the modal — tabs were previously squashed to a thin strip.
 
 
 

--- a/src/api/subsonic.ts
+++ b/src/api/subsonic.ts
@@ -3,9 +3,11 @@ import md5 from 'md5';
 import { useAuthStore } from '../store/authStore';
 import {
   isNavidromeAudiomuseSoftwareEligible,
+  isNavidromeSonicSimilarityEligible,
   type InstantMixProbeResult,
   type SubsonicServerIdentity,
 } from '../utils/server/subsonicServerIdentity';
+import { probeAudiomusePluginWithCredentials } from './subsonicOpenSubsonic';
 import {
   SUBSONIC_CLIENT,
   api,
@@ -104,7 +106,11 @@ export async function probeInstantMixWithCredentials(
   }
 }
 
-/** After a successful ping, probe Instant Mix in the background (Navidrome ≥ 0.60 only). */
+/**
+ * After a successful ping, probe AudioMuse / Instant Mix in the background (Navidrome ≥ 0.60).
+ * Navidrome ≥ 0.62 uses the `sonicSimilarity` OpenSubsonic extension; older builds fall back to
+ * `getSimilarSongs` (may match Last.fm agents, not only AudioMuse).
+ */
 export function scheduleInstantMixProbeForServer(
   serverId: string,
   serverUrl: string,
@@ -113,6 +119,16 @@ export function scheduleInstantMixProbeForServer(
   identity: SubsonicServerIdentity,
 ): void {
   if (!isNavidromeAudiomuseSoftwareEligible(identity)) return;
+
+  if (isNavidromeSonicSimilarityEligible(identity)) {
+    const store = useAuthStore.getState();
+    store.setAudiomusePluginProbe(serverId, 'probing');
+    void probeAudiomusePluginWithCredentials(serverUrl, username, password).then(result =>
+      store.setAudiomusePluginProbe(serverId, result),
+    );
+    return;
+  }
+
   void probeInstantMixWithCredentials(serverUrl, username, password).then(result =>
     useAuthStore.getState().setInstantMixProbe(serverId, result),
   );

--- a/src/api/subsonicOpenSubsonic.test.ts
+++ b/src/api/subsonicOpenSubsonic.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import axios from 'axios';
+import {
+  hasOpenSubsonicExtension,
+  parseOpenSubsonicExtensions,
+  probeAudiomusePluginWithCredentials,
+} from './subsonicOpenSubsonic';
+
+vi.mock('axios');
+
+function okExtensions(extensions: unknown[]) {
+  return {
+    data: {
+      'subsonic-response': {
+        status: 'ok',
+        openSubsonic: true,
+        openSubsonicExtensions: extensions,
+      },
+    },
+  };
+}
+
+describe('parseOpenSubsonicExtensions', () => {
+  it('parses extension names and versions', () => {
+    const parsed = parseOpenSubsonicExtensions([
+      { name: 'sonicSimilarity', versions: [1] },
+      { name: 'playbackReport', versions: [1, 2] },
+      { bad: true },
+    ]);
+    expect(parsed).toEqual([
+      { name: 'sonicSimilarity', versions: [1] },
+      { name: 'playbackReport', versions: [1, 2] },
+    ]);
+  });
+});
+
+describe('hasOpenSubsonicExtension', () => {
+  it('detects sonicSimilarity', () => {
+    const extensions = parseOpenSubsonicExtensions([{ name: 'sonicSimilarity', versions: [1] }]);
+    expect(hasOpenSubsonicExtension(extensions, 'sonicSimilarity')).toBe(true);
+    expect(hasOpenSubsonicExtension(extensions, 'other')).toBe(false);
+  });
+});
+
+describe('probeAudiomusePluginWithCredentials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns present when sonicSimilarity is advertised', async () => {
+    vi.mocked(axios.get).mockResolvedValue(
+      okExtensions([{ name: 'sonicSimilarity', versions: [1] }]),
+    );
+    await expect(
+      probeAudiomusePluginWithCredentials('https://music.test', 'u', 'p'),
+    ).resolves.toBe('present');
+  });
+
+  it('returns absent when sonicSimilarity is missing', async () => {
+    vi.mocked(axios.get).mockResolvedValue(
+      okExtensions([{ name: 'playbackReport', versions: [1] }]),
+    );
+    await expect(
+      probeAudiomusePluginWithCredentials('https://music.test', 'u', 'p'),
+    ).resolves.toBe('absent');
+  });
+
+  it('returns error on request failure', async () => {
+    vi.mocked(axios.get).mockRejectedValue(new Error('boom'));
+    await expect(
+      probeAudiomusePluginWithCredentials('https://music.test', 'u', 'p'),
+    ).resolves.toBe('error');
+  });
+});

--- a/src/api/subsonicOpenSubsonic.ts
+++ b/src/api/subsonicOpenSubsonic.ts
@@ -1,0 +1,49 @@
+import type { AudiomusePluginProbeResult } from '../utils/server/subsonicServerIdentity';
+import { apiWithCredentials } from './subsonicClient';
+
+export interface OpenSubsonicExtension {
+  name: string;
+  versions: number[];
+}
+
+export function parseOpenSubsonicExtensions(raw: unknown): OpenSubsonicExtension[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object' && !Array.isArray(entry))
+    .map(entry => ({
+      name: typeof entry.name === 'string' ? entry.name : '',
+      versions: Array.isArray(entry.versions)
+        ? entry.versions.filter((v): v is number => typeof v === 'number')
+        : [],
+    }))
+    .filter(entry => entry.name.length > 0);
+}
+
+export function hasOpenSubsonicExtension(extensions: readonly OpenSubsonicExtension[], name: string): boolean {
+  return extensions.some(ext => ext.name === name);
+}
+
+/**
+ * Navidrome ≥ 0.62: `sonicSimilarity` in `getOpenSubsonicExtensions` means an audio-similarity
+ * plugin (typically AudioMuse-AI) is active on the server.
+ */
+export async function probeAudiomusePluginWithCredentials(
+  serverUrl: string,
+  username: string,
+  password: string,
+): Promise<Exclude<AudiomusePluginProbeResult, 'probing' | 'unsupported'>> {
+  try {
+    const data = await apiWithCredentials<{ openSubsonicExtensions?: unknown }>(
+      serverUrl,
+      username,
+      password,
+      'getOpenSubsonicExtensions.view',
+      {},
+      12000,
+    );
+    const extensions = parseOpenSubsonicExtensions(data.openSubsonicExtensions);
+    return hasOpenSubsonicExtension(extensions, 'sonicSimilarity') ? 'present' : 'absent';
+  } catch {
+    return 'error';
+  }
+}

--- a/src/components/settings/ServersTab.tsx
+++ b/src/components/settings/ServersTab.tsx
@@ -486,6 +486,7 @@ export function ServersTab({
                   {showAudiomuseNavidromeServerSetting(
                     auth.subsonicServerIdentityByServer[srv.id],
                     auth.instantMixProbeByServer[srv.id],
+                    auth.audiomusePluginProbeByServer[srv.id],
                   ) && (
                     <div
                       className="settings-toggle-row"

--- a/src/components/sidebar/SidebarPerfProbeModal.tsx
+++ b/src/components/sidebar/SidebarPerfProbeModal.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react';
-import { Activity, ScrollText, SlidersHorizontal, Wrench, X } from 'lucide-react';
+import { Activity, Network, ScrollText, SlidersHorizontal, Wrench, X } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import SidebarPerfProbeMonitorTab from './perfProbe/SidebarPerfProbeMonitorTab';
 import SidebarPerfProbeTogglesTab from './perfProbe/SidebarPerfProbeTogglesTab';
 import SidebarPerfProbeTuningTab from './perfProbe/SidebarPerfProbeTuningTab';
 import SidebarPerfProbeLogsTab from './perfProbe/SidebarPerfProbeLogsTab';
+import SidebarPerfProbeConnectionsTab from './perfProbe/SidebarPerfProbeConnectionsTab';
 import { resetPerfProbeFlags, type PerfProbeFlags } from '../../utils/perf/perfFlags';
 import { clearPerfLiveOverlayPins } from '../../utils/perf/perfOverlayPins';
 import { resetPerfOverlayAppearance } from '../../utils/perf/perfOverlayAppearance';
 import { resetPerfOverlayMode } from '../../utils/perf/perfOverlayMode';
 
-type TabId = 'monitor' | 'toggles' | 'tuning' | 'logs';
+type TabId = 'monitor' | 'connections' | 'toggles' | 'tuning' | 'logs';
 
 interface Props {
   open: boolean;
@@ -65,7 +66,7 @@ export default function SidebarPerfProbeModal({
         <header className="sidebar-perf-modal__header">
           <h3 id="psylab-title" className="modal-title">PsyLab</h3>
           <p className="sidebar-perf-modal__hint">
-            Live metrics with optional on-screen overlays, runtime tuning, and diagnostic disable toggles.
+            Live metrics, server connections, runtime tuning, and diagnostic disable toggles.
           </p>
         </header>
 
@@ -79,6 +80,16 @@ export default function SidebarPerfProbeModal({
           >
             <Activity size={15} />
             Monitor
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'connections'}
+            className={`sidebar-perf-modal__tab${tab === 'connections' ? ' sidebar-perf-modal__tab--active' : ''}`}
+            onClick={() => setTab('connections')}
+          >
+            <Network size={15} />
+            Connections
           </button>
           <button
             type="button"
@@ -114,6 +125,7 @@ export default function SidebarPerfProbeModal({
 
         <div className={`sidebar-perf-modal__body${tab === 'logs' ? ' sidebar-perf-modal__body--logs' : ''}`}>
           {tab === 'monitor' && <SidebarPerfProbeMonitorTab />}
+          {tab === 'connections' && <SidebarPerfProbeConnectionsTab />}
           {tab === 'tuning' && <SidebarPerfProbeTuningTab />}
           {tab === 'toggles' && (
             <SidebarPerfProbeTogglesTab

--- a/src/components/sidebar/perfProbe/PerfProbeDetailList.tsx
+++ b/src/components/sidebar/perfProbe/PerfProbeDetailList.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+export interface PerfProbeDetailRow {
+  label: string;
+  value: ReactNode;
+}
+
+interface Props {
+  rows: PerfProbeDetailRow[];
+}
+
+export default function PerfProbeDetailList({ rows }: Props) {
+  return (
+    <dl className="perf-server-dl">
+      {rows.map(row => (
+        <div key={row.label} className="perf-server-dl__row">
+          <dt>{row.label}</dt>
+          <dd>{row.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/src/components/sidebar/perfProbe/PerfProbeMetricCard.tsx
+++ b/src/components/sidebar/perfProbe/PerfProbeMetricCard.tsx
@@ -71,6 +71,7 @@ interface SectionProps {
   hint?: string;
   children: ReactNode;
   defaultOpen?: boolean;
+  layout?: 'grid' | 'stack';
   onOpenChange?: (open: boolean) => void;
 }
 
@@ -79,6 +80,7 @@ export function PerfProbeMetricSection({
   hint,
   children,
   defaultOpen = true,
+  layout = 'grid',
   onOpenChange,
 }: SectionProps) {
   return (
@@ -92,7 +94,9 @@ export function PerfProbeMetricSection({
         <span>{title}</span>
         {hint && <span className="perf-metric-section__hint">{hint}</span>}
       </summary>
-      <div className="perf-metric-section__grid">{children}</div>
+      <div className={layout === 'stack' ? 'perf-metric-section__body' : 'perf-metric-section__grid'}>
+        {children}
+      </div>
     </details>
   );
 }

--- a/src/components/sidebar/perfProbe/PerfProbeStatusBadge.tsx
+++ b/src/components/sidebar/perfProbe/PerfProbeStatusBadge.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+export type PerfProbeBadgeTone = 'ok' | 'warn' | 'error' | 'neutral' | 'muted';
+
+interface Props {
+  tone: PerfProbeBadgeTone;
+  children: ReactNode;
+}
+
+export default function PerfProbeStatusBadge({ tone, children }: Props) {
+  return (
+    <span className={`perf-status-badge perf-status-badge--${tone}`}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeConnectionsTab.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeConnectionsTab.tsx
@@ -1,0 +1,82 @@
+import { useAuthStore } from '../../../store/authStore';
+import { usePlayerStore } from '../../../store/playerStore';
+import { useConnectionStatus } from '../../../hooks/useConnectionStatus';
+import { serverListDisplayLabel } from '../../../utils/server/serverDisplayName';
+import { findServerByIdOrIndexKey } from '../../../utils/server/serverLookup';
+import { PerfProbeMetricSection } from './PerfProbeMetricCard';
+import SidebarPerfProbeServerSection from './SidebarPerfProbeServerSection';
+
+function formatConnectionStatus(status: string): string {
+  switch (status) {
+    case 'connected': return 'Connected';
+    case 'disconnected': return 'Disconnected';
+    case 'checking': return 'Checking…';
+    default: return status;
+  }
+}
+
+export default function SidebarPerfProbeConnectionsTab() {
+  const { status, isLan, serverName } = useConnectionStatus();
+  const isLoggedIn = useAuthStore(s => s.isLoggedIn);
+  const activeServerId = useAuthStore(s => s.activeServerId);
+  const servers = useAuthStore(s => s.servers);
+  const connectUrl = useAuthStore(s => s.getBaseUrl());
+  const queueServerId = usePlayerStore(s => s.queueServerId);
+
+  const queueServer = queueServerId ? findServerByIdOrIndexKey(queueServerId) : undefined;
+  const queueDiffersFromActive = Boolean(
+    queueServerId && activeServerId && queueServerId !== activeServerId,
+  );
+
+  return (
+    <div className="perf-monitor">
+      <PerfProbeMetricSection title="Connection" defaultOpen>
+        <dl className="perf-server-dl">
+          <div className="perf-server-dl__row">
+            <dt>Status</dt>
+            <dd>{formatConnectionStatus(status)}</dd>
+          </div>
+          <div className="perf-server-dl__row">
+            <dt>Session</dt>
+            <dd>{isLoggedIn ? 'Logged in' : 'Not logged in'}</dd>
+          </div>
+          {serverName && (
+            <div className="perf-server-dl__row">
+              <dt>Browse label</dt>
+              <dd>{serverName}</dd>
+            </div>
+          )}
+          {connectUrl && (
+            <div className="perf-server-dl__row">
+              <dt>Connect URL</dt>
+              <dd>{connectUrl}</dd>
+            </div>
+          )}
+          {status === 'connected' && (
+            <div className="perf-server-dl__row">
+              <dt>Endpoint</dt>
+              <dd>{isLan ? 'LAN' : 'Public / remote'}</dd>
+            </div>
+          )}
+        </dl>
+      </PerfProbeMetricSection>
+
+      <SidebarPerfProbeServerSection />
+
+      {queueDiffersFromActive && queueServer && (
+        <PerfProbeMetricSection title="Queue playback server" defaultOpen={false}>
+          <dl className="perf-server-dl">
+            <div className="perf-server-dl__row">
+              <dt>Name</dt>
+              <dd>{serverListDisplayLabel(queueServer, servers)}</dd>
+            </div>
+            <div className="perf-server-dl__row">
+              <dt>Scope key</dt>
+              <dd>{queueServerId}</dd>
+            </div>
+          </dl>
+        </PerfProbeMetricSection>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeConnectionsTab.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeConnectionsTab.tsx
@@ -1,18 +1,45 @@
 import { useAuthStore } from '../../../store/authStore';
 import { usePlayerStore } from '../../../store/playerStore';
 import { useConnectionStatus } from '../../../hooks/useConnectionStatus';
+import { useNavidromeAdminRole } from '../../../hooks/useNavidromeAdminRole';
 import { serverListDisplayLabel } from '../../../utils/server/serverDisplayName';
 import { findServerByIdOrIndexKey } from '../../../utils/server/serverLookup';
 import { PerfProbeMetricSection } from './PerfProbeMetricCard';
+import PerfProbeDetailList from './PerfProbeDetailList';
+import PerfProbeStatusBadge, { type PerfProbeBadgeTone } from './PerfProbeStatusBadge';
 import SidebarPerfProbeServerSection from './SidebarPerfProbeServerSection';
 
-function formatConnectionStatus(status: string): string {
+function connectionStatusBadge(status: string): { tone: PerfProbeBadgeTone; label: string } {
   switch (status) {
-    case 'connected': return 'Connected';
-    case 'disconnected': return 'Disconnected';
-    case 'checking': return 'Checking…';
-    default: return status;
+    case 'connected': return { tone: 'ok', label: 'Connected' };
+    case 'disconnected': return { tone: 'error', label: 'Disconnected' };
+    case 'checking': return { tone: 'warn', label: 'Checking…' };
+    default: return { tone: 'muted', label: status };
   }
+}
+
+function sessionBadge(loggedIn: boolean): { tone: PerfProbeBadgeTone; label: string } {
+  return loggedIn
+    ? { tone: 'ok', label: 'Logged in' }
+    : { tone: 'muted', label: 'Not logged in' };
+}
+
+function adminRoleBadge(role: ReturnType<typeof useNavidromeAdminRole>): { tone: PerfProbeBadgeTone; label: string } {
+  switch (role) {
+    case 'admin': return { tone: 'ok', label: 'Admin' };
+    case 'user': return { tone: 'neutral', label: 'Standard user' };
+    case 'checking':
+    case 'idle': return { tone: 'warn', label: 'Checking…' };
+    case 'error': return { tone: 'error', label: 'Could not verify' };
+    case 'na':
+    default: return { tone: 'muted', label: 'N/A (not Navidrome)' };
+  }
+}
+
+function endpointBadge(isLan: boolean): { tone: PerfProbeBadgeTone; label: string } {
+  return isLan
+    ? { tone: 'ok', label: 'LAN' }
+    : { tone: 'neutral', label: 'Public / remote' };
 }
 
 export default function SidebarPerfProbeConnectionsTab() {
@@ -22,59 +49,79 @@ export default function SidebarPerfProbeConnectionsTab() {
   const servers = useAuthStore(s => s.servers);
   const connectUrl = useAuthStore(s => s.getBaseUrl());
   const queueServerId = usePlayerStore(s => s.queueServerId);
+  const adminRole = useNavidromeAdminRole();
 
   const queueServer = queueServerId ? findServerByIdOrIndexKey(queueServerId) : undefined;
   const queueDiffersFromActive = Boolean(
     queueServerId && activeServerId && queueServerId !== activeServerId,
   );
 
+  const connBadge = connectionStatusBadge(status);
+  const sessBadge = sessionBadge(isLoggedIn);
+  const roleBadge = adminRoleBadge(adminRole);
+
   return (
     <div className="perf-monitor">
-      <PerfProbeMetricSection title="Connection" defaultOpen>
-        <dl className="perf-server-dl">
-          <div className="perf-server-dl__row">
-            <dt>Status</dt>
-            <dd>{formatConnectionStatus(status)}</dd>
+      <div className="perf-conn-summary" aria-label="Connection overview">
+        <div className="perf-conn-summary__item">
+          <span className="perf-conn-summary__label">Link</span>
+          <PerfProbeStatusBadge tone={connBadge.tone}>{connBadge.label}</PerfProbeStatusBadge>
+        </div>
+        <div className="perf-conn-summary__item">
+          <span className="perf-conn-summary__label">Session</span>
+          <PerfProbeStatusBadge tone={sessBadge.tone}>{sessBadge.label}</PerfProbeStatusBadge>
+        </div>
+        {isLoggedIn && (
+          <div className="perf-conn-summary__item">
+            <span className="perf-conn-summary__label">Role</span>
+            <PerfProbeStatusBadge tone={roleBadge.tone}>{roleBadge.label}</PerfProbeStatusBadge>
           </div>
-          <div className="perf-server-dl__row">
-            <dt>Session</dt>
-            <dd>{isLoggedIn ? 'Logged in' : 'Not logged in'}</dd>
-          </div>
-          {serverName && (
-            <div className="perf-server-dl__row">
-              <dt>Browse label</dt>
-              <dd>{serverName}</dd>
-            </div>
-          )}
-          {connectUrl && (
-            <div className="perf-server-dl__row">
-              <dt>Connect URL</dt>
-              <dd>{connectUrl}</dd>
-            </div>
-          )}
-          {status === 'connected' && (
-            <div className="perf-server-dl__row">
-              <dt>Endpoint</dt>
-              <dd>{isLan ? 'LAN' : 'Public / remote'}</dd>
-            </div>
-          )}
-        </dl>
+        )}
+      </div>
+
+      <PerfProbeMetricSection title="Connection" defaultOpen layout="stack">
+        <PerfProbeDetailList
+          rows={[
+            {
+              label: 'Status',
+              value: <PerfProbeStatusBadge tone={connBadge.tone}>{connBadge.label}</PerfProbeStatusBadge>,
+            },
+            {
+              label: 'Session',
+              value: <PerfProbeStatusBadge tone={sessBadge.tone}>{sessBadge.label}</PerfProbeStatusBadge>,
+            },
+            ...(isLoggedIn
+              ? [{
+                  label: 'Navidrome role',
+                  value: <PerfProbeStatusBadge tone={roleBadge.tone}>{roleBadge.label}</PerfProbeStatusBadge>,
+                }]
+              : []),
+            ...(serverName ? [{ label: 'Browse label', value: serverName }] : []),
+            ...(connectUrl ? [{ label: 'Connect URL', value: <code className="perf-server-dl__code">{connectUrl}</code> }] : []),
+            ...(status === 'connected'
+              ? [{
+                  label: 'Endpoint',
+                  value: (
+                    <PerfProbeStatusBadge tone={endpointBadge(isLan).tone}>
+                      {endpointBadge(isLan).label}
+                    </PerfProbeStatusBadge>
+                  ),
+                }]
+              : []),
+          ]}
+        />
       </PerfProbeMetricSection>
 
-      <SidebarPerfProbeServerSection />
+      <SidebarPerfProbeServerSection adminRole={adminRole} />
 
       {queueDiffersFromActive && queueServer && (
-        <PerfProbeMetricSection title="Queue playback server" defaultOpen={false}>
-          <dl className="perf-server-dl">
-            <div className="perf-server-dl__row">
-              <dt>Name</dt>
-              <dd>{serverListDisplayLabel(queueServer, servers)}</dd>
-            </div>
-            <div className="perf-server-dl__row">
-              <dt>Scope key</dt>
-              <dd>{queueServerId}</dd>
-            </div>
-          </dl>
+        <PerfProbeMetricSection title="Queue playback server" defaultOpen={false} layout="stack">
+          <PerfProbeDetailList
+            rows={[
+              { label: 'Name', value: serverListDisplayLabel(queueServer, servers) },
+              { label: 'Scope key', value: <code className="perf-server-dl__code">{queueServerId}</code> },
+            ]}
+          />
         </PerfProbeMetricSection>
       )}
     </div>

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
@@ -1,0 +1,107 @@
+import { useAuthStore } from '../../../store/authStore';
+import {
+  isNavidromeAudiomuseSoftwareEligible,
+  isNavidromeSonicSimilarityEligible,
+  isNavidromeServer,
+} from '../../../utils/server/subsonicServerIdentity';
+import { PerfProbeMetricSection } from './PerfProbeMetricCard';
+
+function formatServerType(identity: { type?: string; serverVersion?: string; openSubsonic?: boolean } | undefined): string {
+  if (!identity?.type?.trim()) return 'Unknown';
+  const version = identity.serverVersion?.trim();
+  return version ? `${identity.type} ${version}` : identity.type;
+}
+
+function formatPluginProbe(
+  sonicEligible: boolean,
+  pluginProbe: string | undefined,
+): string {
+  if (!sonicEligible) return 'N/A (Navidrome < 0.62)';
+  switch (pluginProbe) {
+    case 'present': return 'Detected (sonicSimilarity)';
+    case 'absent': return 'Not detected';
+    case 'probing': return 'Checking…';
+    case 'error': return 'Probe failed';
+    default: return 'Not probed yet';
+  }
+}
+
+function formatLegacyProbe(
+  sonicEligible: boolean,
+  legacyProbe: string | undefined,
+): string | null {
+  if (sonicEligible) return null;
+  if (!legacyProbe) return 'Not probed yet';
+  return legacyProbe;
+}
+
+export default function SidebarPerfProbeServerSection() {
+  const activeServerId = useAuthStore(s => s.activeServerId);
+  const server = useAuthStore(s => s.servers.find(srv => srv.id === s.activeServerId));
+  const identity = useAuthStore(s =>
+    activeServerId ? s.subsonicServerIdentityByServer[activeServerId] : undefined,
+  );
+  const pluginProbe = useAuthStore(s =>
+    activeServerId ? s.audiomusePluginProbeByServer[activeServerId] : undefined,
+  );
+  const legacyProbe = useAuthStore(s =>
+    activeServerId ? s.instantMixProbeByServer[activeServerId] : undefined,
+  );
+  const audiomuseEnabled = useAuthStore(s =>
+    activeServerId ? Boolean(s.audiomuseNavidromeByServer[activeServerId]) : false,
+  );
+
+  if (!server) {
+    return (
+      <PerfProbeMetricSection title="Active server" defaultOpen>
+        <div className="perf-monitor-empty perf-monitor-empty--inline">
+          No server configured.
+        </div>
+      </PerfProbeMetricSection>
+    );
+  }
+
+  const sonicEligible = isNavidromeSonicSimilarityEligible(identity);
+  const legacyLabel = formatLegacyProbe(sonicEligible, legacyProbe);
+
+  return (
+    <PerfProbeMetricSection title="Active server" defaultOpen>
+      <dl className="perf-server-dl">
+        <div className="perf-server-dl__row">
+          <dt>Name</dt>
+          <dd>{server.name || server.url}</dd>
+        </div>
+        <div className="perf-server-dl__row">
+          <dt>Profile URL</dt>
+          <dd>{server.url}</dd>
+        </div>
+        <div className="perf-server-dl__row">
+          <dt>Subsonic server</dt>
+          <dd>{formatServerType(identity)}</dd>
+        </div>
+        <div className="perf-server-dl__row">
+          <dt>OpenSubsonic</dt>
+          <dd>{identity?.openSubsonic ? 'yes' : identity ? 'no' : '—'}</dd>
+        </div>
+        {isNavidromeServer(identity) && isNavidromeAudiomuseSoftwareEligible(identity) && (
+          <>
+            <div className="perf-server-dl__row">
+              <dt>AudioMuse plugin</dt>
+              <dd>{formatPluginProbe(sonicEligible, pluginProbe)}</dd>
+            </div>
+            {legacyLabel != null && (
+              <div className="perf-server-dl__row">
+                <dt>Legacy similar probe</dt>
+                <dd>{legacyLabel}</dd>
+              </div>
+            )}
+            <div className="perf-server-dl__row">
+              <dt>AudioMuse mode</dt>
+              <dd>{audiomuseEnabled ? 'enabled in Settings' : 'off'}</dd>
+            </div>
+          </>
+        )}
+      </dl>
+    </PerfProbeMetricSection>
+  );
+}

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
@@ -1,10 +1,13 @@
 import { useAuthStore } from '../../../store/authStore';
+import type { NavidromeAdminRole } from '../../../hooks/useNavidromeAdminRole';
 import {
   isNavidromeAudiomuseSoftwareEligible,
   isNavidromeSonicSimilarityEligible,
   isNavidromeServer,
 } from '../../../utils/server/subsonicServerIdentity';
 import { PerfProbeMetricSection } from './PerfProbeMetricCard';
+import PerfProbeDetailList, { type PerfProbeDetailRow } from './PerfProbeDetailList';
+import PerfProbeStatusBadge, { type PerfProbeBadgeTone } from './PerfProbeStatusBadge';
 
 function formatServerType(identity: { type?: string; serverVersion?: string; openSubsonic?: boolean } | undefined): string {
   if (!identity?.type?.trim()) return 'Unknown';
@@ -12,30 +15,48 @@ function formatServerType(identity: { type?: string; serverVersion?: string; ope
   return version ? `${identity.type} ${version}` : identity.type;
 }
 
-function formatPluginProbe(
+function pluginProbeBadge(
   sonicEligible: boolean,
   pluginProbe: string | undefined,
-): string {
-  if (!sonicEligible) return 'N/A (Navidrome < 0.62)';
+): { tone: PerfProbeBadgeTone; label: string } {
+  if (!sonicEligible) return { tone: 'muted', label: 'N/A (Navidrome < 0.62)' };
   switch (pluginProbe) {
-    case 'present': return 'Detected (sonicSimilarity)';
-    case 'absent': return 'Not detected';
-    case 'probing': return 'Checking…';
-    case 'error': return 'Probe failed';
-    default: return 'Not probed yet';
+    case 'present': return { tone: 'ok', label: 'Detected (sonicSimilarity)' };
+    case 'absent': return { tone: 'muted', label: 'Not detected' };
+    case 'probing': return { tone: 'warn', label: 'Checking…' };
+    case 'error': return { tone: 'error', label: 'Probe failed' };
+    default: return { tone: 'muted', label: 'Not probed yet' };
   }
 }
 
-function formatLegacyProbe(
+function legacyProbeBadge(
   sonicEligible: boolean,
   legacyProbe: string | undefined,
-): string | null {
+): { tone: PerfProbeBadgeTone; label: string } | null {
   if (sonicEligible) return null;
-  if (!legacyProbe) return 'Not probed yet';
-  return legacyProbe;
+  if (!legacyProbe) return { tone: 'muted', label: 'Not probed yet' };
+  if (legacyProbe === 'ok') return { tone: 'ok', label: legacyProbe };
+  if (legacyProbe === 'empty' || legacyProbe === 'skipped') return { tone: 'muted', label: legacyProbe };
+  return { tone: 'error', label: legacyProbe };
 }
 
-export default function SidebarPerfProbeServerSection() {
+function adminRoleBadge(role: NavidromeAdminRole): { tone: PerfProbeBadgeTone; label: string } {
+  switch (role) {
+    case 'admin': return { tone: 'ok', label: 'Admin' };
+    case 'user': return { tone: 'neutral', label: 'Standard user' };
+    case 'checking':
+    case 'idle': return { tone: 'warn', label: 'Checking…' };
+    case 'error': return { tone: 'error', label: 'Could not verify' };
+    case 'na':
+    default: return { tone: 'muted', label: 'N/A' };
+  }
+}
+
+interface Props {
+  adminRole?: NavidromeAdminRole;
+}
+
+export default function SidebarPerfProbeServerSection({ adminRole = 'na' }: Props) {
   const activeServerId = useAuthStore(s => s.activeServerId);
   const server = useAuthStore(s => s.servers.find(srv => srv.id === s.activeServerId));
   const identity = useAuthStore(s =>
@@ -53,7 +74,7 @@ export default function SidebarPerfProbeServerSection() {
 
   if (!server) {
     return (
-      <PerfProbeMetricSection title="Active server" defaultOpen>
+      <PerfProbeMetricSection title="Active server" defaultOpen layout="stack">
         <div className="perf-monitor-empty perf-monitor-empty--inline">
           No server configured.
         </div>
@@ -62,46 +83,54 @@ export default function SidebarPerfProbeServerSection() {
   }
 
   const sonicEligible = isNavidromeSonicSimilarityEligible(identity);
-  const legacyLabel = formatLegacyProbe(sonicEligible, legacyProbe);
+  const plugin = pluginProbeBadge(sonicEligible, pluginProbe);
+  const legacy = legacyProbeBadge(sonicEligible, legacyProbe);
+  const navidrome = isNavidromeServer(identity);
+  const role = adminRoleBadge(adminRole);
+
+  const rows: PerfProbeDetailRow[] = [
+    { label: 'Name', value: server.name || server.url },
+    { label: 'Profile URL', value: <code className="perf-server-dl__code">{server.url}</code> },
+    { label: 'Subsonic server', value: formatServerType(identity) },
+    {
+      label: 'OpenSubsonic',
+      value: identity?.openSubsonic
+        ? <PerfProbeStatusBadge tone="ok">yes</PerfProbeStatusBadge>
+        : identity
+          ? <PerfProbeStatusBadge tone="muted">no</PerfProbeStatusBadge>
+          : '—',
+    },
+  ];
+
+  if (navidrome) {
+    rows.push({
+      label: 'Navidrome role',
+      value: <PerfProbeStatusBadge tone={role.tone}>{role.label}</PerfProbeStatusBadge>,
+    });
+  }
+
+  if (navidrome && isNavidromeAudiomuseSoftwareEligible(identity)) {
+    rows.push({
+      label: 'AudioMuse plugin',
+      value: <PerfProbeStatusBadge tone={plugin.tone}>{plugin.label}</PerfProbeStatusBadge>,
+    });
+    if (legacy) {
+      rows.push({
+        label: 'Legacy similar probe',
+        value: <PerfProbeStatusBadge tone={legacy.tone}>{legacy.label}</PerfProbeStatusBadge>,
+      });
+    }
+    rows.push({
+      label: 'AudioMuse mode',
+      value: audiomuseEnabled
+        ? <PerfProbeStatusBadge tone="ok">enabled in Settings</PerfProbeStatusBadge>
+        : <PerfProbeStatusBadge tone="muted">off</PerfProbeStatusBadge>,
+    });
+  }
 
   return (
-    <PerfProbeMetricSection title="Active server" defaultOpen>
-      <dl className="perf-server-dl">
-        <div className="perf-server-dl__row">
-          <dt>Name</dt>
-          <dd>{server.name || server.url}</dd>
-        </div>
-        <div className="perf-server-dl__row">
-          <dt>Profile URL</dt>
-          <dd>{server.url}</dd>
-        </div>
-        <div className="perf-server-dl__row">
-          <dt>Subsonic server</dt>
-          <dd>{formatServerType(identity)}</dd>
-        </div>
-        <div className="perf-server-dl__row">
-          <dt>OpenSubsonic</dt>
-          <dd>{identity?.openSubsonic ? 'yes' : identity ? 'no' : '—'}</dd>
-        </div>
-        {isNavidromeServer(identity) && isNavidromeAudiomuseSoftwareEligible(identity) && (
-          <>
-            <div className="perf-server-dl__row">
-              <dt>AudioMuse plugin</dt>
-              <dd>{formatPluginProbe(sonicEligible, pluginProbe)}</dd>
-            </div>
-            {legacyLabel != null && (
-              <div className="perf-server-dl__row">
-                <dt>Legacy similar probe</dt>
-                <dd>{legacyLabel}</dd>
-              </div>
-            )}
-            <div className="perf-server-dl__row">
-              <dt>AudioMuse mode</dt>
-              <dd>{audiomuseEnabled ? 'enabled in Settings' : 'off'}</dd>
-            </div>
-          </>
-        )}
-      </dl>
+    <PerfProbeMetricSection title="Active server" defaultOpen layout="stack">
+      <PerfProbeDetailList rows={rows} />
     </PerfProbeMetricSection>
   );
 }

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -156,6 +156,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Offline browse — local-bytes catalog when server is down, integration contract (context/policy/resolvers), disconnect nav fork, Home stale-cache feed, read-only context menus, PlayerBar rating/favorite guard (PR #1017)',
       'Themed startup splash before Vite loads — deferred window show, per-theme logo gradient (PR #1030)',
       'Artist page: Top Tracks play when album list is empty on the page (PR #1031)',
+      'PsyLab Connections tab with server capability readout, Navidrome admin-role probe, and tab-bar layout fix; AudioMuse plugin detection via OpenSubsonic sonicSimilarity on Navidrome ≥0.62 (PR #1032)',
     ],
   },
   {

--- a/src/hooks/useNavidromeAdminRole.test.ts
+++ b/src/hooks/useNavidromeAdminRole.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { resetAuthStore } from '@/test/helpers/storeReset';
+import { useAuthStore } from '@/store/authStore';
+
+vi.mock('@/api/navidromeAdmin', () => ({
+  ndLogin: vi.fn(),
+}));
+
+import { ndLogin } from '@/api/navidromeAdmin';
+import { useNavidromeAdminRole } from './useNavidromeAdminRole';
+
+beforeEach(() => {
+  resetAuthStore();
+  vi.mocked(ndLogin).mockReset();
+});
+
+function seedNavidromeServer(): string {
+  const id = useAuthStore.getState().addServer({
+    name: 'Home',
+    url: 'music.example.com',
+    username: 'tester',
+    password: 'pw',
+  });
+  useAuthStore.getState().setActiveServer(id);
+  useAuthStore.getState().setLoggedIn(true);
+  useAuthStore.getState().setSubsonicServerIdentity(id, {
+    type: 'navidrome',
+    serverVersion: '0.62.0',
+    openSubsonic: true,
+  });
+  return id;
+}
+
+describe('useNavidromeAdminRole', () => {
+  it('returns na when not logged in', () => {
+    const id = useAuthStore.getState().addServer({
+      name: 'Home',
+      url: 'https://music.example.com',
+      username: 'tester',
+      password: 'pw',
+    });
+    useAuthStore.getState().setActiveServer(id);
+    useAuthStore.getState().setSubsonicServerIdentity(id, {
+      type: 'navidrome',
+      serverVersion: '0.62.0',
+      openSubsonic: true,
+    });
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    expect(result.current).toBe('na');
+    expect(ndLogin).not.toHaveBeenCalled();
+  });
+
+  it('returns checking until server identity is known', () => {
+    const id = useAuthStore.getState().addServer({
+      name: 'Home',
+      url: 'https://music.example.com',
+      username: 'tester',
+      password: 'pw',
+    });
+    useAuthStore.getState().setActiveServer(id);
+    useAuthStore.getState().setLoggedIn(true);
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    expect(result.current).toBe('checking');
+    expect(ndLogin).not.toHaveBeenCalled();
+  });
+
+  it('returns na for non-Navidrome servers', () => {
+    const id = useAuthStore.getState().addServer({
+      name: 'Ampache',
+      url: 'https://music.example.com',
+      username: 'tester',
+      password: 'pw',
+    });
+    useAuthStore.getState().setActiveServer(id);
+    useAuthStore.getState().setLoggedIn(true);
+    useAuthStore.getState().setSubsonicServerIdentity(id, {
+      type: 'ampache',
+      serverVersion: '6.0.0',
+      openSubsonic: false,
+    });
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    expect(result.current).toBe('na');
+    expect(ndLogin).not.toHaveBeenCalled();
+  });
+
+  it('probes Navidrome native login and reports admin', async () => {
+    seedNavidromeServer();
+    vi.mocked(ndLogin).mockResolvedValue({ token: 't', userId: '1', isAdmin: true });
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    await waitFor(() => expect(result.current).toBe('admin'));
+    expect(ndLogin).toHaveBeenCalledWith('http://music.example.com', 'tester', 'pw');
+  });
+
+  it('probes Navidrome native login and reports standard user', async () => {
+    seedNavidromeServer();
+    vi.mocked(ndLogin).mockResolvedValue({ token: 't', userId: '2', isAdmin: false });
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    await waitFor(() => expect(result.current).toBe('user'));
+  });
+
+  it('returns error when native login fails', async () => {
+    seedNavidromeServer();
+    vi.mocked(ndLogin).mockRejectedValue(new Error('denied'));
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    await waitFor(() => expect(result.current).toBe('error'));
+  });
+});

--- a/src/hooks/useNavidromeAdminRole.ts
+++ b/src/hooks/useNavidromeAdminRole.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { ndLogin } from '../api/navidromeAdmin';
+import { useAuthStore } from '../store/authStore';
+import { isNavidromeServer } from '../utils/server/subsonicServerIdentity';
+
+export type NavidromeAdminRole = 'idle' | 'checking' | 'admin' | 'user' | 'na' | 'error';
+
+function normalizeServerUrl(url: string): string {
+  const withScheme = url.startsWith('http') ? url : `http://${url}`;
+  return withScheme.replace(/\/$/, '');
+}
+
+/**
+ * Probes Navidrome native login for the active server to learn whether the
+ * current Subsonic credentials belong to an admin account.
+ */
+export function useNavidromeAdminRole(): NavidromeAdminRole {
+  const isLoggedIn = useAuthStore(s => s.isLoggedIn);
+  const activeServerId = useAuthStore(s => s.activeServerId);
+  const server = useAuthStore(s => s.servers.find(srv => srv.id === s.activeServerId));
+  const identity = useAuthStore(s =>
+    activeServerId ? s.subsonicServerIdentityByServer[activeServerId] : undefined,
+  );
+  const [role, setRole] = useState<NavidromeAdminRole>('idle');
+
+  useEffect(() => {
+    if (!isLoggedIn || !server) {
+      setRole('na');
+      return;
+    }
+    if (!identity) {
+      setRole('checking');
+      return;
+    }
+    if (!isNavidromeServer(identity)) {
+      setRole('na');
+      return;
+    }
+
+    let cancelled = false;
+    setRole('checking');
+    const serverUrl = normalizeServerUrl(server.url);
+    ndLogin(serverUrl, server.username, server.password)
+      .then(res => {
+        if (cancelled) return;
+        setRole(res.isAdmin ? 'admin' : 'user');
+      })
+      .catch(() => {
+        if (!cancelled) setRole('error');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isLoggedIn,
+    activeServerId,
+    server?.id,
+    server?.url,
+    server?.username,
+    server?.password,
+    identity?.type,
+    identity?.serverVersion,
+  ]);
+
+  return role;
+}

--- a/src/store/authPerServerCapabilityActions.ts
+++ b/src/store/authPerServerCapabilityActions.ts
@@ -17,10 +17,9 @@ type SetState = (
  *   ping reveals the server isn't AudioMuse-eligible (wrong type or
  *   too old), wipe the related caps for that id so the UI doesn't
  *   keep a stale toggle.
- * - `setInstantMixProbe` — probe result for getSimilarSongs. If
- *   `empty`, wipe the related AudioMuse caps so the row hides.
- * - `setAudiomuseNavidromeIssue` — set/clear the "current session
- *   saw a failure" flag.
+ * - `setInstantMixProbe` — legacy probe (pre-0.62). If `empty`, wipe AudioMuse caps.
+ * - `setAudiomusePluginProbe` — Navidrome ≥ 0.62 `sonicSimilarity` extension probe.
+ * - `setAudiomuseNavidromeIssue` — set/clear the "current session saw a failure" flag.
  */
 export function createPerServerCapabilityActions(set: SetState): Pick<
   AuthState,
@@ -28,6 +27,7 @@ export function createPerServerCapabilityActions(set: SetState): Pick<
   | 'setAudiomuseNavidromeEnabled'
   | 'setSubsonicServerIdentity'
   | 'setInstantMixProbe'
+  | 'setAudiomusePluginProbe'
   | 'setAudiomuseNavidromeIssue'
 > {
   return {
@@ -55,11 +55,13 @@ export function createPerServerCapabilityActions(set: SetState): Pick<
           const { [serverId]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
           const { [serverId]: _i, ...issueRest } = s.audiomuseNavidromeIssueByServer;
           const { [serverId]: _p, ...probeRest } = s.instantMixProbeByServer;
+          const { [serverId]: _pp, ...pluginProbeRest } = s.audiomusePluginProbeByServer;
           return {
             subsonicServerIdentityByServer,
             audiomuseNavidromeByServer: audiomuseRest,
             audiomuseNavidromeIssueByServer: issueRest,
             instantMixProbeByServer: probeRest,
+            audiomusePluginProbeByServer: pluginProbeRest,
           };
         }
         return { subsonicServerIdentityByServer };
@@ -78,6 +80,21 @@ export function createPerServerCapabilityActions(set: SetState): Pick<
           };
         }
         return { instantMixProbeByServer };
+      }),
+
+    setAudiomusePluginProbe: (serverId, result) =>
+      set(s => {
+        const audiomusePluginProbeByServer = { ...s.audiomusePluginProbeByServer, [serverId]: result };
+        if (result === 'absent' || result === 'error') {
+          const { [serverId]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
+          const { [serverId]: _i, ...issueRest } = s.audiomuseNavidromeIssueByServer;
+          return {
+            audiomusePluginProbeByServer,
+            audiomuseNavidromeByServer: audiomuseRest,
+            audiomuseNavidromeIssueByServer: issueRest,
+          };
+        }
+        return { audiomusePluginProbeByServer };
       }),
 
     setAudiomuseNavidromeIssue: (serverId, hasIssue) =>

--- a/src/store/authServerProfileActions.ts
+++ b/src/store/authServerProfileActions.ts
@@ -56,6 +56,7 @@ export function createServerProfileActions(set: SetState): Pick<
         const { [id]: _idn, ...identityRest } = s.subsonicServerIdentityByServer;
         const { [id]: _iss, ...issueRest } = s.audiomuseNavidromeIssueByServer;
         const { [id]: _pr, ...probeRest } = s.instantMixProbeByServer;
+        const { [id]: _ppl, ...pluginProbeRest } = s.audiomusePluginProbeByServer;
         return {
           servers: newServers,
           activeServerId: switchedAway ? (newServers[0]?.id ?? null) : s.activeServerId,
@@ -65,6 +66,7 @@ export function createServerProfileActions(set: SetState): Pick<
           subsonicServerIdentityByServer: identityRest,
           audiomuseNavidromeIssueByServer: issueRest,
           instantMixProbeByServer: probeRest,
+          audiomusePluginProbeByServer: pluginProbeRest,
         };
       });
     },

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -121,6 +121,7 @@ export const useAuthStore = create<AuthState>()(
       subsonicServerIdentityByServer: {},
       audiomuseNavidromeIssueByServer: {},
       instantMixProbeByServer: {},
+      audiomusePluginProbeByServer: {},
       isLoggedIn: false,
       isConnecting: false,
       connectionError: null,

--- a/src/store/authStoreTypes.ts
+++ b/src/store/authStoreTypes.ts
@@ -1,5 +1,6 @@
 import type { EntityRatingSupportLevel } from '../api/subsonicTypes';
 import type {
+  AudiomusePluginProbeResult,
   InstantMixProbeResult,
   SubsonicServerIdentity,
 } from '../utils/server/subsonicServerIdentity';
@@ -265,10 +266,16 @@ export interface AuthState {
   setAudiomuseNavidromeIssue: (serverId: string, hasIssue: boolean) => void;
 
   /**
-   * `getSimilarSongs` probe per server (after ping). `empty` hides the AudioMuse row; re-run by testing connection.
+   * `getSimilarSongs` probe per server (after ping). `empty` hides the AudioMuse row on pre-0.62 Navidrome.
    */
   instantMixProbeByServer: Record<string, InstantMixProbeResult>;
   setInstantMixProbe: (serverId: string, result: InstantMixProbeResult) => void;
+
+  /**
+   * Navidrome ≥ 0.62: `sonicSimilarity` extension probe (`present` = AudioMuse-style plugin active).
+   */
+  audiomusePluginProbeByServer: Record<string, AudiomusePluginProbeResult>;
+  setAudiomusePluginProbe: (serverId: string, result: AudiomusePluginProbeResult) => void;
 
   // Status
   isLoggedIn: boolean;

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -95,6 +95,8 @@
 
 .sidebar-perf-modal__tabs {
   display: flex;
+  flex: 0 0 auto;
+  flex-shrink: 0;
   gap: 4px;
   margin: 12px 0 10px;
   padding: 4px;
@@ -102,16 +104,19 @@
   background: color-mix(in srgb, var(--bg-card, var(--bg-app)) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--text-muted) 18%, transparent);
   overflow-x: auto;
+  scrollbar-width: thin;
 }
 
 .sidebar-perf-modal__tab {
-  flex: 1 0 auto;
+  flex: 0 0 auto;
   min-width: 4.5rem;
+  min-height: 2.25rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
   padding: 8px 10px;
+  white-space: nowrap;
   border: none;
   border-radius: 9px;
   background: transparent;
@@ -314,32 +319,128 @@
   font-size: 11px;
 }
 
-.perf-server-dl {
-  margin: 0;
-  padding: 0 4px 4px;
+.perf-metric-section__body {
+  padding: 0 10px 10px;
+}
+
+.perf-conn-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 10px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 16%, transparent);
+  background: color-mix(in srgb, var(--bg-card, var(--bg-app)) 88%, transparent);
+}
+
+.perf-conn-summary__item {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  align-items: flex-start;
+  gap: 4px;
+  min-width: 88px;
+  flex: 1 1 auto;
+}
+
+.perf-conn-summary__label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 90%, transparent);
+}
+
+.perf-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.35;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.perf-status-badge--ok {
+  color: #9ece6a;
+  background: color-mix(in srgb, #9ece6a 14%, transparent);
+  border-color: color-mix(in srgb, #9ece6a 28%, transparent);
+}
+
+.perf-status-badge--warn {
+  color: #e0af68;
+  background: color-mix(in srgb, #e0af68 14%, transparent);
+  border-color: color-mix(in srgb, #e0af68 28%, transparent);
+}
+
+.perf-status-badge--error {
+  color: #f7768e;
+  background: color-mix(in srgb, #f7768e 14%, transparent);
+  border-color: color-mix(in srgb, #f7768e 28%, transparent);
+}
+
+.perf-status-badge--neutral {
+  color: #7aa2f7;
+  background: color-mix(in srgb, #7aa2f7 14%, transparent);
+  border-color: color-mix(in srgb, #7aa2f7 28%, transparent);
+}
+
+.perf-status-badge--muted {
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-muted) 10%, transparent);
+  border-color: color-mix(in srgb, var(--text-muted) 20%, transparent);
+}
+
+.perf-server-dl {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
   font-size: 12px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 12%, transparent);
+  overflow: hidden;
 }
 
 .perf-server-dl__row {
   display: grid;
   grid-template-columns: minmax(110px, 38%) 1fr;
   gap: 8px 12px;
-  align-items: baseline;
+  align-items: center;
+  padding: 8px 10px;
+  border-top: 1px solid color-mix(in srgb, var(--text-muted) 10%, transparent);
+}
+
+.perf-server-dl__row:first-child {
+  border-top: none;
+}
+
+.perf-server-dl__row:nth-child(even) {
+  background: color-mix(in srgb, var(--bg-sidebar, var(--bg-app)) 40%, transparent);
 }
 
 .perf-server-dl__row dt {
   margin: 0;
   color: var(--text-muted);
   font-weight: 500;
+  font-size: 11px;
 }
 
 .perf-server-dl__row dd {
   margin: 0;
   color: var(--text-primary, var(--text));
   word-break: break-word;
+}
+
+.perf-server-dl__code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  color: color-mix(in srgb, var(--text-primary, var(--text)) 92%, var(--accent));
+  word-break: break-all;
 }
 
 .perf-live-poll {
@@ -937,6 +1038,7 @@
 }
 
 .sidebar-perf-modal__actions {
+  flex-shrink: 0;
   margin-top: 14px;
   display: flex;
   justify-content: flex-end;

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -95,16 +95,18 @@
 
 .sidebar-perf-modal__tabs {
   display: flex;
-  gap: 6px;
+  gap: 4px;
   margin: 12px 0 10px;
   padding: 4px;
   border-radius: 12px;
   background: color-mix(in srgb, var(--bg-card, var(--bg-app)) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--text-muted) 18%, transparent);
+  overflow-x: auto;
 }
 
 .sidebar-perf-modal__tab {
-  flex: 1;
+  flex: 1 0 auto;
+  min-width: 4.5rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -310,6 +312,34 @@
 .perf-monitor-empty--inline {
   padding: 0.75rem 0.5rem;
   font-size: 11px;
+}
+
+.perf-server-dl {
+  margin: 0;
+  padding: 0 4px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.perf-server-dl__row {
+  display: grid;
+  grid-template-columns: minmax(110px, 38%) 1fr;
+  gap: 8px 12px;
+  align-items: baseline;
+}
+
+.perf-server-dl__row dt {
+  margin: 0;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.perf-server-dl__row dd {
+  margin: 0;
+  color: var(--text-primary, var(--text));
+  word-break: break-word;
 }
 
 .perf-live-poll {

--- a/src/utils/server/subsonicServerIdentity.test.ts
+++ b/src/utils/server/subsonicServerIdentity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isNavidromeSonicSimilarityEligible,
+  parseLeadingSemver,
+  showAudiomuseNavidromeServerSetting,
+} from './subsonicServerIdentity';
+
+describe('parseLeadingSemver', () => {
+  it('parses Navidrome-style version strings', () => {
+    expect(parseLeadingSemver('0.62.0 (2026-06-08)')).toEqual([0, 62, 0]);
+    expect(parseLeadingSemver('v0.61.2')).toEqual([0, 61, 2]);
+  });
+});
+
+describe('isNavidromeSonicSimilarityEligible', () => {
+  it('is true for Navidrome ≥ 0.62', () => {
+    expect(isNavidromeSonicSimilarityEligible({ type: 'navidrome', serverVersion: '0.62.0' })).toBe(true);
+  });
+
+  it('is false for Navidrome 0.61', () => {
+    expect(isNavidromeSonicSimilarityEligible({ type: 'navidrome', serverVersion: '0.61.2' })).toBe(false);
+  });
+
+  it('is false for non-Navidrome servers', () => {
+    expect(isNavidromeSonicSimilarityEligible({ type: 'gonic', serverVersion: '0.62.0' })).toBe(false);
+  });
+});
+
+describe('showAudiomuseNavidromeServerSetting', () => {
+  const nav062 = { type: 'navidrome', serverVersion: '0.62.0' };
+  const nav061 = { type: 'navidrome', serverVersion: '0.61.2' };
+
+  it('shows the toggle on 0.62+ only when sonicSimilarity probe is present', () => {
+    expect(showAudiomuseNavidromeServerSetting(nav062, undefined, 'present')).toBe(true);
+    expect(showAudiomuseNavidromeServerSetting(nav062, 'ok', 'absent')).toBe(false);
+    expect(showAudiomuseNavidromeServerSetting(nav062, undefined, 'probing')).toBe(false);
+  });
+
+  it('keeps legacy instant-mix probe gating on pre-0.62 Navidrome', () => {
+    expect(showAudiomuseNavidromeServerSetting(nav061, 'ok', undefined)).toBe(true);
+    expect(showAudiomuseNavidromeServerSetting(nav061, 'empty', undefined)).toBe(false);
+  });
+});

--- a/src/utils/server/subsonicServerIdentity.ts
+++ b/src/utils/server/subsonicServerIdentity.ts
@@ -8,9 +8,21 @@ export type SubsonicServerIdentity = {
 /** Result of `getRandomSongs` + `getSimilarSongs` probe (Instant Mix / agent chain). */
 export type InstantMixProbeResult = 'ok' | 'empty' | 'error' | 'skipped';
 
-const NAVIDROME_MIN_FOR_PLUGINS: [number, number, number] = [0, 60, 0];
+/**
+ * Navidrome ≥ 0.62 exposes the OpenSubsonic `sonicSimilarity` extension when an audio-similarity
+ * plugin (e.g. AudioMuse-AI) is active — the first reliable plugin signal.
+ */
+export type AudiomusePluginProbeResult =
+  | 'probing'
+  | 'present'
+  | 'absent'
+  | 'unsupported'
+  | 'error';
 
-function parseLeadingSemver(version: string | undefined): [number, number, number] | null {
+const NAVIDROME_MIN_FOR_PLUGINS: [number, number, number] = [0, 60, 0];
+const NAVIDROME_MIN_FOR_SONIC_SIMILARITY: [number, number, number] = [0, 62, 0];
+
+export function parseLeadingSemver(version: string | undefined): [number, number, number] | null {
   if (!version) return null;
   const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(String(version).trim());
   if (!m) return null;
@@ -25,29 +37,44 @@ function semverGte(a: [number, number, number], b: [number, number, number]): bo
   return true;
 }
 
+export function isNavidromeServer(identity: SubsonicServerIdentity | undefined): boolean {
+  if (!identity?.type?.trim()) return false;
+  return identity.type.trim().toLowerCase() === 'navidrome';
+}
+
 /**
  * Navidrome version from ping supports the plugin system (≥ 0.60). Unknown `type` stays permissive
  * until the first successful ping with metadata.
  */
 export function isNavidromeAudiomuseSoftwareEligible(identity: SubsonicServerIdentity | undefined): boolean {
   if (!identity?.type?.trim()) return true;
-  const t = identity.type.trim().toLowerCase();
-  if (t !== 'navidrome') return false;
+  if (!isNavidromeServer(identity)) return false;
   const parsed = parseLeadingSemver(identity.serverVersion);
   if (!parsed) return true;
   return semverGte(parsed, NAVIDROME_MIN_FOR_PLUGINS);
 }
 
+/** Navidrome ≥ 0.62 — `getOpenSubsonicExtensions` can list `sonicSimilarity`. */
+export function isNavidromeSonicSimilarityEligible(identity: SubsonicServerIdentity | undefined): boolean {
+  if (!isNavidromeServer(identity)) return false;
+  const parsed = parseLeadingSemver(identity?.serverVersion);
+  if (!parsed) return false;
+  return semverGte(parsed, NAVIDROME_MIN_FOR_SONIC_SIMILARITY);
+}
+
 /**
  * Whether to show the per-server AudioMuse (Navidrome plugin) toggle in Settings.
- * Uses software eligibility from ping plus an optional Instant Mix probe: if the server returns no
- * similar tracks for several random songs, the row stays hidden (typical when no plugin / no agents).
+ * Navidrome ≥ 0.62: `sonicSimilarity` extension probe. Older Navidrome: legacy Instant Mix probe.
  */
 export function showAudiomuseNavidromeServerSetting(
   identity: SubsonicServerIdentity | undefined,
   instantMixProbe: InstantMixProbeResult | undefined,
+  pluginProbe: AudiomusePluginProbeResult | undefined,
 ): boolean {
   if (!isNavidromeAudiomuseSoftwareEligible(identity)) return false;
+  if (isNavidromeSonicSimilarityEligible(identity)) {
+    return pluginProbe === 'present';
+  }
   if (instantMixProbe === 'empty') return false;
   return true;
 }


### PR DESCRIPTION
## Summary
- **AudioMuse plugin detection (Navidrome ≥0.62):** probe `getOpenSubsonicExtensions` for `sonicSimilarity` instead of relying only on the legacy `getSimilarSongs` Instant Mix probe; older Navidrome keeps the legacy path.
- **PsyLab Connections tab:** session/endpoint overview, active-server capability details (OpenSubsonic, plugin probe, AudioMuse mode), and optional queue-playback server when it differs from the active server.
- **Navidrome admin role:** Connections shows whether the logged-in Subsonic credentials map to an admin or standard user via native `ndLogin`.
- **PsyLab tab bar:** prevent the tab row from vertically collapsing when the Logs tab flex layout fills the modal.

## Test plan
- [ ] Navidrome **≥0.62** with AudioMuse-AI: Settings shows AudioMuse toggle only when `sonicSimilarity` is advertised; PsyLab → Connections shows plugin **Detected**.
- [ ] Navidrome **<0.62** or without plugin: legacy similar probe still drives the Settings toggle; Connections shows legacy probe state.
- [ ] Non-Navidrome server: Connections role shows **N/A (not Navidrome)**; no `ndLogin` errors in console.
- [ ] Navidrome admin vs non-admin account: Connections role badge matches account type.
- [ ] PsyLab → **Logs** tab at short viewport height: tab bar stays readable (not squashed to a thin strip).
- [x] `npm test`, `npx tsc --noEmit`, `npm run test:coverage`, `bash scripts/check-frontend-hot-path-coverage.sh`