### PR TITLE
fix(albums): keyboard year filter entry without per-keystroke clamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Sidebar and shell gates react when hot-cache rows appear; browse pages reload after hot-cache growth and library sync without leaving the page.
 * Album vs track artist credit mode, starred artists, genre filters, and Tracks discovery rails respect the on-disk scope; album artist grouping follows indexed `album_artist` parity.
 
+### All Albums — year filter keyboard entry
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1244](https://github.com/Psychotoxical/psysonic/pull/1244)**
+
+* The year filter on All Albums no longer clamps on every keystroke while typing a four-digit year — drafts commit on blur, Enter, or outside click; incomplete input reverts to the last applied value. Wheel and spinner controls are unchanged.
+
 
 ## [1.49.0] - 2026-06-29
 

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -188,6 +188,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Multi-library filter — priority-ordered multi-select scope across browse/search/detail, sargable library_id + FTS-first SQL, rebuildable library-cluster.db identity keys, locale-aware name normalization (PR #1241)',
       'Genres — full catalog via indexed SQL when All libraries is selected; no longer samples first album page on large libraries (PR #1242)',
       'Offline browse — on-disk-only Artists/Albums/Tracks/Genres (pins, favorites-auto, hot-cache); reactive sidebar gates and sync-idle reload; local credit mode and genre scope (PR #1243)',
+      'All Albums year filter — keyboard entry without per-keystroke clamp; commit on blur/Enter/outside click (PR #1244)',
     ],
   },
   {

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -188,7 +188,6 @@ const CONTRIBUTOR_ENTRIES = [
       'Multi-library filter — priority-ordered multi-select scope across browse/search/detail, sargable library_id + FTS-first SQL, rebuildable library-cluster.db identity keys, locale-aware name normalization (PR #1241)',
       'Genres — full catalog via indexed SQL when All libraries is selected; no longer samples first album page on large libraries (PR #1242)',
       'Offline browse — on-disk-only Artists/Albums/Tracks/Genres (pins, favorites-auto, hot-cache); reactive sidebar gates and sync-idle reload; local credit mode and genre scope (PR #1243)',
-      'All Albums year filter — keyboard entry without per-keystroke clamp; commit on blur/Enter/outside click (PR #1244)',
     ],
   },
   {

--- a/src/lib/library/albumYearFilter.test.ts
+++ b/src/lib/library/albumYearFilter.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 import {
   albumYearFilterClauses,
   albumYearSubsonicParams,
+  commitAlbumYearDraftField,
   clampAlbumYearFieldInput,
   formatAlbumYearFilterLabel,
   normalizeAlbumYearToFieldChange,
   resolveAlbumYearBounds,
+  sanitizeAlbumYearTypingInput,
   stepAlbumYearField,
 } from './albumYearFilter';
 
@@ -94,5 +96,30 @@ describe('album year spinner helpers', () => {
   it('maps first native spinner tick on empty to field to max', () => {
     expect(normalizeAlbumYearToFieldChange('', '1975', min, max)).toBe('2020');
     expect(normalizeAlbumYearToFieldChange('2010', '1975', min, max)).toBe('1975');
+  });
+});
+
+describe('album year typing helpers', () => {
+  const min = 1975;
+  const max = 2020;
+
+  it('sanitizeAlbumYearTypingInput keeps digits only', () => {
+    expect(sanitizeAlbumYearTypingInput('19a9b0')).toBe('1990');
+    expect(sanitizeAlbumYearTypingInput('19999')).toBe('1999');
+  });
+
+  it('commitAlbumYearDraftField keeps partial drafts on blur', () => {
+    expect(commitAlbumYearDraftField('199', '1980', min, max)).toBe('1980');
+    expect(commitAlbumYearDraftField('1', '', min, max)).toBe('');
+  });
+
+  it('commitAlbumYearDraftField clamps complete years', () => {
+    expect(commitAlbumYearDraftField('1990', '', min, max)).toBe('1990');
+    expect(commitAlbumYearDraftField('1960', '', min, max)).toBe('1975');
+    expect(commitAlbumYearDraftField('2030', '2010', min, max)).toBe('2020');
+  });
+
+  it('commitAlbumYearDraftField clears empty draft', () => {
+    expect(commitAlbumYearDraftField('', '1990', min, max)).toBe('');
   });
 });

--- a/src/lib/library/albumYearFilter.ts
+++ b/src/lib/library/albumYearFilter.ts
@@ -56,6 +56,26 @@ export function parseAlbumYearField(raw: string): number | null {
   return n;
 }
 
+/** Digits-only year typing buffer (max four digits). */
+export function sanitizeAlbumYearTypingInput(raw: string): string {
+  return raw.replace(/\D/g, '').slice(0, 4);
+}
+
+/**
+ * Commit a typed year field on blur — incomplete drafts revert to the last applied value.
+ */
+export function commitAlbumYearDraftField(
+  draft: string,
+  previousCommitted: string,
+  min: number,
+  max: number,
+): string {
+  const trimmed = sanitizeAlbumYearTypingInput(draft);
+  if (!trimmed) return '';
+  if (trimmed.length < 4) return previousCommitted;
+  return clampAlbumYearFieldInput(trimmed, min, max);
+}
+
 export function resolveAlbumYearBounds(from: string, to: string): {
   active: boolean;
   bounds: AlbumYearBounds;

--- a/src/ui/YearFilterButton.tsx
+++ b/src/ui/YearFilterButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { CalendarRange, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -7,10 +7,11 @@ import { tooltipAttrs } from '@/ui/tooltipAttrs';
 import {
   ALBUM_YEAR_MAX,
   ALBUM_YEAR_MIN,
-  clampAlbumYearFieldInput,
+  commitAlbumYearDraftField,
   formatAlbumYearFilterLabel,
   normalizeAlbumYearToFieldChange,
   resolveAlbumYearBounds,
+  sanitizeAlbumYearTypingInput,
   stepAlbumYearField,
 } from '@/lib/library/albumYearFilter';
 
@@ -33,10 +34,14 @@ export default function YearFilterButton({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [popStyle, setPopStyle] = useState<React.CSSProperties>({});
+  const [draftFrom, setDraftFrom] = useState(from);
+  const [draftTo, setDraftTo] = useState(to);
 
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popRef = useRef<HTMLDivElement>(null);
   const fromRef = useRef<HTMLInputElement>(null);
+  const fromFocusedRef = useRef(false);
+  const toFocusedRef = useRef(false);
 
   const yMin = catalogMinYear ?? ALBUM_YEAR_MIN;
   const yMax = catalogMaxYear ?? ALBUM_YEAR_MAX;
@@ -76,6 +81,22 @@ export default function YearFilterButton({
   }, [open]);
 
   useEffect(() => {
+    if (!fromFocusedRef.current) {
+      // React Compiler set-state-in-effect rule: draft mirrors applied filter when the field is not being edited.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setDraftFrom(from);
+    }
+  }, [from]);
+
+  useEffect(() => {
+    if (!toFocusedRef.current) {
+      // React Compiler set-state-in-effect rule: draft mirrors applied filter when the field is not being edited.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setDraftTo(to);
+    }
+  }, [to]);
+
+  useEffect(() => {
     if (!open) return;
     const onResize = () => updatePopStyle();
     window.addEventListener('resize', onResize);
@@ -86,6 +107,48 @@ export default function YearFilterButton({
     };
   }, [open]);
 
+  const resolveDraftTo = useCallback((): string => {
+    if (!draftTo.trim()) return '';
+    if (sanitizeAlbumYearTypingInput(draftTo).length < 4) return to;
+    return normalizeAlbumYearToFieldChange(to, draftTo, yMin, yMax);
+  }, [draftTo, to, yMin, yMax]);
+
+  const applyDraftsAndClose = useCallback(() => {
+    fromFocusedRef.current = false;
+    toFocusedRef.current = false;
+    const nextFrom = commitAlbumYearDraftField(draftFrom, from, yMin, yMax);
+    const nextTo = resolveDraftTo();
+    setDraftFrom(nextFrom);
+    setDraftTo(nextTo);
+    onChange(nextFrom, nextTo);
+    setOpen(false);
+  }, [draftFrom, draftTo, from, onChange, resolveDraftTo, yMin, yMax]);
+
+  const commitFromField = useCallback(() => {
+    if (!fromFocusedRef.current) return;
+    fromFocusedRef.current = false;
+    const next = commitAlbumYearDraftField(draftFrom, from, yMin, yMax);
+    setDraftFrom(next);
+    onChange(next, to);
+  }, [draftFrom, from, onChange, to, yMin, yMax]);
+
+  const commitToField = useCallback(() => {
+    if (!toFocusedRef.current) return;
+    toFocusedRef.current = false;
+    if (!draftTo.trim()) {
+      setDraftTo('');
+      onChange(from, '');
+      return;
+    }
+    if (sanitizeAlbumYearTypingInput(draftTo).length < 4) {
+      setDraftTo(to);
+      return;
+    }
+    const next = normalizeAlbumYearToFieldChange(to, draftTo, yMin, yMax);
+    setDraftTo(next);
+    onChange(from, next);
+  }, [draftTo, from, onChange, to, yMin, yMax]);
+
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
@@ -94,25 +157,52 @@ export default function YearFilterButton({
         !popRef.current?.contains(e.target as Node)
       ) setOpen(false);
     };
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        applyDraftsAndClose();
+      }
+    };
     document.addEventListener('mousedown', onDown);
     document.addEventListener('keydown', onKey);
     return () => {
       document.removeEventListener('mousedown', onDown);
       document.removeEventListener('keydown', onKey);
     };
-  }, [open]);
+  }, [open, applyDraftsAndClose]);
 
   const clear = () => {
+    fromFocusedRef.current = false;
+    toFocusedRef.current = false;
+    setDraftFrom('');
+    setDraftTo('');
     onChange('', '');
   };
 
   const handleFromChange = (raw: string) => {
-    onChange(clampAlbumYearFieldInput(raw, yMin, yMax), to);
+    setDraftFrom(sanitizeAlbumYearTypingInput(raw));
   };
 
   const handleToChange = (raw: string) => {
-    onChange(from, normalizeAlbumYearToFieldChange(to, raw, yMin, yMax));
+    const sanitized = sanitizeAlbumYearTypingInput(raw);
+    const spinnerTick = !to.trim()
+      && sanitized === String(yMin)
+      && yMin !== yMax
+      && sanitized.length === 4;
+    if (spinnerTick) {
+      const next = normalizeAlbumYearToFieldChange(to, sanitized, yMin, yMax);
+      toFocusedRef.current = false;
+      setDraftTo(next);
+      onChange(from, next);
+      return;
+    }
+    setDraftTo(sanitized);
+  };
+
+  const onYearFieldKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      applyDraftsAndClose();
+    }
   };
 
   const onYearWheel = (
@@ -122,9 +212,15 @@ export default function YearFilterButton({
     e.preventDefault();
     const delta = e.deltaY < 0 ? 1 : -1;
     if (field === 'from') {
-      onChange(stepAlbumYearField(from, delta, yMin, yMax, 'min'), to);
+      fromFocusedRef.current = false;
+      const nextFrom = stepAlbumYearField(from, delta, yMin, yMax, 'min');
+      setDraftFrom(nextFrom);
+      onChange(nextFrom, to);
     } else {
-      onChange(from, stepAlbumYearField(to, delta, yMin, yMax, 'max'));
+      toFocusedRef.current = false;
+      const nextTo = stepAlbumYearField(to, delta, yMin, yMax, 'max');
+      setDraftTo(nextTo);
+      onChange(from, nextTo);
     }
   };
 
@@ -134,7 +230,16 @@ export default function YearFilterButton({
         ref={triggerRef}
         type="button"
         className={`btn btn-surface${active ? ' btn-sort-active' : ''}`}
-        onClick={() => setOpen(v => !v)}
+        onClick={() => {
+          setOpen(prev => {
+            const next = !prev;
+            if (next) {
+              setDraftFrom(from);
+              setDraftTo(to);
+            }
+            return next;
+          });
+        }}
         aria-haspopup="dialog"
         aria-expanded={open}
         {...tooltipAttrs(t('albums.yearFilterTooltip'), { pos: 'bottom' })}
@@ -168,8 +273,11 @@ export default function YearFilterButton({
                   min={yMin}
                   max={yMax}
                   placeholder={String(yMin)}
-                  value={from}
+                  value={draftFrom}
+                  onFocus={() => { fromFocusedRef.current = true; }}
                   onChange={e => handleFromChange(e.target.value)}
+                  onBlur={commitFromField}
+                  onKeyDown={onYearFieldKeyDown}
                   onWheel={e => onYearWheel(e, 'from')}
                 />
               </div>
@@ -184,8 +292,11 @@ export default function YearFilterButton({
                   min={yMin}
                   max={yMax}
                   placeholder={String(yMax)}
-                  value={to}
+                  value={draftTo}
+                  onFocus={() => { toFocusedRef.current = true; }}
                   onChange={e => handleToChange(e.target.value)}
+                  onBlur={commitToField}
+                  onKeyDown={onYearFieldKeyDown}
                   onWheel={e => onYearWheel(e, 'to')}
                 />
               </div>

--- a/src/ui/YearFilterButton.tsx
+++ b/src/ui/YearFilterButton.tsx
@@ -82,16 +82,12 @@ export default function YearFilterButton({
 
   useEffect(() => {
     if (!fromFocusedRef.current) {
-      // React Compiler set-state-in-effect rule: draft mirrors applied filter when the field is not being edited.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDraftFrom(from);
     }
   }, [from]);
 
   useEffect(() => {
     if (!toFocusedRef.current) {
-      // React Compiler set-state-in-effect rule: draft mirrors applied filter when the field is not being edited.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDraftTo(to);
     }
   }, [to]);
@@ -122,7 +118,7 @@ export default function YearFilterButton({
     setDraftTo(nextTo);
     onChange(nextFrom, nextTo);
     setOpen(false);
-  }, [draftFrom, draftTo, from, onChange, resolveDraftTo, yMin, yMax]);
+  }, [draftFrom, from, onChange, resolveDraftTo, yMin, yMax]);
 
   const commitFromField = useCallback(() => {
     if (!fromFocusedRef.current) return;

--- a/src/ui/YearFilterButton.tsx
+++ b/src/ui/YearFilterButton.tsx
@@ -155,7 +155,9 @@ export default function YearFilterButton({
       if (
         !triggerRef.current?.contains(e.target as Node) &&
         !popRef.current?.contains(e.target as Node)
-      ) setOpen(false);
+      ) {
+        applyDraftsAndClose();
+      }
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -184,7 +186,7 @@ export default function YearFilterButton({
 
   const handleToChange = (raw: string) => {
     const sanitized = sanitizeAlbumYearTypingInput(raw);
-    const spinnerTick = !to.trim()
+    const spinnerTick = !draftTo.trim()
       && sanitized === String(yMin)
       && yMin !== yMax
       && sanitized.length === 4;


### PR DESCRIPTION
## Summary
- Year filter on All Albums no longer clamps on every keystroke while typing a four-digit year; values commit on blur, Enter, or outside click.
- Incomplete drafts (<4 digits) revert to the last committed value; wheel/spinner and clear behavior preserved.

## Test plan
- [ ] Type `1990` in From — digits do not jump to catalog min mid-typing
- [ ] Enter applies both fields and closes the popover
- [ ] Outside click applies drafts and closes
- [ ] Partial `199` + blur reverts to committed value
- [ ] Wheel and native spinner still adjust years
- [ ] Clear button still clears the filter