### PR TITLE
chore(audio): declare windows Power/WindowsAndMessaging features in psysonic-audio

### DIFF
--- a/src-tauri/crates/psysonic-audio/Cargo.toml
+++ b/src-tauri/crates/psysonic-audio/Cargo.toml
@@ -40,6 +40,8 @@ windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_System_Com",
     "Win32_System_Threading",
+    "Win32_System_Power",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- `psysonic-audio/src/power_notify_win.rs` imports `windows::Win32::System::Power` and `windows::Win32::UI::WindowsAndMessaging`, but the crate's `[target.'cfg(windows)'.dependencies]` only declared `Win32_Foundation` / `Win32_System_Com` / `Win32_System_Threading`.
- It compiled only because the root `src-tauri` crate enables those two features and Cargo unifies them across the workspace. Building or testing the crate in isolation on Windows (`cargo check/test -p psysonic-audio`) failed with `E0432` unresolved imports.
- Declare the two features the crate actually uses, so it builds standalone.

No behaviour change — workspace and release builds already had these features unified in. Linux/macOS unaffected (the file is `#[cfg(windows)]`).

## Test plan

- [x] `cargo check -p psysonic-audio --all-targets` (Windows) — previously E0432, now Finished
- [x] Workspace build/CI unaffected (purely additive `windows` features)