### PR TITLE
refactor(themes): make the Now Playing page fully themeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Themes — community Theme Store
 
-**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1009](https://github.com/Psychotoxical/psysonic/pull/1009), [#1011](https://github.com/Psychotoxical/psysonic/pull/1011), [#1012](https://github.com/Psychotoxical/psysonic/pull/1012), [#1013](https://github.com/Psychotoxical/psysonic/pull/1013), [#1014](https://github.com/Psychotoxical/psysonic/pull/1014), [#1015](https://github.com/Psychotoxical/psysonic/pull/1015), [#1016](https://github.com/Psychotoxical/psysonic/pull/1016), [#1018](https://github.com/Psychotoxical/psysonic/pull/1018), [#1020](https://github.com/Psychotoxical/psysonic/pull/1020), [#1036](https://github.com/Psychotoxical/psysonic/pull/1036)**
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1009](https://github.com/Psychotoxical/psysonic/pull/1009), [#1011](https://github.com/Psychotoxical/psysonic/pull/1011), [#1012](https://github.com/Psychotoxical/psysonic/pull/1012), [#1013](https://github.com/Psychotoxical/psysonic/pull/1013), [#1014](https://github.com/Psychotoxical/psysonic/pull/1014), [#1015](https://github.com/Psychotoxical/psysonic/pull/1015), [#1016](https://github.com/Psychotoxical/psysonic/pull/1016), [#1018](https://github.com/Psychotoxical/psysonic/pull/1018), [#1020](https://github.com/Psychotoxical/psysonic/pull/1020), [#1036](https://github.com/Psychotoxical/psysonic/pull/1036), [#1038](https://github.com/Psychotoxical/psysonic/pull/1038)**
 
 * New **Settings → Themes** tab: pick a theme, set the day/night scheduler, and browse a built-in **Theme Store** to install, update and uninstall community themes — with search, a dark/light filter, and full-size thumbnail previews.
 * The app now bundles six core themes (Catppuccin Mocha & Latte, Kanagawa Wave, Stark HUD, and the colour-blind-safe Vision Dark / Vision Navy); every other palette installs on demand from the [psysonic-themes](https://github.com/Psysonic/psysonic-themes) repo. Installed themes are saved locally and apply instantly at startup, even offline.
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Themes are **free-form** — beyond recolouring, they can add their own styling and animations and react to playback / fullscreen / sidebar / lyrics state. A safety floor (no network, no scripts) is always enforced; store themes are reviewed, and imported themes install at your own risk.
 * The store paginates large catalogues, and refreshing the list no longer jumps back to the top.
 * Each store theme shows its **total downloads** and a **last-changed** date, and can be sorted by most popular, newest or name; the catalogue now has numbered page navigation. These stats refresh once a day.
+* The **Now Playing** page now follows the active theme end to end — light themes render it legibly instead of washed-out, with no per-theme tweaks needed.
 * Upgrading from an older build: an active or scheduled theme that has moved to the store and isn't installed falls back to Mocha (dark) / Latte (light).
 
 

--- a/src/styles/components/now-playing-page-2.css
+++ b/src/styles/components/now-playing-page-2.css
@@ -35,11 +35,11 @@
   align-items: center;
   gap: 28px;
   padding: 32px;
-  background: rgba(0, 0, 0, 0.30);
+  background: var(--bg-glass);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border);
   flex-shrink: 0;
 }
 
@@ -92,7 +92,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
   margin-bottom: 10px;
   text-align: right;
 }
@@ -102,8 +102,8 @@
   font-weight: 600;
   padding: 6px 14px;
   border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.10);
-  color: rgba(255, 255, 255, 0.75);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
   letter-spacing: 0.03em;
   white-space: nowrap;
 }
@@ -119,16 +119,16 @@
 }
 .np-tag-clickable:hover {
   background: color-mix(in srgb, var(--accent) 30%, transparent);
-  color: white;
+  color: var(--text-primary);
 }
 
 /* ── Info cards (artist / album) ── */
 .np-info-card {
-  background: rgba(0, 0, 0, 0.22);
+  background: var(--bg-glass);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(255, 255, 255, 0.07);
+  border: 1px solid var(--border);
   padding: 20px 24px;
   display: flex;
   flex-direction: column;
@@ -147,7 +147,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.07em;
-  color: rgba(255, 255, 255, 0.70);
+  color: var(--text-secondary);
   margin: 0;
 }
 
@@ -194,7 +194,7 @@
 .np-bio-text {
   font-size: 13px;
   line-height: 1.65;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-secondary);
   user-select: text;
   display: -webkit-box;
   -webkit-line-clamp: 4;
