### PR TITLE
chore(deps): override undici to ^7.28.0

### DIFF
--- a/nix/upstream-sources.json
+++ b/nix/upstream-sources.json
@@ -1,3 +1,3 @@
 {
-  "npmDepsHash": "sha256-oYSc00guRNrZhWTkRXYlqwSeVZ7tkz+/rA+XOF3NUvw="
+  "npmDepsHash": "sha256-Y5gZccVREEG9XpYJ/MTtoDn7lC3u9sKiZ8tN3OyEYCU="
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3674,9 +3674,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
-      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.14",
     "vitest": "^4.1.8"
+  },
+  "overrides": {
+    "undici": "^7.28.0"
   }
 }


### PR DESCRIPTION
## Summary
- Force the transitive **undici** dependency (pulled by `jsdom`, a devDependency) to `^7.28.0` via a package.json `overrides` entry.
- Clears all 6 open Dependabot advisories (2 high, 2 moderate, 2 low) — every one was the same undici package, all patched in 7.28.0.
- Dev-only: undici is not bundled in the shipped app (frontend uses the WebView fetch, backend uses reqwest), so there is no runtime impact for users.

## Test plan
- `npm install` resolves undici to 7.28.0 under jsdom (range `^7.25.0`); `npm install` reports 0 vulnerabilities.
- `npm run build` + full `vitest` (2155) green — jsdom is the test environment, so an incompatibility would surface here.