### PR TITLE
fix(orbit): cleanup sweep no longer deletes live sessions on other devices

### DIFF
--- a/src/utils/orbit/cleanup.test.ts
+++ b/src/utils/orbit/cleanup.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ORBIT_PLAYLIST_PREFIX,
+  makeInitialOrbitState,
+  orbitOutboxPlaylistName,
+  orbitSessionPlaylistName,
+  type OrbitState,
+} from '../../api/orbit';
+import { ORBIT_ORPHAN_TTL_MS } from './constants';
+
+const { getPlaylists, deletePlaylist } = vi.hoisted(() => ({
+  getPlaylists: vi.fn(),
+  deletePlaylist: vi.fn(),
+}));
+
+const { authState, orbitState } = vi.hoisted(() => ({
+  authState: { username: 'me' as string | undefined },
+  orbitState: { sessionId: null as string | null },
+}));
+
+vi.mock('../../api/subsonicPlaylists', () => ({ getPlaylists, deletePlaylist }));
+vi.mock('../../store/authStore', () => ({
+  useAuthStore: {
+    getState: () => ({
+      getActiveServer: () => (authState.username ? { username: authState.username } : undefined),
+    }),
+  },
+}));
+vi.mock('../../store/orbitStore', () => ({
+  useOrbitStore: { getState: () => ({ sessionId: orbitState.sessionId }) },
+}));
+
+import { cleanupOrphanedOrbitPlaylists } from './cleanup';
+
+type FakePlaylist = {
+  id: string;
+  name: string;
+  owner?: string;
+  comment?: string;
+  changed?: string;
+};
+
+/** A session-playlist comment whose heartbeat (`positionAt`) is `ageMs` old. */
+function sessionComment(sid: string, ageMs: number, ended = false): string {
+  const state: OrbitState = makeInitialOrbitState({ sid, host: 'me', name: 'sesh' });
+  state.positionAt = Date.now() - ageMs;
+  if (ended) state.ended = true;
+  return JSON.stringify(state);
+}
+
+/** An outbox comment whose heartbeat `ts` is `ageMs` old. */
+function outboxComment(ageMs: number): string {
+  return JSON.stringify({ ts: Date.now() - ageMs });
+}
+
+beforeEach(() => {
+  authState.username = 'me';
+  orbitState.sessionId = null;
+  deletePlaylist.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  getPlaylists.mockReset();
+});
+
+async function runWith(playlists: FakePlaylist[]): Promise<string[]> {
+  getPlaylists.mockResolvedValue(playlists);
+  await cleanupOrphanedOrbitPlaylists();
+  return deletePlaylist.mock.calls.map(c => c[0] as string);
+}
+
+describe('cleanupOrphanedOrbitPlaylists', () => {
+  it('keeps a fresh session playlist from another device (regression for the regex bug)', async () => {
+    const sid = 'aaaa1111';
+    const deleted = await runWith([
+      { id: 'p1', name: orbitSessionPlaylistName(sid), owner: 'me', comment: sessionComment(sid, 1_000) },
+    ]);
+    expect(deleted).toEqual([]);
+  });
+
+  it('deletes a stale session playlist past the orphan TTL', async () => {
+    const sid = 'bbbb2222';
+    const deleted = await runWith([
+      {
+        id: 'p2',
+        name: orbitSessionPlaylistName(sid),
+        owner: 'me',
+        comment: sessionComment(sid, ORBIT_ORPHAN_TTL_MS + 60_000),
+      },
+    ]);
+    expect(deleted).toEqual(['p2']);
+  });
+
+  it('deletes a session the host explicitly ended even when fresh', async () => {
+    const sid = 'cccc3333';
+    const deleted = await runWith([
+      {
+        id: 'p3',
+        name: orbitSessionPlaylistName(sid),
+        owner: 'me',
+        comment: sessionComment(sid, 1_000, /* ended */ true),
+      },
+    ]);
+    expect(deleted).toEqual(['p3']);
+  });
+
+  it('never touches this device\'s current session', async () => {
+    const sid = 'dddd4444';
+    orbitState.sessionId = sid;
+    const deleted = await runWith([
+      // Stale heartbeat, but it's *our* live session → must be skipped.
+      {
+        id: 'p4',
+        name: orbitSessionPlaylistName(sid),
+        owner: 'me',
+        comment: sessionComment(sid, ORBIT_ORPHAN_TTL_MS + 60_000),
+      },
+    ]);
+    expect(deleted).toEqual([]);
+  });
+
+  it('keeps a fresh outbox but prunes a stale one', async () => {
+    const sid = 'eeee5555';
+    const deleted = await runWith([
+      { id: 'fresh', name: orbitOutboxPlaylistName(sid, 'bob'), owner: 'me', comment: outboxComment(1_000) },
+      {
+        id: 'stale',
+        name: orbitOutboxPlaylistName(sid, 'eve'),
+        owner: 'me',
+        comment: outboxComment(ORBIT_ORPHAN_TTL_MS + 60_000),
+      },
+    ]);
+    expect(deleted).toEqual(['stale']);
+  });
+
+  it('prunes an unrecognisable __psyorbit_* playlist', async () => {
+    const deleted = await runWith([
+      { id: 'junk', name: `${ORBIT_PLAYLIST_PREFIX}not-a-real-name`, owner: 'me' },
+    ]);
+    expect(deleted).toEqual(['junk']);
+  });
+
+  it('ignores playlists owned by another user', async () => {
+    const sid = 'ffff6666';
+    const deleted = await runWith([
+      {
+        id: 'foreign',
+        name: orbitSessionPlaylistName(sid),
+        owner: 'someone-else',
+        comment: sessionComment(sid, ORBIT_ORPHAN_TTL_MS + 60_000),
+      },
+    ]);
+    expect(deleted).toEqual([]);
+  });
+});

