### PR TITLE
fix(album): localize track count on album detail header

### DIFF
--- a/src/features/album/components/AlbumHeader.test.tsx
+++ b/src/features/album/components/AlbumHeader.test.tsx
@@ -106,6 +106,22 @@ describe('AlbumHeader genres', () => {
     expect(screen.getByRole('button', { name: 'Show all genres' })).toBeInTheDocument();
   });
 
+  it('localizes the track count in the info row', () => {
+    renderWithProviders(
+      <AlbumHeader
+        {...baseProps()}
+        songs={[
+          { id: 't1', duration: 100 } as unknown as SubsonicSong,
+          { id: 't2', duration: 200 } as unknown as SubsonicSong,
+        ]}
+        info={albumInfo()}
+      />,
+      { language: 'nb' },
+    );
+    expect(screen.getByText(/2 spor/)).toBeInTheDocument();
+    expect(screen.queryByText(/Tracks/i)).not.toBeInTheDocument();
+  });
+
   it('opens via keyboard with focus inside the menu, arrow-navigates, and restores focus on close', async () => {
     const user = userEvent.setup();
     renderWithProviders(

--- a/src/features/album/components/AlbumHeader.tsx
+++ b/src/features/album/components/AlbumHeader.tsx
@@ -339,7 +339,7 @@ export default function AlbumHeader({
               )}
               <div className="album-detail-info">
                 {info.year && <span>{info.year}</span>}
-                <span>· {songs.length} Tracks</span>
+                <span>· {t('albumDetail.tracksCount', { n: songs.length })}</span>
                 <span>· {formatLongDuration(totalDuration)}</span>
                 {formatLabel && <span>· {formatLabel}</span>}
                 {info.recordLabel && (


### PR DESCRIPTION
## Summary
- Album detail metadata row used a hardcoded `{n} Tracks` string; it now uses the existing `albumDetail.tracksCount` i18n key (already translated in all locales).
- Reported by HiveMind on Discord.

## Test plan
- [ ] Open an album page with UI language set to Norwegian (or any non-English locale) — track count shows localized text (e.g. `5 spor`), not `Tracks`
- [ ] English locale still shows `5 Tracks`
- [ ] `npx vitest run src/features/album/components/AlbumHeader.test.tsx`