### PR TITLE
chore(aur): bump PKGBUILD to 1.48.0

### DIFF
--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Psychotoxic <psychotoxic@gmx.de>
 pkgname=psysonic
-pkgver=1.46.0
+pkgver=1.48.0
 pkgrel=1
 pkgdesc="Desktop music player for Subsonic API-compatible servers (Navidrome, Gonic, etc.)"
 arch=('x86_64')


### PR DESCRIPTION
Bumps `packages/aur/PKGBUILD` `pkgver` from 1.46.0 to 1.48.0, realigning the in-repo PKGBUILD (source of truth) with the AUR package, which was just published for 1.48.0.

The repo PKGBUILD had been left at 1.46.0 since the 1.47.0 AUR release only touched the AUR clone. The wrapper is already thin-exec here; this is a pure version bump.

No behaviour change in the app.