@@ -270,15 +270,15 @@
   transition: background 0.12s;
 }
 .np-album-track:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--bg-hover);
 }
 .np-album-track.active {
-  background: rgba(255, 255, 255, 0.08);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 .np-album-track-num {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
   text-align: right;
   font-variant-numeric: tabular-nums;
   display: flex;
@@ -291,7 +291,7 @@
 
 .np-album-track-title {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.80);
+  color: var(--text-secondary);
 }
 .np-album-track.active .np-album-track-title {
   color: var(--accent);
@@ -300,7 +300,7 @@
 
 .np-album-track-dur {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-secondary);
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
@@ -312,8 +312,8 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-left: 1px solid rgba(255, 255, 255, 0.07);
-  background: rgba(0, 0, 0, 0.28);
+  border-left: 1px solid var(--border-subtle);
+  background: var(--bg-glass);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
   position: relative;
@@ -322,7 +322,7 @@
 
 .np-qs-header {
   padding: 16px 14px 12px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  border-bottom: 1px solid var(--border-subtle);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -333,12 +333,12 @@
 .np-qs-title {
   font-size: 13px;
   font-weight: 700;
-  color: white;
+  color: var(--text-primary);
 }
 
 .np-qs-meta {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.40);
+  color: var(--text-muted);
   margin-top: 2px;
 }
 
@@ -365,15 +365,15 @@
 }
 .np-qs-item:hover,
 .np-qs-item.context-active {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--bg-hover);
 }
 .np-qs-item.active {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-hover);
 }
 
 .np-qs-num {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.30);
+  color: var(--text-muted);
   text-align: right;
   display: flex;
   align-items: center;
@@ -387,7 +387,7 @@
 
 .np-qs-track-title {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.80);
+  color: var(--text-secondary);
   line-height: 1.3;
 }
 .np-qs-track-title.active {
@@ -397,13 +397,13 @@
 
 .np-qs-track-artist {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.35);
+  color: var(--text-muted);
   margin-top: 1px;
 }
 
 .np-qs-dur {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.30);
+  color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
@@ -464,7 +464,7 @@
   flex-direction: column;
   align-items: center;
   gap: 10px;
-  color: white;
+  color: var(--text-primary);
   max-width: 600px;
 }
 
@@ -473,12 +473,12 @@
   font-size: 36px;
   font-weight: 700;
   line-height: 1.15;
-  color: white;
+  color: var(--text-primary);
 }
 
 .np-artist-album {
   font-size: 19px;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--text-secondary);
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;
@@ -487,7 +487,7 @@
 }
 
 .np-link:hover {
-  color: white;
+  color: var(--text-primary);
   text-decoration: underline;
 }
 
@@ -509,8 +509,8 @@
   font-weight: 600;
   padding: 3px 8px;
   border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.85);
+  background: var(--bg-hover);
+  color: var(--text-primary);
   letter-spacing: 0.04em;
 }
 
@@ -521,7 +521,7 @@
   padding: 2px;
   display: flex;
   align-items: center;
-  color: white;
+  color: var(--text-primary);
   transition: transform 0.15s;
 }
 
@@ -543,7 +543,7 @@
 
 .np-time {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
   min-width: 36px;
@@ -561,7 +561,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--text-secondary);
   display: flex;
   align-items: center;
   padding: 6px;
@@ -570,8 +570,8 @@
 }
 
 .np-ctrl-btn:hover {
-  color: white;
-  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  background: var(--bg-hover);
 }
 
 .np-ctrl-btn:disabled {
@@ -584,14 +584,14 @@
 }
 
 .np-ctrl-lg {
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text-primary);
 }
 
 .np-ctrl-play {
   width: 60px;
   height: 60px;
   border-radius: 50%;
-  background: white;
+  background: var(--text-primary);
   color: var(--bg-app);
   border: none;
   cursor: pointer;
@@ -616,7 +616,7 @@
 
 .np-volume-slider {
   width: 120px;
-  accent-color: white;
+  accent-color: var(--text-primary);
   opacity: 0.7;
   cursor: pointer;
 }

--- a/src/styles/components/np-dash.css
+++ b/src/styles/components/np-dash.css
@@ -12,11 +12,11 @@
   grid-template-columns: auto 1fr;
   gap: 28px;
   padding: 28px;
-  background: rgba(0, 0, 0, 0.30);
+  background: var(--bg-glass);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border);
   align-items: center;
 }
 
