### PR TITLE
docs(readme): add reviews section and winstall install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ See [TELEMETRY.md](TELEMETRY.md) for the telemetry stance and [PRIVACY.md](PRIVA
 
 ---
 
+# Reviews
+
+* [An independent review at falu.github.io](https://falu.github.io/2026/06/19/psysonic.html)
+
+---
+
 # Community & Support
 
 Join the community, report bugs, suggest features, share themes and help shape the future of Psysonic.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ install via Windows Package Manager (WinGet):
 ```powershell
 winget install Psysonic
 ```
+
+You can also browse and install it on [winstall.app](https://winstall.app/apps/Psychotoxical.Psysonic).
+
 ## macOS
 
 Download the signed DMG from the [GitHub Releases](https://github.com/Psychotoxical/psysonic/releases/latest).


### PR DESCRIPTION
## Summary
- Add a **Reviews** section to the README linking the first independent write-up of Psysonic.
- Add a **winstall.app** install link to the Windows section (a friendly front-end for the existing WinGet package).

## Test plan
- Docs-only; rendered the Markdown to confirm the links and section placement.