### PR TITLE
fix(deps): bump transitive form-data to 4.0.6 (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Right-clicking the current track in the player bar opened an album menu, so "Add to playlist" added the entire album instead of the playing song. The player bar menu now acts on the current song.
 
+### Security — transitive form-data CRLF injection (GHSA-hmw2-7cc7-3qxx)
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1118](https://github.com/Psychotoxical/psysonic/pull/1118)**
+
+* Bumped transitive `form-data` 4.0.5 → 4.0.6 (via axios) to close Dependabot alert [#18](https://github.com/Psychotoxical/psysonic/security/dependabot/18) for CRLF injection in multipart field names (CVE-2026-12143). Psysonic only uses axios for GET requests, so exploitability was low; the lockfile bump clears the advisory.
+
 
 ## [1.48.1] - 2026-06-15
 

--- a/nix/upstream-sources.json
+++ b/nix/upstream-sources.json
@@ -1,3 +1,3 @@
 {
-  "npmDepsHash": "sha256-9S/oq66FBCHK7tj5fbcPPawDeETpbSC2JDqU66Ln6aQ="
+  "npmDepsHash": "sha256-oYSc00guRNrZhWTkRXYlqwSeVZ7tkz+/rA+XOF3NUvw="
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2466,16 +2466,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2592,9 +2592,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -166,6 +166,7 @@ const CONTRIBUTOR_ENTRIES = [
       'OpenSubsonic playbackReport — live now-playing state, gliding position bar, and immediate pause/resume on Navidrome ≥0.62 (PR #1080)',
       'Playback speed follow-up — Semitones varispeed strategy, two-decimal speed label, per-strategy tooltips, and Advanced fine-step toggle (PR #1084)',
       'Streamed Opus/Ogg seeking via on-demand HTTP Range fetches — seek mid-stream without a full pre-download (PR #1110)',
+      'npm: bump transitive form-data to 4.0.6 — CRLF injection advisory (PR #1118)',
     ],
   },
   {

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -166,7 +166,6 @@ const CONTRIBUTOR_ENTRIES = [
       'OpenSubsonic playbackReport — live now-playing state, gliding position bar, and immediate pause/resume on Navidrome ≥0.62 (PR #1080)',
       'Playback speed follow-up — Semitones varispeed strategy, two-decimal speed label, per-strategy tooltips, and Advanced fine-step toggle (PR #1084)',
       'Streamed Opus/Ogg seeking via on-demand HTTP Range fetches — seek mid-stream without a full pre-download (PR #1110)',
-      'npm: bump transitive form-data to 4.0.6 — CRLF injection advisory (PR #1118)',
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Bumps transitive `form-data` **4.0.5 → 4.0.6** in `package-lock.json` via `npm audit fix` (closes Dependabot alert [#18](https://github.com/Psychotoxical/psysonic/security/dependabot/18)).
- Addresses [GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx) / CVE-2026-12143 (CRLF injection in multipart field names when untrusted input is used as a field name or filename).
- `form-data` is pulled in by `axios`; Psysonic only uses `axios.get` for Subsonic REST calls, so runtime exploitability is low — this is a lockfile hygiene / advisory closure change.

## Test plan

- [x] `npm audit` — 0 vulnerabilities
- [x] `npm test` — 2039 passed
- [x] `npx tsc --noEmit` — clean