@@ -56,7 +56,7 @@
 
 .np-dash-hero-sub {
   font-size: 15px;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text-secondary);
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -94,13 +94,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-secondary);
   border-radius: var(--radius-sm);
   transition: color 0.15s, background 0.15s;
 }
 .np-dash-icon-btn:hover {
   color: var(--accent);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--bg-hover);
 }
 .np-dash-lfm-btn.is-loved {
   color: var(--accent);
@@ -129,7 +129,7 @@
   gap: 5px;
   margin-top: 8px;
   padding: 12px 14px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-hover);
   border-radius: var(--radius-md);
   border-left: 3px solid var(--accent);
 }
@@ -152,19 +152,19 @@
   align-items: baseline;
   gap: 6px;
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text-secondary);
   font-variant-numeric: tabular-nums;
 }
 .np-dash-hero-lfm-scope {
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--text-primary);
 }
 .np-dash-hero-lfm-sep {
-  color: rgba(255, 255, 255, 0.35);
+  color: var(--text-muted);
   padding: 0 2px;
 }
 .np-dash-hero-lfm-dot {
-  color: rgba(255, 255, 255, 0.30);
+  color: var(--text-muted);
   padding: 0 3px;
 }
 .np-dash-hero-lfm-you {
@@ -185,9 +185,9 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: rgba(255, 255, 255, 0.06);
-  color: rgba(255, 255, 255, 0.75);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   padding: 6px 10px;
   font-size: 12px;
@@ -195,12 +195,12 @@
   transition: background 0.15s, color 0.15s;
 }
 .np-dash-toolbar-btn:hover {
-  background: rgba(255, 255, 255, 0.10);
+  background: var(--bg-hover);
   color: var(--accent);
 }
 .np-dash-toolbar-badge {
   background: var(--accent);
-  color: var(--bg-app, #1e1e2e);
+  color: var(--text-on-accent);
   font-size: 10px;
   font-weight: 700;
   padding: 1px 6px;
@@ -214,8 +214,8 @@
   top: calc(100% + 4px);
   right: 0;
   min-width: 220px;
-  background: var(--bg-app, #1e1e2e);
-  border: 1px solid rgba(255, 255, 255, 0.10);
+  background: var(--menu-bg);
+  border: 1px solid var(--border);
   border-radius: var(--radius-md);
   padding: 6px;
   z-index: 50;
@@ -226,13 +226,13 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--text-muted);
   padding: 6px 8px 4px;
 }
 .np-dash-toolbar-empty {
   padding: 8px 10px;
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.50);
+  color: var(--text-muted);
   font-style: italic;
 }
 .np-dash-toolbar-item {
@@ -243,7 +243,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--text-primary);
   font-size: 12.5px;
   padding: 7px 10px;
   border-radius: var(--radius-sm);
@@ -251,13 +251,13 @@
   transition: background 0.1s;
 }
 .np-dash-toolbar-item:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-hover);
   color: var(--accent);
 }
 .np-dash-toolbar-divider {
   height: 1px;
   margin: 4px 0;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--border-subtle);
 }
 
 /* Widget wrapper — makes each card a psyDnD drag source */
@@ -269,9 +269,9 @@
   transition: transform 0.15s;
 }
 .np-dash-col.is-drop-target {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--bg-hover);
   border-radius: var(--radius-lg);
-  outline: 1px dashed rgba(255, 255, 255, 0.10);
+  outline: 1px dashed var(--border);
   outline-offset: 4px;
 }
 
@@ -292,8 +292,8 @@
   padding: 28px 18px;
   text-align: center;
   font-size: 12.5px;
-  color: rgba(255, 255, 255, 0.40);
-  border: 1px dashed rgba(255, 255, 255, 0.10);
+  color: var(--text-muted);
+  border: 1px dashed var(--border);
   border-radius: var(--radius-lg);
   font-style: italic;
 }
@@ -340,9 +340,9 @@
   font-weight: 600;
   padding: 5px 11px;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.06);
-  color: rgba(255, 255, 255, 0.72);
+  border: 1px solid var(--border);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
   white-space: nowrap;
@@ -352,14 +352,14 @@
 }
 
 .np-artist-tab:hover {
-  background: rgba(255, 255, 255, 0.10);
-  color: rgba(255, 255, 255, 0.92);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .np-artist-tab.is-active {
   background: color-mix(in srgb, var(--accent) 28%, transparent);
   border-color: color-mix(in srgb, var(--accent) 45%, transparent);
-  color: white;
+  color: var(--text-primary);
 }
 
 .np-dash-artist-body {
@@ -388,7 +388,7 @@
 .np-dash-artist-name {
   font-size: 16px;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--text-primary);
 }
 
 .np-dash-similar {
@@ -406,15 +406,15 @@
   font-weight: 500;
   padding: 4px 10px;
   border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.75);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
   white-space: nowrap;
 }
 .np-chip:hover {
   background: color-mix(in srgb, var(--accent) 30%, transparent);
-  color: white;
+  color: var(--text-primary);
 }
 
 /* Album card meta line */
