### PR TITLE
docs: sync WHATS_NEW with latest 1.48 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,22 +227,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-### Internet Radio — station management limited to server admins
-
-**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1086](https://github.com/Psychotoxical/psysonic/pull/1086)**
-
-* Navidrome 0.62 made creating, editing and deleting radio stations admin-only, so those actions failed for standard accounts. Add, edit and delete controls are now hidden for non-admin Navidrome users; playback and favourites stay available to everyone. Other server types are unaffected.
-
-
-### Music Network — self-hosted scrobbling reaches the server
-
-**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1085](https://github.com/Psychotoxical/psysonic/pull/1085)**
-
-* Self-hosted scrobble targets that use a pasted token (Koito, Maloja's ListenBrainz and Audioscrobbler compatibility surfaces) silently recorded nothing: the saved server address dropped the API path, so listens were sent to a route that does not exist while the account still showed as connected.
-* The correct API path is now kept when connecting. Reconnect an affected account once so it picks up the corrected address.
-
-
-
 ### Servers — complete border on the active server card
 
 **By [@Psychotoxical](https://github.com/Psychotoxical), PR [#998](https://github.com/Psychotoxical/psysonic/pull/998)**
@@ -463,6 +447,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **By [@kbennett2000](https://github.com/kbennett2000), PR [#1079](https://github.com/Psychotoxical/psysonic/pull/1079)**
 
 * The Linux auto-installer (`install.sh`) failed before any download because `[INFO]` log lines were captured into the package URL and curl rejected the mangled string; logging now goes to stderr, the reinstall prompt reads from the terminal, and package downloads use `--fail --globoff`.
+
+
+
+### Music Network — self-hosted scrobbling reaches the server
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1085](https://github.com/Psychotoxical/psysonic/pull/1085)**
+
+* Self-hosted scrobble targets that use a pasted token (Koito, Maloja's ListenBrainz and Audioscrobbler compatibility surfaces) silently recorded nothing: the saved server address dropped the API path, so listens were sent to a route that does not exist while the account still showed as connected.
+* The correct API path is now kept when connecting. Reconnect an affected account once so it picks up the corrected address.
+
+
+
+### Internet Radio — station management limited to server admins
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1086](https://github.com/Psychotoxical/psysonic/pull/1086)**
+
+* Navidrome 0.62 made creating, editing and deleting radio stations admin-only, so those actions failed for standard accounts. Add, edit and delete controls are now hidden for non-admin Navidrome users; playback and favourites stay available to everyone. Other server types are unaffected.
 
 ## [1.47.0]
 

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -39,6 +39,7 @@ Within each section, order by **user impact** (most noticeable first) — not PR
 ### Live — richer now playing on Navidrome 0.62+
 
 - On servers with OpenSubsonic **playbackReport** (Navidrome ≥ 0.62), **Live** shows who is playing or paused, how far into the track they are, and playback speed when another client sends it — with smooth position updates between refreshes.
+- In **Who is listening?**, each listener shows a small status dot (playing, paused, or idle) instead of a vague “minutes ago” line.
 
 ### Queue — Timeline mode
 
@@ -57,14 +58,11 @@ Within each section, order by **user impact** (most noticeable first) — not PR
 
 - A themed loading splash appears while the app starts — colours follow your active theme, including community palettes.
 
-### What's New page
-
-- Highlights like this list load from the release on startup (and cache for offline). A **Full changelog** tab on the same page holds the technical detail.
-
 ## Improved
 
 - Audio decoding runs on **Symphonia 0.6**; streams start sooner and recover from stalls without restarting the player.
 - The **Preload Next Track** toggle under **Settings → Storage → Buffering** is gone — playback no longer waits on that extra RAM prefetch. Gapless, crossfade, and Hot Cache behave as before.
+- New **Semitones** playback-speed strategy (±12 st, 0.1 step) with two-decimal speed readout; optional fine steps in **Settings → Audio → Advanced**.
 
 ## Fixed
 
@@ -83,6 +81,7 @@ Within each section, order by **user impact** (most noticeable first) — not PR
 
 ### Themes and integrations
 
+- Self-hosted Music Network targets (Koito, Maloja, custom GNU FM with a pasted token) scrobble again — reconnect once if you connected before this fix.
 - Favoriting from the player bar, fullscreen player, or shortcuts updates the star in track lists and playlists immediately.
 - Discord Rich Presence shows album art again when covers come from the server.
 - Focus rings and dropdown borders follow the active theme consistently.
@@ -101,9 +100,10 @@ Within each section, order by **user impact** (most noticeable first) — not PR
 
 - **Linux:** the `curl | bash` auto-installer works again.
 - **Linux:** internet radio no longer appears twice in the desktop now-playing overlay.
+- On Navidrome **0.62+**, add/edit/delete radio stations is shown only to admin accounts; everyone can still play and favourite stations.
+- **Linux custom title bar:** pick window button styles (dots, flat, pill, and more) and optionally hide minimize in **Settings → Appearance**.
 - The active server card under **Settings → Servers** draws a complete border on all sides.
 
 ## Under the hood
 
 - Navidrome **0.62+** auto-detects **AudioMuse-AI** and routes Instant Mix / Lucky Mix through the smarter API when the plugin is present — older Navidrome keeps the manual toggle you already know.
-- Future release highlights can refresh on the **What's New** page without waiting for a full app update download.


### PR DESCRIPTION
## Summary

- Update `WHATS_NEW.md` for post-#1082 merges: Live listener dots (#1086), Semitones speed (#1084), Linux title bar styles (#1083), Music Network self-hosted scrobble fix (#1085), Navidrome radio admin gating (#1086).
- Remove the meta **What's New page** highlight and the remote-update under-the-hood bullet.
- Re-sort `CHANGELOG.md` **Fixed** block by PR number (#1085/#1086 had landed at the top).

## Test plan

- [x] `node scripts/extract-release-section.mjs WHATS_NEW.md 1.48.0`
- [ ] Spot-check Highlights tab in `tauri:dev`