### PR TITLE
feat(updater): show the WinGet update command in the Windows update modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Sort a playlist by **Date added** (newest or oldest first), or by title, artist, album and the other columns, from a new sort dropdown in the playlist filter toolbar. The Subsonic API has no per-track "added on" date, so this follows the playlist's own order — servers add new tracks at the end, so newest-first puts your latest additions on top.
 
+### WinGet update command in the update dialog (Windows)
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1202](https://github.com/Psychotoxical/psysonic/pull/1202)**
+
+* The Windows update dialog now also shows the WinGet command (`winget upgrade Psysonic`) next to the installer download, so you can update whichever way you installed.
+
 
 ## Changed
 

--- a/src/components/AppUpdater.tsx
+++ b/src/components/AppUpdater.tsx
@@ -13,7 +13,7 @@ export default function AppUpdater() {
   const {
     release, dismissed, setDismissed, changelogOpen, setChangelogOpen,
     dlState, dlProgress, dlError, countdown,
-    asset, showAurHint, useTauriUpdater, showInstallBtn, pct,
+    asset, showAurHint, showWingetHint, useTauriUpdater, showInstallBtn, pct,
     handleSkip, handleRestartNow, handleDownload, handleShowFolder,
   } = useAppUpdater();
 
@@ -182,6 +182,12 @@ export default function AppUpdater() {
               <div className="update-modal-asset">
                 <span className="update-modal-asset-name">{asset.name}</span>
                 <span className="update-modal-asset-size">{formatBytes(asset.size)}</span>
+              </div>
+            )}
+            {dlState === 'idle' && showWingetHint && (
+              <div className="update-modal-winget">
+                <div className="update-modal-winget-title">{t('common.updaterWingetHint')}</div>
+                <code className="update-modal-winget-cmd">winget upgrade Psysonic</code>
               </div>
             )}
             {dlState === 'downloading' && (

--- a/src/hooks/useAppUpdater.ts
+++ b/src/hooks/useAppUpdater.ts
@@ -196,6 +196,11 @@ export function useAppUpdater() {
   };
 
   const showAurHint = IS_LINUX && isArch;
+  // Windows can also update through WinGet once a release clears moderation
+  // (the notice itself is held back for that window, see #1200). Shown next to
+  // the installer download, not instead of it — not every Windows user
+  // installed via WinGet.
+  const showWingetHint = IS_WINDOWS;
   // On macOS the Tauri Updater handles architecture, signature verification
   // and in-place install — we don't need (and should not show) a DMG asset.
   const useTauriUpdater = IS_MACOS;
@@ -208,7 +213,7 @@ export function useAppUpdater() {
   return {
     release, dismissed, setDismissed, changelogOpen, setChangelogOpen,
     dlState, dlProgress, dlError, countdown,
-    asset, showAurHint, useTauriUpdater, showInstallBtn, pct,
+    asset, showAurHint, showWingetHint, useTauriUpdater, showInstallBtn, pct,
     handleSkip, handleRestartNow, handleDownload, handleShowFolder,
   };
 }

--- a/src/locales/de/common.ts
+++ b/src/locales/de/common.ts
@@ -48,6 +48,7 @@ export const common = {
   updaterShowFolder: 'Im Ordner anzeigen',
   updaterInstallHint: 'Psysonic schließen und das Installationsprogramm manuell ausführen.',
   updaterAurHint: 'Update über AUR installieren:',
+  updaterWingetHint: 'Oder per WinGet aktualisieren:',
   updaterErrorMsg: 'Download fehlgeschlagen',
   updaterInstallNow: 'Jetzt installieren',
   updaterMacReadyTitle: 'Bereit zur Installation',

--- a/src/locales/en/common.ts
+++ b/src/locales/en/common.ts
@@ -48,6 +48,7 @@ export const common = {
   updaterShowFolder: 'Show in Folder',
   updaterInstallHint: 'Close Psysonic and run the installer manually.',
   updaterAurHint: 'Install the update via AUR:',
+  updaterWingetHint: 'Or update via WinGet:',
   updaterErrorMsg: 'Download failed',
   updaterRetryBtn: 'Retry',
   updaterInstallNow: 'Install now',

--- a/src/locales/es/common.ts
+++ b/src/locales/es/common.ts
@@ -47,6 +47,7 @@ export const common = {
   updaterShowFolder: 'Mostrar en Carpeta',
   updaterInstallHint: 'Cierra Psysonic y ejecuta el instalador manualmente.',
   updaterAurHint: 'Instala la actualización vía AUR:',
+  updaterWingetHint: 'O actualiza vía WinGet:',
   updaterErrorMsg: 'Error de descarga',
   updaterRetryBtn: 'Reintentar',
   durationHoursMinutes: '{{hours}}h {{minutes}}m',

--- a/src/locales/fr/common.ts
+++ b/src/locales/fr/common.ts
@@ -47,6 +47,7 @@ export const common = {
   updaterShowFolder: 'Afficher dans le dossier',
   updaterInstallHint: 'Fermez Psysonic et lancez le programme d\'installation manuellement.',
   updaterAurHint: 'Installer la mise à jour via AUR :',
+  updaterWingetHint: 'Ou mettez à jour via WinGet :',
   updaterErrorMsg: 'Échec du téléchargement',
   updaterRetryBtn: 'Réessayer',
   durationHoursMinutes: '{{hours}} h {{minutes}} min',

--- a/src/locales/hu/common.ts
+++ b/src/locales/hu/common.ts
@@ -48,6 +48,7 @@ export const common = {
   updaterShowFolder: 'Megjelenítés a mappában',
   updaterInstallHint: 'Zárd be a Psysonicot, és futtasd a telepítőt kézzel.',
   updaterAurHint: 'Telepítsd a frissítést az AUR-on keresztül:',
+  updaterWingetHint: 'Vagy frissíts a WinGeten keresztül:',
   updaterErrorMsg: 'A letöltés nem sikerült',
   updaterRetryBtn: 'Újra',
   updaterInstallNow: 'Telepítés most',

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -48,6 +48,7 @@ export const common = {
   updaterShowFolder: 'フォルダーに表示',
   updaterInstallHint: 'Psysonic を閉じて、インストーラーを手動で実行してください。',
   updaterAurHint: 'AUR からアップデートをインストール:',
+  updaterWingetHint: 'または WinGet で更新:',
   updaterErrorMsg: 'ダウンロードに失敗しました',
   updaterRetryBtn: '再試行',
   updaterInstallNow: '今すぐインストール',

--- a/src/locales/nb/common.ts
+++ b/src/locales/nb/common.ts
@@ -47,6 +47,7 @@ export const common = {
   updaterShowFolder: 'Vis i mappe',
   updaterInstallHint: 'Lukk Psysonic og kjør installasjonsprogrammet manuelt.',
   updaterAurHint: 'Installer oppdateringen via AUR:',
+  updaterWingetHint: 'Eller oppdater via WinGet:',
   updaterErrorMsg: 'Nedlasting mislyktes',
   updaterRetryBtn: 'Prøv igjen',
   durationHoursMinutes: '{{hours}} t {{minutes}} min',

--- a/src/locales/nl/common.ts
+++ b/src/locales/nl/common.ts
@@ -47,6 +47,7 @@ export const common = {
   updaterShowFolder: 'Tonen in map',
   updaterInstallHint: 'Sluit Psysonic en voer het installatieprogramma handmatig uit.',
   updaterAurHint: 'Update installeren via AUR:',
+  updaterWingetHint: 'Of bijwerken via WinGet:',
   updaterErrorMsg: 'Downloaden mislukt',
   updaterRetryBtn: 'Opnieuw proberen',
   durationHoursMinutes: '{{hours}} u {{minutes}} min',

--- a/src/locales/pl/common.ts
+++ b/src/locales/pl/common.ts
@@ -48,6 +48,7 @@ export const common = {
   updaterShowFolder: 'Pokaż w folderze',
   updaterInstallHint: 'Zamknij PsySonic i uruchom instalator ręcznie.',
   updaterAurHint: 'Zainstaluj aktualizację przez AUR:',
+  updaterWingetHint: 'Lub zaktualizuj przez WinGet:',
   updaterErrorMsg: 'Pobieranie nie powiodło się',
   updaterRetryBtn: 'Spróbuj ponownie',
   updaterInstallNow: 'Zainstaluj teraz',

--- a/src/locales/ro/common.ts
+++ b/src/locales/ro/common.ts
@@ -48,6 +48,7 @@ export const common = {
   updaterShowFolder: 'Arată în Folder',
   updaterInstallHint: 'Închide Psysonic și rulează programul de instalare manual.',
   updaterAurHint: 'Instalează update-ul prin AUR:',
+  updaterWingetHint: 'Sau actualizează prin WinGet:',
   updaterErrorMsg: 'Descărcare eșuată',
   updaterRetryBtn: 'Reîncearcă',
   updaterInstallNow: 'Instalează acum',

--- a/src/locales/ru/common.ts
+++ b/src/locales/ru/common.ts
@@ -48,6 +48,7 @@ export const common = {
   updaterShowFolder: 'Показать в папке',
   updaterInstallHint: 'Закройте Psysonic и запустите установщик вручную.',
   updaterAurHint: 'Установить обновление через AUR:',
+  updaterWingetHint: 'Или обновить через WinGet:',
   updaterErrorMsg: 'Ошибка загрузки',
   updaterRetryBtn: 'Повторить',
   updaterInstallNow: 'Установить сейчас',

--- a/src/locales/zh/common.ts
+++ b/src/locales/zh/common.ts
@@ -47,6 +47,7 @@ export const common = {
   updaterShowFolder: '在文件夹中显示',
   updaterInstallHint: '请关闭 Psysonic 并手动运行安装程序。',
   updaterAurHint: '通过 AUR 安装更新：',
+  updaterWingetHint: '或通过 WinGet 更新：',
   updaterErrorMsg: '下载失败',
   updaterRetryBtn: '重试',
   durationHoursMinutes: '{{hours}}小时{{minutes}}分钟',

--- a/src/styles/layout/update-toast.css
+++ b/src/styles/layout/update-toast.css
@@ -280,6 +280,28 @@
 .update-modal-aur-alt {
   color: var(--text-muted);
 }
+/* WinGet update hint — shown alongside the Windows installer download, mirrors
+   the AUR hint styling with a little top gap to separate it from the asset. */
+.update-modal-winget {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+.update-modal-winget-title {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.update-modal-winget-cmd {
+  display: block;
+  background: var(--bg-glass);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--accent);
+  font-family: monospace;
+}
 .update-modal-asset-none {
   padding: 4px 0;
 }


### PR DESCRIPTION
### Summary
- The Windows update modal now shows how to update via WinGet, alongside the existing installer download (not instead of it — not everyone installed through WinGet).
- Command shown: `winget upgrade Psysonic`. Windows only; macOS uses the Tauri updater, Linux the AUR/AppImage paths.
- Mirrors the existing AUR hint styling; pairs with the moderation-window delay (#1200) so the hint only surfaces once the WinGet package is live.

### Test plan
- Manual (Windows): trigger the update modal — the WinGet command appears under the installer asset. Verified the layout on Linux via a temporary platform-gate override.
- New `updaterWingetHint` key across all 12 locales; lint + tsc + frontend-ci green. Frontend-only, no Tauri boundary change.
