### PR TITLE
feat(server): capability framework, AudioMuse sonic routing & PsyLab Connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,19 +129,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### PsyLab — Connections tab and Navidrome admin role
 
-**By [@cucadmuh](https://github.com/cucadmuh), PR [#1032](https://github.com/Psychotoxical/psysonic/pull/1032)**
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1033](https://github.com/Psychotoxical/psysonic/pull/1033)**
 
-* New **Connections** tab: session/endpoint status, active-server capability readout (OpenSubsonic, AudioMuse plugin probe, legacy similar probe, AudioMuse mode), and queue-playback server when it differs from the active profile.
+* New **Connections** tab: session/endpoint status, active-server capability readout (OpenSubsonic, AudioMuse detection, provider/strategy, detection trust, resolved call route, and AudioMuse mode), and queue-playback server when it differs from the active profile.
 * Navidrome **admin vs standard user** badge via native login probe — useful when diagnosing plugin/settings visibility.
 
 
 
-### Servers — AudioMuse plugin probe via OpenSubsonic (Navidrome ≥ 0.62)
+### Servers — capability framework with AudioMuse sonic routing (Navidrome ≥ 0.62)
 
-**By [@cucadmuh](https://github.com/cucadmuh), PR [#1032](https://github.com/Psychotoxical/psysonic/pull/1032)**
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1033](https://github.com/Psychotoxical/psysonic/pull/1033)**
 
-* Navidrome **0.62+**: detect the AudioMuse-AI plugin from `getOpenSubsonicExtensions` when `sonicSimilarity` is advertised — the first reliable signal; the per-server AudioMuse toggle in Settings appears only when the extension is present.
-* Older Navidrome keeps the legacy `getSimilarSongs` Instant Mix probe path.
+* New declarative **server-capability framework** (`src/serverCapabilities/`): a catalog picks a feature strategy per server generation, runs only the needed probes, and routes API calls — replacing scattered version checks in the UI and call sites.
+* Navidrome **0.62+**: detect the AudioMuse-AI plugin from `getOpenSubsonicExtensions` when `sonicSimilarity` is advertised — the first reliable signal. Settings shows an **auto-managed status indicator** (no manual toggle); older Navidrome keeps the manual toggle and the legacy `getSimilarSongs` Instant Mix probe.
+* **Path routing**: Instant Mix and Lucky Mix prefer the OpenSubsonic `getSonicSimilarTracks` endpoint when the plugin is present, falling back to legacy `getSimilarSongs`.
 
 
 
@@ -217,7 +218,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### PsyLab — tab bar no longer collapses on the Logs tab
 
-**By [@cucadmuh](https://github.com/cucadmuh), PR [#1032](https://github.com/Psychotoxical/psysonic/pull/1032)**
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1033](https://github.com/Psychotoxical/psysonic/pull/1033)**
 
 * The PsyLab tab row keeps its height when the Logs flex layout fills the modal — tabs were previously squashed to a thin strip.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### PsyLab — Connections tab and Navidrome admin role
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1032](https://github.com/Psychotoxical/psysonic/pull/1032)**
+
+* New **Connections** tab: session/endpoint status, active-server capability readout (OpenSubsonic, AudioMuse plugin probe, legacy similar probe, AudioMuse mode), and queue-playback server when it differs from the active profile.
+* Navidrome **admin vs standard user** badge via native login probe — useful when diagnosing plugin/settings visibility.
+
+
+
+### Servers — AudioMuse plugin probe via OpenSubsonic (Navidrome ≥ 0.62)
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1032](https://github.com/Psychotoxical/psysonic/pull/1032)**
+
+* Navidrome **0.62+**: detect the AudioMuse-AI plugin from `getOpenSubsonicExtensions` when `sonicSimilarity` is advertised — the first reliable signal; the per-server AudioMuse toggle in Settings appears only when the extension is present.
+* Older Navidrome keeps the legacy `getSimilarSongs` Instant Mix probe path.
+
+
+
 ## Fixed
 
 ### Servers — complete border on the active server card
@@ -194,6 +212,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#1031](https://github.com/Psychotoxical/psysonic/pull/1031)**
 
 * Play on **Top Tracks** rows no longer silently does nothing when the artist page has top songs but no albums loaded (e.g. lossless artist view); playback starts from the clicked track and continues into the catalog when albums are available.
+
+
+
+### PsyLab — tab bar no longer collapses on the Logs tab
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1032](https://github.com/Psychotoxical/psysonic/pull/1032)**
+
+* The PsyLab tab row keeps its height when the Logs flex layout fills the modal — tabs were previously squashed to a thin strip.
 
 
 

--- a/src/api/subsonic.scheduleProbe.test.ts
+++ b/src/api/subsonic.scheduleProbe.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./subsonicOpenSubsonic', () => ({
+  fetchOpenSubsonicExtensionsWithCredentials: vi.fn(),
+}));
+
+import { fetchOpenSubsonicExtensionsWithCredentials } from './subsonicOpenSubsonic';
+import { scheduleInstantMixProbeForServer } from './subsonic';
+import { useAuthStore } from '../store/authStore';
+import type { SubsonicServerIdentity } from '../utils/server/subsonicServerIdentity';
+
+const fetchMock = vi.mocked(fetchOpenSubsonicExtensionsWithCredentials);
+const SID = 'srv-probe';
+const id062: SubsonicServerIdentity = { type: 'navidrome', serverVersion: '0.62.0', openSubsonic: true };
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+function reset() {
+  useAuthStore.setState({
+    subsonicServerIdentityByServer: {},
+    audiomusePluginProbeByServer: {},
+    instantMixProbeByServer: {},
+    audiomuseNavidromeByServer: {},
+    audiomuseNavidromeIssueByServer: {},
+  } as never);
+}
+
+describe('scheduleInstantMixProbeForServer (idempotency)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(['sonicSimilarity']);
+    reset();
+  });
+
+  it('probes once, caches the result, then skips on the next poll', async () => {
+    scheduleInstantMixProbeForServer(SID, 'url', 'u', 'p', id062);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await flush();
+    expect(useAuthStore.getState().audiomusePluginProbeByServer[SID]).toBe('present');
+
+    scheduleInstantMixProbeForServer(SID, 'url', 'u', 'p', id062);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-probes when forced (user-initiated refresh)', async () => {
+    scheduleInstantMixProbeForServer(SID, 'url', 'u', 'p', id062);
+    await flush();
+    scheduleInstantMixProbeForServer(SID, 'url', 'u', 'p', id062, true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-probes after a prior error', async () => {
+    fetchMock.mockResolvedValueOnce(null);
+    scheduleInstantMixProbeForServer(SID, 'url', 'u', 'p', id062);
+    await flush();
+    expect(useAuthStore.getState().audiomusePluginProbeByServer[SID]).toBe('error');
+    scheduleInstantMixProbeForServer(SID, 'url', 'u', 'p', id062);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('setSubsonicServerIdentity (version-change cache invalidation)', () => {
+  beforeEach(reset);
+
+  it('clears cached probes on a version change but keeps the opt-in', () => {
+    useAuthStore.setState({
+      subsonicServerIdentityByServer: { [SID]: id062 },
+      audiomusePluginProbeByServer: { [SID]: 'present' },
+      audiomuseNavidromeByServer: { [SID]: true },
+    } as never);
+
+    useAuthStore.getState().setSubsonicServerIdentity(SID, { type: 'navidrome', serverVersion: '0.63.0', openSubsonic: true });
+
+    const s = useAuthStore.getState();
+    expect(s.audiomusePluginProbeByServer[SID]).toBeUndefined();
+    expect(s.audiomuseNavidromeByServer[SID]).toBe(true);
+  });
+
+  it('keeps cached probes when the identity is unchanged', () => {
+    useAuthStore.setState({
+      subsonicServerIdentityByServer: { [SID]: id062 },
+      audiomusePluginProbeByServer: { [SID]: 'present' },
+    } as never);
+
+    useAuthStore.getState().setSubsonicServerIdentity(SID, { ...id062 });
+
+    expect(useAuthStore.getState().audiomusePluginProbeByServer[SID]).toBe('present');
+  });
+});

--- a/src/api/subsonic.ts
+++ b/src/api/subsonic.ts
@@ -3,9 +3,11 @@ import md5 from 'md5';
 import { useAuthStore } from '../store/authStore';
 import {
   isNavidromeAudiomuseSoftwareEligible,
+  isNavidromeSonicSimilarityEligible,
   type InstantMixProbeResult,
   type SubsonicServerIdentity,
 } from '../utils/server/subsonicServerIdentity';
+import { probeAudiomusePluginWithCredentials } from './subsonicOpenSubsonic';
 import {
   SUBSONIC_CLIENT,
   api,
@@ -104,7 +106,11 @@ export async function probeInstantMixWithCredentials(
   }
 }
 
-/** After a successful ping, probe Instant Mix in the background (Navidrome ≥ 0.60 only). */
+/**
+ * After a successful ping, probe AudioMuse / Instant Mix in the background (Navidrome ≥ 0.60).
+ * Navidrome ≥ 0.62 uses the `sonicSimilarity` OpenSubsonic extension; older builds fall back to
+ * `getSimilarSongs` (may match Last.fm agents, not only AudioMuse).
+ */
 export function scheduleInstantMixProbeForServer(
   serverId: string,
   serverUrl: string,
@@ -113,6 +119,16 @@ export function scheduleInstantMixProbeForServer(
   identity: SubsonicServerIdentity,
 ): void {
   if (!isNavidromeAudiomuseSoftwareEligible(identity)) return;
+
+  if (isNavidromeSonicSimilarityEligible(identity)) {
+    const store = useAuthStore.getState();
+    store.setAudiomusePluginProbe(serverId, 'probing');
+    void probeAudiomusePluginWithCredentials(serverUrl, username, password).then(result =>
+      store.setAudiomusePluginProbe(serverId, result),
+    );
+    return;
+  }
+
   void probeInstantMixWithCredentials(serverUrl, username, password).then(result =>
     useAuthStore.getState().setInstantMixProbe(serverId, result),
   );

--- a/src/api/subsonic.ts
+++ b/src/api/subsonic.ts
@@ -119,6 +119,13 @@ export async function probeInstantMixWithCredentials(
  *
  * Currently: Navidrome ≥ 0.62 → `getOpenSubsonicExtensions` (sonicSimilarity);
  * Navidrome 0.60–0.61 → legacy `getSimilarSongs` Instant Mix probe.
+ *
+ * Idempotent: a server's advertised capabilities are static within a session, so
+ * once a definitive result is cached the probe is skipped. This is called on every
+ * 120 s connection poll, so re-fetching each time would be wasteful and would flip
+ * the resolved status (and the routed endpoint) through a `probing` window. Pass
+ * `force` for user-initiated refreshes (add/edit/test server); a server version or
+ * type change clears the cache (see `setSubsonicServerIdentity`), forcing a re-probe.
  */
 export function scheduleInstantMixProbeForServer(
   serverId: string,
@@ -126,24 +133,33 @@ export function scheduleInstantMixProbeForServer(
   username: string,
   password: string,
   identity: SubsonicServerIdentity,
+  force = false,
 ): void {
   const ctx = buildCapabilityContext(identity);
   const probeIds = neededProbeIds(SERVER_CAPABILITY_CATALOG, ctx);
+  const store = useAuthStore.getState();
 
   if (probeIds.has(PROBE_OPENSUBSONIC_EXTENSIONS)) {
-    const store = useAuthStore.getState();
-    store.setAudiomusePluginProbe(serverId, 'probing');
-    void fetchOpenSubsonicExtensionsWithCredentials(serverUrl, username, password).then(extensions => {
-      const result = extensions === null
-        ? 'error'
-        : extensions.includes(SONIC_SIMILARITY_EXTENSION) ? 'present' : 'absent';
-      useAuthStore.getState().setAudiomusePluginProbe(serverId, result);
-    });
+    const cached = store.audiomusePluginProbeByServer[serverId];
+    // Re-probe only without a definitive cached result (or on force / prior error).
+    // `probing` means an in-flight fetch — skip to avoid a duplicate request.
+    if (force || cached === undefined || cached === 'error') {
+      store.setAudiomusePluginProbe(serverId, 'probing');
+      void fetchOpenSubsonicExtensionsWithCredentials(serverUrl, username, password).then(extensions => {
+        const result = extensions === null
+          ? 'error'
+          : extensions.includes(SONIC_SIMILARITY_EXTENSION) ? 'present' : 'absent';
+        useAuthStore.getState().setAudiomusePluginProbe(serverId, result);
+      });
+    }
   }
 
   if (probeIds.has(PROBE_LEGACY_INSTANT_MIX)) {
-    void probeInstantMixWithCredentials(serverUrl, username, password).then(result =>
-      useAuthStore.getState().setInstantMixProbe(serverId, result),
-    );
+    const cached = store.instantMixProbeByServer[serverId];
+    if (force || cached === undefined || cached === 'error') {
+      void probeInstantMixWithCredentials(serverUrl, username, password).then(result =>
+        useAuthStore.getState().setInstantMixProbe(serverId, result),
+      );
+    }
   }
 }

--- a/src/api/subsonic.ts
+++ b/src/api/subsonic.ts
@@ -2,12 +2,18 @@ import axios from 'axios';
 import md5 from 'md5';
 import { useAuthStore } from '../store/authStore';
 import {
-  isNavidromeAudiomuseSoftwareEligible,
-  isNavidromeSonicSimilarityEligible,
   type InstantMixProbeResult,
   type SubsonicServerIdentity,
 } from '../utils/server/subsonicServerIdentity';
-import { probeAudiomusePluginWithCredentials } from './subsonicOpenSubsonic';
+import { fetchOpenSubsonicExtensionsWithCredentials } from './subsonicOpenSubsonic';
+import { buildCapabilityContext } from '../serverCapabilities/context';
+import {
+  PROBE_LEGACY_INSTANT_MIX,
+  PROBE_OPENSUBSONIC_EXTENSIONS,
+  SERVER_CAPABILITY_CATALOG,
+  SONIC_SIMILARITY_EXTENSION,
+} from '../serverCapabilities/catalog';
+import { neededProbeIds } from '../serverCapabilities/resolve';
 import {
   SUBSONIC_CLIENT,
   api,
@@ -107,9 +113,12 @@ export async function probeInstantMixWithCredentials(
 }
 
 /**
- * After a successful ping, probe AudioMuse / Instant Mix in the background (Navidrome ≥ 0.60).
- * Navidrome ≥ 0.62 uses the `sonicSimilarity` OpenSubsonic extension; older builds fall back to
- * `getSimilarSongs` (may match Last.fm agents, not only AudioMuse).
+ * After a successful ping, run the server-capability probes needed by the catalog
+ * (`serverCapabilities/`). Which probes run is decided by the strategies eligible
+ * for this server generation — not by inline version checks here.
+ *
+ * Currently: Navidrome ≥ 0.62 → `getOpenSubsonicExtensions` (sonicSimilarity);
+ * Navidrome 0.60–0.61 → legacy `getSimilarSongs` Instant Mix probe.
  */
 export function scheduleInstantMixProbeForServer(
   serverId: string,
@@ -118,18 +127,23 @@ export function scheduleInstantMixProbeForServer(
   password: string,
   identity: SubsonicServerIdentity,
 ): void {
-  if (!isNavidromeAudiomuseSoftwareEligible(identity)) return;
+  const ctx = buildCapabilityContext(identity);
+  const probeIds = neededProbeIds(SERVER_CAPABILITY_CATALOG, ctx);
 
-  if (isNavidromeSonicSimilarityEligible(identity)) {
+  if (probeIds.has(PROBE_OPENSUBSONIC_EXTENSIONS)) {
     const store = useAuthStore.getState();
     store.setAudiomusePluginProbe(serverId, 'probing');
-    void probeAudiomusePluginWithCredentials(serverUrl, username, password).then(result =>
-      store.setAudiomusePluginProbe(serverId, result),
-    );
-    return;
+    void fetchOpenSubsonicExtensionsWithCredentials(serverUrl, username, password).then(extensions => {
+      const result = extensions === null
+        ? 'error'
+        : extensions.includes(SONIC_SIMILARITY_EXTENSION) ? 'present' : 'absent';
+      useAuthStore.getState().setAudiomusePluginProbe(serverId, result);
+    });
   }
 
-  void probeInstantMixWithCredentials(serverUrl, username, password).then(result =>
-    useAuthStore.getState().setInstantMixProbe(serverId, result),
-  );
+  if (probeIds.has(PROBE_LEGACY_INSTANT_MIX)) {
+    void probeInstantMixWithCredentials(serverUrl, username, password).then(result =>
+      useAuthStore.getState().setInstantMixProbe(serverId, result),
+    );
+  }
 }

--- a/src/api/subsonicArtists.router.test.ts
+++ b/src/api/subsonicArtists.router.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./subsonicClient', () => ({
+  api: vi.fn(),
+  apiForServer: vi.fn(),
+  libraryFilterParams: () => ({}),
+  libraryFilterParamsForServer: () => ({}),
+}));
+
+vi.mock('./subsonicLibrary', () => ({
+  filterSongsToActiveLibrary: async (songs: unknown[]) => songs,
+  filterSongsToServerLibrary: async (songs: unknown[]) => songs,
+  similarSongsRequestCount: (count: number) => count,
+}));
+
+import { api } from './subsonicClient';
+import { fetchSimilarTracksRouted } from './subsonicArtists';
+import { useAuthStore } from '../store/authStore';
+
+const SID = 'srv-router';
+const apiMock = vi.mocked(api);
+
+function seedServer(identity: Record<string, unknown>, probes: Record<string, unknown>) {
+  useAuthStore.setState({
+    activeServerId: SID,
+    subsonicServerIdentityByServer: { [SID]: identity as never },
+    audiomusePluginProbeByServer: {},
+    instantMixProbeByServer: {},
+    audiomuseNavidromeByServer: {},
+    ...probes,
+  } as never);
+}
+
+const SONIC_RESPONSE = { sonicMatch: [{ entry: { id: 'sonic-1', title: 'Sonic' } }] };
+const SIMILAR_RESPONSE = { similarSongs: { song: [{ id: 'legacy-1', title: 'Legacy' }] } };
+
+describe('fetchSimilarTracksRouted', () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+  });
+
+  it('prefers sonicSimilarity on Navidrome 0.62 with plugin', async () => {
+    seedServer({ type: 'navidrome', serverVersion: '0.62.0', openSubsonic: true }, {
+      audiomusePluginProbeByServer: { [SID]: 'present' },
+    });
+    apiMock.mockImplementation(async (endpoint: string) =>
+      (endpoint === 'getSonicSimilarTracks.view' ? SONIC_RESPONSE : SIMILAR_RESPONSE) as never);
+
+    const result = await fetchSimilarTracksRouted('seed', 10);
+    expect(result.map(s => s.id)).toEqual(['sonic-1']);
+    expect(apiMock).toHaveBeenCalledWith('getSonicSimilarTracks.view', expect.anything());
+    expect(apiMock).not.toHaveBeenCalledWith('getSimilarSongs.view', expect.anything());
+  });
+
+  it('falls back to legacy when sonic returns empty', async () => {
+    seedServer({ type: 'navidrome', serverVersion: '0.62.0', openSubsonic: true }, {
+      audiomusePluginProbeByServer: { [SID]: 'present' },
+    });
+    apiMock.mockImplementation(async (endpoint: string) =>
+      (endpoint === 'getSonicSimilarTracks.view' ? { sonicMatch: [] } : SIMILAR_RESPONSE) as never);
+
+    const result = await fetchSimilarTracksRouted('seed', 10);
+    expect(result.map(s => s.id)).toEqual(['legacy-1']);
+    expect(apiMock).toHaveBeenCalledWith('getSonicSimilarTracks.view', expect.anything());
+    expect(apiMock).toHaveBeenCalledWith('getSimilarSongs.view', expect.anything());
+  });
+
+  it('uses legacy only on Navidrome 0.62 without plugin', async () => {
+    seedServer({ type: 'navidrome', serverVersion: '0.62.0', openSubsonic: true }, {
+      audiomusePluginProbeByServer: { [SID]: 'absent' },
+    });
+    apiMock.mockImplementation(async () => SIMILAR_RESPONSE as never);
+
+    const result = await fetchSimilarTracksRouted('seed', 10);
+    expect(result.map(s => s.id)).toEqual(['legacy-1']);
+    expect(apiMock).not.toHaveBeenCalledWith('getSonicSimilarTracks.view', expect.anything());
+    expect(apiMock).toHaveBeenCalledWith('getSimilarSongs.view', expect.anything());
+  });
+});

--- a/src/api/subsonicArtists.ts
+++ b/src/api/subsonicArtists.ts
@@ -2,6 +2,11 @@ import { useAuthStore } from '../store/authStore';
 import { api, apiForServer, libraryFilterParams, libraryFilterParamsForServer } from './subsonicClient';
 import { filterSongsToServerLibrary } from './subsonicLibrary';
 import { filterSongsToActiveLibrary, similarSongsRequestCount } from './subsonicLibrary';
+import {
+  FEATURE_AUDIOMUSE_SIMILAR_TRACKS,
+  OP_SIMILAR_TRACKS,
+} from '../serverCapabilities/catalog';
+import { resolveCallRoutesForServer } from '../serverCapabilities/storeView';
 import type {
   SubsonicAlbum,
   SubsonicArtist,
@@ -108,4 +113,46 @@ export async function getSimilarSongs(id: string, count = 50): Promise<SubsonicS
   } catch {
     return [];
   }
+}
+
+/**
+ * Sonic (audio-analysis) similar tracks via the OpenSubsonic `sonicSimilarity`
+ * extension (Navidrome ≥ 0.62 + AudioMuse plugin). Returns `[]` when the server
+ * has no provider (HTTP 404) so callers can fall back.
+ */
+export async function getSonicSimilarTracks(id: string, count = 50): Promise<SubsonicSong[]> {
+  try {
+    const requestCount = similarSongsRequestCount(count);
+    const data = await api<{ sonicMatch: Array<{ entry?: SubsonicSong }> | { entry?: SubsonicSong } }>(
+      'getSonicSimilarTracks.view',
+      { id, count: requestCount, ...libraryFilterParams() },
+    );
+    const raw = data.sonicMatch;
+    const list = Array.isArray(raw) ? raw : raw ? [raw] : [];
+    const songs = list.map(m => m.entry).filter((e): e is SubsonicSong => !!e);
+    if (songs.length === 0) return [];
+    const filtered = await filterSongsToActiveLibrary(songs);
+    return filtered.slice(0, count);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Capability-routed similar tracks for the active server. Prefers the sonic
+ * similarity endpoint when the AudioMuse plugin is detected (Navidrome ≥ 0.62),
+ * falling back to legacy `getSimilarSongs` on empty/unavailable.
+ */
+export async function fetchSimilarTracksRouted(songId: string, count = 50): Promise<SubsonicSong[]> {
+  const { activeServerId } = useAuthStore.getState();
+  if (!activeServerId) return getSimilarSongs(songId, count);
+  const routes = resolveCallRoutesForServer(activeServerId, FEATURE_AUDIOMUSE_SIMILAR_TRACKS, OP_SIMILAR_TRACKS);
+  if (routes.length === 0) return getSimilarSongs(songId, count);
+  for (const route of routes) {
+    const songs = route.transport === 'opensubsonic'
+      ? await getSonicSimilarTracks(songId, count)
+      : await getSimilarSongs(songId, count);
+    if (songs.length > 0) return songs;
+  }
+  return [];
 }

--- a/src/api/subsonicOpenSubsonic.test.ts
+++ b/src/api/subsonicOpenSubsonic.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import axios from 'axios';
 import {
+  fetchOpenSubsonicExtensionsWithCredentials,
   hasOpenSubsonicExtension,
   parseOpenSubsonicExtensions,
-  probeAudiomusePluginWithCredentials,
 } from './subsonicOpenSubsonic';
 
 vi.mock('axios');
@@ -42,33 +42,31 @@ describe('hasOpenSubsonicExtension', () => {
   });
 });
 
-describe('probeAudiomusePluginWithCredentials', () => {
+describe('fetchOpenSubsonicExtensionsWithCredentials', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns present when sonicSimilarity is advertised', async () => {
+  it('returns the advertised extension names', async () => {
     vi.mocked(axios.get).mockResolvedValue(
-      okExtensions([{ name: 'sonicSimilarity', versions: [1] }]),
+      okExtensions([{ name: 'sonicSimilarity', versions: [1] }, { name: 'playbackReport', versions: [1] }]),
     );
     await expect(
-      probeAudiomusePluginWithCredentials('https://music.test', 'u', 'p'),
-    ).resolves.toBe('present');
+      fetchOpenSubsonicExtensionsWithCredentials('https://music.test', 'u', 'p'),
+    ).resolves.toEqual(['sonicSimilarity', 'playbackReport']);
   });
 
-  it('returns absent when sonicSimilarity is missing', async () => {
-    vi.mocked(axios.get).mockResolvedValue(
-      okExtensions([{ name: 'playbackReport', versions: [1] }]),
-    );
+  it('returns an empty list when none are advertised', async () => {
+    vi.mocked(axios.get).mockResolvedValue(okExtensions([]));
     await expect(
-      probeAudiomusePluginWithCredentials('https://music.test', 'u', 'p'),
-    ).resolves.toBe('absent');
+      fetchOpenSubsonicExtensionsWithCredentials('https://music.test', 'u', 'p'),
+    ).resolves.toEqual([]);
   });
 
-  it('returns error on request failure', async () => {
+  it('returns null on request failure', async () => {
     vi.mocked(axios.get).mockRejectedValue(new Error('boom'));
     await expect(
-      probeAudiomusePluginWithCredentials('https://music.test', 'u', 'p'),
-    ).resolves.toBe('error');
+      fetchOpenSubsonicExtensionsWithCredentials('https://music.test', 'u', 'p'),
+    ).resolves.toBeNull();
   });
 });

--- a/src/api/subsonicOpenSubsonic.test.ts
+++ b/src/api/subsonicOpenSubsonic.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import axios from 'axios';
+import {
+  hasOpenSubsonicExtension,
+  parseOpenSubsonicExtensions,
+  probeAudiomusePluginWithCredentials,
+} from './subsonicOpenSubsonic';
+
+vi.mock('axios');
+
+function okExtensions(extensions: unknown[]) {
+  return {
+    data: {
+      'subsonic-response': {
+        status: 'ok',
+        openSubsonic: true,
+        openSubsonicExtensions: extensions,
+      },
+    },
+  };
+}
+
+describe('parseOpenSubsonicExtensions', () => {
+  it('parses extension names and versions', () => {
+    const parsed = parseOpenSubsonicExtensions([
+      { name: 'sonicSimilarity', versions: [1] },
+      { name: 'playbackReport', versions: [1, 2] },
+      { bad: true },
+    ]);
+    expect(parsed).toEqual([
+      { name: 'sonicSimilarity', versions: [1] },
+      { name: 'playbackReport', versions: [1, 2] },
+    ]);
+  });
+});
+
+describe('hasOpenSubsonicExtension', () => {
+  it('detects sonicSimilarity', () => {
+    const extensions = parseOpenSubsonicExtensions([{ name: 'sonicSimilarity', versions: [1] }]);
+    expect(hasOpenSubsonicExtension(extensions, 'sonicSimilarity')).toBe(true);
+    expect(hasOpenSubsonicExtension(extensions, 'other')).toBe(false);
+  });
+});
+
+describe('probeAudiomusePluginWithCredentials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns present when sonicSimilarity is advertised', async () => {
+    vi.mocked(axios.get).mockResolvedValue(
+      okExtensions([{ name: 'sonicSimilarity', versions: [1] }]),
+    );
+    await expect(
+      probeAudiomusePluginWithCredentials('https://music.test', 'u', 'p'),
+    ).resolves.toBe('present');
+  });
+
+  it('returns absent when sonicSimilarity is missing', async () => {
+    vi.mocked(axios.get).mockResolvedValue(
+      okExtensions([{ name: 'playbackReport', versions: [1] }]),
+    );
+    await expect(
+      probeAudiomusePluginWithCredentials('https://music.test', 'u', 'p'),
+    ).resolves.toBe('absent');
+  });
+
+  it('returns error on request failure', async () => {
+    vi.mocked(axios.get).mockRejectedValue(new Error('boom'));
+    await expect(
+      probeAudiomusePluginWithCredentials('https://music.test', 'u', 'p'),
+    ).resolves.toBe('error');
+  });
+});

--- a/src/api/subsonicOpenSubsonic.ts
+++ b/src/api/subsonicOpenSubsonic.ts
@@ -1,0 +1,49 @@
+import type { AudiomusePluginProbeResult } from '../utils/server/subsonicServerIdentity';
+import { apiWithCredentials } from './subsonicClient';
+
+export interface OpenSubsonicExtension {
+  name: string;
+  versions: number[];
+}
+
+export function parseOpenSubsonicExtensions(raw: unknown): OpenSubsonicExtension[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object' && !Array.isArray(entry))
+    .map(entry => ({
+      name: typeof entry.name === 'string' ? entry.name : '',
+      versions: Array.isArray(entry.versions)
+        ? entry.versions.filter((v): v is number => typeof v === 'number')
+        : [],
+    }))
+    .filter(entry => entry.name.length > 0);
+}
+
+export function hasOpenSubsonicExtension(extensions: readonly OpenSubsonicExtension[], name: string): boolean {
+  return extensions.some(ext => ext.name === name);
+}
+
+/**
+ * Navidrome ≥ 0.62: `sonicSimilarity` in `getOpenSubsonicExtensions` means an audio-similarity
+ * plugin (typically AudioMuse-AI) is active on the server.
+ */
+export async function probeAudiomusePluginWithCredentials(
+  serverUrl: string,
+  username: string,
+  password: string,
+): Promise<Exclude<AudiomusePluginProbeResult, 'probing' | 'unsupported'>> {
+  try {
+    const data = await apiWithCredentials<{ openSubsonicExtensions?: unknown }>(
+      serverUrl,
+      username,
+      password,
+      'getOpenSubsonicExtensions.view',
+      {},
+      12000,
+    );
+    const extensions = parseOpenSubsonicExtensions(data.openSubsonicExtensions);
+    return hasOpenSubsonicExtension(extensions, 'sonicSimilarity') ? 'present' : 'absent';
+  } catch {
+    return 'error';
+  }
+}

--- a/src/api/subsonicOpenSubsonic.ts
+++ b/src/api/subsonicOpenSubsonic.ts
@@ -24,6 +24,30 @@ export function hasOpenSubsonicExtension(extensions: readonly OpenSubsonicExtens
 }
 
 /**
+ * Fetch the list of OpenSubsonic extension names advertised by the server, or
+ * `null` when the request fails. Shared probe for any extension-gated feature.
+ */
+export async function fetchOpenSubsonicExtensionsWithCredentials(
+  serverUrl: string,
+  username: string,
+  password: string,
+): Promise<string[] | null> {
+  try {
+    const data = await apiWithCredentials<{ openSubsonicExtensions?: unknown }>(
+      serverUrl,
+      username,
+      password,
+      'getOpenSubsonicExtensions.view',
+      {},
+      12000,
+    );
+    return parseOpenSubsonicExtensions(data.openSubsonicExtensions).map(ext => ext.name);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Navidrome ≥ 0.62: `sonicSimilarity` in `getOpenSubsonicExtensions` means an audio-similarity
  * plugin (typically AudioMuse-AI) is active on the server.
  */

--- a/src/api/subsonicOpenSubsonic.ts
+++ b/src/api/subsonicOpenSubsonic.ts
@@ -1,4 +1,3 @@
-import type { AudiomusePluginProbeResult } from '../utils/server/subsonicServerIdentity';
 import { apiWithCredentials } from './subsonicClient';
 
 export interface OpenSubsonicExtension {
@@ -44,30 +43,5 @@ export async function fetchOpenSubsonicExtensionsWithCredentials(
     return parseOpenSubsonicExtensions(data.openSubsonicExtensions).map(ext => ext.name);
   } catch {
     return null;
-  }
-}
-
-/**
- * Navidrome ≥ 0.62: `sonicSimilarity` in `getOpenSubsonicExtensions` means an audio-similarity
- * plugin (typically AudioMuse-AI) is active on the server.
- */
-export async function probeAudiomusePluginWithCredentials(
-  serverUrl: string,
-  username: string,
-  password: string,
-): Promise<Exclude<AudiomusePluginProbeResult, 'probing' | 'unsupported'>> {
-  try {
-    const data = await apiWithCredentials<{ openSubsonicExtensions?: unknown }>(
-      serverUrl,
-      username,
-      password,
-      'getOpenSubsonicExtensions.view',
-      {},
-      12000,
-    );
-    const extensions = parseOpenSubsonicExtensions(data.openSubsonicExtensions);
-    return hasOpenSubsonicExtension(extensions, 'sonicSimilarity') ? 'present' : 'absent';
-  } catch {
-    return 'error';
   }
 }

--- a/src/components/settings/ServersTab.tsx
+++ b/src/components/settings/ServersTab.tsx
@@ -486,6 +486,7 @@ export function ServersTab({
                   {showAudiomuseNavidromeServerSetting(
                     auth.subsonicServerIdentityByServer[srv.id],
                     auth.instantMixProbeByServer[srv.id],
+                    auth.audiomusePluginProbeByServer[srv.id],
                   ) && (
                     <div
                       className="settings-toggle-row"

--- a/src/components/settings/ServersTab.tsx
+++ b/src/components/settings/ServersTab.tsx
@@ -25,11 +25,9 @@ import {
 import { useConfirmModalStore } from '../../store/confirmModalStore';
 import { showToast } from '../../utils/ui/toast';
 import PerfProbeStatusBadge, { type PerfProbeBadgeTone } from '../sidebar/perfProbe/PerfProbeStatusBadge';
-import {
-  isAudiomusePluginAutoManaged,
-  resolveAudiomusePluginProbeUiStatus,
-  showAudiomuseNavidromeServerSetting,
-} from '../../utils/server/subsonicServerIdentity';
+import { FEATURE_AUDIOMUSE_SIMILAR_TRACKS } from '../../serverCapabilities/catalog';
+import { resolveFeatureForServer } from '../../serverCapabilities/storeView';
+import type { CapabilityStatus, ResolvedCapability } from '../../serverCapabilities/types';
 import { serverListDisplayLabel } from '../../utils/server/serverDisplayName';
 import { serverIndexKeyForProfile } from '../../utils/server/serverIndexKey';
 import { switchActiveServer } from '../../utils/server/switchActiveServer';
@@ -39,16 +37,21 @@ import { ServerGripHandle } from './ServerGripHandle';
 const AUDIOMUSE_NV_PLUGIN_URL = 'https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin';
 
 function audiomuseProbeBadge(
-  status: ReturnType<typeof resolveAudiomusePluginProbeUiStatus>,
+  status: CapabilityStatus,
   t: (key: string) => string,
 ): { tone: PerfProbeBadgeTone; label: string } {
   switch (status) {
-    case 'active': return { tone: 'ok', label: t('settings.audiomuseStatusActive') };
-    case 'checking': return { tone: 'warn', label: t('settings.audiomuseStatusChecking') };
-    case 'not_detected': return { tone: 'muted', label: t('settings.audiomuseStatusNotDetected') };
-    case 'failed': return { tone: 'error', label: t('settings.audiomuseStatusProbeFailed') };
+    case 'present': return { tone: 'ok', label: t('settings.audiomuseStatusActive') };
+    case 'absent': return { tone: 'muted', label: t('settings.audiomuseStatusNotDetected') };
+    case 'error': return { tone: 'error', label: t('settings.audiomuseStatusProbeFailed') };
     default: return { tone: 'warn', label: t('settings.audiomuseStatusChecking') };
   }
+}
+
+/** Row visibility: hide only when a manual (legacy) strategy proves the feature absent. */
+function showAudiomuseRow(resolved: ResolvedCapability | null): boolean {
+  if (!resolved || resolved.strategyId === null || resolved.status === 'ineligible') return false;
+  return !(resolved.activation === 'manual' && resolved.status === 'absent');
 }
 
 type ServerDropTarget = { idx: number; before: boolean } | null;
@@ -501,17 +504,11 @@ export function ServersTab({
                     onVerify={() => void librarySync.runServerAction(serverIndexKeyForProfile(srv), 'verify')}
                     onCancel={() => void librarySync.handleCancel()}
                   />
-                  {showAudiomuseNavidromeServerSetting(
-                    auth.subsonicServerIdentityByServer[srv.id],
-                    auth.instantMixProbeByServer[srv.id],
-                    auth.audiomusePluginProbeByServer[srv.id],
-                  ) && (() => {
-                    const serverIdentity = auth.subsonicServerIdentityByServer[srv.id];
-                    const autoManaged = isAudiomusePluginAutoManaged(serverIdentity);
-                    const probeStatus = resolveAudiomusePluginProbeUiStatus(
-                      auth.audiomusePluginProbeByServer[srv.id],
-                    );
-                    const probeBadge = audiomuseProbeBadge(probeStatus, t);
+                  {(() => {
+                    const resolved = resolveFeatureForServer(srv.id, FEATURE_AUDIOMUSE_SIMILAR_TRACKS);
+                    if (!showAudiomuseRow(resolved) || !resolved) return null;
+                    const autoManaged = resolved.activation === 'auto';
+                    const probeBadge = audiomuseProbeBadge(resolved.status, t);
                     const audiomuseActive = !!auth.audiomuseNavidromeByServer[srv.id];
                     return (
                     <div
@@ -533,23 +530,25 @@ export function ServersTab({
                               />
                             )}
                           </div>
-                          <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.45 }}>
-                            <Trans
-                              i18nKey={autoManaged ? 'settings.audiomuseDescAuto' : 'settings.audiomuseDesc'}
-                              components={{
-                                pluginLink: (
-                                  <a
-                                    href={AUDIOMUSE_NV_PLUGIN_URL}
-                                    onClick={e => {
-                                      e.preventDefault();
-                                      void openUrl(AUDIOMUSE_NV_PLUGIN_URL);
-                                    }}
-                                    style={{ color: 'var(--accent)', textDecoration: 'underline' }}
-                                  />
-                                ),
-                              }}
-                            />
-                          </div>
+                          {!autoManaged && (
+                            <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.45 }}>
+                              <Trans
+                                i18nKey="settings.audiomuseDesc"
+                                components={{
+                                  pluginLink: (
+                                    <a
+                                      href={AUDIOMUSE_NV_PLUGIN_URL}
+                                      onClick={e => {
+                                        e.preventDefault();
+                                        void openUrl(AUDIOMUSE_NV_PLUGIN_URL);
+                                      }}
+                                      style={{ color: 'var(--accent)', textDecoration: 'underline' }}
+                                    />
+                                  ),
+                                }}
+                              />
+                            </div>
+                          )}
                         </div>
                       </div>
                       {autoManaged ? (

--- a/src/components/settings/ServersTab.tsx
+++ b/src/components/settings/ServersTab.tsx
@@ -24,7 +24,12 @@ import {
 } from '../../utils/server/serverUrlRemigration';
 import { useConfirmModalStore } from '../../store/confirmModalStore';
 import { showToast } from '../../utils/ui/toast';
-import { showAudiomuseNavidromeServerSetting } from '../../utils/server/subsonicServerIdentity';
+import PerfProbeStatusBadge, { type PerfProbeBadgeTone } from '../sidebar/perfProbe/PerfProbeStatusBadge';
+import {
+  isAudiomusePluginAutoManaged,
+  resolveAudiomusePluginProbeUiStatus,
+  showAudiomuseNavidromeServerSetting,
+} from '../../utils/server/subsonicServerIdentity';
 import { serverListDisplayLabel } from '../../utils/server/serverDisplayName';
 import { serverIndexKeyForProfile } from '../../utils/server/serverIndexKey';
 import { switchActiveServer } from '../../utils/server/switchActiveServer';
@@ -32,6 +37,19 @@ import { AddServerForm } from './AddServerForm';
 import { ServerGripHandle } from './ServerGripHandle';
 
 const AUDIOMUSE_NV_PLUGIN_URL = 'https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin';
+
+function audiomuseProbeBadge(
+  status: ReturnType<typeof resolveAudiomusePluginProbeUiStatus>,
+  t: (key: string) => string,
+): { tone: PerfProbeBadgeTone; label: string } {
+  switch (status) {
+    case 'active': return { tone: 'ok', label: t('settings.audiomuseStatusActive') };
+    case 'checking': return { tone: 'warn', label: t('settings.audiomuseStatusChecking') };
+    case 'not_detected': return { tone: 'muted', label: t('settings.audiomuseStatusNotDetected') };
+    case 'failed': return { tone: 'error', label: t('settings.audiomuseStatusProbeFailed') };
+    default: return { tone: 'warn', label: t('settings.audiomuseStatusChecking') };
+  }
+}
 
 type ServerDropTarget = { idx: number; before: boolean } | null;
 
@@ -487,7 +505,15 @@ export function ServersTab({
                     auth.subsonicServerIdentityByServer[srv.id],
                     auth.instantMixProbeByServer[srv.id],
                     auth.audiomusePluginProbeByServer[srv.id],
-                  ) && (
+                  ) && (() => {
+                    const serverIdentity = auth.subsonicServerIdentityByServer[srv.id];
+                    const autoManaged = isAudiomusePluginAutoManaged(serverIdentity);
+                    const probeStatus = resolveAudiomusePluginProbeUiStatus(
+                      auth.audiomusePluginProbeByServer[srv.id],
+                    );
+                    const probeBadge = audiomuseProbeBadge(probeStatus, t);
+                    const audiomuseActive = !!auth.audiomuseNavidromeByServer[srv.id];
+                    return (
                     <div
                       className="settings-toggle-row"
                       data-settings-search={t('settings.audiomuseTitle')}
@@ -498,7 +524,7 @@ export function ServersTab({
                         <div>
                           <div style={{ fontWeight: 500, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
                             {t('settings.audiomuseTitle')}
-                            {!!auth.audiomuseNavidromeByServer[srv.id] && auth.audiomuseNavidromeIssueByServer[srv.id] && (
+                            {audiomuseActive && auth.audiomuseNavidromeIssueByServer[srv.id] && (
                               <AlertTriangle
                                 size={16}
                                 style={{ color: 'var(--warning, #f59e0b)', flexShrink: 0 }}
@@ -509,7 +535,7 @@ export function ServersTab({
                           </div>
                           <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.45 }}>
                             <Trans
-                              i18nKey="settings.audiomuseDesc"
+                              i18nKey={autoManaged ? 'settings.audiomuseDescAuto' : 'settings.audiomuseDesc'}
                               components={{
                                 pluginLink: (
                                   <a
@@ -526,16 +552,21 @@ export function ServersTab({
                           </div>
                         </div>
                       </div>
-                      <label className="toggle-switch" aria-label={t('settings.audiomuseTitle')}>
-                        <input
-                          type="checkbox"
-                          checked={!!auth.audiomuseNavidromeByServer[srv.id]}
-                          onChange={e => auth.setAudiomuseNavidromeEnabled(srv.id, e.target.checked)}
-                        />
-                        <span className="toggle-track" />
-                      </label>
+                      {autoManaged ? (
+                        <PerfProbeStatusBadge tone={probeBadge.tone}>{probeBadge.label}</PerfProbeStatusBadge>
+                      ) : (
+                        <label className="toggle-switch" aria-label={t('settings.audiomuseTitle')}>
+                          <input
+                            type="checkbox"
+                            checked={audiomuseActive}
+                            onChange={e => auth.setAudiomuseNavidromeEnabled(srv.id, e.target.checked)}
+                          />
+                          <span className="toggle-track" />
+                        </label>
+                      )}
                     </div>
-                  )}
+                    );
+                  })()}
                 </div>
               );
             })}

--- a/src/components/settings/ServersTab.tsx
+++ b/src/components/settings/ServersTab.tsx
@@ -156,7 +156,7 @@ export function ServersTab({
           openSubsonic: probe.ping.openSubsonic,
         };
         auth.setSubsonicServerIdentity(server.id, identity);
-        scheduleInstantMixProbeForServer(server.id, probe.baseUrl, server.username, server.password, identity);
+        scheduleInstantMixProbeForServer(server.id, probe.baseUrl, server.username, server.password, identity, true);
       }
       setConnStatus(s => ({ ...s, [server.id]: probe.ok ? 'ok' : 'error' }));
     } catch {
@@ -253,7 +253,7 @@ export function ServersTab({
           openSubsonic: ping.openSubsonic,
         };
         auth.setSubsonicServerIdentity(id, identity);
-        scheduleInstantMixProbeForServer(id, data.url, data.username, data.password, identity);
+        scheduleInstantMixProbeForServer(id, data.url, data.username, data.password, identity, true);
         setConnStatus(s => ({ ...s, [id]: 'ok' }));
         const added = useAuthStore.getState().servers.find(s => s.id === id);
         if (added) void bootstrapIndexedServer(added);
@@ -345,7 +345,7 @@ export function ServersTab({
           openSubsonic: ping.openSubsonic,
         };
         auth.setSubsonicServerIdentity(id, identity);
-        scheduleInstantMixProbeForServer(id, data.url, data.username, data.password, identity);
+        scheduleInstantMixProbeForServer(id, data.url, data.username, data.password, identity, true);
       }
       setConnStatus(s => ({ ...s, [id]: ping.ok ? 'ok' : 'error' }));
     } catch {

--- a/src/components/sidebar/SidebarPerfProbeModal.tsx
+++ b/src/components/sidebar/SidebarPerfProbeModal.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react';
-import { Activity, ScrollText, SlidersHorizontal, Wrench, X } from 'lucide-react';
+import { Activity, Network, ScrollText, SlidersHorizontal, Wrench, X } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import SidebarPerfProbeMonitorTab from './perfProbe/SidebarPerfProbeMonitorTab';
 import SidebarPerfProbeTogglesTab from './perfProbe/SidebarPerfProbeTogglesTab';
 import SidebarPerfProbeTuningTab from './perfProbe/SidebarPerfProbeTuningTab';
 import SidebarPerfProbeLogsTab from './perfProbe/SidebarPerfProbeLogsTab';
+import SidebarPerfProbeConnectionsTab from './perfProbe/SidebarPerfProbeConnectionsTab';
 import { resetPerfProbeFlags, type PerfProbeFlags } from '../../utils/perf/perfFlags';
 import { clearPerfLiveOverlayPins } from '../../utils/perf/perfOverlayPins';
 import { resetPerfOverlayAppearance } from '../../utils/perf/perfOverlayAppearance';
 import { resetPerfOverlayMode } from '../../utils/perf/perfOverlayMode';
 
-type TabId = 'monitor' | 'toggles' | 'tuning' | 'logs';
+type TabId = 'monitor' | 'connections' | 'toggles' | 'tuning' | 'logs';
 
 interface Props {
   open: boolean;
@@ -65,7 +66,7 @@ export default function SidebarPerfProbeModal({
         <header className="sidebar-perf-modal__header">
           <h3 id="psylab-title" className="modal-title">PsyLab</h3>
           <p className="sidebar-perf-modal__hint">
-            Live metrics with optional on-screen overlays, runtime tuning, and diagnostic disable toggles.
+            Live metrics, server connections, runtime tuning, and diagnostic disable toggles.
           </p>
         </header>
 
@@ -79,6 +80,16 @@ export default function SidebarPerfProbeModal({
           >
             <Activity size={15} />
             Monitor
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'connections'}
+            className={`sidebar-perf-modal__tab${tab === 'connections' ? ' sidebar-perf-modal__tab--active' : ''}`}
+            onClick={() => setTab('connections')}
+          >
+            <Network size={15} />
+            Connections
           </button>
           <button
             type="button"
@@ -114,6 +125,7 @@ export default function SidebarPerfProbeModal({
 
         <div className={`sidebar-perf-modal__body${tab === 'logs' ? ' sidebar-perf-modal__body--logs' : ''}`}>
           {tab === 'monitor' && <SidebarPerfProbeMonitorTab />}
+          {tab === 'connections' && <SidebarPerfProbeConnectionsTab />}
           {tab === 'tuning' && <SidebarPerfProbeTuningTab />}
           {tab === 'toggles' && (
             <SidebarPerfProbeTogglesTab

--- a/src/components/sidebar/perfProbe/PerfProbeDetailList.tsx
+++ b/src/components/sidebar/perfProbe/PerfProbeDetailList.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+export interface PerfProbeDetailRow {
+  label: string;
+  value: ReactNode;
+}
+
+interface Props {
+  rows: PerfProbeDetailRow[];
+}
+
+export default function PerfProbeDetailList({ rows }: Props) {
+  return (
+    <dl className="perf-server-dl">
+      {rows.map(row => (
+        <div key={row.label} className="perf-server-dl__row">
+          <dt>{row.label}</dt>
+          <dd>{row.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/src/components/sidebar/perfProbe/PerfProbeMetricCard.tsx
+++ b/src/components/sidebar/perfProbe/PerfProbeMetricCard.tsx
@@ -71,6 +71,7 @@ interface SectionProps {
   hint?: string;
   children: ReactNode;
   defaultOpen?: boolean;
+  layout?: 'grid' | 'stack';
   onOpenChange?: (open: boolean) => void;
 }
 
@@ -79,6 +80,7 @@ export function PerfProbeMetricSection({
   hint,
   children,
   defaultOpen = true,
+  layout = 'grid',
   onOpenChange,
 }: SectionProps) {
   return (
@@ -92,7 +94,9 @@ export function PerfProbeMetricSection({
         <span>{title}</span>
         {hint && <span className="perf-metric-section__hint">{hint}</span>}
       </summary>
-      <div className="perf-metric-section__grid">{children}</div>
+      <div className={layout === 'stack' ? 'perf-metric-section__body' : 'perf-metric-section__grid'}>
+        {children}
+      </div>
     </details>
   );
 }

--- a/src/components/sidebar/perfProbe/PerfProbeStatusBadge.tsx
+++ b/src/components/sidebar/perfProbe/PerfProbeStatusBadge.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+export type PerfProbeBadgeTone = 'ok' | 'warn' | 'error' | 'neutral' | 'muted';
+
+interface Props {
+  tone: PerfProbeBadgeTone;
+  children: ReactNode;
+}
+
+export default function PerfProbeStatusBadge({ tone, children }: Props) {
+  return (
+    <span className={`perf-status-badge perf-status-badge--${tone}`}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeConnectionsTab.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeConnectionsTab.tsx
@@ -1,0 +1,82 @@
+import { useAuthStore } from '../../../store/authStore';
+import { usePlayerStore } from '../../../store/playerStore';
+import { useConnectionStatus } from '../../../hooks/useConnectionStatus';
+import { serverListDisplayLabel } from '../../../utils/server/serverDisplayName';
+import { findServerByIdOrIndexKey } from '../../../utils/server/serverLookup';
+import { PerfProbeMetricSection } from './PerfProbeMetricCard';
+import SidebarPerfProbeServerSection from './SidebarPerfProbeServerSection';
+
+function formatConnectionStatus(status: string): string {
+  switch (status) {
+    case 'connected': return 'Connected';
+    case 'disconnected': return 'Disconnected';
+    case 'checking': return 'Checking…';
+    default: return status;
+  }
+}
+
+export default function SidebarPerfProbeConnectionsTab() {
+  const { status, isLan, serverName } = useConnectionStatus();
+  const isLoggedIn = useAuthStore(s => s.isLoggedIn);
+  const activeServerId = useAuthStore(s => s.activeServerId);
+  const servers = useAuthStore(s => s.servers);
+  const connectUrl = useAuthStore(s => s.getBaseUrl());
+  const queueServerId = usePlayerStore(s => s.queueServerId);
+
+  const queueServer = queueServerId ? findServerByIdOrIndexKey(queueServerId) : undefined;
+  const queueDiffersFromActive = Boolean(
+    queueServerId && activeServerId && queueServerId !== activeServerId,
+  );
+
+  return (
+    <div className="perf-monitor">
+      <PerfProbeMetricSection title="Connection" defaultOpen>
+        <dl className="perf-server-dl">
+          <div className="perf-server-dl__row">
+            <dt>Status</dt>
+            <dd>{formatConnectionStatus(status)}</dd>
+          </div>
+          <div className="perf-server-dl__row">
+            <dt>Session</dt>
+            <dd>{isLoggedIn ? 'Logged in' : 'Not logged in'}</dd>
+          </div>
+          {serverName && (
+            <div className="perf-server-dl__row">
+              <dt>Browse label</dt>
+              <dd>{serverName}</dd>
+            </div>
+          )}
+          {connectUrl && (
+            <div className="perf-server-dl__row">
+              <dt>Connect URL</dt>
+              <dd>{connectUrl}</dd>
+            </div>
+          )}
+          {status === 'connected' && (
+            <div className="perf-server-dl__row">
+              <dt>Endpoint</dt>
+              <dd>{isLan ? 'LAN' : 'Public / remote'}</dd>
+            </div>
+          )}
+        </dl>
+      </PerfProbeMetricSection>
+
+      <SidebarPerfProbeServerSection />
+
+      {queueDiffersFromActive && queueServer && (
+        <PerfProbeMetricSection title="Queue playback server" defaultOpen={false}>
+          <dl className="perf-server-dl">
+            <div className="perf-server-dl__row">
+              <dt>Name</dt>
+              <dd>{serverListDisplayLabel(queueServer, servers)}</dd>
+            </div>
+            <div className="perf-server-dl__row">
+              <dt>Scope key</dt>
+              <dd>{queueServerId}</dd>
+            </div>
+          </dl>
+        </PerfProbeMetricSection>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeConnectionsTab.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeConnectionsTab.tsx
@@ -1,18 +1,45 @@
 import { useAuthStore } from '../../../store/authStore';
 import { usePlayerStore } from '../../../store/playerStore';
 import { useConnectionStatus } from '../../../hooks/useConnectionStatus';
+import { useNavidromeAdminRole } from '../../../hooks/useNavidromeAdminRole';
 import { serverListDisplayLabel } from '../../../utils/server/serverDisplayName';
 import { findServerByIdOrIndexKey } from '../../../utils/server/serverLookup';
 import { PerfProbeMetricSection } from './PerfProbeMetricCard';
+import PerfProbeDetailList from './PerfProbeDetailList';
+import PerfProbeStatusBadge, { type PerfProbeBadgeTone } from './PerfProbeStatusBadge';
 import SidebarPerfProbeServerSection from './SidebarPerfProbeServerSection';
 
-function formatConnectionStatus(status: string): string {
+function connectionStatusBadge(status: string): { tone: PerfProbeBadgeTone; label: string } {
   switch (status) {
-    case 'connected': return 'Connected';
-    case 'disconnected': return 'Disconnected';
-    case 'checking': return 'Checking…';
-    default: return status;
+    case 'connected': return { tone: 'ok', label: 'Connected' };
+    case 'disconnected': return { tone: 'error', label: 'Disconnected' };
+    case 'checking': return { tone: 'warn', label: 'Checking…' };
+    default: return { tone: 'muted', label: status };
   }
+}
+
+function sessionBadge(loggedIn: boolean): { tone: PerfProbeBadgeTone; label: string } {
+  return loggedIn
+    ? { tone: 'ok', label: 'Logged in' }
+    : { tone: 'muted', label: 'Not logged in' };
+}
+
+function adminRoleBadge(role: ReturnType<typeof useNavidromeAdminRole>): { tone: PerfProbeBadgeTone; label: string } {
+  switch (role) {
+    case 'admin': return { tone: 'ok', label: 'Admin' };
+    case 'user': return { tone: 'neutral', label: 'Standard user' };
+    case 'checking':
+    case 'idle': return { tone: 'warn', label: 'Checking…' };
+    case 'error': return { tone: 'error', label: 'Could not verify' };
+    case 'na':
+    default: return { tone: 'muted', label: 'N/A (not Navidrome)' };
+  }
+}
+
+function endpointBadge(isLan: boolean): { tone: PerfProbeBadgeTone; label: string } {
+  return isLan
+    ? { tone: 'ok', label: 'LAN' }
+    : { tone: 'neutral', label: 'Public / remote' };
 }
 
 export default function SidebarPerfProbeConnectionsTab() {
@@ -22,59 +49,79 @@ export default function SidebarPerfProbeConnectionsTab() {
   const servers = useAuthStore(s => s.servers);
   const connectUrl = useAuthStore(s => s.getBaseUrl());
   const queueServerId = usePlayerStore(s => s.queueServerId);
+  const adminRole = useNavidromeAdminRole();
 
   const queueServer = queueServerId ? findServerByIdOrIndexKey(queueServerId) : undefined;
   const queueDiffersFromActive = Boolean(
     queueServerId && activeServerId && queueServerId !== activeServerId,
   );
 
+  const connBadge = connectionStatusBadge(status);
+  const sessBadge = sessionBadge(isLoggedIn);
+  const roleBadge = adminRoleBadge(adminRole);
+
   return (
     <div className="perf-monitor">
-      <PerfProbeMetricSection title="Connection" defaultOpen>
-        <dl className="perf-server-dl">
-          <div className="perf-server-dl__row">
-            <dt>Status</dt>
-            <dd>{formatConnectionStatus(status)}</dd>
+      <div className="perf-conn-summary" aria-label="Connection overview">
+        <div className="perf-conn-summary__item">
+          <span className="perf-conn-summary__label">Link</span>
+          <PerfProbeStatusBadge tone={connBadge.tone}>{connBadge.label}</PerfProbeStatusBadge>
+        </div>
+        <div className="perf-conn-summary__item">
+          <span className="perf-conn-summary__label">Session</span>
+          <PerfProbeStatusBadge tone={sessBadge.tone}>{sessBadge.label}</PerfProbeStatusBadge>
+        </div>
+        {isLoggedIn && (
+          <div className="perf-conn-summary__item">
+            <span className="perf-conn-summary__label">Role</span>
+            <PerfProbeStatusBadge tone={roleBadge.tone}>{roleBadge.label}</PerfProbeStatusBadge>
           </div>
-          <div className="perf-server-dl__row">
-            <dt>Session</dt>
-            <dd>{isLoggedIn ? 'Logged in' : 'Not logged in'}</dd>
-          </div>
-          {serverName && (
-            <div className="perf-server-dl__row">
-              <dt>Browse label</dt>
-              <dd>{serverName}</dd>
-            </div>
-          )}
-          {connectUrl && (
-            <div className="perf-server-dl__row">
-              <dt>Connect URL</dt>
-              <dd>{connectUrl}</dd>
-            </div>
-          )}
-          {status === 'connected' && (
-            <div className="perf-server-dl__row">
-              <dt>Endpoint</dt>
-              <dd>{isLan ? 'LAN' : 'Public / remote'}</dd>
-            </div>
-          )}
-        </dl>
+        )}
+      </div>
+
+      <PerfProbeMetricSection title="Connection" defaultOpen layout="stack">
+        <PerfProbeDetailList
+          rows={[
+            {
+              label: 'Status',
+              value: <PerfProbeStatusBadge tone={connBadge.tone}>{connBadge.label}</PerfProbeStatusBadge>,
+            },
+            {
+              label: 'Session',
+              value: <PerfProbeStatusBadge tone={sessBadge.tone}>{sessBadge.label}</PerfProbeStatusBadge>,
+            },
+            ...(isLoggedIn
+              ? [{
+                  label: 'Navidrome role',
+                  value: <PerfProbeStatusBadge tone={roleBadge.tone}>{roleBadge.label}</PerfProbeStatusBadge>,
+                }]
+              : []),
+            ...(serverName ? [{ label: 'Browse label', value: serverName }] : []),
+            ...(connectUrl ? [{ label: 'Connect URL', value: <code className="perf-server-dl__code">{connectUrl}</code> }] : []),
+            ...(status === 'connected'
+              ? [{
+                  label: 'Endpoint',
+                  value: (
+                    <PerfProbeStatusBadge tone={endpointBadge(isLan).tone}>
+                      {endpointBadge(isLan).label}
+                    </PerfProbeStatusBadge>
+                  ),
+                }]
+              : []),
+          ]}
+        />
       </PerfProbeMetricSection>
 
-      <SidebarPerfProbeServerSection />
+      <SidebarPerfProbeServerSection adminRole={adminRole} />
 
       {queueDiffersFromActive && queueServer && (
-        <PerfProbeMetricSection title="Queue playback server" defaultOpen={false}>
-          <dl className="perf-server-dl">
-            <div className="perf-server-dl__row">
-              <dt>Name</dt>
-              <dd>{serverListDisplayLabel(queueServer, servers)}</dd>
-            </div>
-            <div className="perf-server-dl__row">
-              <dt>Scope key</dt>
-              <dd>{queueServerId}</dd>
-            </div>
-          </dl>
+        <PerfProbeMetricSection title="Queue playback server" defaultOpen={false} layout="stack">
+          <PerfProbeDetailList
+            rows={[
+              { label: 'Name', value: serverListDisplayLabel(queueServer, servers) },
+              { label: 'Scope key', value: <code className="perf-server-dl__code">{queueServerId}</code> },
+            ]}
+          />
         </PerfProbeMetricSection>
       )}
     </div>

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
@@ -1,11 +1,13 @@
 import { useAuthStore } from '../../../store/authStore';
 import type { NavidromeAdminRole } from '../../../hooks/useNavidromeAdminRole';
+import { isNavidromeServer } from '../../../utils/server/subsonicServerIdentity';
+import { FEATURE_AUDIOMUSE_SIMILAR_TRACKS, OP_SIMILAR_TRACKS } from '../../../serverCapabilities/catalog';
 import {
-  isAudiomusePluginAutoManaged,
-  isNavidromeAudiomuseSoftwareEligible,
-  isNavidromeSonicSimilarityEligible,
-  isNavidromeServer,
-} from '../../../utils/server/subsonicServerIdentity';
+  isFeatureActiveForServer,
+  resolveCallRoutesForServer,
+  resolveFeatureForServer,
+} from '../../../serverCapabilities/storeView';
+import type { CapabilityStatus, FeatureTrust, ResolvedCapability } from '../../../serverCapabilities/types';
 import { PerfProbeMetricSection } from './PerfProbeMetricCard';
 import PerfProbeDetailList, { type PerfProbeDetailRow } from './PerfProbeDetailList';
 import PerfProbeStatusBadge, { type PerfProbeBadgeTone } from './PerfProbeStatusBadge';
@@ -16,29 +18,31 @@ function formatServerType(identity: { type?: string; serverVersion?: string; ope
   return version ? `${identity.type} ${version}` : identity.type;
 }
 
-function pluginProbeBadge(
-  sonicEligible: boolean,
-  pluginProbe: string | undefined,
-): { tone: PerfProbeBadgeTone; label: string } {
-  if (!sonicEligible) return { tone: 'muted', label: 'N/A (Navidrome < 0.62)' };
-  switch (pluginProbe) {
-    case 'present': return { tone: 'ok', label: 'Detected (sonicSimilarity)' };
+function detectionBadge(status: CapabilityStatus): { tone: PerfProbeBadgeTone; label: string } {
+  switch (status) {
+    case 'present': return { tone: 'ok', label: 'Detected' };
     case 'absent': return { tone: 'muted', label: 'Not detected' };
     case 'probing': return { tone: 'warn', label: 'Checking…' };
     case 'error': return { tone: 'error', label: 'Probe failed' };
-    default: return { tone: 'muted', label: 'Not probed yet' };
+    case 'unknown': return { tone: 'muted', label: 'Not probed yet' };
+    default: return { tone: 'muted', label: 'N/A' };
   }
 }
 
-function legacyProbeBadge(
-  sonicEligible: boolean,
-  legacyProbe: string | undefined,
-): { tone: PerfProbeBadgeTone; label: string } | null {
-  if (sonicEligible) return null;
-  if (!legacyProbe) return { tone: 'muted', label: 'Not probed yet' };
-  if (legacyProbe === 'ok') return { tone: 'ok', label: legacyProbe };
-  if (legacyProbe === 'empty' || legacyProbe === 'skipped') return { tone: 'muted', label: legacyProbe };
-  return { tone: 'error', label: legacyProbe };
+function strategyLabel(strategyId: string | null): string {
+  switch (strategyId) {
+    case 'opensubsonic.sonicSimilarity': return 'sonicSimilarity (OpenSubsonic)';
+    case 'subsonic.getSimilarSongs': return 'getSimilarSongs (legacy)';
+    default: return '—';
+  }
+}
+
+function trustBadge(trust: FeatureTrust | null): { tone: PerfProbeBadgeTone; label: string } {
+  switch (trust) {
+    case 'high': return { tone: 'ok', label: 'high' };
+    case 'low': return { tone: 'warn', label: 'heuristic' };
+    default: return { tone: 'muted', label: '—' };
+  }
 }
 
 function adminRoleBadge(role: NavidromeAdminRole): { tone: PerfProbeBadgeTone; label: string } {
@@ -63,15 +67,10 @@ export default function SidebarPerfProbeServerSection({ adminRole = 'na' }: Prop
   const identity = useAuthStore(s =>
     activeServerId ? s.subsonicServerIdentityByServer[activeServerId] : undefined,
   );
-  const pluginProbe = useAuthStore(s =>
-    activeServerId ? s.audiomusePluginProbeByServer[activeServerId] : undefined,
-  );
-  const legacyProbe = useAuthStore(s =>
-    activeServerId ? s.instantMixProbeByServer[activeServerId] : undefined,
-  );
-  const audiomuseEnabled = useAuthStore(s =>
-    activeServerId ? Boolean(s.audiomuseNavidromeByServer[activeServerId]) : false,
-  );
+  // Subscribe to the probe maps so the resolver-derived rows re-render on probe updates.
+  useAuthStore(s => (activeServerId ? s.audiomusePluginProbeByServer[activeServerId] : undefined));
+  useAuthStore(s => (activeServerId ? s.instantMixProbeByServer[activeServerId] : undefined));
+  useAuthStore(s => (activeServerId ? s.audiomuseNavidromeByServer[activeServerId] : undefined));
 
   if (!server) {
     return (
@@ -83,11 +82,17 @@ export default function SidebarPerfProbeServerSection({ adminRole = 'na' }: Prop
     );
   }
 
-  const sonicEligible = isNavidromeSonicSimilarityEligible(identity);
-  const plugin = pluginProbeBadge(sonicEligible, pluginProbe);
-  const legacy = legacyProbeBadge(sonicEligible, legacyProbe);
   const navidrome = isNavidromeServer(identity);
   const role = adminRoleBadge(adminRole);
+  const resolved: ResolvedCapability | null = activeServerId
+    ? resolveFeatureForServer(activeServerId, FEATURE_AUDIOMUSE_SIMILAR_TRACKS)
+    : null;
+  const audiomuseActive = activeServerId
+    ? isFeatureActiveForServer(activeServerId, FEATURE_AUDIOMUSE_SIMILAR_TRACKS)
+    : false;
+  const routes = activeServerId
+    ? resolveCallRoutesForServer(activeServerId, FEATURE_AUDIOMUSE_SIMILAR_TRACKS, OP_SIMILAR_TRACKS)
+    : [];
 
   const rows: PerfProbeDetailRow[] = [
     { label: 'Name', value: server.name || server.url },
@@ -110,28 +115,36 @@ export default function SidebarPerfProbeServerSection({ adminRole = 'na' }: Prop
     });
   }
 
-  if (navidrome && isNavidromeAudiomuseSoftwareEligible(identity)) {
-    rows.push({
-      label: 'AudioMuse plugin',
-      value: <PerfProbeStatusBadge tone={plugin.tone}>{plugin.label}</PerfProbeStatusBadge>,
-    });
-    if (legacy) {
+  if (resolved && resolved.strategyId !== null && resolved.status !== 'ineligible') {
+    const detect = detectionBadge(resolved.status);
+    const trust = trustBadge(resolved.trust);
+    rows.push(
+      {
+        label: 'AudioMuse Instant Mix',
+        value: <PerfProbeStatusBadge tone={detect.tone}>{detect.label}</PerfProbeStatusBadge>,
+      },
+      { label: 'Provider', value: <code className="perf-server-dl__code">{strategyLabel(resolved.strategyId)}</code> },
+      {
+        label: 'Detection trust',
+        value: <PerfProbeStatusBadge tone={trust.tone}>{trust.label}</PerfProbeStatusBadge>,
+      },
+      {
+        label: 'Mode',
+        value: audiomuseActive
+          ? (
+            <PerfProbeStatusBadge tone="ok">
+              {resolved.activation === 'auto' ? 'active (auto)' : 'enabled in Settings'}
+            </PerfProbeStatusBadge>
+          )
+          : <PerfProbeStatusBadge tone="muted">off</PerfProbeStatusBadge>,
+      },
+    );
+    if (routes.length > 0) {
       rows.push({
-        label: 'Legacy similar probe',
-        value: <PerfProbeStatusBadge tone={legacy.tone}>{legacy.label}</PerfProbeStatusBadge>,
+        label: 'Call route',
+        value: <code className="perf-server-dl__code">{routes.map(r => r.endpoint).join(' → ')}</code>,
       });
     }
-    const autoManaged = isAudiomusePluginAutoManaged(identity);
-    rows.push({
-      label: 'AudioMuse mode',
-      value: audiomuseEnabled
-        ? (
-          <PerfProbeStatusBadge tone="ok">
-            {autoManaged ? 'active (auto)' : 'enabled in Settings'}
-          </PerfProbeStatusBadge>
-        )
-        : <PerfProbeStatusBadge tone="muted">off</PerfProbeStatusBadge>,
-    });
   }
 
   return (

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
@@ -1,0 +1,107 @@
+import { useAuthStore } from '../../../store/authStore';
+import {
+  isNavidromeAudiomuseSoftwareEligible,
+  isNavidromeSonicSimilarityEligible,
+  isNavidromeServer,
+} from '../../../utils/server/subsonicServerIdentity';
+import { PerfProbeMetricSection } from './PerfProbeMetricCard';
+
+function formatServerType(identity: { type?: string; serverVersion?: string; openSubsonic?: boolean } | undefined): string {
+  if (!identity?.type?.trim()) return 'Unknown';
+  const version = identity.serverVersion?.trim();
+  return version ? `${identity.type} ${version}` : identity.type;
+}
+
+function formatPluginProbe(
+  sonicEligible: boolean,
+  pluginProbe: string | undefined,
+): string {
+  if (!sonicEligible) return 'N/A (Navidrome < 0.62)';
+  switch (pluginProbe) {
+    case 'present': return 'Detected (sonicSimilarity)';
+    case 'absent': return 'Not detected';
+    case 'probing': return 'Checking…';
+    case 'error': return 'Probe failed';
+    default: return 'Not probed yet';
+  }
+}
+
+function formatLegacyProbe(
+  sonicEligible: boolean,
+  legacyProbe: string | undefined,
+): string | null {
+  if (sonicEligible) return null;
+  if (!legacyProbe) return 'Not probed yet';
+  return legacyProbe;
+}
+
+export default function SidebarPerfProbeServerSection() {
+  const activeServerId = useAuthStore(s => s.activeServerId);
+  const server = useAuthStore(s => s.servers.find(srv => srv.id === s.activeServerId));
+  const identity = useAuthStore(s =>
+    activeServerId ? s.subsonicServerIdentityByServer[activeServerId] : undefined,
+  );
+  const pluginProbe = useAuthStore(s =>
+    activeServerId ? s.audiomusePluginProbeByServer[activeServerId] : undefined,
+  );
+  const legacyProbe = useAuthStore(s =>
+    activeServerId ? s.instantMixProbeByServer[activeServerId] : undefined,
+  );
+  const audiomuseEnabled = useAuthStore(s =>
+    activeServerId ? Boolean(s.audiomuseNavidromeByServer[activeServerId]) : false,
+  );
+
+  if (!server) {
+    return (
+      <PerfProbeMetricSection title="Active server" defaultOpen>
+        <div className="perf-monitor-empty perf-monitor-empty--inline">
+          No server configured.
+        </div>
+      </PerfProbeMetricSection>
+    );
+  }
+
+  const sonicEligible = isNavidromeSonicSimilarityEligible(identity);
+  const legacyLabel = formatLegacyProbe(sonicEligible, legacyProbe);
+
+  return (
+    <PerfProbeMetricSection title="Active server" defaultOpen>
+      <dl className="perf-server-dl">
+        <div className="perf-server-dl__row">
+          <dt>Name</dt>
+          <dd>{server.name || server.url}</dd>
+        </div>
+        <div className="perf-server-dl__row">
+          <dt>Profile URL</dt>
+          <dd>{server.url}</dd>
+        </div>
+        <div className="perf-server-dl__row">
+          <dt>Subsonic server</dt>
+          <dd>{formatServerType(identity)}</dd>
+        </div>
+        <div className="perf-server-dl__row">
+          <dt>OpenSubsonic</dt>
+          <dd>{identity?.openSubsonic ? 'yes' : identity ? 'no' : '—'}</dd>
+        </div>
+        {isNavidromeServer(identity) && isNavidromeAudiomuseSoftwareEligible(identity) && (
+          <>
+            <div className="perf-server-dl__row">
+              <dt>AudioMuse plugin</dt>
+              <dd>{formatPluginProbe(sonicEligible, pluginProbe)}</dd>
+            </div>
+            {legacyLabel != null && (
+              <div className="perf-server-dl__row">
+                <dt>Legacy similar probe</dt>
+                <dd>{legacyLabel}</dd>
+              </div>
+            )}
+            <div className="perf-server-dl__row">
+              <dt>AudioMuse mode</dt>
+              <dd>{audiomuseEnabled ? 'enabled in Settings' : 'off'}</dd>
+            </div>
+          </>
+        )}
+      </dl>
+    </PerfProbeMetricSection>
+  );
+}

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
@@ -1,6 +1,7 @@
 import { useAuthStore } from '../../../store/authStore';
 import type { NavidromeAdminRole } from '../../../hooks/useNavidromeAdminRole';
 import {
+  isAudiomusePluginAutoManaged,
   isNavidromeAudiomuseSoftwareEligible,
   isNavidromeSonicSimilarityEligible,
   isNavidromeServer,
@@ -120,10 +121,15 @@ export default function SidebarPerfProbeServerSection({ adminRole = 'na' }: Prop
         value: <PerfProbeStatusBadge tone={legacy.tone}>{legacy.label}</PerfProbeStatusBadge>,
       });
     }
+    const autoManaged = isAudiomusePluginAutoManaged(identity);
     rows.push({
       label: 'AudioMuse mode',
       value: audiomuseEnabled
-        ? <PerfProbeStatusBadge tone="ok">enabled in Settings</PerfProbeStatusBadge>
+        ? (
+          <PerfProbeStatusBadge tone="ok">
+            {autoManaged ? 'active (auto)' : 'enabled in Settings'}
+          </PerfProbeStatusBadge>
+        )
         : <PerfProbeStatusBadge tone="muted">off</PerfProbeStatusBadge>,
     });
   }

--- a/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
+++ b/src/components/sidebar/perfProbe/SidebarPerfProbeServerSection.tsx
@@ -1,10 +1,13 @@
 import { useAuthStore } from '../../../store/authStore';
+import type { NavidromeAdminRole } from '../../../hooks/useNavidromeAdminRole';
 import {
   isNavidromeAudiomuseSoftwareEligible,
   isNavidromeSonicSimilarityEligible,
   isNavidromeServer,
 } from '../../../utils/server/subsonicServerIdentity';
 import { PerfProbeMetricSection } from './PerfProbeMetricCard';
+import PerfProbeDetailList, { type PerfProbeDetailRow } from './PerfProbeDetailList';
+import PerfProbeStatusBadge, { type PerfProbeBadgeTone } from './PerfProbeStatusBadge';
 
 function formatServerType(identity: { type?: string; serverVersion?: string; openSubsonic?: boolean } | undefined): string {
   if (!identity?.type?.trim()) return 'Unknown';
@@ -12,30 +15,48 @@ function formatServerType(identity: { type?: string; serverVersion?: string; ope
   return version ? `${identity.type} ${version}` : identity.type;
 }
 
-function formatPluginProbe(
+function pluginProbeBadge(
   sonicEligible: boolean,
   pluginProbe: string | undefined,
-): string {
-  if (!sonicEligible) return 'N/A (Navidrome < 0.62)';
+): { tone: PerfProbeBadgeTone; label: string } {
+  if (!sonicEligible) return { tone: 'muted', label: 'N/A (Navidrome < 0.62)' };
   switch (pluginProbe) {
-    case 'present': return 'Detected (sonicSimilarity)';
-    case 'absent': return 'Not detected';
-    case 'probing': return 'Checking…';
-    case 'error': return 'Probe failed';
-    default: return 'Not probed yet';
+    case 'present': return { tone: 'ok', label: 'Detected (sonicSimilarity)' };
+    case 'absent': return { tone: 'muted', label: 'Not detected' };
+    case 'probing': return { tone: 'warn', label: 'Checking…' };
+    case 'error': return { tone: 'error', label: 'Probe failed' };
+    default: return { tone: 'muted', label: 'Not probed yet' };
   }
 }
 
-function formatLegacyProbe(
+function legacyProbeBadge(
   sonicEligible: boolean,
   legacyProbe: string | undefined,
-): string | null {
+): { tone: PerfProbeBadgeTone; label: string } | null {
   if (sonicEligible) return null;
-  if (!legacyProbe) return 'Not probed yet';
-  return legacyProbe;
+  if (!legacyProbe) return { tone: 'muted', label: 'Not probed yet' };
+  if (legacyProbe === 'ok') return { tone: 'ok', label: legacyProbe };
+  if (legacyProbe === 'empty' || legacyProbe === 'skipped') return { tone: 'muted', label: legacyProbe };
+  return { tone: 'error', label: legacyProbe };
 }
 
-export default function SidebarPerfProbeServerSection() {
+function adminRoleBadge(role: NavidromeAdminRole): { tone: PerfProbeBadgeTone; label: string } {
+  switch (role) {
+    case 'admin': return { tone: 'ok', label: 'Admin' };
+    case 'user': return { tone: 'neutral', label: 'Standard user' };
+    case 'checking':
+    case 'idle': return { tone: 'warn', label: 'Checking…' };
+    case 'error': return { tone: 'error', label: 'Could not verify' };
+    case 'na':
+    default: return { tone: 'muted', label: 'N/A' };
+  }
+}
+
+interface Props {
+  adminRole?: NavidromeAdminRole;
+}
+
+export default function SidebarPerfProbeServerSection({ adminRole = 'na' }: Props) {
   const activeServerId = useAuthStore(s => s.activeServerId);
   const server = useAuthStore(s => s.servers.find(srv => srv.id === s.activeServerId));
   const identity = useAuthStore(s =>
@@ -53,7 +74,7 @@ export default function SidebarPerfProbeServerSection() {
 
   if (!server) {
     return (
-      <PerfProbeMetricSection title="Active server" defaultOpen>
+      <PerfProbeMetricSection title="Active server" defaultOpen layout="stack">
         <div className="perf-monitor-empty perf-monitor-empty--inline">
           No server configured.
         </div>
@@ -62,46 +83,54 @@ export default function SidebarPerfProbeServerSection() {
   }
 
   const sonicEligible = isNavidromeSonicSimilarityEligible(identity);
-  const legacyLabel = formatLegacyProbe(sonicEligible, legacyProbe);
+  const plugin = pluginProbeBadge(sonicEligible, pluginProbe);
+  const legacy = legacyProbeBadge(sonicEligible, legacyProbe);
+  const navidrome = isNavidromeServer(identity);
+  const role = adminRoleBadge(adminRole);
+
+  const rows: PerfProbeDetailRow[] = [
+    { label: 'Name', value: server.name || server.url },
+    { label: 'Profile URL', value: <code className="perf-server-dl__code">{server.url}</code> },
+    { label: 'Subsonic server', value: formatServerType(identity) },
+    {
+      label: 'OpenSubsonic',
+      value: identity?.openSubsonic
+        ? <PerfProbeStatusBadge tone="ok">yes</PerfProbeStatusBadge>
+        : identity
+          ? <PerfProbeStatusBadge tone="muted">no</PerfProbeStatusBadge>
+          : '—',
+    },
+  ];
+
+  if (navidrome) {
+    rows.push({
+      label: 'Navidrome role',
+      value: <PerfProbeStatusBadge tone={role.tone}>{role.label}</PerfProbeStatusBadge>,
+    });
+  }
+
+  if (navidrome && isNavidromeAudiomuseSoftwareEligible(identity)) {
+    rows.push({
+      label: 'AudioMuse plugin',
+      value: <PerfProbeStatusBadge tone={plugin.tone}>{plugin.label}</PerfProbeStatusBadge>,
+    });
+    if (legacy) {
+      rows.push({
+        label: 'Legacy similar probe',
+        value: <PerfProbeStatusBadge tone={legacy.tone}>{legacy.label}</PerfProbeStatusBadge>,
+      });
+    }
+    rows.push({
+      label: 'AudioMuse mode',
+      value: audiomuseEnabled
+        ? <PerfProbeStatusBadge tone="ok">enabled in Settings</PerfProbeStatusBadge>
+        : <PerfProbeStatusBadge tone="muted">off</PerfProbeStatusBadge>,
+    });
+  }
 
   return (
-    <PerfProbeMetricSection title="Active server" defaultOpen>
-      <dl className="perf-server-dl">
-        <div className="perf-server-dl__row">
-          <dt>Name</dt>
-          <dd>{server.name || server.url}</dd>
-        </div>
-        <div className="perf-server-dl__row">
-          <dt>Profile URL</dt>
-          <dd>{server.url}</dd>
-        </div>
-        <div className="perf-server-dl__row">
-          <dt>Subsonic server</dt>
-          <dd>{formatServerType(identity)}</dd>
-        </div>
-        <div className="perf-server-dl__row">
-          <dt>OpenSubsonic</dt>
-          <dd>{identity?.openSubsonic ? 'yes' : identity ? 'no' : '—'}</dd>
-        </div>
-        {isNavidromeServer(identity) && isNavidromeAudiomuseSoftwareEligible(identity) && (
-          <>
-            <div className="perf-server-dl__row">
-              <dt>AudioMuse plugin</dt>
-              <dd>{formatPluginProbe(sonicEligible, pluginProbe)}</dd>
-            </div>
-            {legacyLabel != null && (
-              <div className="perf-server-dl__row">
-                <dt>Legacy similar probe</dt>
-                <dd>{legacyLabel}</dd>
-              </div>
-            )}
-            <div className="perf-server-dl__row">
-              <dt>AudioMuse mode</dt>
-              <dd>{audiomuseEnabled ? 'enabled in Settings' : 'off'}</dd>
-            </div>
-          </>
-        )}
-      </dl>
+    <PerfProbeMetricSection title="Active server" defaultOpen layout="stack">
+      <PerfProbeDetailList rows={rows} />
     </PerfProbeMetricSection>
   );
 }

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -156,6 +156,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Offline browse — local-bytes catalog when server is down, integration contract (context/policy/resolvers), disconnect nav fork, Home stale-cache feed, read-only context menus, PlayerBar rating/favorite guard (PR #1017)',
       'Themed startup splash before Vite loads — deferred window show, per-theme logo gradient (PR #1030)',
       'Artist page: Top Tracks play when album list is empty on the page (PR #1031)',
+      'PsyLab Connections tab with server capability readout, Navidrome admin-role probe, and tab-bar layout fix; AudioMuse plugin detection via OpenSubsonic sonicSimilarity on Navidrome ≥0.62 (PR #1032)',
     ],
   },
   {

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -156,7 +156,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Offline browse — local-bytes catalog when server is down, integration contract (context/policy/resolvers), disconnect nav fork, Home stale-cache feed, read-only context menus, PlayerBar rating/favorite guard (PR #1017)',
       'Themed startup splash before Vite loads — deferred window show, per-theme logo gradient (PR #1030)',
       'Artist page: Top Tracks play when album list is empty on the page (PR #1031)',
-      'PsyLab Connections tab with server capability readout, Navidrome admin-role probe, and tab-bar layout fix; AudioMuse plugin detection via OpenSubsonic sonicSimilarity on Navidrome ≥0.62 (PR #1032)',
+      'PsyLab Connections tab with server capability readout, Navidrome admin-role probe, and tab-bar layout fix; server-capability framework with AudioMuse detection via OpenSubsonic sonicSimilarity and sonic Instant Mix routing on Navidrome ≥0.62 (PR #1033)',
     ],
   },
   {

--- a/src/hooks/useNavidromeAdminRole.test.ts
+++ b/src/hooks/useNavidromeAdminRole.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { resetAuthStore } from '@/test/helpers/storeReset';
+import { useAuthStore } from '@/store/authStore';
+
+vi.mock('@/api/navidromeAdmin', () => ({
+  ndLogin: vi.fn(),
+}));
+
+import { ndLogin } from '@/api/navidromeAdmin';
+import { useNavidromeAdminRole } from './useNavidromeAdminRole';
+
+beforeEach(() => {
+  resetAuthStore();
+  vi.mocked(ndLogin).mockReset();
+});
+
+function seedNavidromeServer(): string {
+  const id = useAuthStore.getState().addServer({
+    name: 'Home',
+    url: 'music.example.com',
+    username: 'tester',
+    password: 'pw',
+  });
+  useAuthStore.getState().setActiveServer(id);
+  useAuthStore.getState().setLoggedIn(true);
+  useAuthStore.getState().setSubsonicServerIdentity(id, {
+    type: 'navidrome',
+    serverVersion: '0.62.0',
+    openSubsonic: true,
+  });
+  return id;
+}
+
+describe('useNavidromeAdminRole', () => {
+  it('returns na when not logged in', () => {
+    const id = useAuthStore.getState().addServer({
+      name: 'Home',
+      url: 'https://music.example.com',
+      username: 'tester',
+      password: 'pw',
+    });
+    useAuthStore.getState().setActiveServer(id);
+    useAuthStore.getState().setSubsonicServerIdentity(id, {
+      type: 'navidrome',
+      serverVersion: '0.62.0',
+      openSubsonic: true,
+    });
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    expect(result.current).toBe('na');
+    expect(ndLogin).not.toHaveBeenCalled();
+  });
+
+  it('returns checking until server identity is known', () => {
+    const id = useAuthStore.getState().addServer({
+      name: 'Home',
+      url: 'https://music.example.com',
+      username: 'tester',
+      password: 'pw',
+    });
+    useAuthStore.getState().setActiveServer(id);
+    useAuthStore.getState().setLoggedIn(true);
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    expect(result.current).toBe('checking');
+    expect(ndLogin).not.toHaveBeenCalled();
+  });
+
+  it('returns na for non-Navidrome servers', () => {
+    const id = useAuthStore.getState().addServer({
+      name: 'Ampache',
+      url: 'https://music.example.com',
+      username: 'tester',
+      password: 'pw',
+    });
+    useAuthStore.getState().setActiveServer(id);
+    useAuthStore.getState().setLoggedIn(true);
+    useAuthStore.getState().setSubsonicServerIdentity(id, {
+      type: 'ampache',
+      serverVersion: '6.0.0',
+      openSubsonic: false,
+    });
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    expect(result.current).toBe('na');
+    expect(ndLogin).not.toHaveBeenCalled();
+  });
+
+  it('probes Navidrome native login and reports admin', async () => {
+    seedNavidromeServer();
+    vi.mocked(ndLogin).mockResolvedValue({ token: 't', userId: '1', isAdmin: true });
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    await waitFor(() => expect(result.current).toBe('admin'));
+    expect(ndLogin).toHaveBeenCalledWith('http://music.example.com', 'tester', 'pw');
+  });
+
+  it('probes Navidrome native login and reports standard user', async () => {
+    seedNavidromeServer();
+    vi.mocked(ndLogin).mockResolvedValue({ token: 't', userId: '2', isAdmin: false });
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    await waitFor(() => expect(result.current).toBe('user'));
+  });
+
+  it('returns error when native login fails', async () => {
+    seedNavidromeServer();
+    vi.mocked(ndLogin).mockRejectedValue(new Error('denied'));
+
+    const { result } = renderHook(() => useNavidromeAdminRole());
+    await waitFor(() => expect(result.current).toBe('error'));
+  });
+});

--- a/src/hooks/useNavidromeAdminRole.ts
+++ b/src/hooks/useNavidromeAdminRole.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { ndLogin } from '../api/navidromeAdmin';
+import { useAuthStore } from '../store/authStore';
+import { isNavidromeServer } from '../utils/server/subsonicServerIdentity';
+
+export type NavidromeAdminRole = 'idle' | 'checking' | 'admin' | 'user' | 'na' | 'error';
+
+function normalizeServerUrl(url: string): string {
+  const withScheme = url.startsWith('http') ? url : `http://${url}`;
+  return withScheme.replace(/\/$/, '');
+}
+
+/**
+ * Probes Navidrome native login for the active server to learn whether the
+ * current Subsonic credentials belong to an admin account.
+ */
+export function useNavidromeAdminRole(): NavidromeAdminRole {
+  const isLoggedIn = useAuthStore(s => s.isLoggedIn);
+  const activeServerId = useAuthStore(s => s.activeServerId);
+  const server = useAuthStore(s => s.servers.find(srv => srv.id === s.activeServerId));
+  const identity = useAuthStore(s =>
+    activeServerId ? s.subsonicServerIdentityByServer[activeServerId] : undefined,
+  );
+  const [role, setRole] = useState<NavidromeAdminRole>('idle');
+
+  useEffect(() => {
+    if (!isLoggedIn || !server) {
+      setRole('na');
+      return;
+    }
+    if (!identity) {
+      setRole('checking');
+      return;
+    }
+    if (!isNavidromeServer(identity)) {
+      setRole('na');
+      return;
+    }
+
+    let cancelled = false;
+    setRole('checking');
+    const serverUrl = normalizeServerUrl(server.url);
+    ndLogin(serverUrl, server.username, server.password)
+      .then(res => {
+        if (cancelled) return;
+        setRole(res.isAdmin ? 'admin' : 'user');
+      })
+      .catch(() => {
+        if (!cancelled) setRole('error');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isLoggedIn,
+    activeServerId,
+    server?.id,
+    server?.url,
+    server?.username,
+    server?.password,
+    identity?.type,
+    identity?.serverVersion,
+  ]);
+
+  return role;
+}

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -106,6 +106,10 @@ export const settings = {
   userMgmtMagicStringModalDesc: 'Subsonic-Passwort für „{{username}}" eingeben — es wird in den kopierten Magic-String übernommen.',
   userMgmtMagicStringModalConfirm: 'String kopieren',
   audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+  audiomuseStatusActive: 'Aktiv',
+  audiomuseStatusChecking: 'Wird geprüft…',
+  audiomuseStatusNotDetected: 'Nicht erkannt',
+  audiomuseStatusProbeFailed: 'Prüfung fehlgeschlagen',
   audiomuseDesc:
     'Aktivieren, wenn dieser Server das <pluginLink>AudioMuse-AI-Navidrome-Plugin</pluginLink> nutzt. Schaltet Instant Mix pro Titel frei und nutzt ähnliche Künstler vom Server statt Last.fm auf Künstlerseiten.',
   audiomuseIssueHint:

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -108,6 +108,12 @@ export const settings = {
   audiomuseTitle: 'AudioMuse-AI (Navidrome)',
   audiomuseDesc:
     'Turn on if this server has the <pluginLink>AudioMuse-AI Navidrome plugin</pluginLink> configured. Enables Instant Mix from tracks and uses server-side similar artists instead of Last.fm on artist pages.',
+  audiomuseDescAuto:
+    'On Navidrome 0.62+, Psysonic detects the <pluginLink>AudioMuse-AI plugin</pluginLink> via the OpenSubsonic sonicSimilarity extension and enables Instant Mix automatically when it is present.',
+  audiomuseStatusActive: 'Active',
+  audiomuseStatusChecking: 'Checking…',
+  audiomuseStatusNotDetected: 'Not detected',
+  audiomuseStatusProbeFailed: 'Probe failed',
   audiomuseIssueHint:
     'Instant Mix failed recently — check the Navidrome plugin and AudioMuse API. Similar artists fall back to Last.fm when the server returns none.',
   connected: 'Connected',

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -108,8 +108,6 @@ export const settings = {
   audiomuseTitle: 'AudioMuse-AI (Navidrome)',
   audiomuseDesc:
     'Turn on if this server has the <pluginLink>AudioMuse-AI Navidrome plugin</pluginLink> configured. Enables Instant Mix from tracks and uses server-side similar artists instead of Last.fm on artist pages.',
-  audiomuseDescAuto:
-    'On Navidrome 0.62+, Psysonic detects the <pluginLink>AudioMuse-AI plugin</pluginLink> via the OpenSubsonic sonicSimilarity extension and enables Instant Mix automatically when it is present.',
   audiomuseStatusActive: 'Active',
   audiomuseStatusChecking: 'Checking…',
   audiomuseStatusNotDetected: 'Not detected',

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -105,6 +105,10 @@ export const settings = {
   userMgmtMagicStringModalDesc: 'Introduce la contraseña Subsonic de «{{username}}». Se incluirá en la cadena mágica copiada.',
   userMgmtMagicStringModalConfirm: 'Copiar cadena',
   audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+  audiomuseStatusActive: 'Activo',
+  audiomuseStatusChecking: 'Comprobando…',
+  audiomuseStatusNotDetected: 'No detectado',
+  audiomuseStatusProbeFailed: 'Error de comprobación',
   audiomuseDesc:
     'Activa si este servidor tiene el plugin <pluginLink>AudioMuse-AI Navidrome</pluginLink> configurado. Habilita Mezcla Instantánea desde pistas y usa artistas similares del servidor en lugar de Last.fm en páginas de artistas.',
   audiomuseIssueHint:

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -105,6 +105,10 @@ export const settings = {
   userMgmtMagicStringModalDesc: 'Saisissez le mot de passe Subsonic de « {{username}} ». Il est inclus dans la chaîne magique copiée.',
   userMgmtMagicStringModalConfirm: 'Copier la chaîne',
   audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+  audiomuseStatusActive: 'Actif',
+  audiomuseStatusChecking: 'Vérification…',
+  audiomuseStatusNotDetected: 'Non détecté',
+  audiomuseStatusProbeFailed: 'Échec de la détection',
   audiomuseDesc:
     'Activez si ce serveur utilise le <pluginLink>plugin Navidrome AudioMuse-AI</pluginLink>. Active le mix instantané depuis un morceau et affiche les artistes similaires côté serveur au lieu de Last.fm sur les pages artiste.',
   audiomuseIssueHint:

--- a/src/locales/nb/settings.ts
+++ b/src/locales/nb/settings.ts
@@ -105,6 +105,10 @@ export const settings = {
   userMgmtMagicStringModalDesc: 'Skriv inn Subsonic-passordet for «{{username}}». Det tas med i den kopierte magic string-en.',
   userMgmtMagicStringModalConfirm: 'Kopier streng',
   audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+  audiomuseStatusActive: 'Aktiv',
+  audiomuseStatusChecking: 'Sjekker…',
+  audiomuseStatusNotDetected: 'Ikke oppdaget',
+  audiomuseStatusProbeFailed: 'Sjekk mislyktes',
   audiomuseDesc:
     'Slå på hvis denne serveren bruker <pluginLink>AudioMuse-AI Navidrome-plugin</pluginLink>. Aktiverer Instant Mix fra spor og henter lignende artister fra serveren i stedet for Last.fm på artistsider.',
   audiomuseIssueHint:

--- a/src/locales/nl/settings.ts
+++ b/src/locales/nl/settings.ts
@@ -105,6 +105,10 @@ export const settings = {
   userMgmtMagicStringModalDesc: 'Voer het Subsonic-wachtwoord voor „{{username}}" in. Het wordt opgenomen in de gekopieerde magic string.',
   userMgmtMagicStringModalConfirm: 'String kopiëren',
   audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+  audiomuseStatusActive: 'Actief',
+  audiomuseStatusChecking: 'Controleren…',
+  audiomuseStatusNotDetected: 'Niet gedetecteerd',
+  audiomuseStatusProbeFailed: 'Detectie mislukt',
   audiomuseDesc:
     'Zet aan als deze server de <pluginLink>AudioMuse-AI Navidrome-plugin</pluginLink> gebruikt. Schakelt Instant Mix per nummer in en toont vergelijkbare artiesten van de server i.p.v. Last.fm op artiestpagina’s.',
   audiomuseIssueHint:

--- a/src/locales/ro/settings.ts
+++ b/src/locales/ro/settings.ts
@@ -105,6 +105,10 @@ export const settings = {
   userMgmtMagicStringModalDesc: 'Introdu parola Subsonic pentru "{{username}}". Este inclusă în string-ul magic copiat.',
   userMgmtMagicStringModalConfirm: 'Copiază string-ul',
   audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+  audiomuseStatusActive: 'Activ',
+  audiomuseStatusChecking: 'Se verifică…',
+  audiomuseStatusNotDetected: 'Nedetectat',
+  audiomuseStatusProbeFailed: 'Verificare eșuată',
   audiomuseDesc:
     'Pornește dacă acest server are <pluginLink>AudioMuse-AI Navidrome plugin</pluginLink> configurat. Activează Mixul Instant din piese si folosește artiști similari de pe partea de server în loc de Last.fm pe paginile de artiști.',
   audiomuseIssueHint:

--- a/src/locales/ru/settings.ts
+++ b/src/locales/ru/settings.ts
@@ -105,6 +105,10 @@ export const settings = {
   userMgmtMagicStringModalDesc: 'Введите пароль Subsonic для «{{username}}» — он попадёт в копируемую magic string.',
   userMgmtMagicStringModalConfirm: 'Скопировать строку',
   audiomuseTitle: 'AudioMuse-AI (Navidrome)',
+  audiomuseStatusActive: 'Активно',
+  audiomuseStatusChecking: 'Проверка…',
+  audiomuseStatusNotDetected: 'Не обнаружено',
+  audiomuseStatusProbeFailed: 'Ошибка проверки',
   audiomuseDesc:
     'Включите, если на этом сервере настроен <pluginLink>плагин AudioMuse-AI для Navidrome</pluginLink>. Появится Instant Mix для треков, а на странице исполнителя похожие будут браться с сервера вместо Last.fm.',
   audiomuseIssueHint:

--- a/src/locales/zh/settings.ts
+++ b/src/locales/zh/settings.ts
@@ -105,6 +105,10 @@ export const settings = {
   userMgmtMagicStringModalDesc: '请输入用户「{{username}}」的 Subsonic 密码，它会包含在复制的魔法字符串中。',
   userMgmtMagicStringModalConfirm: '复制字符串',
   audiomuseTitle: 'AudioMuse-AI（Navidrome）',
+  audiomuseStatusActive: '已启用',
+  audiomuseStatusChecking: '检测中…',
+  audiomuseStatusNotDetected: '未检测到',
+  audiomuseStatusProbeFailed: '检测失败',
   audiomuseDesc:
     '若此服务器已配置 <pluginLink>AudioMuse-AI Navidrome 插件</pluginLink>请开启。可从曲目启动即时混音，并在艺人页使用服务器返回的相似艺人，而非 Last.fm。',
   audiomuseIssueHint:

--- a/src/serverCapabilities/catalog.ts
+++ b/src/serverCapabilities/catalog.ts
@@ -1,0 +1,71 @@
+import type { CapabilityDefinition } from './types';
+
+/**
+ * Declarative map of server-side features, the strategies that can provide them
+ * per server generation, how to detect each, and which endpoint to route to.
+ *
+ * To add a feature with a new server path:
+ *   1. (optional) register a probe in `probes.ts` and map it in the orchestrator
+ *      (`api/subsonic.ts`) + read facade (`storeView.ts`).
+ *   2. add a `CapabilityDefinition` here with one strategy per server generation.
+ *   3. consumers read it via `storeView` (UI) and the call router (runtime).
+ * No version `if` checks belong in UI or call sites — they live here.
+ */
+
+export const SONIC_SIMILARITY_EXTENSION = 'sonicSimilarity';
+
+export const FEATURE_AUDIOMUSE_SIMILAR_TRACKS = 'audiomuse.similarTracks';
+
+export const PROBE_OPENSUBSONIC_EXTENSIONS = 'opensubsonic.extensions';
+export const PROBE_LEGACY_INSTANT_MIX = 'navidrome.instantMix.legacy';
+
+/** Operation names used by the call router. */
+export const OP_SIMILAR_TRACKS = 'similarTracks';
+
+export const SERVER_CAPABILITY_CATALOG: CapabilityDefinition[] = [
+  {
+    feature: FEATURE_AUDIOMUSE_SIMILAR_TRACKS,
+    labelKey: 'settings.audiomuseTitle',
+    strategies: [
+      {
+        // Navidrome ≥ 0.62: AudioMuse plugin advertised via OpenSubsonic.
+        id: 'opensubsonic.sonicSimilarity',
+        priority: 100,
+        when: (ctx) => ctx.isNavidrome && ctx.semverGte([0, 62, 0]),
+        detection: {
+          kind: 'extension',
+          probeId: PROBE_OPENSUBSONIC_EXTENSIONS,
+          extension: SONIC_SIMILARITY_EXTENSION,
+        },
+        trust: 'high',
+        activation: 'auto',
+        calls: {
+          [OP_SIMILAR_TRACKS]: { endpoint: 'getSonicSimilarTracks.view', transport: 'opensubsonic' },
+        },
+        labelKey: 'settings.audiomuseStrategySonic',
+      },
+      {
+        // Navidrome ≥ 0.60: legacy Instant Mix via getSimilarSongs (agents/plugin).
+        id: 'subsonic.getSimilarSongs',
+        priority: 50,
+        when: (ctx) => ctx.isNavidrome && ctx.semverGte([0, 60, 0]),
+        detection: {
+          kind: 'functional',
+          probeId: PROBE_LEGACY_INSTANT_MIX,
+          presentWhen: (outcome) => outcome.status === 'present',
+        },
+        trust: 'low',
+        activation: 'manual',
+        alwaysCallable: true,
+        calls: {
+          [OP_SIMILAR_TRACKS]: { endpoint: 'getSimilarSongs.view', transport: 'subsonic' },
+        },
+        labelKey: 'settings.audiomuseStrategyLegacy',
+      },
+    ],
+  },
+];
+
+export function getCapabilityDefinition(feature: string): CapabilityDefinition | undefined {
+  return SERVER_CAPABILITY_CATALOG.find((d) => d.feature === feature);
+}

--- a/src/serverCapabilities/context.ts
+++ b/src/serverCapabilities/context.ts
@@ -1,0 +1,26 @@
+import {
+  isNavidromeServer,
+  parseLeadingSemver,
+  type SubsonicServerIdentity,
+} from '../utils/server/subsonicServerIdentity';
+import type { CapabilityContext, Semver } from './types';
+
+function semverGte(a: Semver, b: Semver): boolean {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] > b[i]) return true;
+    if (a[i] < b[i]) return false;
+  }
+  return true;
+}
+
+/** Build the eligibility context for a connected server from its `ping` identity. */
+export function buildCapabilityContext(identity: SubsonicServerIdentity | undefined): CapabilityContext {
+  const version = parseLeadingSemver(identity?.serverVersion);
+  return {
+    identity,
+    isNavidrome: isNavidromeServer(identity),
+    openSubsonic: !!identity?.openSubsonic,
+    version,
+    semverGte: (min) => (version ? semverGte(version, min) : false),
+  };
+}

--- a/src/serverCapabilities/resolve.test.ts
+++ b/src/serverCapabilities/resolve.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { buildCapabilityContext } from './context';
+import {
+  FEATURE_AUDIOMUSE_SIMILAR_TRACKS,
+  OP_SIMILAR_TRACKS,
+  PROBE_LEGACY_INSTANT_MIX,
+  PROBE_OPENSUBSONIC_EXTENSIONS,
+  SERVER_CAPABILITY_CATALOG,
+  SONIC_SIMILARITY_EXTENSION,
+  getCapabilityDefinition,
+} from './catalog';
+import {
+  isCapabilityActive,
+  neededProbeIds,
+  pickStrategy,
+  resolveCallChain,
+  resolveCapability,
+} from './resolve';
+import type { ProbeOutcome } from './types';
+
+const def = getCapabilityDefinition(FEATURE_AUDIOMUSE_SIMILAR_TRACKS)!;
+
+function ctxFor(version: string | undefined, type = 'navidrome') {
+  return buildCapabilityContext(version === undefined && type === ''
+    ? undefined
+    : { type, serverVersion: version, openSubsonic: true });
+}
+
+const extPresent: ProbeOutcome = { status: 'present', extensions: [SONIC_SIMILARITY_EXTENSION] };
+const extAbsent: ProbeOutcome = { status: 'present', extensions: [] };
+
+describe('pickStrategy', () => {
+  it('chooses sonicSimilarity on Navidrome ≥ 0.62', () => {
+    expect(pickStrategy(def, ctxFor('0.62.0'))?.id).toBe('opensubsonic.sonicSimilarity');
+  });
+  it('chooses legacy getSimilarSongs on Navidrome 0.61', () => {
+    expect(pickStrategy(def, ctxFor('0.61.0'))?.id).toBe('subsonic.getSimilarSongs');
+  });
+  it('is ineligible on non-Navidrome', () => {
+    expect(pickStrategy(def, ctxFor('1.0.0', 'gonic'))).toBeNull();
+  });
+  it('is ineligible on Navidrome older than 0.60', () => {
+    expect(pickStrategy(def, ctxFor('0.59.9'))).toBeNull();
+  });
+});
+
+describe('neededProbeIds', () => {
+  it('asks for the extensions probe on 0.62+', () => {
+    const ids = neededProbeIds(SERVER_CAPABILITY_CATALOG, ctxFor('0.62.0'));
+    expect(ids.has(PROBE_OPENSUBSONIC_EXTENSIONS)).toBe(true);
+    expect(ids.has(PROBE_LEGACY_INSTANT_MIX)).toBe(false);
+  });
+  it('asks for the legacy probe on 0.61', () => {
+    const ids = neededProbeIds(SERVER_CAPABILITY_CATALOG, ctxFor('0.61.0'));
+    expect(ids.has(PROBE_LEGACY_INSTANT_MIX)).toBe(true);
+    expect(ids.has(PROBE_OPENSUBSONIC_EXTENSIONS)).toBe(false);
+  });
+});
+
+describe('resolveCapability', () => {
+  it('present when sonicSimilarity extension is advertised', () => {
+    const r = resolveCapability(def, ctxFor('0.62.0'), { [PROBE_OPENSUBSONIC_EXTENSIONS]: extPresent });
+    expect(r).toMatchObject({ strategyId: 'opensubsonic.sonicSimilarity', status: 'present', trust: 'high', activation: 'auto' });
+  });
+  it('absent when extensions list lacks sonicSimilarity', () => {
+    const r = resolveCapability(def, ctxFor('0.62.0'), { [PROBE_OPENSUBSONIC_EXTENSIONS]: extAbsent });
+    expect(r.status).toBe('absent');
+  });
+  it('error propagates from probe', () => {
+    const r = resolveCapability(def, ctxFor('0.62.0'), { [PROBE_OPENSUBSONIC_EXTENSIONS]: { status: 'error' } });
+    expect(r.status).toBe('error');
+  });
+  it('unknown when not yet probed', () => {
+    expect(resolveCapability(def, ctxFor('0.62.0'), {}).status).toBe('unknown');
+  });
+  it('legacy present when functional probe ok', () => {
+    const r = resolveCapability(def, ctxFor('0.61.0'), { [PROBE_LEGACY_INSTANT_MIX]: { status: 'present' } });
+    expect(r).toMatchObject({ strategyId: 'subsonic.getSimilarSongs', status: 'present', trust: 'low', activation: 'manual' });
+  });
+  it('ineligible on non-Navidrome', () => {
+    expect(resolveCapability(def, ctxFor('1.0.0', 'gonic'), {}).status).toBe('ineligible');
+  });
+});
+
+describe('isCapabilityActive', () => {
+  it('auto feature on iff detected present', () => {
+    const present = resolveCapability(def, ctxFor('0.62.0'), { [PROBE_OPENSUBSONIC_EXTENSIONS]: extPresent });
+    const absent = resolveCapability(def, ctxFor('0.62.0'), { [PROBE_OPENSUBSONIC_EXTENSIONS]: extAbsent });
+    expect(isCapabilityActive(present, false)).toBe(true);
+    expect(isCapabilityActive(absent, true)).toBe(false);
+  });
+  it('manual feature follows opt-in unless proven absent', () => {
+    const ok = resolveCapability(def, ctxFor('0.61.0'), { [PROBE_LEGACY_INSTANT_MIX]: { status: 'present' } });
+    const empty = resolveCapability(def, ctxFor('0.61.0'), { [PROBE_LEGACY_INSTANT_MIX]: { status: 'absent' } });
+    expect(isCapabilityActive(ok, true)).toBe(true);
+    expect(isCapabilityActive(ok, false)).toBe(false);
+    expect(isCapabilityActive(empty, true)).toBe(false);
+  });
+});
+
+describe('resolveCallChain (prefer sonic, fallback legacy)', () => {
+  it('0.62 with plugin → sonic then legacy', () => {
+    const chain = resolveCallChain(def, ctxFor('0.62.0'), { [PROBE_OPENSUBSONIC_EXTENSIONS]: extPresent }, OP_SIMILAR_TRACKS);
+    expect(chain.map(r => r.endpoint)).toEqual(['getSonicSimilarTracks.view', 'getSimilarSongs.view']);
+  });
+  it('0.62 without plugin → legacy only', () => {
+    const chain = resolveCallChain(def, ctxFor('0.62.0'), { [PROBE_OPENSUBSONIC_EXTENSIONS]: extAbsent }, OP_SIMILAR_TRACKS);
+    expect(chain.map(r => r.endpoint)).toEqual(['getSimilarSongs.view']);
+  });
+  it('0.61 → legacy only', () => {
+    const chain = resolveCallChain(def, ctxFor('0.61.0'), {}, OP_SIMILAR_TRACKS);
+    expect(chain.map(r => r.endpoint)).toEqual(['getSimilarSongs.view']);
+  });
+  it('non-Navidrome → empty', () => {
+    expect(resolveCallChain(def, ctxFor('1.0.0', 'gonic'), {}, OP_SIMILAR_TRACKS)).toEqual([]);
+  });
+});

--- a/src/serverCapabilities/resolve.ts
+++ b/src/serverCapabilities/resolve.ts
@@ -1,0 +1,109 @@
+import type {
+  CapabilityCallRoute,
+  CapabilityContext,
+  CapabilityDefinition,
+  CapabilityStatus,
+  CapabilityStrategy,
+  ProbeOutcome,
+  ResolvedCapability,
+  StrategyDetection,
+} from './types';
+
+/** Strategies eligible for this server, strongest first. */
+export function eligibleStrategies(
+  def: CapabilityDefinition,
+  ctx: CapabilityContext,
+): CapabilityStrategy[] {
+  return def.strategies
+    .filter((s) => s.when(ctx))
+    .sort((a, b) => b.priority - a.priority);
+}
+
+/** The single strategy that owns this feature on the connected server. */
+export function pickStrategy(
+  def: CapabilityDefinition,
+  ctx: CapabilityContext,
+): CapabilityStrategy | null {
+  return eligibleStrategies(def, ctx)[0] ?? null;
+}
+
+/** Probe ids that need running for the selected strategy of each catalog feature. */
+export function neededProbeIds(
+  catalog: CapabilityDefinition[],
+  ctx: CapabilityContext,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const def of catalog) {
+    const strategy = pickStrategy(def, ctx);
+    if (strategy) ids.add(strategy.detection.probeId);
+  }
+  return ids;
+}
+
+export function detectionStatus(
+  detection: StrategyDetection,
+  outcome: ProbeOutcome | undefined,
+): CapabilityStatus {
+  if (!outcome) return 'unknown';
+  if (outcome.status === 'probing') return 'probing';
+  if (outcome.status === 'error') return 'error';
+  if (detection.kind === 'extension') {
+    if (outcome.status !== 'present') return 'absent';
+    return (outcome.extensions ?? []).includes(detection.extension) ? 'present' : 'absent';
+  }
+  return detection.presentWhen(outcome) ? 'present' : 'absent';
+}
+
+/** Resolve a feature's current state from catalog + probe outcomes. */
+export function resolveCapability(
+  def: CapabilityDefinition,
+  ctx: CapabilityContext,
+  probes: Record<string, ProbeOutcome | undefined>,
+): ResolvedCapability {
+  const strategy = pickStrategy(def, ctx);
+  if (!strategy) {
+    return { feature: def.feature, strategyId: null, status: 'ineligible', trust: null, activation: null };
+  }
+  const outcome = probes[strategy.detection.probeId];
+  return {
+    feature: def.feature,
+    strategyId: strategy.id,
+    status: detectionStatus(strategy.detection, outcome),
+    trust: strategy.trust,
+    activation: strategy.activation,
+  };
+}
+
+/**
+ * Whether a resolved feature is effectively on. Auto features follow detection;
+ * manual features follow the user opt-in unless detection proves them absent.
+ */
+export function isCapabilityActive(resolved: ResolvedCapability, userOptIn: boolean): boolean {
+  if (resolved.strategyId === null || resolved.status === 'ineligible') return false;
+  if (resolved.activation === 'auto') return resolved.status === 'present';
+  if (resolved.status === 'absent') return false;
+  return userOptIn;
+}
+
+/**
+ * Ordered call routes for an operation: strongest strategy first. A strategy is
+ * included when its detection is present, or when it is marked `alwaysCallable`
+ * (legacy fallback). Enables prefer-new-then-fallback routing.
+ */
+export function resolveCallChain(
+  def: CapabilityDefinition,
+  ctx: CapabilityContext,
+  probes: Record<string, ProbeOutcome | undefined>,
+  op: string,
+): CapabilityCallRoute[] {
+  const routes: CapabilityCallRoute[] = [];
+  for (const strategy of eligibleStrategies(def, ctx)) {
+    const call = strategy.calls[op];
+    if (!call) continue;
+    const status = detectionStatus(strategy.detection, probes[strategy.detection.probeId]);
+    if (status === 'present' || strategy.alwaysCallable) {
+      routes.push({ strategyId: strategy.id, endpoint: call.endpoint, transport: call.transport });
+    }
+  }
+  return routes;
+}

--- a/src/serverCapabilities/storeView.test.ts
+++ b/src/serverCapabilities/storeView.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAuthStore } from '../store/authStore';
+import { FEATURE_AUDIOMUSE_SIMILAR_TRACKS, OP_SIMILAR_TRACKS } from './catalog';
+import {
+  isFeatureActiveForServer,
+  resolveCallRoutesForServer,
+  resolveFeatureForServer,
+} from './storeView';
+
+const SID = 'srv-test';
+
+function seed(identity: Record<string, unknown>, extra: Record<string, unknown> = {}) {
+  useAuthStore.setState({
+    subsonicServerIdentityByServer: { [SID]: identity as never },
+    audiomusePluginProbeByServer: {},
+    instantMixProbeByServer: {},
+    audiomuseNavidromeByServer: {},
+    ...extra,
+  } as never);
+}
+
+describe('storeView (capability read facade)', () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      subsonicServerIdentityByServer: {},
+      audiomusePluginProbeByServer: {},
+      instantMixProbeByServer: {},
+      audiomuseNavidromeByServer: {},
+    } as never);
+  });
+
+  it('resolves sonic strategy as present from the plugin probe map', () => {
+    seed({ type: 'navidrome', serverVersion: '0.62.1', openSubsonic: true }, {
+      audiomusePluginProbeByServer: { [SID]: 'present' },
+    });
+    const resolved = resolveFeatureForServer(SID, FEATURE_AUDIOMUSE_SIMILAR_TRACKS);
+    expect(resolved).toMatchObject({ strategyId: 'opensubsonic.sonicSimilarity', status: 'present', activation: 'auto' });
+    expect(isFeatureActiveForServer(SID, FEATURE_AUDIOMUSE_SIMILAR_TRACKS)).toBe(true);
+    expect(resolveCallRoutesForServer(SID, FEATURE_AUDIOMUSE_SIMILAR_TRACKS, OP_SIMILAR_TRACKS).map(r => r.endpoint))
+      .toEqual(['getSonicSimilarTracks.view', 'getSimilarSongs.view']);
+  });
+
+  it('resolves sonic absent → legacy-only route, feature off', () => {
+    seed({ type: 'navidrome', serverVersion: '0.62.1', openSubsonic: true }, {
+      audiomusePluginProbeByServer: { [SID]: 'absent' },
+    });
+    expect(resolveFeatureForServer(SID, FEATURE_AUDIOMUSE_SIMILAR_TRACKS)?.status).toBe('absent');
+    expect(isFeatureActiveForServer(SID, FEATURE_AUDIOMUSE_SIMILAR_TRACKS)).toBe(false);
+    expect(resolveCallRoutesForServer(SID, FEATURE_AUDIOMUSE_SIMILAR_TRACKS, OP_SIMILAR_TRACKS).map(r => r.endpoint))
+      .toEqual(['getSimilarSongs.view']);
+  });
+
+  it('legacy server: manual opt-in drives active state', () => {
+    seed({ type: 'navidrome', serverVersion: '0.61.0', openSubsonic: false }, {
+      instantMixProbeByServer: { [SID]: 'ok' },
+      audiomuseNavidromeByServer: { [SID]: true },
+    });
+    expect(resolveFeatureForServer(SID, FEATURE_AUDIOMUSE_SIMILAR_TRACKS)?.strategyId).toBe('subsonic.getSimilarSongs');
+    expect(isFeatureActiveForServer(SID, FEATURE_AUDIOMUSE_SIMILAR_TRACKS)).toBe(true);
+  });
+
+  it('non-Navidrome server resolves ineligible with no routes', () => {
+    seed({ type: 'gonic', serverVersion: '0.16.0', openSubsonic: true });
+    expect(resolveFeatureForServer(SID, FEATURE_AUDIOMUSE_SIMILAR_TRACKS)?.status).toBe('ineligible');
+    expect(resolveCallRoutesForServer(SID, FEATURE_AUDIOMUSE_SIMILAR_TRACKS, OP_SIMILAR_TRACKS)).toEqual([]);
+  });
+});

--- a/src/serverCapabilities/storeView.ts
+++ b/src/serverCapabilities/storeView.ts
@@ -1,0 +1,85 @@
+import { useAuthStore } from '../store/authStore';
+import type {
+  AudiomusePluginProbeResult,
+  InstantMixProbeResult,
+} from '../utils/server/subsonicServerIdentity';
+import { buildCapabilityContext } from './context';
+import {
+  PROBE_LEGACY_INSTANT_MIX,
+  PROBE_OPENSUBSONIC_EXTENSIONS,
+  SONIC_SIMILARITY_EXTENSION,
+  getCapabilityDefinition,
+} from './catalog';
+import {
+  isCapabilityActive,
+  resolveCallChain,
+  resolveCapability,
+} from './resolve';
+import type {
+  CapabilityCallRoute,
+  ProbeOutcome,
+  ResolvedCapability,
+} from './types';
+
+/**
+ * Probe results currently live in dedicated per-server store maps. This facade
+ * maps them into the generic `ProbeOutcome` shape the resolver consumes, so the
+ * catalog/resolver/router stay storage-agnostic.
+ */
+function pluginProbeToOutcome(probe: AudiomusePluginProbeResult | undefined): ProbeOutcome | undefined {
+  switch (probe) {
+    case 'present': return { status: 'present', extensions: [SONIC_SIMILARITY_EXTENSION] };
+    case 'absent': return { status: 'present', extensions: [] };
+    case 'probing': return { status: 'probing' };
+    case 'error': return { status: 'error' };
+    default: return undefined;
+  }
+}
+
+function legacyProbeToOutcome(probe: InstantMixProbeResult | undefined): ProbeOutcome | undefined {
+  switch (probe) {
+    case 'ok': return { status: 'present' };
+    case 'empty':
+    case 'skipped': return { status: 'absent' };
+    case 'error': return { status: 'error' };
+    default: return undefined;
+  }
+}
+
+export function buildProbeOutcomesForServer(serverId: string): Record<string, ProbeOutcome | undefined> {
+  const s = useAuthStore.getState();
+  return {
+    [PROBE_OPENSUBSONIC_EXTENSIONS]: pluginProbeToOutcome(s.audiomusePluginProbeByServer[serverId]),
+    [PROBE_LEGACY_INSTANT_MIX]: legacyProbeToOutcome(s.instantMixProbeByServer[serverId]),
+  };
+}
+
+export function resolveFeatureForServer(
+  serverId: string,
+  feature: string,
+): ResolvedCapability | null {
+  const def = getCapabilityDefinition(feature);
+  if (!def) return null;
+  const s = useAuthStore.getState();
+  const ctx = buildCapabilityContext(s.subsonicServerIdentityByServer[serverId]);
+  return resolveCapability(def, ctx, buildProbeOutcomesForServer(serverId));
+}
+
+export function isFeatureActiveForServer(serverId: string, feature: string): boolean {
+  const resolved = resolveFeatureForServer(serverId, feature);
+  if (!resolved) return false;
+  const userOptIn = !!useAuthStore.getState().audiomuseNavidromeByServer[serverId];
+  return isCapabilityActive(resolved, userOptIn);
+}
+
+export function resolveCallRoutesForServer(
+  serverId: string,
+  feature: string,
+  op: string,
+): CapabilityCallRoute[] {
+  const def = getCapabilityDefinition(feature);
+  if (!def) return [];
+  const s = useAuthStore.getState();
+  const ctx = buildCapabilityContext(s.subsonicServerIdentityByServer[serverId]);
+  return resolveCallChain(def, ctx, buildProbeOutcomesForServer(serverId), op);
+}

--- a/src/serverCapabilities/types.ts
+++ b/src/serverCapabilities/types.ts
@@ -1,0 +1,92 @@
+import type { SubsonicServerIdentity } from '../utils/server/subsonicServerIdentity';
+
+export type Semver = [number, number, number];
+
+/**
+ * Derived view of a connected server used by capability strategies to decide
+ * eligibility. Built once from the `ping` identity (see `context.ts`).
+ */
+export interface CapabilityContext {
+  identity: SubsonicServerIdentity | undefined;
+  isNavidrome: boolean;
+  openSubsonic: boolean;
+  version: Semver | null;
+  /** True when the connected server version is ≥ `min` (false when unknown). */
+  semverGte(min: Semver): boolean;
+}
+
+/** Raw outcome of a single probe (one network question against the server). */
+export type ProbeStatus = 'probing' | 'present' | 'absent' | 'error';
+
+export interface ProbeOutcome {
+  status: ProbeStatus;
+  /** OpenSubsonic extension names, for `extension`-kind detectors to read. */
+  extensions?: string[];
+}
+
+export type FeatureTrust = 'high' | 'low';
+export type FeatureActivation = 'auto' | 'manual';
+
+/** How a strategy decides it is actually available on the connected server. */
+export type StrategyDetection =
+  | { kind: 'extension'; probeId: string; extension: string }
+  | { kind: 'functional'; probeId: string; presentWhen: (outcome: ProbeOutcome) => boolean };
+
+/** A concrete API route a strategy can serve for a named operation. */
+export interface CapabilityCall {
+  /** Subsonic REST endpoint, e.g. `getSonicSimilarTracks.view`. */
+  endpoint: string;
+  transport: 'subsonic' | 'opensubsonic';
+}
+
+/**
+ * One way to provide a feature on a given server generation. Higher `priority`
+ * wins when several strategies are eligible for the same server.
+ */
+export interface CapabilityStrategy {
+  id: string;
+  priority: number;
+  /** Eligible for the connected server type/version. */
+  when: (ctx: CapabilityContext) => boolean;
+  detection: StrategyDetection;
+  trust: FeatureTrust;
+  activation: FeatureActivation;
+  /** Operations this strategy can serve, keyed by operation name. */
+  calls: Record<string, CapabilityCall>;
+  /**
+   * Callable as a fallback even when detection is not satisfied — e.g. legacy
+   * `getSimilarSongs` still answers via Last.fm / local agents.
+   */
+  alwaysCallable?: boolean;
+  labelKey: string;
+}
+
+export interface CapabilityDefinition {
+  feature: string;
+  labelKey: string;
+  strategies: CapabilityStrategy[];
+}
+
+export type CapabilityStatus =
+  | 'ineligible'
+  | 'unknown'
+  | 'probing'
+  | 'present'
+  | 'absent'
+  | 'error';
+
+/** Resolved per-server state for one feature, derived from catalog + probes. */
+export interface ResolvedCapability {
+  feature: string;
+  strategyId: string | null;
+  status: CapabilityStatus;
+  trust: FeatureTrust | null;
+  activation: FeatureActivation | null;
+}
+
+/** An ordered call route returned by the router for a feature operation. */
+export interface CapabilityCallRoute {
+  strategyId: string;
+  endpoint: string;
+  transport: 'subsonic' | 'opensubsonic';
+}

--- a/src/store/authPerServerCapabilityActions.ts
+++ b/src/store/authPerServerCapabilityActions.ts
@@ -85,6 +85,12 @@ export function createPerServerCapabilityActions(set: SetState): Pick<
     setAudiomusePluginProbe: (serverId, result) =>
       set(s => {
         const audiomusePluginProbeByServer = { ...s.audiomusePluginProbeByServer, [serverId]: result };
+        if (result === 'present') {
+          return {
+            audiomusePluginProbeByServer,
+            audiomuseNavidromeByServer: { ...s.audiomuseNavidromeByServer, [serverId]: true },
+          };
+        }
         if (result === 'absent' || result === 'error') {
           const { [serverId]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
           const { [serverId]: _i, ...issueRest } = s.audiomuseNavidromeIssueByServer;

--- a/src/store/authPerServerCapabilityActions.ts
+++ b/src/store/authPerServerCapabilityActions.ts
@@ -17,10 +17,9 @@ type SetState = (
  *   ping reveals the server isn't AudioMuse-eligible (wrong type or
  *   too old), wipe the related caps for that id so the UI doesn't
  *   keep a stale toggle.
- * - `setInstantMixProbe` — probe result for getSimilarSongs. If
- *   `empty`, wipe the related AudioMuse caps so the row hides.
- * - `setAudiomuseNavidromeIssue` — set/clear the "current session
- *   saw a failure" flag.
+ * - `setInstantMixProbe` — legacy probe (pre-0.62). If `empty`, wipe AudioMuse caps.
+ * - `setAudiomusePluginProbe` — Navidrome ≥ 0.62 `sonicSimilarity` extension probe.
+ * - `setAudiomuseNavidromeIssue` — set/clear the "current session saw a failure" flag.
  */
 export function createPerServerCapabilityActions(set: SetState): Pick<
   AuthState,
@@ -28,6 +27,7 @@ export function createPerServerCapabilityActions(set: SetState): Pick<
   | 'setAudiomuseNavidromeEnabled'
   | 'setSubsonicServerIdentity'
   | 'setInstantMixProbe'
+  | 'setAudiomusePluginProbe'
   | 'setAudiomuseNavidromeIssue'
 > {
   return {
@@ -55,11 +55,13 @@ export function createPerServerCapabilityActions(set: SetState): Pick<
           const { [serverId]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
           const { [serverId]: _i, ...issueRest } = s.audiomuseNavidromeIssueByServer;
           const { [serverId]: _p, ...probeRest } = s.instantMixProbeByServer;
+          const { [serverId]: _pp, ...pluginProbeRest } = s.audiomusePluginProbeByServer;
           return {
             subsonicServerIdentityByServer,
             audiomuseNavidromeByServer: audiomuseRest,
             audiomuseNavidromeIssueByServer: issueRest,
             instantMixProbeByServer: probeRest,
+            audiomusePluginProbeByServer: pluginProbeRest,
           };
         }
         return { subsonicServerIdentityByServer };
@@ -78,6 +80,21 @@ export function createPerServerCapabilityActions(set: SetState): Pick<
           };
         }
         return { instantMixProbeByServer };
+      }),
+
+    setAudiomusePluginProbe: (serverId, result) =>
+      set(s => {
+        const audiomusePluginProbeByServer = { ...s.audiomusePluginProbeByServer, [serverId]: result };
+        if (result === 'absent' || result === 'error') {
+          const { [serverId]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
+          const { [serverId]: _i, ...issueRest } = s.audiomuseNavidromeIssueByServer;
+          return {
+            audiomusePluginProbeByServer,
+            audiomuseNavidromeByServer: audiomuseRest,
+            audiomuseNavidromeIssueByServer: issueRest,
+          };
+        }
+        return { audiomusePluginProbeByServer };
       }),
 
     setAudiomuseNavidromeIssue: (serverId, hasIssue) =>

--- a/src/store/authPerServerCapabilityActions.ts
+++ b/src/store/authPerServerCapabilityActions.ts
@@ -50,6 +50,7 @@ export function createPerServerCapabilityActions(set: SetState): Pick<
 
     setSubsonicServerIdentity: (serverId, identity) =>
       set(s => {
+        const prev = s.subsonicServerIdentityByServer[serverId];
         const subsonicServerIdentityByServer = { ...s.subsonicServerIdentityByServer, [serverId]: { ...identity } };
         if (!isNavidromeAudiomuseSoftwareEligible(identity)) {
           const { [serverId]: _a, ...audiomuseRest } = s.audiomuseNavidromeByServer;
@@ -60,6 +61,18 @@ export function createPerServerCapabilityActions(set: SetState): Pick<
             subsonicServerIdentityByServer,
             audiomuseNavidromeByServer: audiomuseRest,
             audiomuseNavidromeIssueByServer: issueRest,
+            instantMixProbeByServer: probeRest,
+            audiomusePluginProbeByServer: pluginProbeRest,
+          };
+        }
+        // Server generation changed (version/type) → drop cached capability probes
+        // so the next probe re-runs against the new generation. The user opt-in
+        // (`audiomuseNavidromeByServer`) is preserved.
+        if (prev && (prev.serverVersion !== identity.serverVersion || prev.type !== identity.type)) {
+          const { [serverId]: _p, ...probeRest } = s.instantMixProbeByServer;
+          const { [serverId]: _pp, ...pluginProbeRest } = s.audiomusePluginProbeByServer;
+          return {
+            subsonicServerIdentityByServer,
             instantMixProbeByServer: probeRest,
             audiomusePluginProbeByServer: pluginProbeRest,
           };

--- a/src/store/authServerProfileActions.ts
+++ b/src/store/authServerProfileActions.ts
@@ -56,6 +56,7 @@ export function createServerProfileActions(set: SetState): Pick<
         const { [id]: _idn, ...identityRest } = s.subsonicServerIdentityByServer;
         const { [id]: _iss, ...issueRest } = s.audiomuseNavidromeIssueByServer;
         const { [id]: _pr, ...probeRest } = s.instantMixProbeByServer;
+        const { [id]: _ppl, ...pluginProbeRest } = s.audiomusePluginProbeByServer;
         return {
           servers: newServers,
           activeServerId: switchedAway ? (newServers[0]?.id ?? null) : s.activeServerId,
@@ -65,6 +66,7 @@ export function createServerProfileActions(set: SetState): Pick<
           subsonicServerIdentityByServer: identityRest,
           audiomuseNavidromeIssueByServer: issueRest,
           instantMixProbeByServer: probeRest,
+          audiomusePluginProbeByServer: pluginProbeRest,
         };
       });
     },

--- a/src/store/authStore.settings.test.ts
+++ b/src/store/authStore.settings.test.ts
@@ -255,6 +255,18 @@ describe('per-server bookkeeping setters', () => {
       'srv-1': true,
     });
   });
+
+  it('setAudiomusePluginProbe auto-enables AudioMuse when sonicSimilarity is present', () => {
+    useAuthStore.getState().setAudiomusePluginProbe('srv-1', 'present');
+    expect(useAuthStore.getState().audiomusePluginProbeByServer).toEqual({ 'srv-1': 'present' });
+    expect(useAuthStore.getState().audiomuseNavidromeByServer).toEqual({ 'srv-1': true });
+  });
+
+  it('setAudiomusePluginProbe clears AudioMuse when the extension is absent', () => {
+    useAuthStore.getState().setAudiomuseNavidromeEnabled('srv-1', true);
+    useAuthStore.getState().setAudiomusePluginProbe('srv-1', 'absent');
+    expect(useAuthStore.getState().audiomuseNavidromeByServer).toEqual({});
+  });
 });
 
 describe('genre blacklist + audio output device', () => {

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -121,6 +121,7 @@ export const useAuthStore = create<AuthState>()(
       subsonicServerIdentityByServer: {},
       audiomuseNavidromeIssueByServer: {},
       instantMixProbeByServer: {},
+      audiomusePluginProbeByServer: {},
       isLoggedIn: false,
       isConnecting: false,
       connectionError: null,

--- a/src/store/authStoreTypes.ts
+++ b/src/store/authStoreTypes.ts
@@ -251,7 +251,8 @@ export interface AuthState {
   setEntityRatingSupport: (serverId: string, level: EntityRatingSupportLevel) => void;
 
   /**
-   * Per server: Navidrome has the AudioMuse-AI plugin — use `getSimilarSongs` (Instant Mix) and
+   * Per server: AudioMuse-AI features active — manual opt-in on pre-0.62 Navidrome; auto-set on
+   * 0.62+ when `sonicSimilarity` probe is `present`. Uses `getSimilarSongs` (Instant Mix) and
    * `getArtistInfo2` similar artists instead of Last.fm for discovery on this server.
    */
   audiomuseNavidromeByServer: Record<string, boolean>;

--- a/src/store/authStoreTypes.ts
+++ b/src/store/authStoreTypes.ts
@@ -1,5 +1,6 @@
 import type { EntityRatingSupportLevel } from '../api/subsonicTypes';
 import type {
+  AudiomusePluginProbeResult,
   InstantMixProbeResult,
   SubsonicServerIdentity,
 } from '../utils/server/subsonicServerIdentity';
@@ -265,10 +266,16 @@ export interface AuthState {
   setAudiomuseNavidromeIssue: (serverId: string, hasIssue: boolean) => void;
 
   /**
-   * `getSimilarSongs` probe per server (after ping). `empty` hides the AudioMuse row; re-run by testing connection.
+   * `getSimilarSongs` probe per server (after ping). `empty` hides the AudioMuse row on pre-0.62 Navidrome.
    */
   instantMixProbeByServer: Record<string, InstantMixProbeResult>;
   setInstantMixProbe: (serverId: string, result: InstantMixProbeResult) => void;
+
+  /**
+   * Navidrome ≥ 0.62: `sonicSimilarity` extension probe (`present` = AudioMuse-style plugin active).
+   */
+  audiomusePluginProbeByServer: Record<string, AudiomusePluginProbeResult>;
+  setAudiomusePluginProbe: (serverId: string, result: AudiomusePluginProbeResult) => void;
 
   // Status
   isLoggedIn: boolean;

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -95,6 +95,8 @@
 
 .sidebar-perf-modal__tabs {
   display: flex;
+  flex: 0 0 auto;
+  flex-shrink: 0;
   gap: 4px;
   margin: 12px 0 10px;
   padding: 4px;
@@ -102,16 +104,19 @@
   background: color-mix(in srgb, var(--bg-card, var(--bg-app)) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--text-muted) 18%, transparent);
   overflow-x: auto;
+  scrollbar-width: thin;
 }
 
 .sidebar-perf-modal__tab {
-  flex: 1 0 auto;
+  flex: 0 0 auto;
   min-width: 4.5rem;
+  min-height: 2.25rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
   padding: 8px 10px;
+  white-space: nowrap;
   border: none;
   border-radius: 9px;
   background: transparent;
@@ -314,32 +319,128 @@
   font-size: 11px;
 }
 
-.perf-server-dl {
-  margin: 0;
-  padding: 0 4px 4px;
+.perf-metric-section__body {
+  padding: 0 10px 10px;
+}
+
+.perf-conn-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 10px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 16%, transparent);
+  background: color-mix(in srgb, var(--bg-card, var(--bg-app)) 88%, transparent);
+}
+
+.perf-conn-summary__item {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  align-items: flex-start;
+  gap: 4px;
+  min-width: 88px;
+  flex: 1 1 auto;
+}
+
+.perf-conn-summary__label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 90%, transparent);
+}
+
+.perf-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.35;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.perf-status-badge--ok {
+  color: #9ece6a;
+  background: color-mix(in srgb, #9ece6a 14%, transparent);
+  border-color: color-mix(in srgb, #9ece6a 28%, transparent);
+}
+
+.perf-status-badge--warn {
+  color: #e0af68;
+  background: color-mix(in srgb, #e0af68 14%, transparent);
+  border-color: color-mix(in srgb, #e0af68 28%, transparent);
+}
+
+.perf-status-badge--error {
+  color: #f7768e;
+  background: color-mix(in srgb, #f7768e 14%, transparent);
+  border-color: color-mix(in srgb, #f7768e 28%, transparent);
+}
+
+.perf-status-badge--neutral {
+  color: #7aa2f7;
+  background: color-mix(in srgb, #7aa2f7 14%, transparent);
+  border-color: color-mix(in srgb, #7aa2f7 28%, transparent);
+}
+
+.perf-status-badge--muted {
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-muted) 10%, transparent);
+  border-color: color-mix(in srgb, var(--text-muted) 20%, transparent);
+}
+
+.perf-server-dl {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
   font-size: 12px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 12%, transparent);
+  overflow: hidden;
 }
 
 .perf-server-dl__row {
   display: grid;
   grid-template-columns: minmax(110px, 38%) 1fr;
   gap: 8px 12px;
-  align-items: baseline;
+  align-items: center;
+  padding: 8px 10px;
+  border-top: 1px solid color-mix(in srgb, var(--text-muted) 10%, transparent);
+}
+
+.perf-server-dl__row:first-child {
+  border-top: none;
+}
+
+.perf-server-dl__row:nth-child(even) {
+  background: color-mix(in srgb, var(--bg-sidebar, var(--bg-app)) 40%, transparent);
 }
 
 .perf-server-dl__row dt {
   margin: 0;
   color: var(--text-muted);
   font-weight: 500;
+  font-size: 11px;
 }
 
 .perf-server-dl__row dd {
   margin: 0;
   color: var(--text-primary, var(--text));
   word-break: break-word;
+}
+
+.perf-server-dl__code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  color: color-mix(in srgb, var(--text-primary, var(--text)) 92%, var(--accent));
+  word-break: break-all;
 }
 
 .perf-live-poll {
@@ -937,6 +1038,7 @@
 }
 
 .sidebar-perf-modal__actions {
+  flex-shrink: 0;
   margin-top: 14px;
   display: flex;
   justify-content: flex-end;

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -95,16 +95,18 @@
 
 .sidebar-perf-modal__tabs {
   display: flex;
-  gap: 6px;
+  gap: 4px;
   margin: 12px 0 10px;
   padding: 4px;
   border-radius: 12px;
   background: color-mix(in srgb, var(--bg-card, var(--bg-app)) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--text-muted) 18%, transparent);
+  overflow-x: auto;
 }
 
 .sidebar-perf-modal__tab {
-  flex: 1;
+  flex: 1 0 auto;
+  min-width: 4.5rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -310,6 +312,34 @@
 .perf-monitor-empty--inline {
   padding: 0.75rem 0.5rem;
   font-size: 11px;
+}
+
+.perf-server-dl {
+  margin: 0;
+  padding: 0 4px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.perf-server-dl__row {
+  display: grid;
+  grid-template-columns: minmax(110px, 38%) 1fr;
+  gap: 8px 12px;
+  align-items: baseline;
+}
+
+.perf-server-dl__row dt {
+  margin: 0;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.perf-server-dl__row dd {
+  margin: 0;
+  color: var(--text-primary, var(--text));
+  word-break: break-word;
 }
 
 .perf-live-poll {

--- a/src/utils/componentHelpers/contextMenuActions.ts
+++ b/src/utils/componentHelpers/contextMenuActions.ts
@@ -1,6 +1,6 @@
 import { join } from '@tauri-apps/api/path';
 import { invoke } from '@tauri-apps/api/core';
-import { getSimilarSongs2, getSimilarSongs, getTopSongs } from '../../api/subsonicArtists';
+import { getSimilarSongs2, fetchSimilarTracksRouted, getTopSongs } from '../../api/subsonicArtists';
 import { filterSongsForLuckyMixRatings, getMixMinRatingsConfigFromAuth } from '../mix/mixRatingFilter';
 import { buildDownloadUrl } from '../../api/subsonicStreamUrl';
 import { useAuthStore } from '../../store/authStore';
@@ -112,7 +112,7 @@ export async function startInstantMix(
   usePlayerStore.getState().reseedQueueForInstantMix(song);
   const serverId = useAuthStore.getState().activeServerId;
   try {
-    const similar = await getSimilarSongs(song.id, 50);
+    const similar = await fetchSimilarTracksRouted(song.id, 50);
     if (serverId) useAuthStore.getState().setAudiomuseNavidromeIssue(serverId, false);
     const mixCfg = getMixMinRatingsConfigFromAuth();
     const ratedFiltered = await filterSongsForLuckyMixRatings(

--- a/src/utils/mix/luckyMix.ts
+++ b/src/utils/mix/luckyMix.ts
@@ -1,4 +1,4 @@
-import { getSimilarSongs } from '../../api/subsonicArtists';
+import { fetchSimilarTracksRouted } from '../../api/subsonicArtists';
 import { filterSongsToActiveLibrary, getRandomSongs } from '../../api/subsonicLibrary';
 import type { SubsonicAlbum, SubsonicSong } from '../../api/subsonicTypes';
 import type { QueueItemRef } from '../../store/playerStoreTypes';
@@ -292,7 +292,7 @@ export async function buildAndPlayLuckyMix(): Promise<void> {
     for (let i = 0; i < seeds.length; i++) {
       bailIfCancelled();
       const seed = seeds[i];
-      const oneRaw = await getSimilarSongs(seed.id, 60).catch(() => [] as SubsonicSong[]);
+      const oneRaw = await fetchSimilarTracksRouted(seed.id, 60).catch(() => [] as SubsonicSong[]);
       const oneScoped = await filterSongsToActiveLibrary(oneRaw);
       similarRaw = uniqueAppend(similarRaw, oneRaw);
       similar = uniqueAppend(similar, oneScoped);

--- a/src/utils/server/subsonicServerIdentity.test.ts
+++ b/src/utils/server/subsonicServerIdentity.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
-  isAudiomusePluginAutoManaged,
-  isNavidromeSonicSimilarityEligible,
+  isNavidromeAudiomuseSoftwareEligible,
+  isNavidromeServer,
   parseLeadingSemver,
-  resolveAudiomusePluginProbeUiStatus,
-  showAudiomuseNavidromeServerSetting,
 } from './subsonicServerIdentity';
 
 describe('parseLeadingSemver', () => {
@@ -12,50 +10,31 @@ describe('parseLeadingSemver', () => {
     expect(parseLeadingSemver('0.62.0 (2026-06-08)')).toEqual([0, 62, 0]);
     expect(parseLeadingSemver('v0.61.2')).toEqual([0, 61, 2]);
   });
-});
 
-describe('isNavidromeSonicSimilarityEligible', () => {
-  it('is true for Navidrome ≥ 0.62', () => {
-    expect(isNavidromeSonicSimilarityEligible({ type: 'navidrome', serverVersion: '0.62.0' })).toBe(true);
-  });
-
-  it('is false for Navidrome 0.61', () => {
-    expect(isNavidromeSonicSimilarityEligible({ type: 'navidrome', serverVersion: '0.61.2' })).toBe(false);
-  });
-
-  it('is false for non-Navidrome servers', () => {
-    expect(isNavidromeSonicSimilarityEligible({ type: 'gonic', serverVersion: '0.62.0' })).toBe(false);
+  it('returns null for unparseable input', () => {
+    expect(parseLeadingSemver(undefined)).toBeNull();
+    expect(parseLeadingSemver('unknown')).toBeNull();
   });
 });
 
-describe('showAudiomuseNavidromeServerSetting', () => {
-  const nav062 = { type: 'navidrome', serverVersion: '0.62.0' };
-  const nav061 = { type: 'navidrome', serverVersion: '0.61.2' };
-
-  it('shows the status row on all Navidrome 0.62+ servers', () => {
-    expect(showAudiomuseNavidromeServerSetting(nav062, undefined, 'present')).toBe(true);
-    expect(showAudiomuseNavidromeServerSetting(nav062, 'ok', 'absent')).toBe(true);
-    expect(showAudiomuseNavidromeServerSetting(nav062, undefined, 'probing')).toBe(true);
-  });
-
-  it('keeps legacy instant-mix probe gating on pre-0.62 Navidrome', () => {
-    expect(showAudiomuseNavidromeServerSetting(nav061, 'ok', undefined)).toBe(true);
-    expect(showAudiomuseNavidromeServerSetting(nav061, 'empty', undefined)).toBe(false);
+describe('isNavidromeServer', () => {
+  it('matches the navidrome type case-insensitively', () => {
+    expect(isNavidromeServer({ type: 'navidrome' })).toBe(true);
+    expect(isNavidromeServer({ type: 'Navidrome' })).toBe(true);
+    expect(isNavidromeServer({ type: 'gonic' })).toBe(false);
+    expect(isNavidromeServer(undefined)).toBe(false);
   });
 });
 
-describe('isAudiomusePluginAutoManaged', () => {
-  it('is true only for Navidrome ≥ 0.62', () => {
-    expect(isAudiomusePluginAutoManaged({ type: 'navidrome', serverVersion: '0.62.0' })).toBe(true);
-    expect(isAudiomusePluginAutoManaged({ type: 'navidrome', serverVersion: '0.61.2' })).toBe(false);
+describe('isNavidromeAudiomuseSoftwareEligible', () => {
+  it('is permissive until a typed ping arrives', () => {
+    expect(isNavidromeAudiomuseSoftwareEligible(undefined)).toBe(true);
+    expect(isNavidromeAudiomuseSoftwareEligible({})).toBe(true);
   });
-});
 
-describe('resolveAudiomusePluginProbeUiStatus', () => {
-  it('maps probe results to UI status', () => {
-    expect(resolveAudiomusePluginProbeUiStatus('present')).toBe('active');
-    expect(resolveAudiomusePluginProbeUiStatus('probing')).toBe('checking');
-    expect(resolveAudiomusePluginProbeUiStatus('absent')).toBe('not_detected');
-    expect(resolveAudiomusePluginProbeUiStatus('error')).toBe('failed');
+  it('requires Navidrome ≥ 0.60 once metadata is known', () => {
+    expect(isNavidromeAudiomuseSoftwareEligible({ type: 'navidrome', serverVersion: '0.60.0' })).toBe(true);
+    expect(isNavidromeAudiomuseSoftwareEligible({ type: 'navidrome', serverVersion: '0.59.9' })).toBe(false);
+    expect(isNavidromeAudiomuseSoftwareEligible({ type: 'gonic', serverVersion: '1.0.0' })).toBe(false);
   });
 });

--- a/src/utils/server/subsonicServerIdentity.test.ts
+++ b/src/utils/server/subsonicServerIdentity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isNavidromeSonicSimilarityEligible,
+  parseLeadingSemver,
+  showAudiomuseNavidromeServerSetting,
+} from './subsonicServerIdentity';
+
+describe('parseLeadingSemver', () => {
+  it('parses Navidrome-style version strings', () => {
+    expect(parseLeadingSemver('0.62.0 (2026-06-08)')).toEqual([0, 62, 0]);
+    expect(parseLeadingSemver('v0.61.2')).toEqual([0, 61, 2]);
+  });
+});
+
+describe('isNavidromeSonicSimilarityEligible', () => {
+  it('is true for Navidrome ≥ 0.62', () => {
+    expect(isNavidromeSonicSimilarityEligible({ type: 'navidrome', serverVersion: '0.62.0' })).toBe(true);
+  });
+
+  it('is false for Navidrome 0.61', () => {
+    expect(isNavidromeSonicSimilarityEligible({ type: 'navidrome', serverVersion: '0.61.2' })).toBe(false);
+  });
+
+  it('is false for non-Navidrome servers', () => {
+    expect(isNavidromeSonicSimilarityEligible({ type: 'gonic', serverVersion: '0.62.0' })).toBe(false);
+  });
+});
+
+describe('showAudiomuseNavidromeServerSetting', () => {
+  const nav062 = { type: 'navidrome', serverVersion: '0.62.0' };
+  const nav061 = { type: 'navidrome', serverVersion: '0.61.2' };
+
+  it('shows the toggle on 0.62+ only when sonicSimilarity probe is present', () => {
+    expect(showAudiomuseNavidromeServerSetting(nav062, undefined, 'present')).toBe(true);
+    expect(showAudiomuseNavidromeServerSetting(nav062, 'ok', 'absent')).toBe(false);
+    expect(showAudiomuseNavidromeServerSetting(nav062, undefined, 'probing')).toBe(false);
+  });
+
+  it('keeps legacy instant-mix probe gating on pre-0.62 Navidrome', () => {
+    expect(showAudiomuseNavidromeServerSetting(nav061, 'ok', undefined)).toBe(true);
+    expect(showAudiomuseNavidromeServerSetting(nav061, 'empty', undefined)).toBe(false);
+  });
+});

--- a/src/utils/server/subsonicServerIdentity.test.ts
+++ b/src/utils/server/subsonicServerIdentity.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isAudiomusePluginAutoManaged,
   isNavidromeSonicSimilarityEligible,
   parseLeadingSemver,
+  resolveAudiomusePluginProbeUiStatus,
   showAudiomuseNavidromeServerSetting,
 } from './subsonicServerIdentity';
 
@@ -30,14 +32,30 @@ describe('showAudiomuseNavidromeServerSetting', () => {
   const nav062 = { type: 'navidrome', serverVersion: '0.62.0' };
   const nav061 = { type: 'navidrome', serverVersion: '0.61.2' };
 
-  it('shows the toggle on 0.62+ only when sonicSimilarity probe is present', () => {
+  it('shows the status row on all Navidrome 0.62+ servers', () => {
     expect(showAudiomuseNavidromeServerSetting(nav062, undefined, 'present')).toBe(true);
-    expect(showAudiomuseNavidromeServerSetting(nav062, 'ok', 'absent')).toBe(false);
-    expect(showAudiomuseNavidromeServerSetting(nav062, undefined, 'probing')).toBe(false);
+    expect(showAudiomuseNavidromeServerSetting(nav062, 'ok', 'absent')).toBe(true);
+    expect(showAudiomuseNavidromeServerSetting(nav062, undefined, 'probing')).toBe(true);
   });
 
   it('keeps legacy instant-mix probe gating on pre-0.62 Navidrome', () => {
     expect(showAudiomuseNavidromeServerSetting(nav061, 'ok', undefined)).toBe(true);
     expect(showAudiomuseNavidromeServerSetting(nav061, 'empty', undefined)).toBe(false);
+  });
+});
+
+describe('isAudiomusePluginAutoManaged', () => {
+  it('is true only for Navidrome ≥ 0.62', () => {
+    expect(isAudiomusePluginAutoManaged({ type: 'navidrome', serverVersion: '0.62.0' })).toBe(true);
+    expect(isAudiomusePluginAutoManaged({ type: 'navidrome', serverVersion: '0.61.2' })).toBe(false);
+  });
+});
+
+describe('resolveAudiomusePluginProbeUiStatus', () => {
+  it('maps probe results to UI status', () => {
+    expect(resolveAudiomusePluginProbeUiStatus('present')).toBe('active');
+    expect(resolveAudiomusePluginProbeUiStatus('probing')).toBe('checking');
+    expect(resolveAudiomusePluginProbeUiStatus('absent')).toBe('not_detected');
+    expect(resolveAudiomusePluginProbeUiStatus('error')).toBe('failed');
   });
 });

--- a/src/utils/server/subsonicServerIdentity.ts
+++ b/src/utils/server/subsonicServerIdentity.ts
@@ -62,19 +62,36 @@ export function isNavidromeSonicSimilarityEligible(identity: SubsonicServerIdent
   return semverGte(parsed, NAVIDROME_MIN_FOR_SONIC_SIMILARITY);
 }
 
+/** Navidrome ≥ 0.62 — AudioMuse is auto-enabled from the `sonicSimilarity` probe (no manual toggle). */
+export function isAudiomusePluginAutoManaged(identity: SubsonicServerIdentity | undefined): boolean {
+  return isNavidromeSonicSimilarityEligible(identity);
+}
+
+export type AudiomusePluginProbeUiStatus = 'checking' | 'active' | 'not_detected' | 'failed' | 'unknown';
+
+export function resolveAudiomusePluginProbeUiStatus(
+  probe: AudiomusePluginProbeResult | undefined,
+): AudiomusePluginProbeUiStatus {
+  switch (probe) {
+    case 'present': return 'active';
+    case 'probing': return 'checking';
+    case 'absent': return 'not_detected';
+    case 'error': return 'failed';
+    default: return 'unknown';
+  }
+}
+
 /**
- * Whether to show the per-server AudioMuse (Navidrome plugin) toggle in Settings.
- * Navidrome ≥ 0.62: `sonicSimilarity` extension probe. Older Navidrome: legacy Instant Mix probe.
+ * Whether to show the per-server AudioMuse row in Settings.
+ * Navidrome ≥ 0.62: always (status indicator). Older Navidrome: legacy Instant Mix probe gate.
  */
 export function showAudiomuseNavidromeServerSetting(
   identity: SubsonicServerIdentity | undefined,
   instantMixProbe: InstantMixProbeResult | undefined,
-  pluginProbe: AudiomusePluginProbeResult | undefined,
+  _pluginProbe: AudiomusePluginProbeResult | undefined,
 ): boolean {
   if (!isNavidromeAudiomuseSoftwareEligible(identity)) return false;
-  if (isNavidromeSonicSimilarityEligible(identity)) {
-    return pluginProbe === 'present';
-  }
+  if (isNavidromeSonicSimilarityEligible(identity)) return true;
   if (instantMixProbe === 'empty') return false;
   return true;
 }

--- a/src/utils/server/subsonicServerIdentity.ts
+++ b/src/utils/server/subsonicServerIdentity.ts
@@ -8,9 +8,21 @@ export type SubsonicServerIdentity = {
 /** Result of `getRandomSongs` + `getSimilarSongs` probe (Instant Mix / agent chain). */
 export type InstantMixProbeResult = 'ok' | 'empty' | 'error' | 'skipped';
 
-const NAVIDROME_MIN_FOR_PLUGINS: [number, number, number] = [0, 60, 0];
+/**
+ * Navidrome ≥ 0.62 exposes the OpenSubsonic `sonicSimilarity` extension when an audio-similarity
+ * plugin (e.g. AudioMuse-AI) is active — the first reliable plugin signal.
+ */
+export type AudiomusePluginProbeResult =
+  | 'probing'
+  | 'present'
+  | 'absent'
+  | 'unsupported'
+  | 'error';
 
-function parseLeadingSemver(version: string | undefined): [number, number, number] | null {
+const NAVIDROME_MIN_FOR_PLUGINS: [number, number, number] = [0, 60, 0];
+const NAVIDROME_MIN_FOR_SONIC_SIMILARITY: [number, number, number] = [0, 62, 0];
+
+export function parseLeadingSemver(version: string | undefined): [number, number, number] | null {
   if (!version) return null;
   const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(String(version).trim());
   if (!m) return null;
@@ -25,29 +37,44 @@ function semverGte(a: [number, number, number], b: [number, number, number]): bo
   return true;
 }
 
+export function isNavidromeServer(identity: SubsonicServerIdentity | undefined): boolean {
+  if (!identity?.type?.trim()) return false;
+  return identity.type.trim().toLowerCase() === 'navidrome';
+}
+
 /**
  * Navidrome version from ping supports the plugin system (≥ 0.60). Unknown `type` stays permissive
  * until the first successful ping with metadata.
  */
 export function isNavidromeAudiomuseSoftwareEligible(identity: SubsonicServerIdentity | undefined): boolean {
   if (!identity?.type?.trim()) return true;
-  const t = identity.type.trim().toLowerCase();
-  if (t !== 'navidrome') return false;
+  if (!isNavidromeServer(identity)) return false;
   const parsed = parseLeadingSemver(identity.serverVersion);
   if (!parsed) return true;
   return semverGte(parsed, NAVIDROME_MIN_FOR_PLUGINS);
 }
 
+/** Navidrome ≥ 0.62 — `getOpenSubsonicExtensions` can list `sonicSimilarity`. */
+export function isNavidromeSonicSimilarityEligible(identity: SubsonicServerIdentity | undefined): boolean {
+  if (!isNavidromeServer(identity)) return false;
+  const parsed = parseLeadingSemver(identity?.serverVersion);
+  if (!parsed) return false;
+  return semverGte(parsed, NAVIDROME_MIN_FOR_SONIC_SIMILARITY);
+}
+
 /**
  * Whether to show the per-server AudioMuse (Navidrome plugin) toggle in Settings.
- * Uses software eligibility from ping plus an optional Instant Mix probe: if the server returns no
- * similar tracks for several random songs, the row stays hidden (typical when no plugin / no agents).
+ * Navidrome ≥ 0.62: `sonicSimilarity` extension probe. Older Navidrome: legacy Instant Mix probe.
  */
 export function showAudiomuseNavidromeServerSetting(
   identity: SubsonicServerIdentity | undefined,
   instantMixProbe: InstantMixProbeResult | undefined,
+  pluginProbe: AudiomusePluginProbeResult | undefined,
 ): boolean {
   if (!isNavidromeAudiomuseSoftwareEligible(identity)) return false;
+  if (isNavidromeSonicSimilarityEligible(identity)) {
+    return pluginProbe === 'present';
+  }
   if (instantMixProbe === 'empty') return false;
   return true;
 }

--- a/src/utils/server/subsonicServerIdentity.ts
+++ b/src/utils/server/subsonicServerIdentity.ts
@@ -16,11 +16,9 @@ export type AudiomusePluginProbeResult =
   | 'probing'
   | 'present'
   | 'absent'
-  | 'unsupported'
   | 'error';
 
 const NAVIDROME_MIN_FOR_PLUGINS: [number, number, number] = [0, 60, 0];
-const NAVIDROME_MIN_FOR_SONIC_SIMILARITY: [number, number, number] = [0, 62, 0];
 
 export function parseLeadingSemver(version: string | undefined): [number, number, number] | null {
   if (!version) return null;
@@ -52,46 +50,4 @@ export function isNavidromeAudiomuseSoftwareEligible(identity: SubsonicServerIde
   const parsed = parseLeadingSemver(identity.serverVersion);
   if (!parsed) return true;
   return semverGte(parsed, NAVIDROME_MIN_FOR_PLUGINS);
-}
-
-/** Navidrome ≥ 0.62 — `getOpenSubsonicExtensions` can list `sonicSimilarity`. */
-export function isNavidromeSonicSimilarityEligible(identity: SubsonicServerIdentity | undefined): boolean {
-  if (!isNavidromeServer(identity)) return false;
-  const parsed = parseLeadingSemver(identity?.serverVersion);
-  if (!parsed) return false;
-  return semverGte(parsed, NAVIDROME_MIN_FOR_SONIC_SIMILARITY);
-}
-
-/** Navidrome ≥ 0.62 — AudioMuse is auto-enabled from the `sonicSimilarity` probe (no manual toggle). */
-export function isAudiomusePluginAutoManaged(identity: SubsonicServerIdentity | undefined): boolean {
-  return isNavidromeSonicSimilarityEligible(identity);
-}
-
-export type AudiomusePluginProbeUiStatus = 'checking' | 'active' | 'not_detected' | 'failed' | 'unknown';
-
-export function resolveAudiomusePluginProbeUiStatus(
-  probe: AudiomusePluginProbeResult | undefined,
-): AudiomusePluginProbeUiStatus {
-  switch (probe) {
-    case 'present': return 'active';
-    case 'probing': return 'checking';
-    case 'absent': return 'not_detected';
-    case 'error': return 'failed';
-    default: return 'unknown';
-  }
-}
-
-/**
- * Whether to show the per-server AudioMuse row in Settings.
- * Navidrome ≥ 0.62: always (status indicator). Older Navidrome: legacy Instant Mix probe gate.
- */
-export function showAudiomuseNavidromeServerSetting(
-  identity: SubsonicServerIdentity | undefined,
-  instantMixProbe: InstantMixProbeResult | undefined,
-  _pluginProbe: AudiomusePluginProbeResult | undefined,
-): boolean {
-  if (!isNavidromeAudiomuseSoftwareEligible(identity)) return false;
-  if (isNavidromeSonicSimilarityEligible(identity)) return true;
-  if (instantMixProbe === 'empty') return false;
-  return true;
 }


### PR DESCRIPTION
## Summary

Adds a declarative **server-capability framework** and uses it to detect and route Navidrome/AudioMuse features, plus a new **PsyLab → Connections** diagnostics tab.

### Server capability framework (`src/serverCapabilities/`)
- Declarative **catalog** of features → strategies per server generation, with detection, trust, activation and call routing — no version `if`s scattered across UI/call-sites.
- `context` (type/version/openSubsonic + semver), `resolve` (pickStrategy, neededProbeIds, resolveCapability, isCapabilityActive, resolveCallChain), and a `storeView` read facade over the existing per-server probe maps.

### AudioMuse detection & path routing
- Probe AudioMuse via the OpenSubsonic `sonicSimilarity` extension on **Navidrome 0.62+** (reliable plugin signal); legacy `getSimilarSongs` probe on 0.60–0.61.
- New `getSonicSimilarTracks` API client + `fetchSimilarTracksRouted` router: **prefers `getSonicSimilarTracks` on 0.62+ with the plugin, falls back to legacy `getSimilarSongs`** otherwise.
- Instant Mix and Lucky Mix now go through the router.

### Settings (Servers tab)
- Navidrome **0.62+**: AudioMuse becomes an **auto-managed status indicator** (Active / Not detected / Checking / Probe failed), no manual toggle, no description noise — just the feature and its status.
- Older Navidrome: keeps the **manual toggle** and its explanatory text.

### PsyLab → Connections tab
- New diagnostics tab: connection/session status badges, server identity, **Navidrome admin vs standard-user role** probe, AudioMuse provider/detection/trust/mode and the resolved call route.
- UI polish (status badges, detail lists) and a fix for the tab bar collapsing in height.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm test` — full suite green (1888 tests) + CSS import graph
- [x] New unit tests: `serverCapabilities/resolve`, `serverCapabilities/storeView`, `subsonicArtists.router`
- [ ] Manual: Navidrome 0.62+ with AudioMuse → indicator shows Active, Instant Mix uses sonic endpoint
- [ ] Manual: Navidrome 0.62+ without plugin → Not detected, Instant Mix falls back to getSimilarSongs
- [ ] Manual: Navidrome 0.60/0.61 → manual toggle + description