--- a/src/utils/orbit/cleanup.ts
+++ b/src/utils/orbit/cleanup.ts
@@ -25,7 +25,12 @@ export async function cleanupOrphanedOrbitPlaylists(): Promise<number> {
   const TTL = ORBIT_ORPHAN_TTL_MS;
   const currentSid = useOrbitStore.getState().sessionId;
 
-  const nameRe = new RegExp(`^${ORBIT_PLAYLIST_PREFIX}([a-f0-9]+)(_from_.+__)?$`);
+  // The trailing `__` is part of *both* the session name (`__psyorbit_<sid>__`)
+  // and the outbox name (`__psyorbit_<sid>_from_<user>__`), so it must sit
+  // outside the optional `_from_…` group. Keeping it inside (the old bug) meant
+  // the bare session name never matched and fell into the unconditional-prune
+  // branch below — deleting live sessions on the user's other devices.
+  const nameRe = new RegExp(`^${ORBIT_PLAYLIST_PREFIX}([a-f0-9]+)(_from_.+)?__$`);
   let deleted = 0;
 
   for (const p of all) {


### PR DESCRIPTION
## Problem

The Orbit app-start orphan-cleanup sweep deletes the live session playlist of a session running on the user's **other device**.

The regex in `src/utils/orbit/cleanup.ts` anchored the trailing `__` *inside* the optional `_from_…` group:

```
^__psyorbit_([a-f0-9]+)(_from_.+__)?$
```

So the canonical session-playlist name `__psyorbit_<sid>__` never matched (`[a-f0-9]+` can't consume the trailing `__`, and the optional group requires the literal `_from_`). It then fell into the `if (!match)` "unrecognised → prune" branch, which deletes **unconditionally**, bypassing the `ORBIT_ORPHAN_TTL_MS` grace window that exists specifically to protect another device's session. Guests on the other device see the playlist vanish and treat it as host-ended.

Outbox playlists (`…_from_<user>__`) matched fine, so only session playlists were affected.

## Fix

Move the trailing `__` outside the optional group and make it required:

```
^__psyorbit_([a-f0-9]+)(_from_.+)?__$
```

Both the session and outbox names now match; `match[1]` (sid) and `match[2]` (outbox indicator) keep the same meaning, so the existing sid / TTL / ended logic applies as intended.

## Tests

New `src/utils/orbit/cleanup.test.ts` drives `cleanupOrphanedOrbitPlaylists` with mocked playlist/store/auth deps:

- keeps a fresh session playlist from another device (the regression)
- prunes a stale session past the TTL
- prunes a host-ended session even when fresh
- never touches this device's current session
- keeps a fresh outbox, prunes a stale one
- prunes a genuinely unrecognisable `__psyorbit_*` name
- ignores foreign-owned playlists

Verified the two device-loss cases fail against the old regex and pass with the fix.