### PR TITLE
fix(i18n): correct Polish locale typos and strings

### DIFF
--- a/src/locales/pl/albumDetail.ts
+++ b/src/locales/pl/albumDetail.ts
@@ -35,7 +35,7 @@ export const albumDetail = {
   trackAlbum: 'Album',
   trackArtist: 'Wykonawca',
   trackGenre: 'Gatunek',
-  trackPlayCount: 'Pdtworzenia',
+  trackPlayCount: 'Powtórzenia',
   trackLastPlayed: 'Ostatnio odtworzono',
   trackBpm: 'BPM',
   trackFormat: 'Format',

--- a/src/locales/pl/favorites.ts
+++ b/src/locales/pl/favorites.ts
@@ -1,6 +1,6 @@
 export const favorites = {
   title: 'Ulubione',
-  empty: "Nie masz jeszcze żadnych ulubionych.",
+  empty: "Nie dodałeś jeszcze nic do ulubionych.",
   artists: 'Wykonawcy',
   albums: 'Albumy',
   songs: 'Utwory',

--- a/src/locales/pl/nowPlaying.ts
+++ b/src/locales/pl/nowPlaying.ts
@@ -13,7 +13,7 @@ export const nowPlaying = {
   fromAlbum: 'Z tego albumu',
   viewAlbum: 'Zobacz album',
   goToArtist: 'Idź do wykonawcy',
-  readMore: 'Czytaj więcej',
+  readMore: 'Pokaż więcej',
   showLess: 'Pokaż mniej',
   genreInfo: 'Gatunek',
   trackInfo: 'Informacje o utworze',

--- a/src/locales/pl/nowPlayingInfo.ts
+++ b/src/locales/pl/nowPlayingInfo.ts
@@ -7,7 +7,7 @@ export const nowPlayingInfo = {
   noTourEvents: 'Żadnych nadchodzących koncertów',
   tourLoading: 'Ładowanie…',
   poweredByBandsintown: 'Dane o koncertach przez Bandsintown',
-  bioReadMore: 'Czytaj więcej',
+  bioReadMore: 'Pokaż więcej',
   bioReadLess: 'Pokaż mniej',
   showMoreTours_one: 'Pokaż jeszcze {{count}}',
   showMoreTours_other: 'Pokaż jeszcze {{count}}',

--- a/src/locales/pl/sidebar.ts
+++ b/src/locales/pl/sidebar.ts
@@ -11,7 +11,7 @@ export const sidebar = {
   favorites: 'Ulubione',
   nowPlaying: 'Teraz odtwarzane',
   system: 'System',
-  statistics: 'Statistyki',
+  statistics: 'Statystyki',
   settings: 'Ustawienia',
   help: 'Pomoc',
   expand: 'Rozwiń pasek boczny',


### PR DESCRIPTION
## Summary

- Fix two Polish typos: track play count (`Pdtworzenia` → `Powtórzenia`) and sidebar Statistics (`Statistyki` → `Statystyki`).
- Improve the favorites empty-state copy and align expand/collapse labels (`Czytaj więcej` → `Pokaż więcej`) with the existing `Pokaż mniej` wording in Now Playing.

**Audience:** Polish UI only — no English keys or code changes.

## Test plan

- [ ] Settings → System → Language → Polski
- [ ] Sidebar: **Statystyki**
- [ ] Album detail track list: play count column **Powtórzenia**
- [ ] Favorites empty state reads naturally
- [ ] Now Playing bio/tour: **Pokaż więcej** / **Pokaż mniej**

## Notes

- `src/locales/pl/` only.
- No Tauri / Rust boundary changes.