### PR TITLE
fix(linux): detect Niri as a tiling window manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The Live header badge only refreshed `getNowPlaying` while the "Who is listening?" popover was open, so the listener count could stay stale or hidden until opened. Poll every 30 s while the window is visible (10 s while the popover is open); background fetches are silent so the header does not flash a loading state.
 
+### Niri compositor tiling WM detection
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1127](https://github.com/Psychotoxical/psysonic/pull/1127)**
+
+* Niri is now recognized as a tiling window manager (`NIRI_SOCKET`, `XDG_CURRENT_DESKTOP=niri`), so it gets the same custom title bar, window decorations, and mini-player behavior as Hyprland and Sway instead of being treated like a floating desktop.
+
 
 ## [1.48.1] - 2026-06-15
 

--- a/src-tauri/src/lib_commands/sync/tray.rs
+++ b/src-tauri/src/lib_commands/sync/tray.rs
@@ -415,7 +415,7 @@ pub(crate) fn toggle_tray_icon(
 
 pub(crate) use crate::audio::stop_audio_engine;
 
-/// Returns `true` if running under a tiling window manager (Hyprland, Sway, i3,
+/// Returns `true` if running under a tiling window manager (Hyprland, Niri, Sway, i3,
 /// bspwm, AwesomeWM, Openbox, etc.).  Detection is based on environment variables
 /// set by the compositor / DE.
 #[cfg(target_os = "linux")]
@@ -423,6 +423,7 @@ pub(crate) fn is_tiling_wm() -> bool {
     // Direct compositor signatures (most reliable).
     let direct = [
         "HYPRLAND_INSTANCE_SIGNATURE", // Hyprland
+        "NIRI_SOCKET",                  // Niri
         "SWAYSOCK",                     // Sway
         "I3SOCK",                       // i3
     ]
@@ -437,7 +438,7 @@ pub(crate) fn is_tiling_wm() -> bool {
     if let Ok(desktop) = std::env::var("XDG_CURRENT_DESKTOP") {
         let desktop = desktop.to_lowercase();
         let tiling_wms = [
-            "hyprland", "sway", "i3", "bspwm", "awesome", "openbox",
+            "hyprland", "niri", "sway", "i3", "bspwm", "awesome", "openbox",
             "xmonad", "dwm", "qtile", "herbstluftwm", "leftwm",
         ];
         if tiling_wms.iter().any(|&wm| desktop.contains(wm)) {

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -167,6 +167,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Playback speed follow-up — Semitones varispeed strategy, two-decimal speed label, per-strategy tooltips, and Advanced fine-step toggle (PR #1084)',
       'Streamed Opus/Ogg seeking via on-demand HTTP Range fetches — seek mid-stream without a full pre-download (PR #1110)',
       'AutoDJ — content-aware crossfade: waveform-driven silence trim, content-driven overlap, scenario-A self-fade, readiness gate + engine auto-crossfade suppression (PR #1122)',
+      'Niri compositor tiling WM detection (PR #1127)',
     ],
   },
   {


### PR DESCRIPTION
Closes #1097

## Summary
- Add `NIRI_SOCKET` and `niri` in `XDG_CURRENT_DESKTOP` to `is_tiling_wm()` so the Niri compositor is treated like Hyprland/Sway/i3.
- On Niri, the custom title bar stays hidden, native decorations stay off, and mini-player sizing/always-on-top rules match other tiling WMs — restoring the pre–1.48 behaviour reported in [#1097](https://github.com/Psychotoxical/psysonic/issues/1097).

## Test plan
- [ ] On Niri: `is_tiling_wm_cmd` returns true (e.g. via devtools `invoke('is_tiling_wm_cmd')`).
- [ ] On Niri: Settings → Appearance does not show the custom title bar toggle; no GTK title bar.
- [ ] On GNOME/KDE: behavior unchanged (`is_tiling_wm_cmd` false).