@@ -424,11 +424,11 @@
   align-items: baseline;
   gap: 8px;
   font-size: 12.5px;
-  color: rgba(255, 255, 255, 0.70);
+  color: var(--text-secondary);
 }
 .np-dash-album-name {
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--text-primary);
 }
 .np-dash-album-stats {
   display: inline-flex;
@@ -454,15 +454,15 @@
   transition: background 0.12s;
 }
 .np-dash-top-row:hover {
-  background: rgba(255, 255, 255, 0.07);
+  background: var(--bg-hover);
 }
 .np-dash-top-row.active {
-  background: rgba(255, 255, 255, 0.10);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 .np-dash-top-rank {
   font-size: 12px;
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
@@ -477,7 +477,7 @@
 }
 .np-dash-top-title {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--text-primary);
 }
 .np-dash-top-row.active .np-dash-top-title {
   color: var(--accent);
@@ -485,15 +485,15 @@
 }
 .np-dash-top-sub {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.50);
+  color: var(--text-muted);
 }
 .np-dash-top-dur {
   font-size: 12px;
   font-variant-numeric: tabular-nums;
-  color: rgba(255, 255, 255, 0.60);
+  color: var(--text-muted);
 }
 .np-dash-top-play {
-  color: rgba(255, 255, 255, 0.35);
+  color: var(--text-muted);
   transition: color 0.15s;
 }
 .np-dash-top-row:hover .np-dash-top-play {
@@ -501,7 +501,7 @@
 }
 .np-dash-top-credit {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.40);
+  color: var(--text-muted);
   margin-top: 2px;
 }
 
@@ -545,7 +545,7 @@
   aspect-ratio: 1 / 1;
   border-radius: var(--radius-sm);
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-hover);
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.35);
   position: relative;
 }
@@ -564,7 +564,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.30);
+  color: var(--text-muted);
 }
 
 /* Last.fm stats */
@@ -576,14 +576,14 @@
 .np-dash-stats-row + .np-dash-stats-row {
   margin-top: 4px;
   padding-top: 12px;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid var(--border-subtle);
 }
 .np-dash-stats-label {
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--text-muted);
 }
 .np-dash-stats-values {
   display: flex;
@@ -599,7 +599,7 @@
 .np-dash-stat-value {
   font-size: 20px;
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--text-primary);
   letter-spacing: -0.01em;
   font-variant-numeric: tabular-nums;
 }
@@ -608,7 +608,7 @@
 }
 .np-dash-stat-sub {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.50);
+  color: var(--text-muted);
   text-transform: lowercase;
 }
 .np-dash-stats-links {

--- a/src/styles/components/radio-nowplaying-section.css
+++ b/src/styles/components/radio-nowplaying-section.css
@@ -27,14 +27,14 @@
 
 .np-radio-time {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-muted);
   min-width: 32px;
 }
 
 .np-radio-progress-bar {
   flex: 1;
   height: 4px;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--bg-hover);
   border-radius: 2px;
   overflow: hidden;
 }
@@ -94,7 +94,7 @@
 .radio-progress-bar {
   width: 100%;
   height: 4px;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--bg-hover);
   border-radius: 2px;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- The Now Playing page (`np-dash.css`, `now-playing-page-2.css`, `radio-nowplaying-section.css`) had ~80 hardcoded `rgba(255,255,255,…)` / `rgba(0,0,0,…)` colours built for dark themes, so light themes rendered it washed-out white-on-light and theme designers couldn't fix it.
- All of them now read from the semantic token surface (text / surface / border / `--bg-glass`), so **any theme themes the page via the standard tokens** — no per-component overrides needed.
- Dark themes are unchanged (the tokens' dark values match the previous hardcodes); the info-card / queue glass panels move to `--bg-glass` (slightly more present on dark, readable on light).
- Cover-art content (fullscreen player, home hero) is intentionally left fixed white and is out of scope.

## Test plan
- `npm run build` clean.
- Verified live (`--theme-watch`): a light theme now renders the page legibly; Mocha (dark) unchanged apart from the slightly more present glass panels.
- grep-verified: zero colour hardcodes left in the four Now Playing CSS files (box-shadows aside).