### PR TITLE
docs(changelog): record #1225 frontend restructure (changelog + credits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New **Square Corners** toggle under **Settings → Appearance → Visual Options → Display** overrides the active theme to render cards and cover art with square, non-rounded corners. Covers album, playlist, artist and song cards, detail-page cover art, the Now Playing / Radio and fullscreen views, the cover lightbox, the queue cover, and the mini player. Off by default; buttons, inputs and dialogs keep the theme's corners.
 
 
+## Changed
+
+### Frontend restructure — feature-folder architecture and hardening
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), with additional architecture by [@cucadmuh](https://github.com/cucadmuh), PR [#1225](https://github.com/Psychotoxical/psysonic/pull/1225)**
+
+* Reorganised the frontend into a feature-folder architecture with a CI-enforced layering guard, added unit + behavior-scenario + boot-smoke test coverage, and introduced a compile-time frontend/backend IPC contract via tauri-specta. Internal only — no change to how the app looks or behaves.
+
+
 ## [1.49.0] - 2026-06-29
 
 ## Added

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -394,6 +394,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Playlist sort — sort a playlist by date added (newest/oldest) or any track column from a visible sort dropdown (PR #1191)',
       'Configurable artist backdrops — per-place source order + on/off (mainstage hero, artist page, fullscreen), with the mainstage hero showing the artist backdrop and prefetching upcoming ones (PR #1193)',
       'Themed window title bar on macOS — follows the active theme instead of the grey system bar, with the native window buttons floating over it (PR #1199)',
+      'Frontend feature-folder restructure — CI-enforced layering guard, added unit/behavior-scenario/boot-smoke tests, and a compile-time frontend/backend IPC contract via tauri-specta (PR #1225)',
     ],
   },
   {


### PR DESCRIPTION
Retroactive changelog + credits for the merged feature-folder restructure (#1225).

- 1.50.0 `## Changed` entry — internal restructure, no user-facing change; additional architecture credited to @cucadmuh.
- Contributions line under @Psychotoxical in the settings credits.
