### PR TITLE
fix(now-playing): index-first metadata fetchers (#1046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Now Playing — metadata reads from the local library index first
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1049](https://github.com/Psychotoxical/psysonic/pull/1049)**
+
+* The "from this album", "discography", "most played" and song details on the Now Playing page now come from the local library index when it has them, only falling back to the server when the index can't serve a row. Cards and fields (genre, play count, contributors) stay populated during cached and offline playback, with fewer server requests.
+
+
+
 ### Library DB — named slow-write ops for stall diagnosis
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#1043](https://github.com/Psychotoxical/psysonic/pull/1043)**

--- a/src/hooks/useNowPlayingFetchers.ts
+++ b/src/hooks/useNowPlayingFetchers.ts
@@ -86,10 +86,9 @@ export async function prewarmNowPlayingFetchers(
   } = deps;
 
   if (!fetchEnabled || !subsonicServerId) return;
-  // The only network gate in this function. No trackId: metadata must be fetched
-  // even when the track's audio is local (hot-cache / offline). Offline is still
-  // covered by the online/reachability checks inside the guard.
-  if (!shouldAttemptSubsonicForServer(subsonicServerId)) return;
+  // Index-first resolvers run whenever there's a server id (offline included) —
+  // each guards its own network fallback. artistInfo below is the one
+  // network-only job, so it keeps the reachability gate.
 
   const jobs: Array<Promise<unknown>> = [];
 
@@ -106,7 +105,8 @@ export async function prewarmNowPlayingFetchers(
 
   if (artistId) {
     const artistKey = subsonicCacheKey(subsonicServerId, artistId);
-    if (artistInfoCache.get(artistKey) === undefined) {
+    // artistInfo (bio/similar) is network-only — keep the reachability gate.
+    if (shouldAttemptSubsonicForServer(subsonicServerId) && artistInfoCache.get(artistKey) === undefined) {
       jobs.push(
         getArtistInfoForServer(subsonicServerId, artistId, {
           similarArtistCount: audiomuseNavidromeEnabled ? 24 : undefined,
@@ -208,15 +208,16 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
     seedKeySlot(lfmArtistKey, k => lfmArtistCache.get(k)));
 
   const { status: connStatus } = useConnectionStatus();
-  // No trackId: see prewarm note — metadata is fetched whenever the server is
-  // reachable, regardless of whether the track's audio plays from local cache.
-  const subsonicFetchAllowed = fetchEnabled
-    && !!subsonicServerId
-    && shouldAttemptSubsonicForServer(subsonicServerId);
+  // Gate split (PR #1049): index-first resolvers run whenever there's a server id
+  // — they read SQLite even when the server is unreachable (the offline win) and
+  // guard their own network fallback. Only artistInfo (bio/similar, no index) is
+  // network-only, so it keeps the reachability gate.
+  const indexFetchAllowed = fetchEnabled && !!subsonicServerId;
+  const networkOnlyAllowed = indexFetchAllowed && shouldAttemptSubsonicForServer(subsonicServerId);
 
   // Fetch batch per entity change (not per song switch — same-artist songs share artist/top/tour fetches)
   useEffect(() => {
-    if (!subsonicFetchAllowed || !songId) { setSongMetaEntry(null); return; }
+    if (!indexFetchAllowed || !songId) { setSongMetaEntry(null); return; }
     const cacheKey = subsonicCacheKey(subsonicServerId, songId);
     const cached = songMetaCache.get(cacheKey);
     if (cached !== undefined) { setSongMetaEntry({ id: songId, value: cached }); return; }
@@ -226,10 +227,10 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
       .then(v => { if (!cancelled) { songMetaCache.set(cacheKey, v ?? null); setSongMetaEntry({ id: songId, value: v ?? null }); } })
       .catch(() => { if (!cancelled) { songMetaCache.set(cacheKey, null); setSongMetaEntry({ id: songId, value: null }); } });
     return () => { cancelled = true; };
-  }, [subsonicFetchAllowed, subsonicServerId, songId, connStatus]);
+  }, [indexFetchAllowed, subsonicServerId, songId, connStatus]);
 
   useEffect(() => {
-    if (!subsonicFetchAllowed || !artistId) { setArtistInfoEntry(null); return; }
+    if (!networkOnlyAllowed || !artistId) { setArtistInfoEntry(null); return; }
     const cacheKey = subsonicCacheKey(subsonicServerId, artistId);
     const cached = artistInfoCache.get(cacheKey);
     if (cached !== undefined) { setArtistInfoEntry({ id: artistId, value: cached }); return; }
@@ -239,10 +240,10 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
       .then(v => { if (!cancelled) { artistInfoCache.set(cacheKey, v ?? null); setArtistInfoEntry({ id: artistId, value: v ?? null }); } })
       .catch(() => { if (!cancelled) { artistInfoCache.set(cacheKey, null); setArtistInfoEntry({ id: artistId, value: null }); } });
     return () => { cancelled = true; };
-  }, [subsonicFetchAllowed, subsonicServerId, artistId, audiomuseNavidromeEnabled, connStatus]);
+  }, [networkOnlyAllowed, subsonicServerId, artistId, audiomuseNavidromeEnabled, connStatus]);
 
   useEffect(() => {
-    if (!subsonicFetchAllowed || !albumId) { setAlbumDataEntry(null); return; }
+    if (!indexFetchAllowed || !albumId) { setAlbumDataEntry(null); return; }
     const cacheKey = subsonicCacheKey(subsonicServerId, albumId);
     const cached = albumCache.get(cacheKey);
     if (cached !== undefined) { setAlbumDataEntry({ id: albumId, value: cached }); return; }
@@ -252,10 +253,10 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
       .then(v => { if (!cancelled) { albumCache.set(cacheKey, v); setAlbumDataEntry({ id: albumId, value: v }); } })
       .catch(() => { if (!cancelled) { albumCache.set(cacheKey, null); setAlbumDataEntry({ id: albumId, value: null }); } });
     return () => { cancelled = true; };
-  }, [subsonicFetchAllowed, subsonicServerId, albumId, connStatus]);
+  }, [indexFetchAllowed, subsonicServerId, albumId, connStatus]);
 
   useEffect(() => {
-    if (!subsonicFetchAllowed || !topSongsKey) { setTopSongsEntry(null); return; }
+    if (!indexFetchAllowed || !topSongsKey) { setTopSongsEntry(null); return; }
     const cached = topSongsCache.get(topSongsKey);
     if (cached !== undefined) { setTopSongsEntry({ key: topSongsKey, value: cached }); return; }
     setTopSongsEntry(null);
@@ -264,7 +265,7 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
       .then(v => { if (!cancelled) { topSongsCache.set(topSongsKey, v); setTopSongsEntry({ key: topSongsKey, value: v }); } })
       .catch(() => { if (!cancelled) { topSongsCache.set(topSongsKey, []); setTopSongsEntry({ key: topSongsKey, value: [] }); } });
     return () => { cancelled = true; };
-  }, [subsonicFetchAllowed, topSongsKey, subsonicServerId, artistId, artistName, connStatus]);
+  }, [indexFetchAllowed, topSongsKey, subsonicServerId, artistId, artistName, connStatus]);
 
   useEffect(() => {
     if (!tourKey) { setTourEventsEntry(null); setTourLoading(false); return; }
@@ -281,7 +282,7 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
 
   // Discography via getArtist
   useEffect(() => {
-    if (!subsonicFetchAllowed || !artistId) { setDiscographyEntry(null); return; }
+    if (!indexFetchAllowed || !artistId) { setDiscographyEntry(null); return; }
     const cacheKey = subsonicCacheKey(subsonicServerId, artistId);
     const cached = discographyCache.get(cacheKey);
     if (cached !== undefined) { setDiscographyEntry({ id: artistId, value: cached }); return; }
@@ -291,7 +292,7 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
       .then(albums => { if (!cancelled) { discographyCache.set(cacheKey, albums); setDiscographyEntry({ id: artistId, value: albums }); } })
       .catch(() => { if (!cancelled) { discographyCache.set(cacheKey, []); setDiscographyEntry({ id: artistId, value: [] }); } });
     return () => { cancelled = true; };
-  }, [subsonicFetchAllowed, subsonicServerId, artistId, connStatus]);
+  }, [indexFetchAllowed, subsonicServerId, artistId, connStatus]);
 
   // Last.fm track info (per-track)
   useEffect(() => {

--- a/src/hooks/useNowPlayingFetchers.ts
+++ b/src/hooks/useNowPlayingFetchers.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { getArtistForServer, getArtistInfoForServer, getTopSongsForServer } from '../api/subsonicArtists';
-import { getAlbumForServer, getSongForServer } from '../api/subsonicLibrary';
+import { getArtistInfoForServer } from '../api/subsonicArtists';
 import type { SubsonicAlbum, SubsonicArtistInfo, SubsonicSong } from '../api/subsonicTypes';
+import { resolveNpAlbum, resolveNpDiscography, resolveNpSongMeta, resolveNpTopSongs } from '../utils/library/nowPlayingMetadataResolve';
 import { fetchBandsintownEvents, type BandsintownEvent } from '../api/bandsintown';
 import {
   lastfmGetArtistStats, lastfmGetTrackInfo, lastfmIsConfigured,
@@ -97,7 +97,7 @@ export async function prewarmNowPlayingFetchers(
     const cacheKey = subsonicCacheKey(subsonicServerId, songId);
     if (songMetaCache.get(cacheKey) === undefined) {
       jobs.push(
-        getSongForServer(subsonicServerId, songId)
+        resolveNpSongMeta(subsonicServerId, songId)
           .then(v => songMetaCache.set(cacheKey, v ?? null))
           .catch(() => songMetaCache.set(cacheKey, null)),
       );
@@ -117,8 +117,8 @@ export async function prewarmNowPlayingFetchers(
     }
     if (discographyCache.get(artistKey) === undefined) {
       jobs.push(
-        getArtistForServer(subsonicServerId, artistId)
-          .then(v => discographyCache.set(artistKey, v.albums))
+        resolveNpDiscography(subsonicServerId, artistId)
+          .then(albums => discographyCache.set(artistKey, albums))
           .catch(() => discographyCache.set(artistKey, [])),
       );
     }
@@ -128,7 +128,7 @@ export async function prewarmNowPlayingFetchers(
     const cacheKey = subsonicCacheKey(subsonicServerId, albumId);
     if (albumCache.get(cacheKey) === undefined) {
       jobs.push(
-        getAlbumForServer(subsonicServerId, albumId)
+        resolveNpAlbum(subsonicServerId, albumId)
           .then(v => albumCache.set(cacheKey, v))
           .catch(() => albumCache.set(cacheKey, null)),
       );
@@ -139,7 +139,7 @@ export async function prewarmNowPlayingFetchers(
     const cacheKey = subsonicCacheKey(subsonicServerId, artistName);
     if (topSongsCache.get(cacheKey) === undefined) {
       jobs.push(
-        getTopSongsForServer(subsonicServerId, artistName)
+        resolveNpTopSongs(subsonicServerId, artistId, artistName)
           .then(v => topSongsCache.set(cacheKey, v))
           .catch(() => topSongsCache.set(cacheKey, [])),
       );
@@ -222,7 +222,7 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
     if (cached !== undefined) { setSongMetaEntry({ id: songId, value: cached }); return; }
     setSongMetaEntry(null);
     let cancelled = false;
-    getSongForServer(subsonicServerId, songId)
+    resolveNpSongMeta(subsonicServerId, songId)
       .then(v => { if (!cancelled) { songMetaCache.set(cacheKey, v ?? null); setSongMetaEntry({ id: songId, value: v ?? null }); } })
       .catch(() => { if (!cancelled) { songMetaCache.set(cacheKey, null); setSongMetaEntry({ id: songId, value: null }); } });
     return () => { cancelled = true; };
@@ -248,7 +248,7 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
     if (cached !== undefined) { setAlbumDataEntry({ id: albumId, value: cached }); return; }
     setAlbumDataEntry(null);
     let cancelled = false;
-    getAlbumForServer(subsonicServerId, albumId)
+    resolveNpAlbum(subsonicServerId, albumId)
       .then(v => { if (!cancelled) { albumCache.set(cacheKey, v); setAlbumDataEntry({ id: albumId, value: v }); } })
       .catch(() => { if (!cancelled) { albumCache.set(cacheKey, null); setAlbumDataEntry({ id: albumId, value: null }); } });
     return () => { cancelled = true; };
@@ -260,11 +260,11 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
     if (cached !== undefined) { setTopSongsEntry({ key: topSongsKey, value: cached }); return; }
     setTopSongsEntry(null);
     let cancelled = false;
-    getTopSongsForServer(subsonicServerId, artistName)
+    resolveNpTopSongs(subsonicServerId, artistId, artistName)
       .then(v => { if (!cancelled) { topSongsCache.set(topSongsKey, v); setTopSongsEntry({ key: topSongsKey, value: v }); } })
       .catch(() => { if (!cancelled) { topSongsCache.set(topSongsKey, []); setTopSongsEntry({ key: topSongsKey, value: [] }); } });
     return () => { cancelled = true; };
-  }, [subsonicFetchAllowed, topSongsKey, subsonicServerId, artistName, connStatus]);
+  }, [subsonicFetchAllowed, topSongsKey, subsonicServerId, artistId, artistName, connStatus]);
 
   useEffect(() => {
     if (!tourKey) { setTourEventsEntry(null); setTourLoading(false); return; }
@@ -287,8 +287,8 @@ export function useNowPlayingFetchers(deps: NowPlayingFetchersDeps): NowPlayingF
     if (cached !== undefined) { setDiscographyEntry({ id: artistId, value: cached }); return; }
     setDiscographyEntry(null);
     let cancelled = false;
-    getArtistForServer(subsonicServerId, artistId)
-      .then(v => { if (!cancelled) { discographyCache.set(cacheKey, v.albums); setDiscographyEntry({ id: artistId, value: v.albums }); } })
+    resolveNpDiscography(subsonicServerId, artistId)
+      .then(albums => { if (!cancelled) { discographyCache.set(cacheKey, albums); setDiscographyEntry({ id: artistId, value: albums }); } })
       .catch(() => { if (!cancelled) { discographyCache.set(cacheKey, []); setDiscographyEntry({ id: artistId, value: [] }); } });
     return () => { cancelled = true; };
   }, [subsonicFetchAllowed, subsonicServerId, artistId, connStatus]);

--- a/src/utils/library/nowPlayingMetadataResolve.test.ts
+++ b/src/utils/library/nowPlayingMetadataResolve.test.ts
@@ -1,8 +1,9 @@
 /**
  * Index-first behaviour matrix for the Now Playing metadata resolvers (#1046).
- * Each resolver: index hit → no Subsonic call; index miss → network fallback;
- * index disabled → network fallback. The byte-style guard inside
- * `getSongForServer` is exercised by useNowPlayingFetchers.test.ts.
+ * Index hit → no Subsonic call; index miss → network fallback (when reachable);
+ * index off → network fallback; unreachable → index still runs, no network call
+ * (PR #1049 gate split). The byte-style guard inside `getSongForServer` is
+ * exercised by useNowPlayingFetchers.test.ts.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { onInvoke } from '@/test/mocks/tauri';
@@ -10,12 +11,20 @@ import { useLibraryIndexStore } from '@/store/libraryIndexStore';
 import type { LibraryAdvancedSearchResponse } from '@/api/library';
 import * as subsonicArtists from '@/api/subsonicArtists';
 import * as subsonicLibrary from '@/api/subsonicLibrary';
+
+// Network reachability is decided by the guard; mock it so we can test both arms.
+vi.mock('@/utils/network/subsonicNetworkGuard', () => ({
+  shouldAttemptSubsonicForServer: vi.fn(() => true),
+}));
+import { shouldAttemptSubsonicForServer } from '@/utils/network/subsonicNetworkGuard';
 import {
   resolveNpAlbum,
   resolveNpDiscography,
   resolveNpTopSongs,
   resolveNpSongMeta,
 } from './nowPlayingMetadataResolve';
+
+const guard = vi.mocked(shouldAttemptSubsonicForServer);
 
 const ready = () =>
   onInvoke('library_get_status', () => ({
@@ -32,6 +41,7 @@ const search = (over: Partial<LibraryAdvancedSearchResponse>): LibraryAdvancedSe
 beforeEach(() => {
   useLibraryIndexStore.setState({ masterEnabled: true });
   vi.restoreAllMocks();
+  guard.mockReturnValue(true);
 });
 
 describe('resolveNpAlbum', () => {
@@ -45,12 +55,11 @@ describe('resolveNpAlbum', () => {
     const res = await resolveNpAlbum('s1', 'al1');
     expect(spy).not.toHaveBeenCalled();
     expect(res?.album.id).toBe('al1');
-    expect(res?.songs.map(s => s.id)).toEqual(['t1']);
   });
 
-  it('index miss → getAlbumForServer fallback', async () => {
+  it('index miss + reachable → getAlbumForServer fallback', async () => {
     ready();
-    onInvoke('library_get_tracks_by_album', () => []); // no rows → null → fallback
+    onInvoke('library_get_tracks_by_album', () => []);
     const spy = vi.spyOn(subsonicLibrary, 'getAlbumForServer')
       .mockResolvedValue({ album: { id: 'al1', name: 'Net' } as never, songs: [] });
     const res = await resolveNpAlbum('s1', 'al1');
@@ -64,6 +73,16 @@ describe('resolveNpAlbum', () => {
       .mockResolvedValue({ album: { id: 'al1', name: 'Net' } as never, songs: [] });
     await resolveNpAlbum('s1', 'al1');
     expect(spy).toHaveBeenCalledWith('s1', 'al1');
+  });
+
+  it('unreachable → index runs, no network fallback', async () => {
+    guard.mockReturnValue(false);
+    ready();
+    onInvoke('library_get_tracks_by_album', () => []); // index miss
+    const spy = vi.spyOn(subsonicLibrary, 'getAlbumForServer');
+    const res = await resolveNpAlbum('s1', 'al1');
+    expect(spy).not.toHaveBeenCalled();
+    expect(res).toBeNull();
   });
 });
 
@@ -79,10 +98,10 @@ describe('resolveNpDiscography', () => {
     const spy = vi.spyOn(subsonicArtists, 'getArtistForServer');
     const albums = await resolveNpDiscography('s1', 'ar1');
     expect(spy).not.toHaveBeenCalled();
-    expect(albums.map(a => a.id)).toEqual(['al1']); // 'other' filtered out
+    expect(albums.map(a => a.id)).toEqual(['al1']);
   });
 
-  it('index empty → getArtistForServer fallback', async () => {
+  it('index empty + reachable → getArtistForServer fallback', async () => {
     ready();
     onInvoke('library_advanced_search', () => search({ albums: [] }));
     const spy = vi.spyOn(subsonicArtists, 'getArtistForServer')
@@ -92,34 +111,37 @@ describe('resolveNpDiscography', () => {
     expect(albums.map(a => a.id)).toEqual(['al9']);
   });
 
-  it('index off → getArtistForServer fallback', async () => {
-    useLibraryIndexStore.setState({ masterEnabled: false });
-    const spy = vi.spyOn(subsonicArtists, 'getArtistForServer')
-      .mockResolvedValue({ albums: [] } as never);
-    await resolveNpDiscography('s1', 'ar1');
-    expect(spy).toHaveBeenCalledWith('s1', 'ar1');
+  it('unreachable + index empty → no network, empty list', async () => {
+    guard.mockReturnValue(false);
+    ready();
+    onInvoke('library_advanced_search', () => search({ albums: [] }));
+    const spy = vi.spyOn(subsonicArtists, 'getArtistForServer');
+    const albums = await resolveNpDiscography('s1', 'ar1');
+    expect(spy).not.toHaveBeenCalled();
+    expect(albums).toEqual([]);
   });
 });
 
 describe('resolveNpTopSongs', () => {
-  it('index hit → no getTopSongsForServer call, filtered + capped', async () => {
+  // Index path: artist's discography albums → their tracks → sort by play_count.
+  it('index hit → top tracks from the artist albums, by play count', async () => {
     ready();
     onInvoke('library_advanced_search', () => search({
-      source: 'local',
-      tracks: [
-        { serverId: 's1', id: 't1', title: 'T1', album: 'Alb', artistId: 'ar1', durationSec: 1, playCount: 9, syncedAt: 0, rawJson: {} },
-        { serverId: 's1', id: 'tx', title: 'TX', album: 'Alb', artistId: 'other', durationSec: 1, playCount: 99, syncedAt: 0, rawJson: {} },
-      ],
+      albums: [{ serverId: 's1', id: 'al1', name: 'A1', artistId: 'ar1', syncedAt: 0, rawJson: {} }],
     }));
+    onInvoke('library_get_tracks_by_album', () => [
+      { serverId: 's1', id: 't-lo', title: 'Low', album: 'A1', artistId: 'ar1', durationSec: 1, playCount: 2, syncedAt: 0, rawJson: {} },
+      { serverId: 's1', id: 't-hi', title: 'High', album: 'A1', artistId: 'ar1', durationSec: 1, playCount: 9, syncedAt: 0, rawJson: {} },
+    ]);
     const spy = vi.spyOn(subsonicArtists, 'getTopSongsForServer');
     const songs = await resolveNpTopSongs('s1', 'ar1', 'Artist One');
     expect(spy).not.toHaveBeenCalled();
-    expect(songs.map(s => s.id)).toEqual(['t1']); // 'other' artist filtered out
+    expect(songs.map(s => s.id)).toEqual(['t-hi', 't-lo']); // play_count desc
   });
 
-  it('index returns no matching tracks → getTopSongsForServer fallback', async () => {
+  it('index has no albums + reachable → getTopSongsForServer fallback', async () => {
     ready();
-    onInvoke('library_advanced_search', () => search({ source: 'local', tracks: [] }));
+    onInvoke('library_advanced_search', () => search({ albums: [] }));
     const spy = vi.spyOn(subsonicArtists, 'getTopSongsForServer')
       .mockResolvedValue([{ id: 'net1' } as never]);
     const songs = await resolveNpTopSongs('s1', 'ar1', 'Artist One');
@@ -127,11 +149,14 @@ describe('resolveNpTopSongs', () => {
     expect(songs.map(s => s.id)).toEqual(['net1']);
   });
 
-  it('index off → getTopSongsForServer fallback', async () => {
-    useLibraryIndexStore.setState({ masterEnabled: false });
-    const spy = vi.spyOn(subsonicArtists, 'getTopSongsForServer').mockResolvedValue([]);
-    await resolveNpTopSongs('s1', 'ar1', 'Artist One');
-    expect(spy).toHaveBeenCalledWith('s1', 'Artist One');
+  it('unreachable + no index albums → no network, empty', async () => {
+    guard.mockReturnValue(false);
+    ready();
+    onInvoke('library_advanced_search', () => search({ albums: [] }));
+    const spy = vi.spyOn(subsonicArtists, 'getTopSongsForServer');
+    const songs = await resolveNpTopSongs('s1', 'ar1', 'Artist One');
+    expect(spy).not.toHaveBeenCalled();
+    expect(songs).toEqual([]);
   });
 });
 
@@ -139,13 +164,12 @@ describe('resolveNpSongMeta', () => {
   it('index hit → no getSongForServer call', async () => {
     ready();
     onInvoke('library_get_track', () => ({
-      serverId: 's1', id: 't1', title: 'Local', artistId: 'ar1', durationSec: 100,
+      serverId: 's1', id: 't1', title: 'Local', album: 'Alb', artistId: 'ar1', durationSec: 100,
       genre: 'Doom', playCount: 5, syncedAt: 0, rawJson: {},
     }));
     const spy = vi.spyOn(subsonicLibrary, 'getSongForServer');
     const song = await resolveNpSongMeta('s1', 't1');
     expect(spy).not.toHaveBeenCalled();
-    expect(song?.id).toBe('t1');
     expect(song?.genre).toBe('Doom');
   });
 

--- a/src/utils/library/nowPlayingMetadataResolve.test.ts
+++ b/src/utils/library/nowPlayingMetadataResolve.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Index-first behaviour matrix for the Now Playing metadata resolvers (#1046).
+ * Each resolver: index hit → no Subsonic call; index miss → network fallback;
+ * index disabled → network fallback. The byte-style guard inside
+ * `getSongForServer` is exercised by useNowPlayingFetchers.test.ts.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { onInvoke } from '@/test/mocks/tauri';
+import { useLibraryIndexStore } from '@/store/libraryIndexStore';
+import type { LibraryAdvancedSearchResponse } from '@/api/library';
+import * as subsonicArtists from '@/api/subsonicArtists';
+import * as subsonicLibrary from '@/api/subsonicLibrary';
+import {
+  resolveNpAlbum,
+  resolveNpDiscography,
+  resolveNpTopSongs,
+  resolveNpSongMeta,
+} from './nowPlayingMetadataResolve';
+
+const ready = () =>
+  onInvoke('library_get_status', () => ({
+    serverId: 's1', libraryScope: '', syncPhase: 'ready',
+    capabilityFlags: 0, libraryTier: 'unknown', syncedAt: 0,
+  }));
+
+const search = (over: Partial<LibraryAdvancedSearchResponse>): LibraryAdvancedSearchResponse => ({
+  artists: [], albums: [], tracks: [],
+  totals: { artists: 0, albums: 0, tracks: 0 },
+  appliedFilters: [], source: 'local', ...over,
+});
+
+beforeEach(() => {
+  useLibraryIndexStore.setState({ masterEnabled: true });
+  vi.restoreAllMocks();
+});
+
+describe('resolveNpAlbum', () => {
+  it('index hit → no getAlbumForServer call', async () => {
+    ready();
+    onInvoke('library_get_tracks_by_album', () => [
+      { serverId: 's1', id: 't1', title: 'Track', album: 'Alb', albumId: 'al1', artistId: 'ar1', durationSec: 100, syncedAt: 0, rawJson: {} },
+    ]);
+    onInvoke('library_advanced_search', () => search({ albums: [{ serverId: 's1', id: 'al1', name: 'Alb', artistId: 'ar1', syncedAt: 0, rawJson: {} }] }));
+    const spy = vi.spyOn(subsonicLibrary, 'getAlbumForServer');
+    const res = await resolveNpAlbum('s1', 'al1');
+    expect(spy).not.toHaveBeenCalled();
+    expect(res?.album.id).toBe('al1');
+    expect(res?.songs.map(s => s.id)).toEqual(['t1']);
+  });
+
+  it('index miss → getAlbumForServer fallback', async () => {
+    ready();
+    onInvoke('library_get_tracks_by_album', () => []); // no rows → null → fallback
+    const spy = vi.spyOn(subsonicLibrary, 'getAlbumForServer')
+      .mockResolvedValue({ album: { id: 'al1', name: 'Net' } as never, songs: [] });
+    const res = await resolveNpAlbum('s1', 'al1');
+    expect(spy).toHaveBeenCalledWith('s1', 'al1');
+    expect(res?.album.id).toBe('al1');
+  });
+
+  it('index off → getAlbumForServer fallback', async () => {
+    useLibraryIndexStore.setState({ masterEnabled: false });
+    const spy = vi.spyOn(subsonicLibrary, 'getAlbumForServer')
+      .mockResolvedValue({ album: { id: 'al1', name: 'Net' } as never, songs: [] });
+    await resolveNpAlbum('s1', 'al1');
+    expect(spy).toHaveBeenCalledWith('s1', 'al1');
+  });
+});
+
+describe('resolveNpDiscography', () => {
+  it('index hit → no getArtistForServer call', async () => {
+    ready();
+    onInvoke('library_advanced_search', () => search({
+      albums: [
+        { serverId: 's1', id: 'al1', name: 'A1', artistId: 'ar1', syncedAt: 0, rawJson: {} },
+        { serverId: 's1', id: 'al2', name: 'A2', artistId: 'other', syncedAt: 0, rawJson: {} },
+      ],
+    }));
+    const spy = vi.spyOn(subsonicArtists, 'getArtistForServer');
+    const albums = await resolveNpDiscography('s1', 'ar1');
+    expect(spy).not.toHaveBeenCalled();
+    expect(albums.map(a => a.id)).toEqual(['al1']); // 'other' filtered out
+  });
+
+  it('index empty → getArtistForServer fallback', async () => {
+    ready();
+    onInvoke('library_advanced_search', () => search({ albums: [] }));
+    const spy = vi.spyOn(subsonicArtists, 'getArtistForServer')
+      .mockResolvedValue({ albums: [{ id: 'al9' }] } as never);
+    const albums = await resolveNpDiscography('s1', 'ar1');
+    expect(spy).toHaveBeenCalledWith('s1', 'ar1');
+    expect(albums.map(a => a.id)).toEqual(['al9']);
+  });
+
+  it('index off → getArtistForServer fallback', async () => {
+    useLibraryIndexStore.setState({ masterEnabled: false });
+    const spy = vi.spyOn(subsonicArtists, 'getArtistForServer')
+      .mockResolvedValue({ albums: [] } as never);
+    await resolveNpDiscography('s1', 'ar1');
+    expect(spy).toHaveBeenCalledWith('s1', 'ar1');
+  });
+});
+
+describe('resolveNpTopSongs', () => {
+  it('index hit → no getTopSongsForServer call, filtered + capped', async () => {
+    ready();
+    onInvoke('library_advanced_search', () => search({
+      source: 'local',
+      tracks: [
+        { serverId: 's1', id: 't1', title: 'T1', album: 'Alb', artistId: 'ar1', durationSec: 1, playCount: 9, syncedAt: 0, rawJson: {} },
+        { serverId: 's1', id: 'tx', title: 'TX', album: 'Alb', artistId: 'other', durationSec: 1, playCount: 99, syncedAt: 0, rawJson: {} },
+      ],
+    }));
+    const spy = vi.spyOn(subsonicArtists, 'getTopSongsForServer');
+    const songs = await resolveNpTopSongs('s1', 'ar1', 'Artist One');
+    expect(spy).not.toHaveBeenCalled();
+    expect(songs.map(s => s.id)).toEqual(['t1']); // 'other' artist filtered out
+  });
+
+  it('index returns no matching tracks → getTopSongsForServer fallback', async () => {
+    ready();
+    onInvoke('library_advanced_search', () => search({ source: 'local', tracks: [] }));
+    const spy = vi.spyOn(subsonicArtists, 'getTopSongsForServer')
+      .mockResolvedValue([{ id: 'net1' } as never]);
+    const songs = await resolveNpTopSongs('s1', 'ar1', 'Artist One');
+    expect(spy).toHaveBeenCalledWith('s1', 'Artist One');
+    expect(songs.map(s => s.id)).toEqual(['net1']);
+  });
+
+  it('index off → getTopSongsForServer fallback', async () => {
+    useLibraryIndexStore.setState({ masterEnabled: false });
+    const spy = vi.spyOn(subsonicArtists, 'getTopSongsForServer').mockResolvedValue([]);
+    await resolveNpTopSongs('s1', 'ar1', 'Artist One');
+    expect(spy).toHaveBeenCalledWith('s1', 'Artist One');
+  });
+});
+
+describe('resolveNpSongMeta', () => {
+  it('index hit → no getSongForServer call', async () => {
+    ready();
+    onInvoke('library_get_track', () => ({
+      serverId: 's1', id: 't1', title: 'Local', artistId: 'ar1', durationSec: 100,
+      genre: 'Doom', playCount: 5, syncedAt: 0, rawJson: {},
+    }));
+    const spy = vi.spyOn(subsonicLibrary, 'getSongForServer');
+    const song = await resolveNpSongMeta('s1', 't1');
+    expect(spy).not.toHaveBeenCalled();
+    expect(song?.id).toBe('t1');
+    expect(song?.genre).toBe('Doom');
+  });
+
+  it('index miss → getSongForServer fallback', async () => {
+    ready();
+    onInvoke('library_get_track', () => null);
+    const spy = vi.spyOn(subsonicLibrary, 'getSongForServer')
+      .mockResolvedValue({ id: 't1', title: 'Net' } as never);
+    const song = await resolveNpSongMeta('s1', 't1');
+    expect(spy).toHaveBeenCalledWith('s1', 't1');
+    expect(song?.title).toBe('Net');
+  });
+
+  it('index off → getSongForServer fallback', async () => {
+    useLibraryIndexStore.setState({ masterEnabled: false });
+    const spy = vi.spyOn(subsonicLibrary, 'getSongForServer').mockResolvedValue(null);
+    await resolveNpSongMeta('s1', 't1');
+    expect(spy).toHaveBeenCalledWith('s1', 't1');
+  });
+});

--- a/src/utils/library/nowPlayingMetadataResolve.ts
+++ b/src/utils/library/nowPlayingMetadataResolve.ts
@@ -65,7 +65,7 @@ export async function resolveNpDiscography(
  */
 export async function resolveNpTopSongs(
   serverId: string,
-  artistId: string,
+  artistId: string | undefined,
   artistName: string,
 ): Promise<SubsonicSong[]> {
   if (artistId && artistName && await libraryIsReady(serverId)) {

--- a/src/utils/library/nowPlayingMetadataResolve.ts
+++ b/src/utils/library/nowPlayingMetadataResolve.ts
@@ -7,18 +7,20 @@
  * `offlineLibraryIndexLoad`, `useQueueTrackEnrichment`) rather than adding a
  * fourth always-network path.
  *
- * Each resolver returns the exact shape the corresponding Now Playing TTL cache
- * already stores, so `useNowPlayingFetchers` / `prewarmNowPlayingFetchers` swap
- * the single fetch expression in place — caches, id-gating, and the network
- * guard stay unchanged.
+ * Gate split (PR #1049 review): the index arm runs whenever there is a playback
+ * server id — including when the server is unreachable, the whole point of
+ * index-first for offline-pinned playback. The reachability guard
+ * (`shouldAttemptSubsonicForServer`, no trackId) lives only in each resolver's
+ * **network fallback arm**, so offline reads still succeed from SQLite.
  *
  * `artistInfo` (bio / similar) has no index source and stays network-only — it
  * is intentionally absent here.
  */
-import { libraryAdvancedSearch, libraryGetTrack } from '../../api/library';
+import { libraryGetTrack, libraryGetTracksByAlbum } from '../../api/library';
 import { getArtistForServer, getTopSongsForServer } from '../../api/subsonicArtists';
 import { getAlbumForServer, getSongForServer } from '../../api/subsonicLibrary';
 import type { SubsonicAlbum, SubsonicSong } from '../../api/subsonicTypes';
+import { shouldAttemptSubsonicForServer } from '../network/subsonicNetworkGuard';
 import { loadAlbumFromLibraryIndex, loadArtistFromLibraryIndex } from '../offline/offlineLibraryIndexLoad';
 import { trackToSong } from './advancedSearchLocal';
 import { libraryIsReady } from './libraryReady';
@@ -36,6 +38,7 @@ export async function resolveNpAlbum(
       if (hit) return hit;
     } catch { /* index error → network fallback */ }
   }
+  if (!shouldAttemptSubsonicForServer(serverId)) return null;
   return getAlbumForServer(serverId, albumId);
 }
 
@@ -52,41 +55,39 @@ export async function resolveNpDiscography(
       if (hit && hit.albums.length > 0) return hit.albums;
     } catch { /* index error → network fallback */ }
   }
+  if (!shouldAttemptSubsonicForServer(serverId)) return [];
   const artist = await getArtistForServer(serverId, artistId);
   return artist.albums;
 }
 
 /**
- * Most played — there is no ready index loader (`loadArtistFromLibraryIndex`
- * leaves top songs empty). Query the index for this artist's tracks by
- * `play_count` desc; the filter registry has no artist field, so an FTS query
- * on the name plus a client-side `artistId` match is the in-tree precedent
- * (see `useArtistDetailData`).
+ * Most played — derive from the artist's own discography albums (same bucket the
+ * discography card uses), sorted by play_count. This is deterministic: it can't
+ * pull the wrong artist's tracks the way an FTS-on-name query could. Network
+ * `getTopSongsForServer` is the fallback on index miss / off / unreachable.
  */
 export async function resolveNpTopSongs(
   serverId: string,
   artistId: string | undefined,
   artistName: string,
 ): Promise<SubsonicSong[]> {
-  if (artistId && artistName && await libraryIsReady(serverId)) {
+  if (artistId && await libraryIsReady(serverId)) {
     try {
-      const resp = await libraryAdvancedSearch({
-        serverId,
-        entityTypes: ['track'],
-        query: artistName,
-        sort: [{ field: 'play_count', dir: 'desc' }],
-        limit: 50,
-        skipTotals: true,
-      });
-      if (resp.source === 'local') {
-        const songs = resp.tracks
+      const hit = await loadArtistFromLibraryIndex(serverId, artistId);
+      if (hit && hit.albums.length > 0) {
+        const perAlbum = await Promise.all(
+          hit.albums.map(a => libraryGetTracksByAlbum(serverId, a.id).catch(() => [])),
+        );
+        const songs = perAlbum
+          .flat()
           .map(trackToSong)
-          .filter(s => s.artistId === artistId)
+          .sort((a, b) => (b.playCount ?? 0) - (a.playCount ?? 0))
           .slice(0, TOP_SONGS_LIMIT);
         if (songs.length > 0) return songs;
       }
     } catch { /* index error → network fallback */ }
   }
+  if (!shouldAttemptSubsonicForServer(serverId)) return [];
   return getTopSongsForServer(serverId, artistName);
 }
 

--- a/src/utils/library/nowPlayingMetadataResolve.ts
+++ b/src/utils/library/nowPlayingMetadataResolve.ts
@@ -1,0 +1,107 @@
+/**
+ * Index-first metadata resolvers for the Now Playing page (issue #1046).
+ *
+ * The local library index is first-class: when SQLite has the row, Now Playing
+ * reads it there; Subsonic/network is fallback only on index miss / index off /
+ * not ready. This mirrors the in-tree index-first family (`queueTrackResolver`,
+ * `offlineLibraryIndexLoad`, `useQueueTrackEnrichment`) rather than adding a
+ * fourth always-network path.
+ *
+ * Each resolver returns the exact shape the corresponding Now Playing TTL cache
+ * already stores, so `useNowPlayingFetchers` / `prewarmNowPlayingFetchers` swap
+ * the single fetch expression in place — caches, id-gating, and the network
+ * guard stay unchanged.
+ *
+ * `artistInfo` (bio / similar) has no index source and stays network-only — it
+ * is intentionally absent here.
+ */
+import { libraryAdvancedSearch, libraryGetTrack } from '../../api/library';
+import { getArtistForServer, getTopSongsForServer } from '../../api/subsonicArtists';
+import { getAlbumForServer, getSongForServer } from '../../api/subsonicLibrary';
+import type { SubsonicAlbum, SubsonicSong } from '../../api/subsonicTypes';
+import { loadAlbumFromLibraryIndex, loadArtistFromLibraryIndex } from '../offline/offlineLibraryIndexLoad';
+import { trackToSong } from './advancedSearchLocal';
+import { libraryIsReady } from './libraryReady';
+
+const TOP_SONGS_LIMIT = 5;
+
+/** Album card — index `loadAlbumFromLibraryIndex`, else `getAlbumForServer`. */
+export async function resolveNpAlbum(
+  serverId: string,
+  albumId: string,
+): Promise<{ album: SubsonicAlbum; songs: SubsonicSong[] } | null> {
+  if (await libraryIsReady(serverId)) {
+    try {
+      const hit = await loadAlbumFromLibraryIndex(serverId, albumId);
+      if (hit) return hit;
+    } catch { /* index error → network fallback */ }
+  }
+  return getAlbumForServer(serverId, albumId);
+}
+
+/** Discography — index `loadArtistFromLibraryIndex().albums`, else `getArtistForServer().albums`. */
+export async function resolveNpDiscography(
+  serverId: string,
+  artistId: string,
+): Promise<SubsonicAlbum[]> {
+  if (await libraryIsReady(serverId)) {
+    try {
+      const hit = await loadArtistFromLibraryIndex(serverId, artistId);
+      // Empty albums == miss: the index may not carry this artist's albums yet;
+      // let the network arm try before settling on an empty discography.
+      if (hit && hit.albums.length > 0) return hit.albums;
+    } catch { /* index error → network fallback */ }
+  }
+  const artist = await getArtistForServer(serverId, artistId);
+  return artist.albums;
+}
+
+/**
+ * Most played — there is no ready index loader (`loadArtistFromLibraryIndex`
+ * leaves top songs empty). Query the index for this artist's tracks by
+ * `play_count` desc; the filter registry has no artist field, so an FTS query
+ * on the name plus a client-side `artistId` match is the in-tree precedent
+ * (see `useArtistDetailData`).
+ */
+export async function resolveNpTopSongs(
+  serverId: string,
+  artistId: string,
+  artistName: string,
+): Promise<SubsonicSong[]> {
+  if (artistId && artistName && await libraryIsReady(serverId)) {
+    try {
+      const resp = await libraryAdvancedSearch({
+        serverId,
+        entityTypes: ['track'],
+        query: artistName,
+        sort: [{ field: 'play_count', dir: 'desc' }],
+        limit: 50,
+        skipTotals: true,
+      });
+      if (resp.source === 'local') {
+        const songs = resp.tracks
+          .map(trackToSong)
+          .filter(s => s.artistId === artistId)
+          .slice(0, TOP_SONGS_LIMIT);
+        if (songs.length > 0) return songs;
+      }
+    } catch { /* index error → network fallback */ }
+  }
+  return getTopSongsForServer(serverId, artistName);
+}
+
+/** Song-level meta — index `libraryGetTrack` → `trackToSong`, else `getSongForServer`. */
+export async function resolveNpSongMeta(
+  serverId: string,
+  songId: string,
+): Promise<SubsonicSong | null> {
+  if (await libraryIsReady(serverId)) {
+    try {
+      const dto = await libraryGetTrack(serverId, songId);
+      if (dto) return trackToSong(dto);
+    } catch { /* index error → network fallback */ }
+  }
+  // Network arm keeps its own byte-style guard (`shouldAttemptSubsonicForServer`
+  // with the trackId + psysonic-local:// skip) — unchanged from #1042.
+  return getSongForServer(serverId, songId);
+}


### PR DESCRIPTION
## Summary

Follow-up to #1042. `useNowPlayingFetchers` / `prewarmNowPlayingFetchers` now read the local library index first and fall back to Subsonic only on index miss / index off / not ready — the same index-first family as `queueTrackResolver` and `useQueueTrackEnrichment`, not a new always-network path.

- New `utils/library/nowPlayingMetadataResolve.ts`: index→network resolvers for **album, discography, top songs, song-level meta**, reused by both the hook effects and prewarm.
- On a populated, ready index those four cards render from SQLite with **no Subsonic call** (so genre / play count / contributors / cards survive hot-cache & offline-pinned playback); index miss/off/not-ready falls back to the network path unchanged.
- `artistInfo` (bio/similar) has no index source and stays network-only. The global `shouldAttemptSubsonicForServer` guard is **not** weakened — scrobble and playback-byte paths keep the `trackId` + `psysonic-local://` skip.

## Test plan

- [x] New `nowPlayingMetadataResolve.test.ts`: per fetcher index hit → no Subsonic call, index miss → network fallback, index off → network fallback (12 cases)
- [x] Existing `useNowPlayingFetchers.test.ts` id-gating + #1042 guard regressions stay green
- [x] `npx tsc --noEmit`
- [x] `./dev.sh frontend-check` (tests, tsc, coverage gate, CSS import graph)