### PR TITLE
refactor(settings): SettingsSubCard primitives + Audio tab consistency

### DIFF
--- a/src/components/settings/SettingsSubCard.tsx
+++ b/src/components/settings/SettingsSubCard.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+
+/**
+ * Settings sub-card primitives — the canonical way to render per-mode / detail
+ * controls as a set-apart group inside a settings section (e.g. the "Target
+ * LUFS" box under the Normalization engine picker). The Audio tab's first four
+ * sections are the reference for this look.
+ *
+ * These wrap the shared `settings-norm-*` styles so callers never hand-roll the
+ * box with inline padding or one-off classes. New settings sub-options should
+ * use these instead of bare `<div>`s — see `NormalizationBlock` for usage.
+ */
+
+/** Bordered, accent-tinted panel that groups detail controls inside a section. */
+export function SettingsSubCard({
+  children,
+  style,
+  className,
+}: {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+  className?: string;
+}) {
+  return (
+    <div className={`settings-norm-block${className ? ` ${className}` : ''}`} style={style}>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * One labelled group inside a {@link SettingsSubCard}: an optional title and
+ * description, the controls, and an optional grey note line below them.
+ *
+ * `row` lays the label out beside the controls (for a slider/value pair, like
+ * the Normalization sliders); the default stacks label → description →
+ * controls (for a picker, like the Hi-Res blend-rate buttons).
+ */
+export function SettingsField({
+  label,
+  desc,
+  note,
+  row = false,
+  children,
+}: {
+  label?: React.ReactNode;
+  desc?: React.ReactNode;
+  note?: React.ReactNode;
+  row?: boolean;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="settings-norm-field">
+      {row ? (
+        <>
+          <div className="settings-norm-row">
+            {label != null && <span className="settings-norm-label">{label}</span>}
+            {children}
+          </div>
+          {desc != null && <div className="settings-norm-help">{desc}</div>}
+        </>
+      ) : (
+        <>
+          {label != null && (
+            <span className="settings-norm-label" style={{ minWidth: 0 }}>
+              {label}
+            </span>
+          )}
+          {desc != null && <div className="settings-norm-help">{desc}</div>}
+          {children}
+        </>
+      )}
+      {note != null && (
+        <div className="settings-norm-help" role="note">
+          {note}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A horizontal control row (label and/or control + value side by side), for a
+ * standalone slider inside a {@link SettingsSubCard} or a nested slider/value
+ * pair inside a stacked {@link SettingsField}. For a labelled field whose
+ * description sits below the row, prefer `<SettingsField row …>`.
+ */
+export function SettingsRow({ children }: { children: React.ReactNode }) {
+  return <div className="settings-norm-row">{children}</div>;
+}
+
+/** Right-aligned, tabular value readout for a slider row. */
+export function SettingsValue({ children }: { children: React.ReactNode }) {
+  return <span className="settings-norm-value">{children}</span>;
+}
+
+/**
+ * Accent callout (border-left + tinted background) for an important caveat
+ * inside a {@link SettingsSubCard} — e.g. the Normalization first-play note.
+ * For a plain grey note line, use the `note` prop on {@link SettingsField}.
+ */
+export function SettingsCallout({ children }: { children: React.ReactNode }) {
+  return <div className="settings-norm-note">{children}</div>;
+}

--- a/src/components/settings/audio/HiResCrossfadeResampleBlock.tsx
+++ b/src/components/settings/audio/HiResCrossfadeResampleBlock.tsx
@@ -4,6 +4,7 @@ import {
   sanitizeHiResCrossfadeResampleHz,
 } from '../../../utils/audio/hiResCrossfadeResample';
 import type { TFunction } from 'i18next';
+import { SettingsSubCard, SettingsField } from '../SettingsSubCard';
 
 interface Props {
   enabled: boolean;
@@ -28,12 +29,12 @@ export function HiResCrossfadeResampleBlock({
   if (!enabled) return null;
 
   return (
-    <div className="settings-norm-block" style={{ marginTop: '0.85rem' }}>
-      <div className="settings-norm-field">
-        <span className="settings-norm-label" style={{ minWidth: 0 }}>
-          {t('settings.hiResCrossfadeResampleTitle')}
-        </span>
-        <div className="settings-norm-help">{t('settings.hiResCrossfadeResampleDesc')}</div>
+    <SettingsSubCard style={{ marginTop: '0.85rem' }}>
+      <SettingsField
+        label={t('settings.hiResCrossfadeResampleTitle')}
+        desc={t('settings.hiResCrossfadeResampleDesc')}
+        note={t('settings.hiResCrossfadeResampleWarning')}
+      >
         <div className="settings-segmented">
           {HI_RES_CROSSFADE_RESAMPLE_OPTIONS.map((hz) => (
             <button
@@ -46,10 +47,7 @@ export function HiResCrossfadeResampleBlock({
             </button>
           ))}
         </div>
-        <div className="settings-norm-help" role="note">
-          {t('settings.hiResCrossfadeResampleWarning')}
-        </div>
-      </div>
-    </div>
+      </SettingsField>
+    </SettingsSubCard>
   );
 }

--- a/src/components/settings/audio/NormalizationBlock.tsx
+++ b/src/components/settings/audio/NormalizationBlock.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '../../../store/authStore';
 import { DEFAULT_LOUDNESS_PRE_ANALYSIS_ATTENUATION_DB } from '../../../store/authStoreDefaults';
 import { LoudnessLufsButtonGroup } from '../LoudnessLufsButtonGroup';
 import { SettingsGroup } from '../SettingsGroup';
+import { SettingsSubCard, SettingsField, SettingsValue, SettingsCallout } from '../SettingsSubCard';
 
 interface Props {
   preAnalysisEffectiveDb: number;
@@ -68,116 +69,102 @@ export function NormalizationBlock({ preAnalysisEffectiveDb, t }: Props) {
         </button>
       </div>
       {auth.normalizationEngine === 'replaygain' && (
-        <div className="settings-norm-block">
-          <div className="settings-norm-field">
-            <div className="settings-norm-row">
-              <span className="settings-norm-label">{t('settings.replayGainMode')}</span>
-              <div style={{ display: 'flex', gap: '0.4rem', flexWrap: 'wrap' }}>
-                <button
-                  className={`btn ${auth.replayGainMode === 'auto' ? 'btn-primary' : 'btn-ghost'}`}
-                  style={{ fontSize: 12, padding: '4px 14px' }}
-                  onClick={() => auth.setReplayGainMode('auto')}
-                >
-                  {t('settings.replayGainAuto')}
-                </button>
-                <button
-                  className={`btn ${auth.replayGainMode === 'track' ? 'btn-primary' : 'btn-ghost'}`}
-                  style={{ fontSize: 12, padding: '4px 14px' }}
-                  onClick={() => auth.setReplayGainMode('track')}
-                >
-                  {t('settings.replayGainTrack')}
-                </button>
-                <button
-                  className={`btn ${auth.replayGainMode === 'album' ? 'btn-primary' : 'btn-ghost'}`}
-                  style={{ fontSize: 12, padding: '4px 14px' }}
-                  onClick={() => auth.setReplayGainMode('album')}
-                >
-                  {t('settings.replayGainAlbum')}
-                </button>
-              </div>
-            </div>
-            {auth.replayGainMode === 'auto' && (
-              <div className="settings-norm-help">{t('settings.replayGainAutoDesc')}</div>
-            )}
-          </div>
-          <div className="settings-norm-field">
-            <div className="settings-norm-row">
-              <span className="settings-norm-label">{t('settings.replayGainPreGain')}</span>
-              <input
-                type="range" min={0} max={6} step={0.5}
-                value={auth.replayGainPreGainDb}
-                onChange={e => auth.setReplayGainPreGainDb(Number(e.target.value))}
-              />
-              <span className="settings-norm-value">
-                {auth.replayGainPreGainDb > 0 ? `+${auth.replayGainPreGainDb}` : auth.replayGainPreGainDb} dB
-              </span>
-            </div>
-            <div className="settings-norm-help">{t('settings.replayGainPreGainDesc')}</div>
-          </div>
-          <div className="settings-norm-field">
-            <div className="settings-norm-row">
-              <span className="settings-norm-label">{t('settings.replayGainFallback')}</span>
-              <input
-                type="range" min={-6} max={0} step={0.5}
-                value={auth.replayGainFallbackDb}
-                onChange={e => auth.setReplayGainFallbackDb(Number(e.target.value))}
-              />
-              <span className="settings-norm-value">
-                {auth.replayGainFallbackDb > 0 ? `+${auth.replayGainFallbackDb}` : auth.replayGainFallbackDb} dB
-              </span>
-            </div>
-            <div className="settings-norm-help">{t('settings.replayGainFallbackDesc')}</div>
-          </div>
-        </div>
-      )}
-      {auth.normalizationEngine === 'loudness' && (
-        <div className="settings-norm-block">
-          <div className="settings-norm-field">
-            <div className="settings-norm-row">
-              <span className="settings-norm-label">{t('settings.loudnessTargetLufs')}</span>
-              <LoudnessLufsButtonGroup value={auth.loudnessTargetLufs} onSelect={auth.setLoudnessTargetLufs} />
-            </div>
-            <div className="settings-norm-help">{t('settings.loudnessTargetLufsDesc')}</div>
-          </div>
-          <div className="settings-norm-field">
-            <div className="settings-norm-row">
-              <span className="settings-norm-label">{t('settings.loudnessPreAnalysisAttenuation')}</span>
-              <input
-                type="range"
-                min={-24}
-                max={0}
-                step={0.5}
-                value={auth.loudnessPreAnalysisAttenuationDb}
-                onChange={e => auth.setLoudnessPreAnalysisAttenuationDb(Number(e.target.value))}
-              />
-              <span className="settings-norm-value">
-                {preAnalysisEffectiveDb} dB
-              </span>
+        <SettingsSubCard>
+          <SettingsField
+            label={t('settings.replayGainMode')}
+            desc={auth.replayGainMode === 'auto' ? t('settings.replayGainAutoDesc') : undefined}
+            row
+          >
+            <div style={{ display: 'flex', gap: '0.4rem', flexWrap: 'wrap' }}>
               <button
-                type="button"
-                className="icon-btn"
-                style={{ flexShrink: 0 }}
-                disabled={
-                  auth.loudnessPreAnalysisAttenuationDb === DEFAULT_LOUDNESS_PRE_ANALYSIS_ATTENUATION_DB
-                }
-                onClick={() => auth.resetLoudnessPreAnalysisAttenuationDbDefault()}
-                data-tooltip={t('settings.loudnessPreAnalysisAttenuationReset')}
-                aria-label={t('settings.loudnessPreAnalysisAttenuationReset')}
+                className={`btn ${auth.replayGainMode === 'auto' ? 'btn-primary' : 'btn-ghost'}`}
+                style={{ fontSize: 12, padding: '4px 14px' }}
+                onClick={() => auth.setReplayGainMode('auto')}
               >
-                <RotateCcw size={15} />
+                {t('settings.replayGainAuto')}
+              </button>
+              <button
+                className={`btn ${auth.replayGainMode === 'track' ? 'btn-primary' : 'btn-ghost'}`}
+                style={{ fontSize: 12, padding: '4px 14px' }}
+                onClick={() => auth.setReplayGainMode('track')}
+              >
+                {t('settings.replayGainTrack')}
+              </button>
+              <button
+                className={`btn ${auth.replayGainMode === 'album' ? 'btn-primary' : 'btn-ghost'}`}
+                style={{ fontSize: 12, padding: '4px 14px' }}
+                onClick={() => auth.setReplayGainMode('album')}
+              >
+                {t('settings.replayGainAlbum')}
               </button>
             </div>
-            <div className="settings-norm-help">
-              {t('settings.loudnessPreAnalysisAttenuationDesc')}{' '}
-              {t('settings.loudnessPreAnalysisAttenuationRef', {
-                ref: auth.loudnessPreAnalysisAttenuationDb,
-                eff: preAnalysisEffectiveDb,
-                tgt: auth.loudnessTargetLufs,
-              })}
-            </div>
-          </div>
-          <div className="settings-norm-note">{t('settings.loudnessFirstPlayNote')}</div>
-        </div>
+          </SettingsField>
+          <SettingsField label={t('settings.replayGainPreGain')} desc={t('settings.replayGainPreGainDesc')} row>
+            <input
+              type="range" min={0} max={6} step={0.5}
+              value={auth.replayGainPreGainDb}
+              onChange={e => auth.setReplayGainPreGainDb(Number(e.target.value))}
+            />
+            <SettingsValue>
+              {auth.replayGainPreGainDb > 0 ? `+${auth.replayGainPreGainDb}` : auth.replayGainPreGainDb} dB
+            </SettingsValue>
+          </SettingsField>
+          <SettingsField label={t('settings.replayGainFallback')} desc={t('settings.replayGainFallbackDesc')} row>
+            <input
+              type="range" min={-6} max={0} step={0.5}
+              value={auth.replayGainFallbackDb}
+              onChange={e => auth.setReplayGainFallbackDb(Number(e.target.value))}
+            />
+            <SettingsValue>
+              {auth.replayGainFallbackDb > 0 ? `+${auth.replayGainFallbackDb}` : auth.replayGainFallbackDb} dB
+            </SettingsValue>
+          </SettingsField>
+        </SettingsSubCard>
+      )}
+      {auth.normalizationEngine === 'loudness' && (
+        <SettingsSubCard>
+          <SettingsField label={t('settings.loudnessTargetLufs')} desc={t('settings.loudnessTargetLufsDesc')} row>
+            <LoudnessLufsButtonGroup value={auth.loudnessTargetLufs} onSelect={auth.setLoudnessTargetLufs} />
+          </SettingsField>
+          <SettingsField
+            label={t('settings.loudnessPreAnalysisAttenuation')}
+            desc={
+              <>
+                {t('settings.loudnessPreAnalysisAttenuationDesc')}{' '}
+                {t('settings.loudnessPreAnalysisAttenuationRef', {
+                  ref: auth.loudnessPreAnalysisAttenuationDb,
+                  eff: preAnalysisEffectiveDb,
+                  tgt: auth.loudnessTargetLufs,
+                })}
+              </>
+            }
+            row
+          >
+            <input
+              type="range"
+              min={-24}
+              max={0}
+              step={0.5}
+              value={auth.loudnessPreAnalysisAttenuationDb}
+              onChange={e => auth.setLoudnessPreAnalysisAttenuationDb(Number(e.target.value))}
+            />
+            <SettingsValue>{preAnalysisEffectiveDb} dB</SettingsValue>
+            <button
+              type="button"
+              className="icon-btn"
+              style={{ flexShrink: 0 }}
+              disabled={
+                auth.loudnessPreAnalysisAttenuationDb === DEFAULT_LOUDNESS_PRE_ANALYSIS_ATTENUATION_DB
+              }
+              onClick={() => auth.resetLoudnessPreAnalysisAttenuationDbDefault()}
+              data-tooltip={t('settings.loudnessPreAnalysisAttenuationReset')}
+              aria-label={t('settings.loudnessPreAnalysisAttenuationReset')}
+            >
+              <RotateCcw size={15} />
+            </button>
+          </SettingsField>
+          <SettingsCallout>{t('settings.loudnessFirstPlayNote')}</SettingsCallout>
+        </SettingsSubCard>
       )}
     </SettingsGroup>
   );

--- a/src/components/settings/audio/TrackPreviewsSection.tsx
+++ b/src/components/settings/audio/TrackPreviewsSection.tsx
@@ -7,6 +7,7 @@ import type { TrackPreviewLocation } from '../../../store/authStoreTypes';
 import SettingsSubSection from '../../SettingsSubSection';
 import { SettingsGroup } from '../SettingsGroup';
 import { SettingsToggle } from '../SettingsToggle';
+import { SettingsSubCard, SettingsField, SettingsValue } from '../SettingsSubCard';
 
 interface Props {
   t: TFunction;
@@ -37,20 +38,12 @@ export function TrackPreviewsSection({ t }: Props) {
           />
 
           {auth.trackPreviewsEnabled && (
-            <>
-              <div className="divider" />
-              <div>
-                <div style={{ fontWeight: 500, marginBottom: 4 }}>
-                  {t('settings.trackPreviewLocationsTitle')}
-                </div>
-                <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 12 }}>
-                  {t('settings.trackPreviewLocationsDesc')}
-                </div>
-                <div style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 2,
-                }}>
+            <SettingsSubCard style={{ marginTop: '0.85rem' }}>
+              <SettingsField
+                label={t('settings.trackPreviewLocationsTitle')}
+                desc={t('settings.trackPreviewLocationsDesc')}
+              >
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                   {TRACK_PREVIEW_LOCATIONS.map((loc: TrackPreviewLocation) => (
                     <div key={loc} className="settings-toggle-row" style={{ padding: '6px var(--space-3)' }}>
                       <div style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
@@ -64,58 +57,44 @@ export function TrackPreviewsSection({ t }: Props) {
                     </div>
                   ))}
                 </div>
-              </div>
+              </SettingsField>
 
-              <div className="divider" />
-              <div>
-                <div style={{ fontWeight: 500, marginBottom: 4 }}>
-                  {t('settings.trackPreviewStart')}
-                </div>
-                <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 8 }}>
-                  {t('settings.trackPreviewStartDesc')}
-                </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-                  <input
-                    type="range"
-                    min={0}
-                    max={0.9}
-                    step={0.01}
-                    value={auth.trackPreviewStartRatio}
-                    onChange={e => auth.setTrackPreviewStartRatio(parseFloat(e.target.value))}
-                    style={{ flex: 1, minWidth: 80, maxWidth: 240 }}
-                    aria-label={t('settings.trackPreviewStart')}
-                  />
-                  <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 44 }}>
-                    {Math.round(auth.trackPreviewStartRatio * 100)}%
-                  </span>
-                </div>
-              </div>
+              <SettingsField
+                label={t('settings.trackPreviewStart')}
+                desc={t('settings.trackPreviewStartDesc')}
+                row
+              >
+                <input
+                  type="range"
+                  min={0}
+                  max={0.9}
+                  step={0.01}
+                  value={auth.trackPreviewStartRatio}
+                  onChange={e => auth.setTrackPreviewStartRatio(parseFloat(e.target.value))}
+                  aria-label={t('settings.trackPreviewStart')}
+                />
+                <SettingsValue>{Math.round(auth.trackPreviewStartRatio * 100)}%</SettingsValue>
+              </SettingsField>
 
-              <div className="divider" />
-              <div>
-                <div style={{ fontWeight: 500, marginBottom: 4 }}>
-                  {t('settings.trackPreviewDuration')}
-                </div>
-                <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 8 }}>
-                  {t('settings.trackPreviewDurationDesc')}
-                </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-                  <input
-                    type="range"
-                    min={5}
-                    max={60}
-                    step={1}
-                    value={auth.trackPreviewDurationSec}
-                    onChange={e => auth.setTrackPreviewDurationSec(parseInt(e.target.value, 10))}
-                    style={{ flex: 1, minWidth: 80, maxWidth: 240 }}
-                    aria-label={t('settings.trackPreviewDuration')}
-                  />
-                  <span style={{ fontSize: 13, color: 'var(--text-secondary)', minWidth: 44 }}>
-                    {t('settings.trackPreviewDurationSecs', { n: auth.trackPreviewDurationSec })}
-                  </span>
-                </div>
-              </div>
-            </>
+              <SettingsField
+                label={t('settings.trackPreviewDuration')}
+                desc={t('settings.trackPreviewDurationDesc')}
+                row
+              >
+                <input
+                  type="range"
+                  min={5}
+                  max={60}
+                  step={1}
+                  value={auth.trackPreviewDurationSec}
+                  onChange={e => auth.setTrackPreviewDurationSec(parseInt(e.target.value, 10))}
+                  aria-label={t('settings.trackPreviewDuration')}
+                />
+                <SettingsValue>
+                  {t('settings.trackPreviewDurationSecs', { n: auth.trackPreviewDurationSec })}
+                </SettingsValue>
+              </SettingsField>
+            </SettingsSubCard>
           )}
         </SettingsGroup>
       </div>

--- a/src/components/settings/audio/TrackTransitionsBlock.tsx
+++ b/src/components/settings/audio/TrackTransitionsBlock.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../utils/playback/playbackTransition';
 import { SettingsGroup } from '../SettingsGroup';
 import { SettingsToggle } from '../SettingsToggle';
+import { SettingsSubCard, SettingsField, SettingsRow, SettingsValue } from '../SettingsSubCard';
 
 interface Props {
   t: TFunction;
@@ -70,8 +71,8 @@ export function TrackTransitionsBlock({ t }: Props) {
       </div>
 
       {mode === 'crossfade' && (
-        <div className="settings-norm-block" style={{ marginTop: '0.85rem' }}>
-          <div className="settings-norm-row">
+        <SettingsSubCard style={{ marginTop: '0.85rem' }}>
+          <SettingsRow>
             <input
               type="range"
               min={0.1}
@@ -82,20 +83,19 @@ export function TrackTransitionsBlock({ t }: Props) {
               onChange={e => auth.setCrossfadeSecs(parseFloat(e.target.value))}
               id="crossfade-secs-slider"
             />
-            <span className="settings-norm-value">
+            <SettingsValue>
               {t('settings.crossfadeSecs', { n: auth.crossfadeSecs.toFixed(1) })}
-            </span>
-          </div>
-        </div>
+            </SettingsValue>
+          </SettingsRow>
+        </SettingsSubCard>
       )}
       {mode === 'autodj' && (
-        <div className="settings-norm-block" style={{ marginTop: '0.85rem' }}>
-          <div className="settings-norm-help">{t('settings.autoDjDesc')}</div>
-          <div className="settings-norm-field">
-            <span className="settings-norm-label" style={{ minWidth: 0 }}>
-              {t('settings.autodjOverlapCapTitle')}
-            </span>
-            <div className="settings-norm-help">{t('settings.autodjOverlapCapDesc')}</div>
+        <SettingsSubCard style={{ marginTop: '0.85rem' }}>
+          <SettingsField desc={t('settings.autoDjDesc')} />
+          <SettingsField
+            label={t('settings.autodjOverlapCapTitle')}
+            desc={t('settings.autodjOverlapCapDesc')}
+          >
             <div className="settings-segmented">
               <button
                 type="button"
@@ -115,7 +115,7 @@ export function TrackTransitionsBlock({ t }: Props) {
               </button>
             </div>
             {auth.autodjOverlapCapMode === 'limit' && (
-              <div className="settings-norm-row">
+              <SettingsRow>
                 <input
                   type="range"
                   min={AUTODJ_OVERLAP_CAP_MIN_SEC}
@@ -126,12 +126,12 @@ export function TrackTransitionsBlock({ t }: Props) {
                   onChange={e => auth.setAutodjOverlapCapSec(parseInt(e.target.value, 10))}
                   id="autodj-overlap-cap-slider"
                 />
-                <span className="settings-norm-value">
+                <SettingsValue>
                   {t('settings.autodjOverlapCapSecs', { n: auth.autodjOverlapCapSec })}
-                </span>
-              </div>
+                </SettingsValue>
+              </SettingsRow>
             )}
-          </div>
+          </SettingsField>
           <SettingsToggle
             label={t('settings.autodjSmoothSkip')}
             desc={t('settings.autodjSmoothSkipDesc')}
@@ -139,7 +139,7 @@ export function TrackTransitionsBlock({ t }: Props) {
             disabled={hostControlled}
             onChange={auth.setAutodjSmoothSkip}
           />
-        </div>
+        </SettingsSubCard>
       )}
     </SettingsGroup>
   );


### PR DESCRIPTION
First step toward consistent settings sub-sections. Introduces a reusable primitive so per-mode / detail controls stop drifting off the design — the root cause was that the sub-card was only a CSS convention (settings-norm-*), never a component, so new additions hand-rolled their own markup.

## Summary
- New `SettingsSubCard` primitives: `SettingsSubCard`, `SettingsField` (with a `row` variant), `SettingsRow`, `SettingsValue`, `SettingsCallout` — encapsulating the shared `settings-norm-*` styles.
- Move the Audio tab onto them: Normalization, Track transitions, Hi-Res rebuilt from the primitives (no visual change).
- Track Previews previously rendered its sub-options bare (inline styles + dividers); it now uses the sub-card, so the whole Audio tab matches the reference look.

## Test plan
- `npm run lint` (strict) and `tsc --noEmit` green
- Manual: Settings → Audio — all sections render identical sub-cards; Track Previews now boxed with labelled slider rows. Verified by maintainer.