### PR TITLE
fix(home): stop Most Played load-more from snapping the page upward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Home — Most Played no longer jumps the page when loading more
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), reported by zunoz on Discord, PR [#1053](https://github.com/Psychotoxical/psysonic/pull/1053)**
+
+* Clicking the arrow to load more albums in the **Most Played** rail sometimes snapped the page up to an earlier section. Loading more now keeps the viewport in place.
+
+
+
 ## [1.47.0]
 
 > **🙏 Thank you to our amazing Discord community.** This release would not have been possible without your tireless support, quality checks, bug reports and all-round collaboration. Every report, every repro and every bit of feedback shaped what shipped here — thank you. Come join us: [discord.gg/AMnDRErm4u](https://discord.gg/AMnDRErm4u)

--- a/src/components/BecauseYouLikeRail.tsx
+++ b/src/components/BecauseYouLikeRail.tsx
@@ -519,7 +519,13 @@ export default function BecauseYouLikeRail({
     })();
 
     return () => { cancelled = true; };
-  }, [pool, activeServerId, musicLibraryFilterVersion, disableArtwork, poolKey]);
+    // Gate on poolKey (the stable top-anchor identity), not the `pool` array ref.
+    // `pool` is rebuilt whenever Home's mostPlayed changes, so loading more Most
+    // Played albums (which feeds this pool) would otherwise re-run this effect and
+    // swap the cards — a height blip above the row that scroll anchoring turns into
+    // an upward viewport jump. The sibling reserve effect already keys on poolKey.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poolKey, activeServerId, musicLibraryFilterVersion, disableArtwork]);
 
   useLibraryCoverPrefetch(
     disableArtwork || recs.length === 0 ? [] : [{ albums: recs, priority: 'high' }],


### PR DESCRIPTION
## Summary
- Loading more in the **Mainstage → Most Played** rail sometimes snapped the viewport up to an element higher on the page.
- Root cause: `mostPlayed` seeds the Because-You-Like anchor pool, and that rail's fetch effect keyed on the `pool` array ref — which is rebuilt on every Most Played append. So each load-more re-ran the effect and swapped the upper rail's cards, a height blip that scroll anchoring turned into an upward jump.
- Gated the effect on `poolKey` (the stable top-anchor identity), matching the sibling reserve effect, so it only re-runs on a real seed change. No other rail feeds a rail above it.

## Test plan
- `npx tsc --noEmit` clean.
- Verified in dev: repeated load-more in Most Played keeps the viewport in place; the Because-You-Like rail stays put.