### PR TITLE
chore(aur): bump PKGBUILD to v1.49.0

### DIFF
--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Psychotoxic <psychotoxic@gmx.de>
 pkgname=psysonic
-pkgver=1.48.1
+pkgver=1.49.0
 pkgrel=1
 pkgdesc="Desktop music player for Subsonic API-compatible servers (Navidrome, Gonic, etc.)"
 arch=('x86_64')


### PR DESCRIPTION
Bumps `packages/aur/PKGBUILD` `pkgver` to 1.49.0, keeping the in-repo source of truth in sync with the AUR package (already pushed to `aur.archlinux.org/psysonic`).

Version bump only — PKGBUILD body unchanged (thin-exec wrapper kept). `.SRCINFO` is maintained on the AUR side, not tracked in-repo.