### PR TITLE
fix(themes): apply Theme Store themes in production release builds

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' ipc: http://ipc.localhost tauri:; connect-src 'self' ipc: http://ipc.localhost tauri: https: http: ws: wss:; img-src 'self' asset: http://asset.localhost https: http: data: blob:; media-src 'self' asset: http://asset.localhost https: http: data: blob:;",
+      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' ipc: http://ipc.localhost tauri:; style-src 'self' 'unsafe-inline' asset: http://asset.localhost https://asset.localhost tauri: blob:; style-src-elem 'self' 'unsafe-inline' asset: http://asset.localhost https://asset.localhost tauri: blob:; font-src 'self' data: asset: http://asset.localhost https://asset.localhost; connect-src 'self' ipc: http://ipc.localhost tauri: https: http: ws: wss:; img-src 'self' asset: http://asset.localhost https: http: data: blob:; media-src 'self' asset: http://asset.localhost https: http: data: blob:;",
       "assetProtocol": {
         "enable": true,
         "scope": [

--- a/src/hooks/useThemeScheduler.ts
+++ b/src/hooks/useThemeScheduler.ts
@@ -1,18 +1,34 @@
 import { useEffect, useState } from 'react';
 import { useThemeStore, getScheduledTheme } from '../store/themeStore';
 
+/**
+ * Effective theme id for `data-theme` — scheduler-aware when enabled.
+ * Derived synchronously from the store so `App.tsx` never paints a stale id
+ * (the previous useState+mirror lag could leave `data-theme` on Mocha for a
+ * commit cycle in production React).
+ */
 export function useThemeScheduler(): string {
-  const state = useThemeStore();
-  const [effectiveTheme, setEffectiveTheme] = useState(() => getScheduledTheme(state));
+  const enableScheduler = useThemeStore(s => s.enableThemeScheduler);
+  const theme = useThemeStore(s => s.theme);
+  const themeDay = useThemeStore(s => s.themeDay);
+  const themeNight = useThemeStore(s => s.themeNight);
+  const timeDayStart = useThemeStore(s => s.timeDayStart);
+  const timeNightStart = useThemeStore(s => s.timeNightStart);
+  const [tick, setTick] = useState(0);
 
   useEffect(() => {
-    setEffectiveTheme(getScheduledTheme(useThemeStore.getState()));
-    if (!state.enableThemeScheduler) return;
-    const id = setInterval(() => {
-      setEffectiveTheme(getScheduledTheme(useThemeStore.getState()));
-    }, 60_000);
+    if (!enableScheduler) return;
+    const id = setInterval(() => setTick(n => n + 1), 60_000);
     return () => clearInterval(id);
-  }, [state.enableThemeScheduler, state.theme, state.themeDay, state.themeNight, state.timeDayStart, state.timeNightStart]);
+  }, [enableScheduler, themeDay, themeNight, timeDayStart, timeNightStart]);
 
-  return effectiveTheme;
+  void tick;
+  return getScheduledTheme({
+    enableThemeScheduler: enableScheduler,
+    theme,
+    themeDay,
+    themeNight,
+    timeDayStart,
+    timeNightStart,
+  });
 }


### PR DESCRIPTION
## Summary

- Extend Tauri CSP with `style-src` / `style-src-elem` (`unsafe-inline` for runtime `<style data-installed-theme>` injection) and `font-src data:` for bundled `@fontsource` fonts in release WebViews.
- Derive the effective theme synchronously in `useThemeScheduler` so `data-theme` updates on the same React commit in production (no one-frame lag via `useState` mirror).

Fixes community Theme Store **Apply** appearing to do nothing in `tauri build` / release while built-in themes and `tauri dev` worked.

Investigation: workdocs `internal/collaboration/handoffs/2026-06-12-theme-store-windows-activation-investigation.md`.

## Test plan

- [x] `npm test`, `npx tsc --noEmit`, `npm run test:coverage`, `scripts/check-frontend-hot-path-coverage.sh`
- [x] `cargo test --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Manual: release build on Linux — Theme Store Apply repaints UI (`PSYSONIC_OPEN_DEVTOOLS=0`)
- [ ] Manual: release build on Windows — same Apply check