### PR TITLE
Fullscreen player — Prism style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Settings → Appearance → Fullscreen player style** lets you choose **Minimal** (the current view) or **Immersive** — the earlier fullscreen player, with the artist photo/backdrop, a cover-derived accent colour, and rail or Apple-style scrolling lyrics.
 * In Immersive, **Show artist photo** and **Photo dimming** are configurable; Apple-style lyrics show the artist image as a dimmed full-screen backdrop.
 
+### Fullscreen player — Prism style
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1251](https://github.com/Psychotoxical/psysonic/pull/1251)**
+
+* A third **Fullscreen player style**, **Prism** — a full-bleed artist backdrop with a floating glass lyrics panel on the right and a single glass control bar at the bottom (transport, a centred now-playing pill with an integrated progress line, and utilities). The cover-derived accent colour drives the progress fill and the active lyric line, and upcoming lyric lines fade out with a progressive blur.
+
 
 ## Changed
 

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -14,7 +14,7 @@ import DevNetworkModeToggle from '@/app/DevNetworkModeToggle';
 import { NowPlayingDropdown } from '@/features/nowPlaying';
 import QueuePanel from '@/features/queue';
 import AppRoutes from './AppRoutes';
-import FullscreenPlayer, { FullscreenPlayerImmersive } from '@/features/fullscreenPlayer';
+import FullscreenPlayer, { FullscreenPlayerImmersive, FullscreenPlayerPrism } from '@/features/fullscreenPlayer';
 import ContextMenu from '@/features/contextMenu/components/ContextMenu';
 import SongInfoModal from '@/features/playback/components/SongInfoModal';
 import { DownloadFolderModal } from '@/features/offline';
@@ -341,7 +341,9 @@ export function AppShell() {
       {isFullscreenOpen && (
         fullscreenPlayerStyle === 'immersive'
           ? <FullscreenPlayerImmersive onClose={toggleFullscreen} />
-          : <FullscreenPlayer onClose={toggleFullscreen} />
+          : fullscreenPlayerStyle === 'prism'
+            ? <FullscreenPlayerPrism onClose={toggleFullscreen} />
+            : <FullscreenPlayer onClose={toggleFullscreen} />
       )}
       <ContextMenu />
       <SongInfoModal />

--- a/src/features/fullscreenPlayer/components/FsLyricsApple.tsx
+++ b/src/features/fullscreenPlayer/components/FsLyricsApple.tsx
@@ -128,6 +128,7 @@ export const FsLyricsApple = memo(function FsLyricsApple({ currentTrack }: { cur
               ref={el => { lineRefs.current[i] = el; }}
               className={`fsa-lyric-line${i === activeIdx ? ' fsal-active' : i < activeIdx ? ' fsal-past' : ''}`}
               data-time={line.time}
+              style={{ '--fsa-dist': activeIdx < 0 ? 0 : i - activeIdx } as React.CSSProperties}
             >
               {line.words.length > 0
                 ? line.words.map((w, j) => (
@@ -146,6 +147,7 @@ export const FsLyricsApple = memo(function FsLyricsApple({ currentTrack }: { cur
               ref={el => { lineRefs.current[i] = el; }}
               className={`fsa-lyric-line${i === activeIdx ? ' fsal-active' : i < activeIdx ? ' fsal-past' : ''}`}
               data-time={line.time}
+              style={{ '--fsa-dist': activeIdx < 0 ? 0 : i - activeIdx } as React.CSSProperties}
             >
               {line.text || ' '}
             </div>

--- a/src/features/fullscreenPlayer/components/FsSeekbar.tsx
+++ b/src/features/fullscreenPlayer/components/FsSeekbar.tsx
@@ -1,61 +1,35 @@
-import React, { memo, useCallback, useEffect, useRef } from 'react';
-import { usePlayerStore, getPlaybackProgressSnapshot, subscribePlaybackProgress } from '@/features/playback';
+import { memo, useCallback, useRef } from 'react';
+import { usePlayerStore, type PlaybackProgressSnapshot } from '@/features/playback';
 import { formatTrackTime } from '@/lib/format/formatDuration';
+import { useImperativeSeek } from '@/features/fullscreenPlayer/hooks/useImperativeSeek';
 
 // Full-width seekbar — imperative DOM updates, zero React re-renders on tick.
 export const FsSeekbar = memo(function FsSeekbar({ duration }: { duration: number }) {
-  const seek        = usePlayerStore(s => s.seek);
   const timeRef     = useRef<HTMLSpanElement>(null);
   const playedRef   = useRef<HTMLDivElement>(null);
   const bufRef      = useRef<HTMLDivElement>(null);
   const inputRef    = useRef<HTMLInputElement>(null);
-  const isDraggingRef = useRef(false);
-  const pendingSeekRef = useRef<number | null>(null);
 
-  const previewSeek = useCallback((progress: number) => {
-    const s = usePlayerStore.getState();
-    const p = Math.max(0, Math.min(1, progress));
-    pendingSeekRef.current = p;
-    if (timeRef.current) {
-      const previewTime = duration > 0 ? p * duration : s.currentTime;
-      timeRef.current.textContent = formatTrackTime(previewTime);
-    }
-    if (playedRef.current) playedRef.current.style.width = `${p * 100}%`;
-    if (bufRef.current) bufRef.current.style.width = `${Math.max(p * 100, s.buffered * 100)}%`;
-    if (inputRef.current) inputRef.current.value = String(p);
-  }, [duration]);
-
-  const commitSeek = useCallback(() => {
-    const pending = pendingSeekRef.current;
-    if (pending === null) return;
-    pendingSeekRef.current = null;
-    seek(pending);
-  }, [seek]);
-
-  useEffect(() => {
-    const s = getPlaybackProgressSnapshot();
+  const paint = useCallback((s: PlaybackProgressSnapshot) => {
     const pct = s.progress * 100;
     if (timeRef.current)   timeRef.current.textContent  = formatTrackTime(s.currentTime);
     if (playedRef.current) playedRef.current.style.width = `${pct}%`;
     if (bufRef.current)    bufRef.current.style.width    = `${Math.max(pct, s.buffered * 100)}%`;
     if (inputRef.current)  inputRef.current.value        = String(s.progress);
-
-    return subscribePlaybackProgress(state => {
-      if (isDraggingRef.current) return;
-      const p = state.progress * 100;
-      if (timeRef.current)   timeRef.current.textContent  = formatTrackTime(state.currentTime);
-      if (playedRef.current) playedRef.current.style.width = `${p}%`;
-      if (bufRef.current)    bufRef.current.style.width    = `${Math.max(p, state.buffered * 100)}%`;
-      if (inputRef.current)  inputRef.current.value        = String(state.progress);
-    });
   }, []);
 
-  const handleSeek = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      previewSeek(parseFloat(e.target.value));
-    },
-    [previewSeek]
-  );
+  const previewPaint = useCallback((p: number) => {
+    const s = usePlayerStore.getState();
+    if (timeRef.current) {
+      const previewTime = duration > 0 ? p * duration : s.currentTime;
+      timeRef.current.textContent = formatTrackTime(previewTime);
+    }
+    if (playedRef.current) playedRef.current.style.width = `${p * 100}%`;
+    if (bufRef.current)    bufRef.current.style.width    = `${Math.max(p * 100, s.buffered * 100)}%`;
+    if (inputRef.current)  inputRef.current.value        = String(p);
+  }, [duration]);
+
+  const seekHandlers = useImperativeSeek({ paint, previewPaint });
 
   return (
     <div className="fs-seekbar-wrap">
@@ -71,17 +45,8 @@ export const FsSeekbar = memo(function FsSeekbar({ duration }: { duration: numbe
           ref={inputRef}
           type="range" min={0} max={1} step={0.001}
           defaultValue={0}
-          onChange={handleSeek}
-          onMouseDown={() => { isDraggingRef.current = true; }}
-          onMouseUp={() => { isDraggingRef.current = false; commitSeek(); }}
-          onTouchStart={() => { isDraggingRef.current = true; }}
-          onTouchEnd={() => { isDraggingRef.current = false; commitSeek(); }}
-          onPointerDown={() => { isDraggingRef.current = true; }}
-          onPointerUp={() => { isDraggingRef.current = false; commitSeek(); }}
-          onKeyDown={() => { isDraggingRef.current = true; }}
-          onKeyUp={() => { isDraggingRef.current = false; commitSeek(); }}
-          onBlur={() => { isDraggingRef.current = false; commitSeek(); }}
           aria-label="Seek"
+          {...seekHandlers}
         />
       </div>
     </div>

--- a/src/features/fullscreenPlayer/components/FsTimeReadout.tsx
+++ b/src/features/fullscreenPlayer/components/FsTimeReadout.tsx
@@ -2,25 +2,42 @@ import { memo, useEffect, useRef } from 'react';
 import { getPlaybackProgressSnapshot, subscribePlaybackProgress } from '@/features/playback/store/playbackProgress';
 import { formatTrackTime } from '@/lib/format/formatDuration';
 
+interface Props {
+  duration: number;
+  /** Show a live `-remaining` tail (e.g. `1:35 / -2:42`) instead of the total. */
+  remaining?: boolean;
+  /** Outer span class — lets each player style the readout. Defaults to `fsp-time`. */
+  className?: string;
+}
+
 /**
- * Centered "current / total" readout for the control bar. Updates the current
- * time imperatively from the playback-progress store — no React re-render per
- * tick (same pattern as FsSeekbar).
+ * Centered "current / total" readout for the control bar. Updates imperatively
+ * from the playback-progress store — no React re-render per tick (same pattern
+ * as FsSeekbar). With `remaining`, the tail counts down (`current / -remaining`)
+ * and is repainted every tick too.
  */
-export const FsTimeReadout = memo(function FsTimeReadout({ duration }: { duration: number }) {
-  const ref = useRef<HTMLSpanElement>(null);
+export const FsTimeReadout = memo(function FsTimeReadout({
+  duration, remaining = false, className = 'fsp-time',
+}: Props) {
+  const curRef = useRef<HTMLSpanElement>(null);
+  const tailRef = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
     const apply = (state: { currentTime: number }) => {
-      if (ref.current) ref.current.textContent = formatTrackTime(state.currentTime);
+      if (curRef.current) curRef.current.textContent = formatTrackTime(state.currentTime);
+      if (tailRef.current) {
+        tailRef.current.textContent = remaining
+          ? `-${formatTrackTime(Math.max(0, duration - state.currentTime))}`
+          : formatTrackTime(duration);
+      }
     };
     apply(getPlaybackProgressSnapshot());
     return subscribePlaybackProgress(apply);
-  }, []);
+  }, [duration, remaining]);
 
   return (
-    <span className="fsp-time">
-      <span ref={ref} /> / {formatTrackTime(duration)}
+    <span className={className}>
+      <span ref={curRef} /> / <span ref={tailRef} />
     </span>
   );
 });

--- a/src/features/fullscreenPlayer/components/FullscreenPlayerImmersive.tsx
+++ b/src/features/fullscreenPlayer/components/FullscreenPlayerImmersive.tsx
@@ -1,6 +1,6 @@
 import { queueSongStar, playbackCoverArtForAlbum, usePlayerStore } from '@/features/playback';
 import { usePlaybackCoverArt } from '@/cover/usePlaybackCoverArt';
-import { useAlbumCoverRef, useArtistCoverRef } from '@/cover/useLibraryCoverRef';
+import { useAlbumCoverRef } from '@/cover/useLibraryCoverRef';
 import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react';
 import {
   SkipBack, SkipForward,
@@ -10,9 +10,7 @@ import { useCachedUrl } from '@/ui/CachedImage';
 import { getCachedBlob } from '@/cover/imageCache';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/store/authStore';
-import { useThemeStore } from '@/store/themeStore';
-import { useArtistFanart } from '@/cover/useArtistFanart';
-import { backdropFromConfig } from '@/cover/artistBackdrop';
+import { useFsArtistBackdrop } from '@/features/fullscreenPlayer/hooks/useFsArtistBackdrop';
 import { FsLyricsApple } from './FsLyricsApple';
 import { FsLyricsRail } from './FsLyricsRail';
 import { FsArt } from './FsArt';
@@ -71,23 +69,11 @@ export default function FullscreenPlayer({ onClose }: FullscreenPlayerProps) {
   // same-album tracks reuse the color without re-fetching.
   const dynamicAccent = useFsDynamicAccent(artUrl, artKey);
 
-  // Artist image → portrait on right. Resolved through the shared backdrop
-  // pipeline (banner / fanart.tv / Navidrome artist cover, in the user's
+  // Artist image → portrait on right. Resolved through the shared fullscreen
+  // backdrop hook (banner / fanart.tv / Navidrome artist cover, in the user's
   // configured fullscreen-player source order) — the same source the Minimal
   // player uses. Falls back to the album cover when nothing resolves.
-  const fsBackdropCfg = useThemeStore(s => s.backdrops.fullscreenPlayer);
-  const fanart = useArtistFanart(currentTrack?.artistId, {
-    artistName: currentTrack?.artist,
-    albumTitle: currentTrack?.album,
-  });
-  const artistCoverRef =
-    useArtistCoverRef(currentTrack?.artistId, undefined, undefined, { libraryResolve: false }) ??
-    undefined;
-  const artistImage = usePlaybackCoverArt(artistCoverRef, 2000, { fullRes: true });
-  const artistImgUrl = useCachedUrl(artistImage.src, artistImage.cacheKey, true);
-  const artistBgUrl = fsBackdropCfg.enabled
-    ? backdropFromConfig(fsBackdropCfg.sources, { fanart, navidrome: artistImgUrl }).url
-    : '';
+  const artistBgUrl = useFsArtistBackdrop(currentTrack);
   const portraitUrl = artistBgUrl || resolvedCoverUrl;
   const showFullscreenLyrics   = useAuthStore(s => s.showFullscreenLyrics);
   const fsLyricsStyle          = useAuthStore(s => s.fsLyricsStyle);

--- a/src/features/fullscreenPlayer/components/FullscreenPlayerPrism.test.tsx
+++ b/src/features/fullscreenPlayer/components/FullscreenPlayerPrism.test.tsx
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+
+vi.mock('@/ui/CachedImage', async () => {
+  const actual = await vi.importActual<typeof import('@/ui/CachedImage')>('@/ui/CachedImage');
+  return { ...actual, useCachedUrl: vi.fn((url: string) => (url ? `mock://${url}` : '')) };
+});
+
+import FullscreenPlayerPrism from './FullscreenPlayerPrism';
+import { renderWithProviders } from '@/test/helpers/renderWithProviders';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { useAuthStore } from '@/store/authStore';
+import { resetAllStores } from '@/test/helpers/storeReset';
+import { makeTrack } from '@/test/helpers/factories';
+import { onInvoke, registerDefaultCoverInvokeHandlers } from '@/test/mocks/tauri';
+
+beforeEach(() => {
+  resetAllStores();
+  const id = useAuthStore.getState().addServer({
+    name: 'T', url: 'https://x.test', username: 'u', password: 'p',
+  });
+  useAuthStore.getState().setActiveServer(id);
+  useAuthStore.setState({ fullscreenPlayerStyle: 'prism' });
+  registerDefaultCoverInvokeHandlers();
+  onInvoke('audio_stop', () => undefined);
+  onInvoke('audio_get_state', () => ({ playing: false }));
+});
+
+describe('FullscreenPlayerPrism', () => {
+  it('renders the labelled fullscreen dialog and close button', () => {
+    usePlayerStore.setState({ currentTrack: makeTrack() });
+    const { getByLabelText } = renderWithProviders(<FullscreenPlayerPrism onClose={() => {}} />);
+    expect(getByLabelText('Fullscreen Player')).toBeInTheDocument();
+    expect(getByLabelText('Close Fullscreen')).toBeInTheDocument();
+  });
+
+  it('clicking Close calls the onClose prop', () => {
+    usePlayerStore.setState({ currentTrack: makeTrack() });
+    const onClose = vi.fn();
+    const { getByLabelText } = renderWithProviders(<FullscreenPlayerPrism onClose={onClose} />);
+    fireEvent.click(getByLabelText('Close Fullscreen'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('the volume button mutes the player', () => {
+    usePlayerStore.setState({ currentTrack: makeTrack(), volume: 0.7 });
+    const { getByLabelText } = renderWithProviders(<FullscreenPlayerPrism onClose={() => {}} />);
+    fireEvent.click(getByLabelText('Mute'));
+    expect(usePlayerStore.getState().volume).toBe(0);
+  });
+});

--- a/src/features/fullscreenPlayer/components/FullscreenPlayerPrism.tsx
+++ b/src/features/fullscreenPlayer/components/FullscreenPlayerPrism.tsx
@@ -1,65 +1,33 @@
-import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import React, { memo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   SkipBack, SkipForward, Play, Pause, Repeat, Repeat1,
   Volume2, VolumeX, ListMusic, MessageSquare, Shrink,
 } from 'lucide-react';
-import {
-  usePlayerStore, getPlaybackProgressSnapshot, subscribePlaybackProgress,
-} from '@/features/playback';
-import { useThemeStore } from '@/store/themeStore';
-import { useArtistFanart } from '@/cover/useArtistFanart';
-import { backdropFromConfig } from '@/cover/artistBackdrop';
-import { useAlbumCoverRef, useArtistCoverRef } from '@/cover/useLibraryCoverRef';
+import { usePlayerStore, useVolumeToggle, type PlaybackProgressSnapshot } from '@/features/playback';
+import { useAlbumCoverRef } from '@/cover/useLibraryCoverRef';
 import { usePlaybackCoverArt } from '@/cover/usePlaybackCoverArt';
-import { useCachedUrl } from '@/ui/CachedImage';
-import { formatTrackTime } from '@/lib/format/formatDuration';
+import { useFsArtistBackdrop } from '@/features/fullscreenPlayer/hooks/useFsArtistBackdrop';
+import { useImperativeSeek } from '@/features/fullscreenPlayer/hooks/useImperativeSeek';
 import { useFsDynamicAccent } from '@/features/fullscreenPlayer/hooks/useFsDynamicAccent';
 import { useFsIdleFade } from '@/features/fullscreenPlayer/hooks/useFsIdleFade';
+import { FsTimeReadout } from './FsTimeReadout';
 import { FsLyricsApple } from './FsLyricsApple';
 import { FsQueueModal } from './FsQueueModal';
 
-/** Elapsed / −remaining readout (e.g. `1:35 / -2:42`), imperative — no re-render per tick. */
-const PrismTime = memo(function PrismTime({ duration }: { duration: number }) {
-  const ref = useRef<HTMLSpanElement>(null);
-  useEffect(() => {
-    const paint = (currentTime: number) => {
-      if (!ref.current) return;
-      const remaining = duration > 0 ? Math.max(0, duration - currentTime) : 0;
-      ref.current.textContent = `${formatTrackTime(currentTime)} / -${formatTrackTime(remaining)}`;
-    };
-    paint(getPlaybackProgressSnapshot().currentTime);
-    return subscribePlaybackProgress(s => paint(s.currentTime));
-  }, [duration]);
-  return <span className="fsp2-time" ref={ref} />;
-});
-
-/** The now-playing pill's integrated progress line — imperative width + click/drag seek. */
-const PrismProgress = memo(function PrismProgress({ duration }: { duration: number }) {
-  const seek = usePlayerStore(s => s.seek);
+/** The now-playing pill's integrated progress line — imperative width + scrub seek. */
+const PrismProgress = memo(function PrismProgress() {
   const playedRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const draggingRef = useRef(false);
-  const pendingRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    const paint = (progress: number) => {
-      if (playedRef.current) playedRef.current.style.width = `${progress * 100}%`;
-      if (inputRef.current) inputRef.current.value = String(progress);
-    };
-    paint(getPlaybackProgressSnapshot().progress);
-    return subscribePlaybackProgress(s => { if (!draggingRef.current) paint(s.progress); });
+  const paint = useCallback((s: PlaybackProgressSnapshot) => {
+    if (playedRef.current) playedRef.current.style.width = `${s.progress * 100}%`;
+    if (inputRef.current) inputRef.current.value = String(s.progress);
   }, []);
-
-  const preview = useCallback((p: number) => {
-    const v = Math.max(0, Math.min(1, p));
-    pendingRef.current = v;
-    if (playedRef.current) playedRef.current.style.width = `${v * 100}%`;
+  const previewPaint = useCallback((p: number) => {
+    if (playedRef.current) playedRef.current.style.width = `${p * 100}%`;
   }, []);
-  const commit = useCallback(() => {
-    draggingRef.current = false;
-    if (pendingRef.current !== null) { seek(pendingRef.current); pendingRef.current = null; }
-  }, [seek]);
+  const seekHandlers = useImperativeSeek({ paint, previewPaint });
 
   return (
     <div className="fsp2-progress">
@@ -67,14 +35,8 @@ const PrismProgress = memo(function PrismProgress({ duration }: { duration: numb
       <input
         ref={inputRef}
         type="range" min={0} max={1} step={0.001} defaultValue={0}
-        onChange={e => preview(parseFloat(e.target.value))}
-        onMouseDown={() => { draggingRef.current = true; }}
-        onMouseUp={commit}
-        onKeyDown={() => { draggingRef.current = true; }}
-        onKeyUp={commit}
-        onBlur={commit}
         aria-label="Seek"
-        aria-valuetext={duration > 0 ? undefined : ''}
+        {...seekHandlers}
       />
     </div>
   );
@@ -83,19 +45,13 @@ const PrismProgress = memo(function PrismProgress({ duration }: { duration: numb
 /** Compact volume — icon toggles mute, hover reveals the slider. */
 const PrismVolume = memo(function PrismVolume() {
   const { t } = useTranslation();
-  const volume = usePlayerStore(s => s.volume);
-  const setVolume = usePlayerStore(s => s.setVolume);
-  const prevRef = useRef(volume || 1);
-  const muted = volume <= 0;
+  const { volume, setVolume, muted, toggleMute } = useVolumeToggle();
   return (
     <div className="fsp2-volume">
       <button
         className="fsp2-btn"
-        aria-label={t('player.volume')}
-        onClick={() => {
-          if (muted) { setVolume(prevRef.current || 1); }
-          else { prevRef.current = volume; setVolume(0); }
-        }}
+        aria-label={muted ? t('player.unmute') : t('player.mute')}
+        onClick={toggleMute}
       >
         {muted ? <VolumeX size={18} /> : <Volume2 size={18} />}
       </button>
@@ -121,19 +77,8 @@ export default function FullscreenPlayerPrism({ onClose }: { onClose: () => void
   const previous     = usePlayerStore(s => s.previous);
   const toggleRepeat = usePlayerStore(s => s.toggleRepeat);
 
-  // Full-bleed backdrop — same resolution the Minimal/Immersive players use.
-  const fsBackdropCfg = useThemeStore(s => s.backdrops.fullscreenPlayer);
-  const fanart = useArtistFanart(currentTrack?.artistId, {
-    artistName: currentTrack?.artist,
-    albumTitle: currentTrack?.album,
-  });
-  const artistCoverRef =
-    useArtistCoverRef(currentTrack?.artistId, undefined, undefined, { libraryResolve: false }) ?? undefined;
-  const artistImage = usePlaybackCoverArt(artistCoverRef, 2000, { fullRes: true });
-  const artistImgUrl = useCachedUrl(artistImage.src, artistImage.cacheKey, true);
-  const bgUrl = fsBackdropCfg.enabled
-    ? backdropFromConfig(fsBackdropCfg.sources, { fanart, navidrome: artistImgUrl }).url
-    : '';
+  // Full-bleed backdrop — the same shared resolution all three FS players use.
+  const bgUrl = useFsArtistBackdrop(currentTrack);
 
   // Cover-derived accent (album-keyed so it stays stable within an album).
   const albumRef =
@@ -183,7 +128,7 @@ export default function FullscreenPlayerPrism({ onClose }: { onClose: () => void
           >
             {repeatIcon}
           </button>
-          <PrismTime duration={duration} />
+          <FsTimeReadout duration={duration} remaining className="fsp2-time" />
         </div>
 
         {/* Now-playing pill with integrated progress */}
@@ -194,7 +139,7 @@ export default function FullscreenPlayerPrism({ onClose }: { onClose: () => void
               {[currentTrack?.album, currentTrack?.artist].filter(Boolean).join(' · ')}
             </span>
           </div>
-          <PrismProgress duration={duration} />
+          <PrismProgress />
         </div>
 
         {/* Utilities */}

--- a/src/features/fullscreenPlayer/components/FullscreenPlayerPrism.tsx
+++ b/src/features/fullscreenPlayer/components/FullscreenPlayerPrism.tsx
@@ -1,0 +1,226 @@
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  SkipBack, SkipForward, Play, Pause, Repeat, Repeat1,
+  Volume2, VolumeX, ListMusic, MessageSquare, Shrink,
+} from 'lucide-react';
+import {
+  usePlayerStore, getPlaybackProgressSnapshot, subscribePlaybackProgress,
+} from '@/features/playback';
+import { useThemeStore } from '@/store/themeStore';
+import { useArtistFanart } from '@/cover/useArtistFanart';
+import { backdropFromConfig } from '@/cover/artistBackdrop';
+import { useAlbumCoverRef, useArtistCoverRef } from '@/cover/useLibraryCoverRef';
+import { usePlaybackCoverArt } from '@/cover/usePlaybackCoverArt';
+import { useCachedUrl } from '@/ui/CachedImage';
+import { formatTrackTime } from '@/lib/format/formatDuration';
+import { useFsDynamicAccent } from '@/features/fullscreenPlayer/hooks/useFsDynamicAccent';
+import { useFsIdleFade } from '@/features/fullscreenPlayer/hooks/useFsIdleFade';
+import { FsLyricsApple } from './FsLyricsApple';
+import { FsQueueModal } from './FsQueueModal';
+
+/** Elapsed / −remaining readout (e.g. `1:35 / -2:42`), imperative — no re-render per tick. */
+const PrismTime = memo(function PrismTime({ duration }: { duration: number }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    const paint = (currentTime: number) => {
+      if (!ref.current) return;
+      const remaining = duration > 0 ? Math.max(0, duration - currentTime) : 0;
+      ref.current.textContent = `${formatTrackTime(currentTime)} / -${formatTrackTime(remaining)}`;
+    };
+    paint(getPlaybackProgressSnapshot().currentTime);
+    return subscribePlaybackProgress(s => paint(s.currentTime));
+  }, [duration]);
+  return <span className="fsp2-time" ref={ref} />;
+});
+
+/** The now-playing pill's integrated progress line — imperative width + click/drag seek. */
+const PrismProgress = memo(function PrismProgress({ duration }: { duration: number }) {
+  const seek = usePlayerStore(s => s.seek);
+  const playedRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const draggingRef = useRef(false);
+  const pendingRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const paint = (progress: number) => {
+      if (playedRef.current) playedRef.current.style.width = `${progress * 100}%`;
+      if (inputRef.current) inputRef.current.value = String(progress);
+    };
+    paint(getPlaybackProgressSnapshot().progress);
+    return subscribePlaybackProgress(s => { if (!draggingRef.current) paint(s.progress); });
+  }, []);
+
+  const preview = useCallback((p: number) => {
+    const v = Math.max(0, Math.min(1, p));
+    pendingRef.current = v;
+    if (playedRef.current) playedRef.current.style.width = `${v * 100}%`;
+  }, []);
+  const commit = useCallback(() => {
+    draggingRef.current = false;
+    if (pendingRef.current !== null) { seek(pendingRef.current); pendingRef.current = null; }
+  }, [seek]);
+
+  return (
+    <div className="fsp2-progress">
+      <div className="fsp2-progress-played" ref={playedRef} />
+      <input
+        ref={inputRef}
+        type="range" min={0} max={1} step={0.001} defaultValue={0}
+        onChange={e => preview(parseFloat(e.target.value))}
+        onMouseDown={() => { draggingRef.current = true; }}
+        onMouseUp={commit}
+        onKeyDown={() => { draggingRef.current = true; }}
+        onKeyUp={commit}
+        onBlur={commit}
+        aria-label="Seek"
+        aria-valuetext={duration > 0 ? undefined : ''}
+      />
+    </div>
+  );
+});
+
+/** Compact volume — icon toggles mute, hover reveals the slider. */
+const PrismVolume = memo(function PrismVolume() {
+  const { t } = useTranslation();
+  const volume = usePlayerStore(s => s.volume);
+  const setVolume = usePlayerStore(s => s.setVolume);
+  const prevRef = useRef(volume || 1);
+  const muted = volume <= 0;
+  return (
+    <div className="fsp2-volume">
+      <button
+        className="fsp2-btn"
+        aria-label={t('player.volume')}
+        onClick={() => {
+          if (muted) { setVolume(prevRef.current || 1); }
+          else { prevRef.current = volume; setVolume(0); }
+        }}
+      >
+        {muted ? <VolumeX size={18} /> : <Volume2 size={18} />}
+      </button>
+      <input
+        className="fsp2-volume-slider"
+        type="range" min={0} max={1} step={0.01}
+        value={volume}
+        onChange={e => setVolume(parseFloat(e.target.value))}
+        aria-label={t('player.volume')}
+      />
+    </div>
+  );
+});
+
+export default function FullscreenPlayerPrism({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
+
+  const currentTrack = usePlayerStore(s => s.currentTrack);
+  const isPlaying    = usePlayerStore(s => s.isPlaying);
+  const repeatMode   = usePlayerStore(s => s.repeatMode);
+  const togglePlay   = usePlayerStore(s => s.togglePlay);
+  const next         = usePlayerStore(s => s.next);
+  const previous     = usePlayerStore(s => s.previous);
+  const toggleRepeat = usePlayerStore(s => s.toggleRepeat);
+
+  // Full-bleed backdrop — same resolution the Minimal/Immersive players use.
+  const fsBackdropCfg = useThemeStore(s => s.backdrops.fullscreenPlayer);
+  const fanart = useArtistFanart(currentTrack?.artistId, {
+    artistName: currentTrack?.artist,
+    albumTitle: currentTrack?.album,
+  });
+  const artistCoverRef =
+    useArtistCoverRef(currentTrack?.artistId, undefined, undefined, { libraryResolve: false }) ?? undefined;
+  const artistImage = usePlaybackCoverArt(artistCoverRef, 2000, { fullRes: true });
+  const artistImgUrl = useCachedUrl(artistImage.src, artistImage.cacheKey, true);
+  const bgUrl = fsBackdropCfg.enabled
+    ? backdropFromConfig(fsBackdropCfg.sources, { fanart, navidrome: artistImgUrl }).url
+    : '';
+
+  // Cover-derived accent (album-keyed so it stays stable within an album).
+  const albumRef =
+    useAlbumCoverRef(currentTrack?.albumId, undefined, undefined, { libraryResolve: false }) ?? undefined;
+  const cover = usePlaybackCoverArt(albumRef, 300);
+  const dynamicAccent = useFsDynamicAccent(cover.src, cover.cacheKey);
+
+  const [lyricsOpen, setLyricsOpen] = useState(true);
+  const [queueOpen, setQueueOpen] = useState(false);
+  const { isIdle, handleMouseMove } = useFsIdleFade(onClose);
+
+  const duration = currentTrack?.duration ?? 0;
+  const repeatIcon =
+    repeatMode === 'one' ? <Repeat1 size={18} /> : <Repeat size={18} />;
+
+  return (
+    <div
+      className="fsp2-player"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('player.fullscreen')}
+      data-idle={isIdle}
+      onMouseMove={handleMouseMove}
+      style={dynamicAccent ? ({ '--dynamic-fs-accent': dynamicAccent } as React.CSSProperties) : undefined}
+    >
+      {bgUrl && <div className="fsp2-bg" style={{ backgroundImage: `url("${bgUrl}")` }} aria-hidden="true" />}
+      <div className="fsp2-bg-tint" aria-hidden="true" />
+
+      {lyricsOpen && (
+        <div className="fsp2-lyrics-panel">
+          <FsLyricsApple currentTrack={currentTrack} />
+        </div>
+      )}
+
+      <div className="fsp2-bar">
+        {/* Transport + time */}
+        <div className="fsp2-bar-left">
+          <button className="fsp2-btn" onClick={previous} aria-label={t('player.prev')}><SkipBack size={18} /></button>
+          <button className="fsp2-btn fsp2-btn-play" onClick={togglePlay} aria-label={isPlaying ? t('player.pause') : t('player.play')}>
+            {isPlaying ? <Pause size={20} /> : <Play size={20} />}
+          </button>
+          <button className="fsp2-btn" onClick={() => next()} aria-label={t('player.next')}><SkipForward size={18} /></button>
+          <button
+            className={`fsp2-btn${repeatMode !== 'off' ? ' fsp2-btn-active' : ''}`}
+            onClick={toggleRepeat}
+            aria-label={t('player.repeat')}
+          >
+            {repeatIcon}
+          </button>
+          <PrismTime duration={duration} />
+        </div>
+
+        {/* Now-playing pill with integrated progress */}
+        <div className="fsp2-pill">
+          <div className="fsp2-pill-info">
+            <span className="fsp2-pill-title">{currentTrack?.title ?? '—'}</span>
+            <span className="fsp2-pill-sub">
+              {[currentTrack?.album, currentTrack?.artist].filter(Boolean).join(' · ')}
+            </span>
+          </div>
+          <PrismProgress duration={duration} />
+        </div>
+
+        {/* Utilities */}
+        <div className="fsp2-bar-right">
+          <PrismVolume />
+          <button
+            className={`fsp2-btn${queueOpen ? ' fsp2-btn-active' : ''}`}
+            onClick={() => setQueueOpen(o => !o)}
+            aria-label={t('queue.title')}
+          >
+            <ListMusic size={18} />
+          </button>
+          <button
+            className={`fsp2-btn${lyricsOpen ? ' fsp2-btn-active' : ''}`}
+            onClick={() => setLyricsOpen(o => !o)}
+            aria-label={t('player.fsLyricsToggle')}
+          >
+            <MessageSquare size={18} />
+          </button>
+          <button className="fsp2-btn" onClick={onClose} aria-label={t('player.closeFullscreen')}>
+            <Shrink size={18} />
+          </button>
+        </div>
+      </div>
+
+      {queueOpen && <FsQueueModal onClose={() => setQueueOpen(false)} />}
+    </div>
+  );
+}

--- a/src/features/fullscreenPlayer/components/FullscreenPlayerStatic.tsx
+++ b/src/features/fullscreenPlayer/components/FullscreenPlayerStatic.tsx
@@ -6,12 +6,10 @@ import {
 import { useTranslation } from 'react-i18next';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { queueSongStar, queueSongRating } from '@/features/playback/store/pendingStarSync';
-import { useAlbumCoverRef, useArtistCoverRef } from '@/cover/useLibraryCoverRef';
+import { useAlbumCoverRef } from '@/cover/useLibraryCoverRef';
 import { usePlaybackCoverArt } from '@/cover/usePlaybackCoverArt';
 import { useCachedUrl } from '@/ui/CachedImage';
-import { useArtistFanart } from '@/cover/useArtistFanart';
-import { backdropFromConfig } from '@/cover/artistBackdrop';
-import { useThemeStore } from '@/store/themeStore';
+import { useFsArtistBackdrop } from '@/features/fullscreenPlayer/hooks/useFsArtistBackdrop';
 import { useFsIdleFade } from '@/features/fullscreenPlayer/hooks/useFsIdleFade';
 import { useQueueTrackAt } from '@/features/queue';
 import { WaveformSeek } from '@/features/waveform';
@@ -96,23 +94,13 @@ export default function FullscreenPlayerStatic({ onClose }: Props) {
   const thumbUrl = coverUrl;
   // Background (§28). The album cover is deliberately NOT a background source —
   // it only ever feeds the foreground thumbnail. The user-configurable source
-  // list (fanart / Navidrome artist image, no banner) drives the rest: with the
-  // scraper on and fanart first, the fanart.tv 16:9 image is the background and
-  // while it resolves the background stays empty (no album/artist flash), then
-  // falls back per the list; with the scraper off the fanart source reports a
-  // non-pending miss, so the chain steps straight to the Navidrome artist image.
-  const fsBackdropCfg = useThemeStore((s) => s.backdrops.fullscreenPlayer);
-  const fanart = useArtistFanart(currentTrack?.artistId, {
-    artistName: currentTrack?.artist,
-    albumTitle: currentTrack?.album,
-  });
-  const artistCoverRef =
-    useArtistCoverRef(currentTrack?.artistId, undefined, undefined, { libraryResolve: false }) ??
-    undefined;
-  const artistImage = usePlaybackCoverArt(artistCoverRef, 2000, { fullRes: true });
-  const artistImgUrl = useCachedUrl(artistImage.src, artistImage.cacheKey, true);
-  const fsBackdrop = backdropFromConfig(fsBackdropCfg.sources, { fanart, navidrome: artistImgUrl });
-  const bgUrl = fsBackdropCfg.enabled ? fsBackdrop.url : '';
+  // list (fanart / Navidrome artist image, no banner) drives the rest, resolved
+  // through the shared fullscreen backdrop hook: with the scraper on and fanart
+  // first, the fanart.tv 16:9 image is the background and while it resolves the
+  // background stays empty (no album/artist flash), then falls back per the list;
+  // with the scraper off the fanart source reports a non-pending miss, so the
+  // chain steps straight to the Navidrome artist image.
+  const bgUrl = useFsArtistBackdrop(currentTrack);
 
   const nextTrack = useQueueTrackAt(queueIndex + 1);
 

--- a/src/features/fullscreenPlayer/hooks/useFsArtistBackdrop.ts
+++ b/src/features/fullscreenPlayer/hooks/useFsArtistBackdrop.ts
@@ -1,0 +1,32 @@
+import { useThemeStore } from '@/store/themeStore';
+import { useArtistFanart } from '@/cover/useArtistFanart';
+import { backdropFromConfig } from '@/cover/artistBackdrop';
+import { useArtistCoverRef } from '@/cover/useLibraryCoverRef';
+import { usePlaybackCoverArt } from '@/cover/usePlaybackCoverArt';
+import { useCachedUrl } from '@/ui/CachedImage';
+import type { Track } from '@/lib/media/trackTypes';
+
+/**
+ * Resolves the fullscreen-player artist backdrop URL through the shared cover
+ * pipeline, in the user's configured source order (fanart.tv → Navidrome artist
+ * image), honouring the per-surface enable toggle. Returns '' when the backdrop
+ * is disabled or nothing resolves.
+ *
+ * Single source of truth for all three fullscreen player styles — no player
+ * re-derives the backdrop; they all call this.
+ */
+export function useFsArtistBackdrop(currentTrack: Track | null): string {
+  const cfg = useThemeStore(s => s.backdrops.fullscreenPlayer);
+  const fanart = useArtistFanart(currentTrack?.artistId, {
+    artistName: currentTrack?.artist,
+    albumTitle: currentTrack?.album,
+  });
+  const artistCoverRef =
+    useArtistCoverRef(currentTrack?.artistId, undefined, undefined, { libraryResolve: false }) ?? undefined;
+  const artistImage = usePlaybackCoverArt(artistCoverRef, 2000, { fullRes: true });
+  const artistImgUrl = useCachedUrl(artistImage.src, artistImage.cacheKey, true);
+
+  return cfg.enabled
+    ? backdropFromConfig(cfg.sources, { fanart, navidrome: artistImgUrl }).url
+    : '';
+}

--- a/src/features/fullscreenPlayer/hooks/useImperativeSeek.ts
+++ b/src/features/fullscreenPlayer/hooks/useImperativeSeek.ts
@@ -1,0 +1,66 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import {
+  usePlayerStore, getPlaybackProgressSnapshot, subscribePlaybackProgress,
+  type PlaybackProgressSnapshot,
+} from '@/features/playback';
+
+/** Handlers to spread onto a `<input type="range">` for imperative scrub seeking. */
+export interface ImperativeSeekHandlers {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onMouseDown: () => void;
+  onMouseUp: () => void;
+  onTouchStart: () => void;
+  onTouchEnd: () => void;
+  onPointerDown: () => void;
+  onPointerUp: () => void;
+  onKeyDown: () => void;
+  onKeyUp: () => void;
+  onBlur: () => void;
+}
+
+/**
+ * Shared seekbar interaction for the fullscreen players: subscribes to the
+ * playback-progress channel and repaints imperatively (zero re-renders per
+ * tick) via `paint`, pauses repaints while the user drags, previews the drag
+ * position via `previewPaint`, and commits the seek on release. Covers mouse,
+ * touch, pointer, and keyboard input so every input method scrubs.
+ *
+ * `paint` and `previewPaint` must be stable (wrap in `useCallback` with a
+ * ref-only body) — `paint` is a subscription dependency.
+ */
+export function useImperativeSeek(opts: {
+  paint: (s: PlaybackProgressSnapshot) => void;
+  previewPaint: (progress: number) => void;
+}): ImperativeSeekHandlers {
+  const { paint, previewPaint } = opts;
+  const seek = usePlayerStore(s => s.seek);
+  const draggingRef = useRef(false);
+  const pendingRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    paint(getPlaybackProgressSnapshot());
+    return subscribePlaybackProgress(s => { if (!draggingRef.current) paint(s); });
+  }, [paint]);
+
+  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const p = Math.max(0, Math.min(1, parseFloat(e.target.value)));
+    pendingRef.current = p;
+    previewPaint(p);
+  }, [previewPaint]);
+
+  const startDrag = useCallback(() => { draggingRef.current = true; }, []);
+  const endDrag = useCallback(() => {
+    draggingRef.current = false;
+    const pending = pendingRef.current;
+    if (pending !== null) { pendingRef.current = null; seek(pending); }
+  }, [seek]);
+
+  return {
+    onChange,
+    onMouseDown: startDrag, onMouseUp: endDrag,
+    onTouchStart: startDrag, onTouchEnd: endDrag,
+    onPointerDown: startDrag, onPointerUp: endDrag,
+    onKeyDown: startDrag, onKeyUp: endDrag,
+    onBlur: endDrag,
+  };
+}

--- a/src/features/fullscreenPlayer/index.ts
+++ b/src/features/fullscreenPlayer/index.ts
@@ -8,3 +8,4 @@
  */
 export { default } from './components/FullscreenPlayerStatic';
 export { default as FullscreenPlayerImmersive } from './components/FullscreenPlayerImmersive';
+export { default as FullscreenPlayerPrism } from './components/FullscreenPlayerPrism';

--- a/src/features/playback/hooks/useVolumeToggle.test.ts
+++ b/src/features/playback/hooks/useVolumeToggle.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useVolumeToggle } from './useVolumeToggle';
+import { usePlayerStore } from '../store/playerStore';
+import { resetAllStores } from '@/test/helpers/storeReset';
+
+beforeEach(() => {
+  resetAllStores();
+});
+
+describe('useVolumeToggle', () => {
+  it('mutes to 0 and restores the pre-mute level on unmute', () => {
+    usePlayerStore.setState({ volume: 0.8 });
+    const setVolume = vi
+      .spyOn(usePlayerStore.getState(), 'setVolume')
+      .mockImplementation(v => usePlayerStore.setState({ volume: v }));
+
+    const { result } = renderHook(() => useVolumeToggle());
+
+    act(() => { result.current.toggleMute(); });
+    expect(setVolume).toHaveBeenLastCalledWith(0);
+
+    act(() => { result.current.toggleMute(); });
+    expect(setVolume).toHaveBeenLastCalledWith(0.8);
+  });
+
+  it('restores the last non-zero level after the slider was dragged to 0 (not via the mute button)', () => {
+    usePlayerStore.setState({ volume: 0.6 });
+    const setVolume = vi
+      .spyOn(usePlayerStore.getState(), 'setVolume')
+      .mockImplementation(v => usePlayerStore.setState({ volume: v }));
+
+    const { result } = renderHook(() => useVolumeToggle());
+
+    // User drags the slider to 0 directly — the mute button was never clicked.
+    act(() => { usePlayerStore.setState({ volume: 0 }); });
+
+    act(() => { result.current.toggleMute(); });
+    expect(setVolume).toHaveBeenLastCalledWith(0.6);
+  });
+});

--- a/src/features/playback/hooks/useVolumeToggle.ts
+++ b/src/features/playback/hooks/useVolumeToggle.ts
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { usePlayerStore } from '../store/playerStore';
+
+/**
+ * Volume with a mute toggle that restores the pre-mute level. Unlike a ref set
+ * only at mute time, this continuously remembers the last non-zero volume, so
+ * unmuting after the user dragged the slider to 0 (rather than clicking mute)
+ * still restores a sensible level instead of a stale one.
+ */
+export function useVolumeToggle() {
+  const volume = usePlayerStore(s => s.volume);
+  const setVolume = usePlayerStore(s => s.setVolume);
+
+  const lastNonZeroRef = useRef(volume > 0 ? volume : 1);
+  useEffect(() => {
+    if (volume > 0) lastNonZeroRef.current = volume;
+  }, [volume]);
+
+  const muted = volume <= 0;
+  const toggleMute = useCallback(() => {
+    if (muted) setVolume(lastNonZeroRef.current || 1);
+    else setVolume(0);
+  }, [muted, setVolume]);
+
+  return { volume, setVolume, muted, toggleMute };
+}

--- a/src/features/playback/index.ts
+++ b/src/features/playback/index.ts
@@ -6,4 +6,6 @@
 export { usePlayerStore } from './store/playerStore';
 export { queueSongStar } from './store/pendingStarSync';
 export { getPlaybackProgressSnapshot, subscribePlaybackProgress } from './store/playbackProgress';
+export type { PlaybackProgressSnapshot } from './store/playbackProgress';
 export { playbackCoverArtForAlbum } from './utils/playback/playbackServer';
+export { useVolumeToggle } from './hooks/useVolumeToggle';

--- a/src/features/settings/components/AppearanceTab.tsx
+++ b/src/features/settings/components/AppearanceTab.tsx
@@ -26,9 +26,10 @@ export function AppearanceTab() {
   const fontStore = useFontStore();
   const [isTilingWm, setIsTilingWm] = useState(false);
 
-  const fullscreenPlayerStyleOptions: SegmentedOption<'minimal' | 'immersive'>[] = [
+  const fullscreenPlayerStyleOptions: SegmentedOption<'minimal' | 'immersive' | 'prism'>[] = [
     { id: 'minimal', label: t('settings.fullscreenPlayerMinimal') },
     { id: 'immersive', label: t('settings.fullscreenPlayerImmersive') },
+    { id: 'prism', label: t('settings.fullscreenPlayerPrism') },
   ];
 
   useEffect(() => {

--- a/src/locales/bg/settings.ts
+++ b/src/locales/bg/settings.ts
@@ -728,6 +728,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Изберете как да изглежда изгледът за възпроизвеждане на цял екран.',
   fullscreenPlayerMinimal: 'Минимален',
   fullscreenPlayerImmersive: 'Завладяващ',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Показвай снимка на изпълнителя',
   fsShowArtistPortraitDesc: 'Показвай снимката на изпълнителя (или обложката на албума) от дясната страна на плейъра на цял екран.',
   fsPortraitDim: 'Затъмняване на снимката',

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -661,6 +661,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Wähle, wie die Vollbild-Wiedergabeansicht aussieht.',
   fullscreenPlayerMinimal: 'Minimal',
   fullscreenPlayerImmersive: 'Immersiv',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Künstlerfoto anzeigen',
   fsShowArtistPortraitDesc: 'Künstlerfoto (oder Albumcover) auf der rechten Seite des Vollbild-Players anzeigen.',
   fsPortraitDim: 'Abdunkelung des Fotos',

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -728,6 +728,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Choose how the fullscreen now-playing view looks.',
   fullscreenPlayerMinimal: 'Minimal',
   fullscreenPlayerImmersive: 'Immersive',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Show artist photo',
   fsShowArtistPortraitDesc: 'Display the artist photo (or album art) on the right side of the fullscreen player.',
   fsPortraitDim: 'Photo dimming',

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -660,6 +660,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Elige el aspecto de la vista de reproducción a pantalla completa.',
   fullscreenPlayerMinimal: 'Minimalista',
   fullscreenPlayerImmersive: 'Inmersivo',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Mostrar foto del artista',
   fsShowArtistPortraitDesc: 'Muestra la foto del artista (o portada del álbum) en el lado derecho del reproductor pantalla completa.',
   fsPortraitDim: 'Oscurecimiento de foto',

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -648,6 +648,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Choisissez l’apparence de la vue plein écran en cours de lecture.',
   fullscreenPlayerMinimal: 'Minimal',
   fullscreenPlayerImmersive: 'Immersif',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Afficher la photo de l\'artiste',
   fsShowArtistPortraitDesc: 'Afficher la photo de l\'artiste (ou la pochette) sur le côté droit du lecteur plein écran.',
   fsPortraitDim: 'Assombrissement de la photo',

--- a/src/locales/hu/settings.ts
+++ b/src/locales/hu/settings.ts
@@ -728,6 +728,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Válaszd ki, hogyan nézzen ki a teljes képernyős lejátszási nézet.',
   fullscreenPlayerMinimal: 'Minimál',
   fullscreenPlayerImmersive: 'Magával ragadó',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Előadó fotójának megjelenítése',
   fsShowArtistPortraitDesc: 'Az előadó fotójának (vagy az albumborítónak) megjelenítése a teljes képernyős lejátszó jobb oldalán.',
   fsPortraitDim: 'Fotó sötétítése',

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -722,6 +722,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'フルスクリーン再生画面の見た目を選びます。',
   fullscreenPlayerMinimal: 'ミニマル',
   fullscreenPlayerImmersive: '没入型',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'アーティスト写真を表示',
   fsShowArtistPortraitDesc: 'フルスクリーンプレーヤーの右側にアーティスト写真（またはアルバムアート）を表示します。',
   fsPortraitDim: '写真の暗さ',

--- a/src/locales/nb/settings.ts
+++ b/src/locales/nb/settings.ts
@@ -647,6 +647,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Velg hvordan fullskjermsvisningen ser ut.',
   fullscreenPlayerMinimal: 'Minimal',
   fullscreenPlayerImmersive: 'Oppslukende',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Vis artistbilde',
   fsShowArtistPortraitDesc: 'Vis artistbilde (eller albumomslag) på høyre side av fullskjermspilleren.',
   fsPortraitDim: 'Mørklegging av bilde',

--- a/src/locales/nl/settings.ts
+++ b/src/locales/nl/settings.ts
@@ -648,6 +648,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Kies hoe de volledig scherm-weergave eruitziet.',
   fullscreenPlayerMinimal: 'Minimaal',
   fullscreenPlayerImmersive: 'Meeslepend',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Artiestfoto tonen',
   fsShowArtistPortraitDesc: 'Artiestfoto (of albumhoes) weergeven aan de rechterkant van de volledigschermspeler.',
   fsPortraitDim: 'Verduistering foto',

--- a/src/locales/pl/settings.ts
+++ b/src/locales/pl/settings.ts
@@ -728,6 +728,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Wybierz wygląd pełnoekranowego widoku odtwarzania.',
   fullscreenPlayerMinimal: 'Minimalistyczny',
   fullscreenPlayerImmersive: 'Immersyjny',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Pokaż zdjęcie artysty',
   fsShowArtistPortraitDesc: 'Wyświetlaj zdjęcie artysty (lub okładkę albumu) po prawej stronie odtwarzacza pełnoekranowego.',
   fsPortraitDim: 'Przyciemnienie zdjęcia',

--- a/src/locales/ro/settings.ts
+++ b/src/locales/ro/settings.ts
@@ -663,6 +663,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Alege cum arată vizualizarea de redare pe ecran complet.',
   fullscreenPlayerMinimal: 'Minimal',
   fullscreenPlayerImmersive: 'Imersiv',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Arată poza artistului',
   fsShowArtistPortraitDesc: 'Arată poza artistului (sau arta albumului) în partea dreaptă a playerului pe ecran complet.',
   fsPortraitDim: 'Estomparea fotografiei',

--- a/src/locales/ru/settings.ts
+++ b/src/locales/ru/settings.ts
@@ -750,6 +750,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: 'Выберите вид полноэкранного экрана воспроизведения.',
   fullscreenPlayerMinimal: 'Минимальный',
   fullscreenPlayerImmersive: 'Иммерсивный',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: 'Отображать фото артиста',
   fsShowArtistPortraitDesc: 'Показывать фото артиста (или обложку альбома) в правой части полноэкранного плеера.',
   fsPortraitDim: 'Затемнение фото',

--- a/src/locales/zh/settings.ts
+++ b/src/locales/zh/settings.ts
@@ -647,6 +647,7 @@ export const settings = {
   fullscreenPlayerStyleDesc: '选择全屏播放视图的外观。',
   fullscreenPlayerMinimal: '简约',
   fullscreenPlayerImmersive: '沉浸式',
+  fullscreenPlayerPrism: 'Prism',
   fsShowArtistPortrait: '显示艺术家照片',
   fsShowArtistPortraitDesc: '在全屏播放器右侧显示艺术家照片（或专辑封面）。',
   fsPortraitDim: '照片暗化',

--- a/src/store/authStoreTypes.ts
+++ b/src/store/authStoreTypes.ts
@@ -244,7 +244,7 @@ export interface AuthState {
   fsLyricsStyle: 'rail' | 'apple';
   showFsArtistPortrait: boolean;
   fsPortraitDim: number;
-  fullscreenPlayerStyle: 'minimal' | 'immersive';
+  fullscreenPlayerStyle: 'minimal' | 'immersive' | 'prism';
   showChangelogOnUpdate: boolean;
   lastSeenChangelogVersion: string;
   /** Signature of the installed-theme updates last dismissed in the sidebar
@@ -444,7 +444,7 @@ export interface AuthState {
   setFsLyricsStyle: (v: 'rail' | 'apple') => void;
   setShowFsArtistPortrait: (v: boolean) => void;
   setFsPortraitDim: (v: number) => void;
-  setFullscreenPlayerStyle: (v: 'minimal' | 'immersive') => void;
+  setFullscreenPlayerStyle: (v: 'minimal' | 'immersive' | 'prism') => void;
   setShowChangelogOnUpdate: (v: boolean) => void;
   setLastSeenChangelogVersion: (v: string) => void;
   setLastDismissedThemeUpdateSig: (v: string) => void;

--- a/src/styles/components/fullscreen-player-prism.css
+++ b/src/styles/components/fullscreen-player-prism.css
@@ -137,8 +137,16 @@
   border: 1px solid rgba(255, 255, 255, 0.05);
   overflow: hidden;
 }
-.fsp2-pill-info { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.fsp2-pill-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+  text-align: center;
+}
 .fsp2-pill-title {
+  max-width: 100%;
   font-size: 14px;
   font-weight: 700;
   color: #fff;
@@ -147,6 +155,7 @@
   text-overflow: ellipsis;
 }
 .fsp2-pill-sub {
+  max-width: 100%;
   font-size: 12px;
   color: rgba(255, 255, 255, 0.58);
   white-space: nowrap;

--- a/src/styles/components/fullscreen-player-prism.css
+++ b/src/styles/components/fullscreen-player-prism.css
@@ -1,0 +1,179 @@
+/* Prism fullscreen player — full-bleed backdrop, a floating right-side lyrics
+   panel, and a glassy bottom control bar (transport · now-playing pill · utils).
+   Cover-derived accent drives the progress + active states via --dynamic-fs-accent. */
+
+.fsp2-player {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  overflow: hidden;
+  background: #05060a;
+  animation: fsp2-fade-in 220ms ease;
+}
+
+@keyframes fsp2-fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+/* ── Full-bleed backdrop + legibility tint ─────────────────────────────────── */
+.fsp2-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center 30%;
+}
+.fsp2-bg-tint {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(120% 90% at 30% 20%, transparent 40%, rgba(5, 6, 10, 0.55) 100%),
+    linear-gradient(to top, rgba(5, 6, 10, 0.82) 0%, rgba(5, 6, 10, 0.25) 26%, transparent 46%);
+}
+
+/* ── Right-side lyrics panel (glass) ───────────────────────────────────────── */
+.fsp2-lyrics-panel {
+  position: absolute;
+  right: 3vw;
+  top: 8vh;
+  bottom: 12vh;
+  width: min(46%, 720px);
+  border-radius: 26px;
+  overflow: hidden;
+  background: rgba(10, 14, 18, 0.42);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(28px) saturate(1.1);
+  -webkit-backdrop-filter: blur(28px) saturate(1.1);
+}
+/* The reused FsLyricsApple container fills the panel; give it inner breathing room. */
+.fsp2-lyrics-panel .fsa-lyrics-container {
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+/* ── Bottom bar ────────────────────────────────────────────────────────────── */
+.fsp2-bar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 20px 26px calc(20px + env(safe-area-inset-bottom, 0px));
+  transition: opacity 300ms ease;
+}
+.fsp2-player[data-idle='true'] .fsp2-bar { opacity: 0; }
+
+.fsp2-bar-left,
+.fsp2-bar-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 16px;
+  background: rgba(12, 14, 20, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+.fsp2-bar-left { gap: 4px; }
+
+.fsp2-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.82);
+  cursor: pointer;
+  transition: background 140ms ease, color 140ms ease;
+}
+.fsp2-btn:hover { background: rgba(255, 255, 255, 0.1); color: #fff; }
+.fsp2-btn-play { color: #fff; }
+.fsp2-btn-active {
+  color: var(--dynamic-fs-accent, var(--accent));
+  background: color-mix(in srgb, var(--dynamic-fs-accent, var(--accent)) 16%, transparent);
+}
+
+.fsp2-time {
+  margin-left: 8px;
+  padding-right: 6px;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.7);
+  white-space: nowrap;
+}
+
+/* ── Now-playing pill ──────────────────────────────────────────────────────── */
+.fsp2-pill {
+  position: relative;
+  flex: 0 1 420px;
+  min-width: 220px;
+  padding: 8px 18px 12px;
+  border-radius: 16px;
+  background: rgba(8, 10, 16, 0.62);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  overflow: hidden;
+}
+.fsp2-pill-info { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.fsp2-pill-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fsp2-pill-sub {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.58);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Integrated progress line at the pill's bottom edge; the range input is a
+   transparent full-cover overlay so the whole pill scrubs. */
+.fsp2-progress { position: absolute; left: 0; right: 0; bottom: 0; height: 3px; }
+.fsp2-progress-played {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  background: var(--dynamic-fs-accent, var(--accent));
+  box-shadow: 0 0 10px var(--dynamic-fs-accent, var(--accent));
+}
+.fsp2-progress input[type='range'] {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 16px; /* generous hit target above the visual line */
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+/* ── Volume ────────────────────────────────────────────────────────────────── */
+.fsp2-volume { display: flex; align-items: center; gap: 2px; }
+.fsp2-volume-slider {
+  width: 0;
+  opacity: 0;
+  transition: width 160ms ease, opacity 160ms ease;
+  accent-color: var(--dynamic-fs-accent, var(--accent));
+  cursor: pointer;
+}
+.fsp2-volume:hover .fsp2-volume-slider,
+.fsp2-volume:focus-within .fsp2-volume-slider { width: 84px; opacity: 1; }
+
+@media (max-width: 900px) {
+  .fsp2-lyrics-panel { left: 3vw; width: auto; }
+  .fsp2-pill { display: none; }
+}

--- a/src/styles/components/fullscreen-player-prism.css
+++ b/src/styles/components/fullscreen-player-prism.css
@@ -51,18 +51,25 @@
 }
 
 /* ── Bottom bar ────────────────────────────────────────────────────────────── */
-/* Centred control row (a middle band, not edge-to-edge). Only the now-playing
-   element is boxed; transport (left) and utilities (right) float bare. */
+/* Outer bar — a wide translucent glass strip holding the whole control row.
+   Transport (left) and utilities (right) sit bare inside it; the now-playing
+   element is a darker nested box (see .fsp2-pill). */
 .fsp2-bar {
   position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 40px;
+  right: 40px;
   bottom: 22px;
-  width: min(1180px, calc(100% - 44px));
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
+  padding: 8px 14px;
+  border-radius: 20px;
+  background: rgba(12, 15, 20, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 55px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(24px) saturate(1.1);
+  -webkit-backdrop-filter: blur(24px) saturate(1.1);
 }
 /* Controls stay visible; only the cursor hides while idle. */
 .fsp2-player[data-idle='true'] { cursor: none; }
@@ -74,10 +81,6 @@
   gap: 6px;
 }
 .fsp2-bar-left { gap: 4px; }
-/* Bare transport/utility icons sit directly on the image → drop shadow for legibility. */
-.fsp2-bar-left .fsp2-btn,
-.fsp2-bar-right .fsp2-btn,
-.fsp2-time { filter: drop-shadow(0 1px 5px rgba(0, 0, 0, 0.7)); }
 
 .fsp2-btn {
   display: inline-flex;
@@ -109,19 +112,15 @@
 }
 
 /* ── Now-playing pill ──────────────────────────────────────────────────────── */
-/* Centre now-playing pill — the one boxed element (cider-style); transport and
-   utilities flank it bare. */
+/* Centre now-playing pill — a darker box NESTED inside the outer bar. */
 .fsp2-pill {
   position: relative;
   flex: 0 1 460px;
   min-width: 220px;
-  padding: 8px 18px 12px;
-  border-radius: 14px;
-  background: rgba(8, 10, 16, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  box-shadow: 0 10px 34px rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
+  padding: 6px 16px 10px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.05);
   overflow: hidden;
 }
 .fsp2-pill-info { display: flex; flex-direction: column; gap: 2px; min-width: 0; }

--- a/src/styles/components/fullscreen-player-prism.css
+++ b/src/styles/components/fullscreen-player-prism.css
@@ -56,9 +56,10 @@
    element is a darker nested box (see .fsp2-pill). */
 .fsp2-bar {
   position: absolute;
-  left: 40px;
-  right: 40px;
+  left: 50%;
+  transform: translateX(-50%);
   bottom: 22px;
+  width: clamp(560px, 50%, 1040px);
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/styles/components/fullscreen-player-prism.css
+++ b/src/styles/components/fullscreen-player-prism.css
@@ -51,22 +51,28 @@
 }
 
 /* ── Bottom bar ────────────────────────────────────────────────────────────── */
+/* One continuous glass bar spanning the width — transport (left), now-playing
+   (centre), utilities (right) all live inside it, so it reads as a single bar. */
 .fsp2-bar {
   position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  left: 22px;
+  right: 22px;
+  bottom: 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 18px;
-  padding: 20px 26px calc(20px + env(safe-area-inset-bottom, 0px));
+  gap: 20px;
+  padding: 8px 16px;
+  border-radius: 18px;
+  background: rgba(10, 12, 18, 0.46);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 16px 50px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(22px) saturate(1.05);
+  -webkit-backdrop-filter: blur(22px) saturate(1.05);
 }
 /* Controls stay visible; only the cursor hides while idle. */
 .fsp2-player[data-idle='true'] { cursor: none; }
 
-/* Transport + utilities float bare over the backdrop (only the now-playing pill
-   gets a glass container), so the bar reads as one row, not three boxes. */
 .fsp2-bar-left,
 .fsp2-bar-right {
   display: flex;
@@ -74,10 +80,6 @@
   gap: 6px;
 }
 .fsp2-bar-left { gap: 4px; }
-/* Legibility drop shadow since the icons sit directly on the image. */
-.fsp2-bar-left .fsp2-btn,
-.fsp2-bar-right .fsp2-btn,
-.fsp2-time { filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.6)); }
 
 .fsp2-btn {
   display: inline-flex;
@@ -109,17 +111,12 @@
 }
 
 /* ── Now-playing pill ──────────────────────────────────────────────────────── */
+/* Centre now-playing block — part of the one bar, no separate box. */
 .fsp2-pill {
   position: relative;
-  flex: 0 1 420px;
-  min-width: 220px;
-  padding: 8px 18px 12px;
-  border-radius: 16px;
-  background: rgba(8, 10, 16, 0.62);
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
-  overflow: hidden;
+  flex: 0 1 460px;
+  min-width: 200px;
+  padding: 2px 0 8px;
 }
 .fsp2-pill-info { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .fsp2-pill-title {

--- a/src/styles/components/fullscreen-player-prism.css
+++ b/src/styles/components/fullscreen-player-prism.css
@@ -50,6 +50,19 @@
   padding-right: 40px;
 }
 
+/* Upcoming lines get a progressive blur (sharp active line → hazier ahead) via
+   the per-line --fsa-dist (distance from the active line; past lines are ≤0). */
+.fsp2-lyrics-panel .fsa-lyric-line {
+  filter: blur(clamp(0px, calc(max(var(--fsa-dist, 0), 0) * 0.9px), 5px));
+  transition: filter 320ms ease, color 320ms ease;
+}
+/* Active line takes on the cover accent — like the progress bar. */
+.fsp2-lyrics-panel .fsa-lyric-line.fsal-active,
+.fsp2-lyrics-panel .fsa-lyric-line.fsal-active .fsa-lyric-word.played,
+.fsp2-lyrics-panel .fsa-lyric-line.fsal-active .fsa-lyric-word.active {
+  color: var(--dynamic-fs-accent, var(--accent));
+}
+
 /* ── Bottom bar ────────────────────────────────────────────────────────────── */
 /* Outer bar — a wide translucent glass strip holding the whole control row.
    Transport (left) and utilities (right) sit bare inside it; the now-playing

--- a/src/styles/components/fullscreen-player-prism.css
+++ b/src/styles/components/fullscreen-player-prism.css
@@ -61,23 +61,23 @@
   justify-content: space-between;
   gap: 18px;
   padding: 20px 26px calc(20px + env(safe-area-inset-bottom, 0px));
-  transition: opacity 300ms ease;
 }
-.fsp2-player[data-idle='true'] .fsp2-bar { opacity: 0; }
+/* Controls stay visible; only the cursor hides while idle. */
+.fsp2-player[data-idle='true'] { cursor: none; }
 
+/* Transport + utilities float bare over the backdrop (only the now-playing pill
+   gets a glass container), so the bar reads as one row, not three boxes. */
 .fsp2-bar-left,
 .fsp2-bar-right {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 10px;
-  border-radius: 16px;
-  background: rgba(12, 14, 20, 0.5);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
 }
 .fsp2-bar-left { gap: 4px; }
+/* Legibility drop shadow since the icons sit directly on the image. */
+.fsp2-bar-left .fsp2-btn,
+.fsp2-bar-right .fsp2-btn,
+.fsp2-time { filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.6)); }
 
 .fsp2-btn {
   display: inline-flex;

--- a/src/styles/components/fullscreen-player-prism.css
+++ b/src/styles/components/fullscreen-player-prism.css
@@ -51,24 +51,18 @@
 }
 
 /* ── Bottom bar ────────────────────────────────────────────────────────────── */
-/* One continuous glass bar spanning the width — transport (left), now-playing
-   (centre), utilities (right) all live inside it, so it reads as a single bar. */
+/* Centred control row (a middle band, not edge-to-edge). Only the now-playing
+   element is boxed; transport (left) and utilities (right) float bare. */
 .fsp2-bar {
   position: absolute;
-  left: 22px;
-  right: 22px;
-  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 22px;
+  width: min(1180px, calc(100% - 44px));
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
-  padding: 8px 16px;
-  border-radius: 18px;
-  background: rgba(10, 12, 18, 0.46);
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  box-shadow: 0 16px 50px rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(22px) saturate(1.05);
-  -webkit-backdrop-filter: blur(22px) saturate(1.05);
 }
 /* Controls stay visible; only the cursor hides while idle. */
 .fsp2-player[data-idle='true'] { cursor: none; }
@@ -80,6 +74,10 @@
   gap: 6px;
 }
 .fsp2-bar-left { gap: 4px; }
+/* Bare transport/utility icons sit directly on the image → drop shadow for legibility. */
+.fsp2-bar-left .fsp2-btn,
+.fsp2-bar-right .fsp2-btn,
+.fsp2-time { filter: drop-shadow(0 1px 5px rgba(0, 0, 0, 0.7)); }
 
 .fsp2-btn {
   display: inline-flex;
@@ -111,12 +109,20 @@
 }
 
 /* ── Now-playing pill ──────────────────────────────────────────────────────── */
-/* Centre now-playing block — part of the one bar, no separate box. */
+/* Centre now-playing pill — the one boxed element (cider-style); transport and
+   utilities flank it bare. */
 .fsp2-pill {
   position: relative;
   flex: 0 1 460px;
-  min-width: 200px;
-  padding: 2px 0 8px;
+  min-width: 220px;
+  padding: 8px 18px 12px;
+  border-radius: 14px;
+  background: rgba(8, 10, 16, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 10px 34px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  overflow: hidden;
 }
 .fsp2-pill-info { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .fsp2-pill-title {

--- a/src/styles/components/index.css
+++ b/src/styles/components/index.css
@@ -35,6 +35,7 @@
 @import './fullscreen-player-adaptive-portrait.css';
 @import './fullscreen-player-static.css';
 @import './fullscreen-player-immersive.css';
+@import './fullscreen-player-prism.css';
 @import './context-menu.css';
 @import './css-tooltips.css';
 @import './playlists-page.css';


### PR DESCRIPTION
Adds **Prism**, a third selectable fullscreen player style alongside Minimal and Immersive.

## Prism

A full-bleed artist backdrop with a floating glass lyrics panel on the right and a single glass control bar at the bottom (transport · centred now-playing pill with integrated progress · utilities). The cover-derived accent drives the progress fill and the active lyric line; upcoming lyric lines get a progressive blur. Selectable under **Settings → Appearance → Fullscreen player style**.

## Shared building blocks

All three fullscreen styles (Minimal/Static, Immersive, Prism) share single sources of truth rather than each carrying its own seek/volume/backdrop/time code:

- **`useFsArtistBackdrop`** — artist-backdrop URL resolution through the existing cover pipeline (fanart.tv → Navidrome artist image).
- **`useImperativeSeek`** — the drag/preview/commit loop plus the progress subscription, with mouse, touch, pointer and keyboard handlers.
- **`useVolumeToggle`** — mute toggle that continuously tracks the last non-zero volume, so unmuting restores the right level however the slider reached 0.
- **`FsTimeReadout`** — gains `remaining` / `className` props so each player styles it and picks total vs. countdown.

No new cover/image resolution paths — Prism resolves covers and backdrops solely through the existing `@/cover/*`, `@/ui/CachedImage` and player-store surface.

## Tests

- `useVolumeToggle` unit test covering the restore-after-drag-to-0 path.
- `FullscreenPlayerPrism` smoke test (dialog/close/mute).
- Existing fullscreen + playback suites stay green.