### PR TITLE
chore(aur): bump PKGBUILD to v1.48.1

### DIFF
--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Psychotoxic <psychotoxic@gmx.de>
 pkgname=psysonic
-pkgver=1.48.0
+pkgver=1.48.1
 pkgrel=1
 pkgdesc="Desktop music player for Subsonic API-compatible servers (Navidrome, Gonic, etc.)"
 arch=('x86_64')


### PR DESCRIPTION
Keeps the in-repo PKGBUILD in sync with the already-published AUR package.

- pkgver 1.48.0 → 1.48.1
- source points at the published `app-v1.48.1` release tarball

No build/runtime change; AUR (`aur.archlinux.org/psysonic.git`) already updated and pushed separately.