### PR TITLE
fix(installer): stderr logging, /dev/tty reinstall prompt, hardened download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -396,6 +396,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Auto-install script — `curl | sudo bash` works again
+
+**By [@kbennett2000](https://github.com/kbennett2000), PR [#1079](https://github.com/Psychotoxical/psysonic/pull/1079)**
+
+* The Linux auto-installer (`install.sh`) failed before any download because `[INFO]` log lines were captured into the package URL and curl rejected the mangled string; logging now goes to stderr, the reinstall prompt reads from the terminal, and package downloads use `--fail --globoff`.
+
+
+
 ## [1.47.0]
 
 > **🙏 Thank you to our amazing Discord community.** This release would not have been possible without your tireless support, quality checks, bug reports and all-round collaboration. Every report, every repro and every bit of feedback shaped what shipped here — thank you. Come join us: [discord.gg/AMnDRErm4u](https://discord.gg/AMnDRErm4u)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,7 +107,7 @@ install_package() {
     
     if [ "$OS_TYPE" = "debian" ]; then
         package_file="${package_file}.deb"
-        curl -L -o "$package_file" "$download_url"
+        curl --fail --globoff -L -o "$package_file" "$download_url"
         
         info "Installing package..."
         $PACKAGE_MANAGER install -y "$package_file" || {
@@ -116,7 +116,7 @@ install_package() {
         }
     elif [ "$OS_TYPE" = "rhel" ]; then
         package_file="${package_file}.rpm"
-        curl -L -o "$package_file" "$download_url"
+        curl --fail --globoff -L -o "$package_file" "$download_url"
         
         info "Installing package..."
         $PACKAGE_MANAGER install -y "$package_file"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,7 +130,9 @@ install_package() {
 check_installed() {
     if command -v $APP_NAME &> /dev/null || command -v ${APP_NAME^} &> /dev/null; then
         warn "${APP_NAME} appears to be already installed."
-        read -p "Do you want to reinstall? (y/N): " -n 1 -r
+        # Under `curl ... | bash`, stdin is the script stream itself, so
+        # read the answer from the controlling terminal instead.
+        read -p "Do you want to reinstall? (y/N): " -n 1 -r < /dev/tty
         echo
         if [[ ! $REPLY =~ ^[Yy]$ ]]; then
             info "Installation cancelled."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -131,9 +131,16 @@ check_installed() {
     if command -v $APP_NAME &> /dev/null || command -v ${APP_NAME^} &> /dev/null; then
         warn "${APP_NAME} appears to be already installed."
         # Under `curl ... | bash`, stdin is the script stream itself, so
-        # read the answer from the controlling terminal instead.
-        read -p "Do you want to reinstall? (y/N): " -n 1 -r < /dev/tty
-        echo
+        # read the answer from the controlling terminal instead. Probe by
+        # opening: `[ -r /dev/tty ]` passes on the 0666 device node even
+        # without a controlling terminal; only open() reports the failure.
+        if { : < /dev/tty; } 2>/dev/null; then
+            read -p "Do you want to reinstall? (y/N): " -n 1 -r < /dev/tty
+            echo
+        else
+            warn "No terminal available for prompt; skipping reinstall."
+            exit 0
+        fi
         if [[ ! $REPLY =~ ^[Yy]$ ]]; then
             info "Installation cancelled."
             exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,20 +14,22 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Log helpers write to stderr so functions that return values via stdout
+# (e.g. get_download_url) stay clean when called in command substitution.
 info() {
-    echo -e "${BLUE}[INFO]${NC} $1"
+    echo -e "${BLUE}[INFO]${NC} $1" >&2
 }
 
 success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
+    echo -e "${GREEN}[SUCCESS]${NC} $1" >&2
 }
 
 warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
+    echo -e "${YELLOW}[WARN]${NC} $1" >&2
 }
 
 error() {
-    echo -e "${RED}[ERROR]${NC} $1"
+    echo -e "${RED}[ERROR]${NC} $1" >&2
     exit 1
 }
 

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -377,6 +377,13 @@ const CONTRIBUTOR_ENTRIES = [
       'Long-press album Play to shuffle with hold progress animation (PR #888)',
     ],
   },
+  {
+    github: 'kbennett2000',
+    since: '1.48.0',
+    contributions: [
+      'Linux auto-install script — fix curl | sudo bash URL capture bug (PR #1079)',
+    ],
+  },
 ] as const;
 
 // PR number of a contributor's first listed contribution, used as the


### PR DESCRIPTION
Fixes #1078

## What changed
`scripts/install.sh` only, four commits:

1. The four log helpers (`info`, `success`, `warn`, `error`) now write to **stderr**, so functions returning values over stdout (`get_download_url`) stay clean inside command substitution.
2. The reinstall prompt in `check_installed()` reads from `/dev/tty` instead of stdin.
3. The two package-download `curl` calls (apt and dnf/yum branches) gain `--fail --globoff`.
4. The reinstall prompt degrades gracefully when no controlling terminal can be opened: warn and `exit 0` instead of failing under `set -e` (review suggestion).

## Why
- **stderr logging:** `main()` captures `get_download_url()` with command substitution; with `info()` on stdout, `$download_url` held two `[INFO]` lines (ANSI escapes included) plus the URL. curl's URL globber trips on the `[` characters and aborts with `curl: (3) bad range in URL position 4` before any request; `set -e` then kills the install. Side benefits: `error()` messages raised inside substituted functions are now visible instead of being swallowed, and the `[INFO]` lines print in their natural order.
- **/dev/tty read:** under the documented `curl … | sudo bash` invocation, stdin is the script stream, so a bare `read` consumes the next line of the script as the user's "answer" rather than keyboard input.
- **--fail --globoff:** on an HTTP error the old call saved the error page as the `.deb`/`.rpm` and handed it to the package manager; `--fail` aborts instead. `--globoff` makes curl treat the URL literally as defense in depth against bracket characters.
- **terminal probe:** the guard opens `/dev/tty` rather than testing `[ -r /dev/tty ]`, because the node is present and mode 0666 even without a controlling terminal — `test -r` passes there while the subsequent open still fails with ENXIO. Probing with an actual open catches both the no-ctty case and a missing node.

## Who should notice
End users installing with the `curl | sudo bash` one-liner. The dnf/yum branch shares the same helpers and download call, so it gets the same fixes. No app code touched — developers and existing installs unaffected.

## How to verify
- `bash -n scripts/install.sh`; shellcheck (0.9.0) reports zero findings before and after.
- On an apt-based machine: `sudo bash scripts/install.sh` from this branch resolves the latest release, downloads, and installs.
- URL-capture fix: ran the script before/after against a stub `curl` (fixture for the GitHub API call; real curl binary doing URL *parsing* for the download call) and a stub `apt`, as root on Ubuntu. Before: download curl invoked with the mangled three-line URL, exits 3, `apt` never reached. After: clean single-line URL, download proceeds, `apt install -y …` invoked.
- /dev/tty fix: allocated a pty with `script(1)`, put a fake `psysonic` on `PATH` to trigger the reinstall prompt, then fed *different* answers to stdin (pipe) and the terminal. Old behavior follows the pipe in both directions; fixed behavior follows the terminal in both directions.
- Terminal probe: under `setsid` (no controlling terminal) with the package "already installed", the script now warns and exits 0; the same scenario with a bare `[ -r /dev/tty ]` guard passes the test but still dies on the read with ENXIO. Interactive pty behavior is unchanged in both the y and n directions, and the fresh-install path never reaches the prompt.

## Scope notes
- Tauri boundary not touched.
