### PR TITLE
fix(whats-new): allow plugin-fs write into AppData cache dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,6 +341,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### What's New — release-notes cache file on disk (RC/stable)
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#TBD](https://github.com/Psychotoxical/psysonic/pull/TBD)**
+
+* RC and stable builds now persist the downloaded `whats-new.md` slice under AppData — `plugin-fs` had mkdir but lacked recursive write scope, so the `release-notes/` folder appeared empty and every launch re-fetched from GitHub.
+
+
+
 ## [1.47.0]
 
 > **🙏 Thank you to our amazing Discord community.** This release would not have been possible without your tireless support, quality checks, bug reports and all-round collaboration. Every report, every repro and every bit of feedback shaped what shipped here — thank you. Come join us: [discord.gg/AMnDRErm4u](https://discord.gg/AMnDRErm4u)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,7 +343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### What's New — release-notes cache file on disk (RC/stable)
 
-**By [@cucadmuh](https://github.com/cucadmuh), PR [#TBD](https://github.com/Psychotoxical/psysonic/pull/TBD)**
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1062](https://github.com/Psychotoxical/psysonic/pull/1062)**
 
 * RC and stable builds now persist the downloaded `whats-new.md` slice under AppData — `plugin-fs` had mkdir but lacked recursive write scope, so the `release-notes/` folder appeared empty and every launch re-fetched from GitHub.
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -22,6 +22,7 @@
     "fs:allow-write-file",
     "fs:allow-read-file",
     "fs:allow-mkdir",
+    "fs:allow-app-write-recursive",
     "fs:scope-download-recursive",
     "fs:scope-home-recursive",
     "window-state:allow-save-window-state",


### PR DESCRIPTION
## Summary
- RC/stable What's New fetched `whats-new.md` successfully but never wrote the cache file — `release-notes/` appeared under AppData with no `.md` inside.
- `fs:default` grants recursive **read** and `mkdir` for app dirs; nested `write_text_file` needs `fs:allow-app-write-recursive`.
- Without the cache file, every app launch re-downloaded the release asset.

## Test plan
- [ ] Windows RC build: delete `%APPDATA%\dev.psysonic.player\release-notes\`, launch app, confirm `1.48.0-rc.1.md` (or current version) is created
- [ ] Second launch: no new GitHub download; file mtime unchanged
- [ ] What's New page still shows highlights + Changelog tab