### PR TITLE
fix(library): prune orphaned artist/album rows after resync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Library — renamed artists/albums no longer linger as ghosts after resync
 
-**By [@cucadmuh](https://github.com/cucadmuh), PR [#1253](https://github.com/Psychotoxical/psysonic/pull/1253)**
+**By [@cucadmuh](https://github.com/cucadmuh), reported by Seraphim on the Psysonic Discord, PR [#1253](https://github.com/Psychotoxical/psysonic/pull/1253)**
 
 * Renaming an artist (or album) on the server no longer leaves a stale entry in the local Artists/Albums list that opened to "Artist not found" — a sync now prunes browse-index rows the server no longer lists that also have no remaining tracks, keeping starred albums. Cleanup runs on both full and delta syncs, and a one-time pass at startup clears ghosts already accumulated in existing libraries.
 * The renamed artist/album now appears right after a resync instead of only after an app restart: the Artists and Albums pages refresh their cached catalog when a library sync finishes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The **Settings → Integrations → Discord → Cover art source → Server** option sent your server's cover URL to Discord, which republishes external image links, so anyone viewing your Rich Presence could read your username and login token. That option has been removed — cover art now comes only from **None** (app icon) or **Apple Music**, neither of which carries your credentials. Any saved **Server** setting is switched to **None**. Reported by lavioso on Discord.
 
+### Library — renamed artists/albums no longer linger as ghosts after resync
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1253](https://github.com/Psychotoxical/psysonic/pull/1253)**
+
+* Renaming an artist (or album) on the server no longer leaves a stale entry in the local Artists/Albums list that opened to "Artist not found" — a sync now prunes browse-index rows the server no longer lists that also have no remaining tracks, keeping starred albums. Cleanup runs on both full and delta syncs, and a one-time pass at startup clears ghosts already accumulated in existing libraries.
+* The renamed artist/album now appears right after a resync instead of only after an app restart: the Artists and Albums pages refresh their cached catalog when a library sync finishes.
+
 
 ## [1.49.0] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,12 +178,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The **Settings → Integrations → Discord → Cover art source → Server** option sent your server's cover URL to Discord, which republishes external image links, so anyone viewing your Rich Presence could read your username and login token. That option has been removed — cover art now comes only from **None** (app icon) or **Apple Music**, neither of which carries your credentials. Any saved **Server** setting is switched to **None**. Reported by lavioso on Discord.
 
-### Library — renamed artists/albums no longer linger as ghosts after resync
+### Library — renamed artists no longer linger as ghosts after resync
 
 **By [@cucadmuh](https://github.com/cucadmuh), reported by Seraphim on the Psysonic Discord, PR [#1253](https://github.com/Psychotoxical/psysonic/pull/1253)**
 
-* Renaming an artist (or album) on the server no longer leaves a stale entry in the local Artists/Albums list that opened to "Artist not found" — a sync now prunes browse-index rows the server no longer lists that also have no remaining tracks, keeping starred albums. Cleanup runs on both full and delta syncs, and a one-time pass at startup clears ghosts already accumulated in existing libraries.
-* The renamed artist/album now appears right after a resync instead of only after an app restart: the Artists and Albums pages refresh their cached catalog when a library sync finishes.
+* Renaming an artist on the server no longer leaves a stale entry in the local Artists list that opened to "Artist not found" — a sync now prunes artist rows the latest server listing no longer confirms that also have no remaining tracks. Cleanup runs on both full and delta syncs (only after a confirmed artist listing, so a transient empty response can't drop valid entries), plus a one-time pass at startup that clears ghosts already accumulated in existing libraries.
+* Newly added or renamed entries now show up right after a resync instead of only after an app restart: the Artists and Albums pages refresh their cached catalog when a library sync finishes.
 
 
 ## [1.49.0] - 2026-06-29

--- a/src-tauri/crates/psysonic-library/migrations/018_artist_synced_index.sql
+++ b/src-tauri/crates/psysonic-library/migrations/018_artist_synced_index.sql
@@ -1,0 +1,5 @@
+-- Speeds up the orphan-artist prune's freshness check: the prune keeps the
+-- freshest getArtists pass per server (MAX(synced_at)) and deletes stale rows
+-- below it. Without this index that lookup scans every artist row for the
+-- server on each sync; the composite index turns it into a seek + range.
+CREATE INDEX IF NOT EXISTS idx_artist_synced ON artist(server_id, synced_at);

--- a/src-tauri/crates/psysonic-library/src/lib.rs
+++ b/src-tauri/crates/psysonic-library/src/lib.rs
@@ -32,6 +32,7 @@ pub mod genre_tags_backfill;
 pub mod identity;
 pub mod mood_groups;
 pub mod live_search;
+pub mod orphan_cleanup;
 pub mod lossless_albums;
 pub mod lossless_formats;
 pub mod payload;

--- a/src-tauri/crates/psysonic-library/src/orphan_cleanup.rs
+++ b/src-tauri/crates/psysonic-library/src/orphan_cleanup.rs
@@ -1,61 +1,75 @@
-//! Remove browse-index rows orphaned by server-side renames/removals.
+//! Remove `artist` browse rows orphaned by server-side renames/removals.
 //!
-//! `getArtists` derives artist ids from tags, so renaming an artist (or an
-//! album) mints a *new* id server-side and drops the old one. Track ingest
-//! moves the affected tracks onto the new id (or the resync orphan sweep /
-//! tombstone reconciler soft-deletes them), but the stale **`artist`** and
-//! **`album`** browse rows were never pruned — they lingered in the catalog and
-//! opened to "Artist not found" because detail resolves from live tracks.
+//! `getArtists` derives artist ids from tags, so renaming an artist mints a
+//! *new* id server-side and drops the old one. Track ingest moves the affected
+//! tracks onto the new id (or the resync orphan sweep / tombstone reconciler
+//! soft-deletes them), but the stale **`artist`** browse row was never pruned —
+//! it lingered in the catalog and opened to "Artist not found" because detail
+//! resolves from live tracks.
 //!
-//! These prunes run on every sync that refreshes the artist index (full and
-//! delta), right after the track sweep, and once at open for pre-existing DBs
-//! (see `store::maybe_reconcile_orphan_browse_rows`). All three share the same
-//! conn-level statements below.
+//! **Authority.** A row is removed only when *both* signals agree:
+//! - it is **not confirmed by the latest `getArtists` pass** — its `synced_at`
+//!   is older than the freshest `artist` row for the same server (every artist
+//!   the pass returned was re-stamped `now`), and
+//! - **no live (`deleted = 0`) track credits it** (any album/track credit).
 //!
-//! Safety — a row is removed only when it is genuinely unreachable:
-//! - **Artist:** not confirmed by the latest `getArtists` pass (its
-//!   `synced_at` is older than the freshest artist row for the same server)
-//!   **and** no live (`deleted = 0`) track credits it. Artists still backing a
-//!   live track (any library scope, album credit) or refreshed this pass are
-//!   kept, so nothing browsable/openable is dropped.
-//! - **Album:** no live track references it **and** it is not starred, so a
-//!   favourited album is never dropped even if it briefly loses every track.
+//! Callers must only invoke the prune after a *confirmed* `getArtists` pass
+//! (`upsert_index` wrote ≥ 1 row): otherwise `backfill_from_tracks` can advance
+//! the freshest `synced_at` from a track alone, and an empty/partial `getArtists`
+//! would mass-prune album-artist-only rows. The sync call sites gate on that
+//! count; the one-time open reconcile only runs on the last authoritative
+//! snapshot already in the DB.
+//!
+//! **Album rows are intentionally not pruned here.** They have no `getArtists`
+//! equivalent to supply a freshness stamp (N1 ingest never stamps `album`, and
+//! several on-demand paths insert track-less rows), so a "no live track" delete
+//! is unsafe. Album-ghost cleanup needs its own positive-confirmation signal —
+//! tracked as a follow-up.
+//!
+//! **Scope.** Track matching is server-wide, which is correct for the default
+//! all-libraries sync. A session bound to a single `library_scope` is a
+//! pre-existing sweep hazard (it soft-deletes other libraries' tracks); this
+//! prune inherits that assumption and should only run for all-libraries syncs.
 
-use rusqlite::{Connection, Result as SqlResult};
+use rusqlite::{params, Connection, Result as SqlResult};
 
 use crate::store::LibraryStore;
 
-/// Rows removed by a single [`prune_library_orphans_for_server`] call.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct OrphanPruneReport {
-    pub artists: u32,
-    pub albums: u32,
-}
-
-/// Prune orphaned `artist` + `album` rows for one server (sync paths).
-pub fn prune_library_orphans_for_server(
+/// Prune orphaned `artist` rows for one server (sync paths). Computes the
+/// freshest `synced_at` once (index-backed) and deletes rows below it with no
+/// live track. Caller must confirm `getArtists` returned ≥ 1 artist first.
+pub fn prune_orphan_artists_for_server(
     store: &LibraryStore,
     server_id: &str,
-) -> Result<OrphanPruneReport, String> {
-    store.with_conn_mut("orphan_cleanup.prune_server", |conn| {
-        let artists = prune_orphan_artists(conn, Some(server_id))?;
-        let albums = prune_orphan_albums(conn, Some(server_id))?;
-        Ok(OrphanPruneReport {
-            artists: artists as u32,
-            albums: albums as u32,
-        })
+) -> Result<u32, String> {
+    store.with_conn_mut("orphan_cleanup.prune_artists", |conn| {
+        let cutoff: Option<i64> = conn.query_row(
+            "SELECT MAX(synced_at) FROM artist WHERE server_id = ?1",
+            params![server_id],
+            |r| r.get(0),
+        )?;
+        let Some(cutoff) = cutoff else { return Ok(0) };
+        let removed = conn.execute(
+            "DELETE FROM artist \
+             WHERE server_id = ?1 AND synced_at < ?2 \
+               AND NOT EXISTS ( \
+                 SELECT 1 FROM track \
+                 WHERE track.server_id = artist.server_id \
+                   AND track.artist_id = artist.id \
+                   AND track.deleted = 0 \
+               )",
+            params![server_id, cutoff],
+        )?;
+        Ok(removed as u32)
     })
 }
 
-/// Delete `artist` rows the latest server pass did not confirm that also have
-/// no live track crediting them. Pass `Some(server_id)` to scope to one server
-/// (sync paths) or `None` to sweep every server (one-time open reconcile).
-pub fn prune_orphan_artists(conn: &Connection, server_id: Option<&str>) -> SqlResult<usize> {
-    // The freshest `synced_at` per server marks the most recent successful
-    // `getArtists` pass — every artist confirmed then shares it, so rows left
-    // below it were dropped by the server. Correlated on `artist.server_id` so
-    // the same statement works scoped or global.
-    let base = "DELETE FROM artist \
+/// Prune orphaned `artist` rows across **every** server (one-time open
+/// reconcile). Per-server freshest `synced_at` via a correlated subquery — runs
+/// once at open, not on the hot sync path.
+pub fn prune_orphan_artists_all(conn: &Connection) -> SqlResult<usize> {
+    conn.execute(
+        "DELETE FROM artist \
          WHERE synced_at < ( \
              SELECT MAX(ai.synced_at) FROM artist ai WHERE ai.server_id = artist.server_id \
          ) \
@@ -64,34 +78,9 @@ pub fn prune_orphan_artists(conn: &Connection, server_id: Option<&str>) -> SqlRe
              WHERE track.server_id = artist.server_id \
                AND track.artist_id = artist.id \
                AND track.deleted = 0 \
-         )";
-    match server_id {
-        Some(sid) => {
-            let sql = format!("{base} AND server_id = ?1");
-            conn.execute(&sql, rusqlite::params![sid])
-        }
-        None => conn.execute(base, []),
-    }
-}
-
-/// Delete `album` rows with no live track and no favourite (`starred_at`).
-/// Pass `Some(server_id)` to scope to one server or `None` to sweep all.
-pub fn prune_orphan_albums(conn: &Connection, server_id: Option<&str>) -> SqlResult<usize> {
-    let base = "DELETE FROM album \
-         WHERE starred_at IS NULL \
-         AND NOT EXISTS ( \
-             SELECT 1 FROM track \
-             WHERE track.server_id = album.server_id \
-               AND track.album_id = album.id \
-               AND track.deleted = 0 \
-         )";
-    match server_id {
-        Some(sid) => {
-            let sql = format!("{base} AND server_id = ?1");
-            conn.execute(&sql, rusqlite::params![sid])
-        }
-        None => conn.execute(base, []),
-    }
+         )",
+        [],
+    )
 }
 
 #[cfg(test)]
@@ -104,39 +93,20 @@ mod tests {
                 c.execute(
                     "INSERT INTO artist (server_id, id, name, name_sort, synced_at) \
                      VALUES (?1, ?2, ?2, ?2, ?3)",
-                    rusqlite::params![server, id, synced_at],
+                    params![server, id, synced_at],
                 )
             })
             .unwrap();
     }
 
-    fn seed_track(
-        store: &LibraryStore,
-        server: &str,
-        id: &str,
-        artist_id: &str,
-        album_id: &str,
-        deleted: bool,
-    ) {
+    fn seed_track(store: &LibraryStore, server: &str, id: &str, artist_id: &str, deleted: bool) {
         store
             .with_conn_mut("test.seed_track", |c| {
                 c.execute(
-                    "INSERT INTO track (server_id, id, title, artist_id, album, album_id, \
+                    "INSERT INTO track (server_id, id, title, artist_id, album, \
                        duration_sec, deleted, synced_at, raw_json) \
-                     VALUES (?1, ?2, 'Song', ?3, 'Al', ?4, 1, ?5, 1, '{}')",
-                    rusqlite::params![server, id, artist_id, album_id, i64::from(deleted)],
-                )
-            })
-            .unwrap();
-    }
-
-    fn seed_album(store: &LibraryStore, server: &str, id: &str, starred_at: Option<i64>) {
-        store
-            .with_conn_mut("test.seed_album", |c| {
-                c.execute(
-                    "INSERT INTO album (server_id, id, name, starred_at, synced_at, raw_json) \
-                     VALUES (?1, ?2, ?2, ?3, 1, '{}')",
-                    rusqlite::params![server, id, starred_at],
+                     VALUES (?1, ?2, 'Song', ?3, 'Al', 1, ?4, 1, '{}')",
+                    params![server, id, artist_id, i64::from(deleted)],
                 )
             })
             .unwrap();
@@ -148,20 +118,7 @@ mod tests {
                 let mut stmt = c
                     .prepare("SELECT id FROM artist WHERE server_id = ?1 ORDER BY id")?;
                 let rows = stmt
-                    .query_map(rusqlite::params![server], |r| r.get::<_, String>(0))?
-                    .collect::<rusqlite::Result<Vec<_>>>()?;
-                Ok(rows)
-            })
-            .unwrap()
-    }
-
-    fn album_ids(store: &LibraryStore, server: &str) -> Vec<String> {
-        store
-            .with_read_conn(|c| {
-                let mut stmt =
-                    c.prepare("SELECT id FROM album WHERE server_id = ?1 ORDER BY id")?;
-                let rows = stmt
-                    .query_map(rusqlite::params![server], |r| r.get::<_, String>(0))?
+                    .query_map(params![server], |r| r.get::<_, String>(0))?
                     .collect::<rusqlite::Result<Vec<_>>>()?;
                 Ok(rows)
             })
@@ -173,16 +130,16 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         // ar_new: confirmed this pass (fresh synced_at) + live track → keep.
         seed_artist(&store, "s1", "ar_new", 100);
-        seed_track(&store, "s1", "tr_1", "ar_new", "al_1", false);
+        seed_track(&store, "s1", "tr_1", "ar_new", false);
         // ar_old: stale synced_at, only a soft-deleted track (renamed away) → prune.
         seed_artist(&store, "s1", "ar_old", 50);
-        seed_track(&store, "s1", "tr_1_old", "ar_old", "al_1", true);
-        // ar_scopeb: stale synced_at but still backs a live track (other scope) → keep.
+        seed_track(&store, "s1", "tr_1_old", "ar_old", true);
+        // ar_scopeb: stale synced_at but still backs a live track → keep.
         seed_artist(&store, "s1", "ar_scopeb", 50);
-        seed_track(&store, "s1", "tr_2", "ar_scopeb", "al_2", false);
+        seed_track(&store, "s1", "tr_2", "ar_scopeb", false);
 
-        let report = prune_library_orphans_for_server(&store, "s1").unwrap();
-        assert_eq!(report.artists, 1);
+        let removed = prune_orphan_artists_for_server(&store, "s1").unwrap();
+        assert_eq!(removed, 1);
         assert_eq!(artist_ids(&store, "s1"), vec!["ar_new", "ar_scopeb"]);
     }
 
@@ -193,56 +150,54 @@ mod tests {
         // confirmed by getArtists (shares the freshest synced_at) → keep.
         seed_artist(&store, "s1", "ar_va", 100);
         seed_artist(&store, "s1", "ar_real", 100);
-        seed_track(&store, "s1", "tr_1", "ar_real", "al_1", false);
+        seed_track(&store, "s1", "tr_1", "ar_real", false);
 
-        let report = prune_library_orphans_for_server(&store, "s1").unwrap();
-        assert_eq!(report.artists, 0);
+        let removed = prune_orphan_artists_for_server(&store, "s1").unwrap();
+        assert_eq!(removed, 0);
         assert_eq!(artist_ids(&store, "s1"), vec!["ar_real", "ar_va"]);
     }
 
     #[test]
-    fn prunes_orphan_album_but_keeps_starred_and_live() {
+    fn all_synced_at_equal_prunes_nothing() {
+        // No authoritative "newer" pass to distinguish a ghost from a fresh
+        // album-artist → cutoff equals every row, `synced_at < cutoff` is empty.
         let store = LibraryStore::open_in_memory();
-        seed_album(&store, "s1", "al_live", None);
-        seed_track(&store, "s1", "tr_1", "ar_1", "al_live", false);
-        seed_album(&store, "s1", "al_orphan", None);
-        seed_track(&store, "s1", "tr_2", "ar_1", "al_orphan", true);
-        seed_album(&store, "s1", "al_starred", Some(1_700_000_000_000));
+        seed_artist(&store, "s1", "ar_a", 100);
+        seed_artist(&store, "s1", "ar_b", 100);
 
-        let report = prune_library_orphans_for_server(&store, "s1").unwrap();
-        assert_eq!(report.albums, 1);
-        assert_eq!(album_ids(&store, "s1"), vec!["al_live", "al_starred"]);
+        let removed = prune_orphan_artists_for_server(&store, "s1").unwrap();
+        assert_eq!(removed, 0);
+        assert_eq!(artist_ids(&store, "s1"), vec!["ar_a", "ar_b"]);
     }
 
     #[test]
-    fn scopes_prune_to_a_single_server() {
+    fn for_server_scopes_prune_to_a_single_server() {
         let store = LibraryStore::open_in_memory();
         seed_artist(&store, "s1", "ar_fresh", 100);
-        seed_track(&store, "s1", "tr_1", "ar_fresh", "al_1", false);
+        seed_track(&store, "s1", "tr_1", "ar_fresh", false);
         seed_artist(&store, "s1", "ar_ghost", 50);
-        // Another server with its own ghost — must be untouched by scoped prune.
         seed_artist(&store, "s2", "ar_fresh2", 100);
-        seed_track(&store, "s2", "tr_2", "ar_fresh2", "al_2", false);
+        seed_track(&store, "s2", "tr_2", "ar_fresh2", false);
         seed_artist(&store, "s2", "ar_ghost2", 50);
 
-        let report = prune_library_orphans_for_server(&store, "s1").unwrap();
-        assert_eq!(report.artists, 1);
+        let removed = prune_orphan_artists_for_server(&store, "s1").unwrap();
+        assert_eq!(removed, 1);
         assert_eq!(artist_ids(&store, "s1"), vec!["ar_fresh"]);
         assert_eq!(artist_ids(&store, "s2"), vec!["ar_fresh2", "ar_ghost2"]);
     }
 
     #[test]
-    fn global_prune_sweeps_every_server() {
+    fn all_prune_sweeps_every_server() {
         let store = LibraryStore::open_in_memory();
         seed_artist(&store, "s1", "ar_fresh", 100);
-        seed_track(&store, "s1", "tr_1", "ar_fresh", "al_1", false);
+        seed_track(&store, "s1", "tr_1", "ar_fresh", false);
         seed_artist(&store, "s1", "ar_ghost", 50);
         seed_artist(&store, "s2", "ar_fresh2", 100);
-        seed_track(&store, "s2", "tr_2", "ar_fresh2", "al_2", false);
+        seed_track(&store, "s2", "tr_2", "ar_fresh2", false);
         seed_artist(&store, "s2", "ar_ghost2", 50);
 
         let removed = store
-            .with_conn_mut("test.global", |c| prune_orphan_artists(c, None))
+            .with_conn_mut("test.all", |c| prune_orphan_artists_all(c))
             .unwrap();
         assert_eq!(removed, 2);
         assert_eq!(artist_ids(&store, "s1"), vec!["ar_fresh"]);

--- a/src-tauri/crates/psysonic-library/src/orphan_cleanup.rs
+++ b/src-tauri/crates/psysonic-library/src/orphan_cleanup.rs
@@ -1,0 +1,251 @@
+//! Remove browse-index rows orphaned by server-side renames/removals.
+//!
+//! `getArtists` derives artist ids from tags, so renaming an artist (or an
+//! album) mints a *new* id server-side and drops the old one. Track ingest
+//! moves the affected tracks onto the new id (or the resync orphan sweep /
+//! tombstone reconciler soft-deletes them), but the stale **`artist`** and
+//! **`album`** browse rows were never pruned — they lingered in the catalog and
+//! opened to "Artist not found" because detail resolves from live tracks.
+//!
+//! These prunes run on every sync that refreshes the artist index (full and
+//! delta), right after the track sweep, and once at open for pre-existing DBs
+//! (see `store::maybe_reconcile_orphan_browse_rows`). All three share the same
+//! conn-level statements below.
+//!
+//! Safety — a row is removed only when it is genuinely unreachable:
+//! - **Artist:** not confirmed by the latest `getArtists` pass (its
+//!   `synced_at` is older than the freshest artist row for the same server)
+//!   **and** no live (`deleted = 0`) track credits it. Artists still backing a
+//!   live track (any library scope, album credit) or refreshed this pass are
+//!   kept, so nothing browsable/openable is dropped.
+//! - **Album:** no live track references it **and** it is not starred, so a
+//!   favourited album is never dropped even if it briefly loses every track.
+
+use rusqlite::{Connection, Result as SqlResult};
+
+use crate::store::LibraryStore;
+
+/// Rows removed by a single [`prune_library_orphans_for_server`] call.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OrphanPruneReport {
+    pub artists: u32,
+    pub albums: u32,
+}
+
+/// Prune orphaned `artist` + `album` rows for one server (sync paths).
+pub fn prune_library_orphans_for_server(
+    store: &LibraryStore,
+    server_id: &str,
+) -> Result<OrphanPruneReport, String> {
+    store.with_conn_mut("orphan_cleanup.prune_server", |conn| {
+        let artists = prune_orphan_artists(conn, Some(server_id))?;
+        let albums = prune_orphan_albums(conn, Some(server_id))?;
+        Ok(OrphanPruneReport {
+            artists: artists as u32,
+            albums: albums as u32,
+        })
+    })
+}
+
+/// Delete `artist` rows the latest server pass did not confirm that also have
+/// no live track crediting them. Pass `Some(server_id)` to scope to one server
+/// (sync paths) or `None` to sweep every server (one-time open reconcile).
+pub fn prune_orphan_artists(conn: &Connection, server_id: Option<&str>) -> SqlResult<usize> {
+    // The freshest `synced_at` per server marks the most recent successful
+    // `getArtists` pass — every artist confirmed then shares it, so rows left
+    // below it were dropped by the server. Correlated on `artist.server_id` so
+    // the same statement works scoped or global.
+    let base = "DELETE FROM artist \
+         WHERE synced_at < ( \
+             SELECT MAX(ai.synced_at) FROM artist ai WHERE ai.server_id = artist.server_id \
+         ) \
+         AND NOT EXISTS ( \
+             SELECT 1 FROM track \
+             WHERE track.server_id = artist.server_id \
+               AND track.artist_id = artist.id \
+               AND track.deleted = 0 \
+         )";
+    match server_id {
+        Some(sid) => {
+            let sql = format!("{base} AND server_id = ?1");
+            conn.execute(&sql, rusqlite::params![sid])
+        }
+        None => conn.execute(base, []),
+    }
+}
+
+/// Delete `album` rows with no live track and no favourite (`starred_at`).
+/// Pass `Some(server_id)` to scope to one server or `None` to sweep all.
+pub fn prune_orphan_albums(conn: &Connection, server_id: Option<&str>) -> SqlResult<usize> {
+    let base = "DELETE FROM album \
+         WHERE starred_at IS NULL \
+         AND NOT EXISTS ( \
+             SELECT 1 FROM track \
+             WHERE track.server_id = album.server_id \
+               AND track.album_id = album.id \
+               AND track.deleted = 0 \
+         )";
+    match server_id {
+        Some(sid) => {
+            let sql = format!("{base} AND server_id = ?1");
+            conn.execute(&sql, rusqlite::params![sid])
+        }
+        None => conn.execute(base, []),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seed_artist(store: &LibraryStore, server: &str, id: &str, synced_at: i64) {
+        store
+            .with_conn_mut("test.seed_artist", |c| {
+                c.execute(
+                    "INSERT INTO artist (server_id, id, name, name_sort, synced_at) \
+                     VALUES (?1, ?2, ?2, ?2, ?3)",
+                    rusqlite::params![server, id, synced_at],
+                )
+            })
+            .unwrap();
+    }
+
+    fn seed_track(
+        store: &LibraryStore,
+        server: &str,
+        id: &str,
+        artist_id: &str,
+        album_id: &str,
+        deleted: bool,
+    ) {
+        store
+            .with_conn_mut("test.seed_track", |c| {
+                c.execute(
+                    "INSERT INTO track (server_id, id, title, artist_id, album, album_id, \
+                       duration_sec, deleted, synced_at, raw_json) \
+                     VALUES (?1, ?2, 'Song', ?3, 'Al', ?4, 1, ?5, 1, '{}')",
+                    rusqlite::params![server, id, artist_id, album_id, i64::from(deleted)],
+                )
+            })
+            .unwrap();
+    }
+
+    fn seed_album(store: &LibraryStore, server: &str, id: &str, starred_at: Option<i64>) {
+        store
+            .with_conn_mut("test.seed_album", |c| {
+                c.execute(
+                    "INSERT INTO album (server_id, id, name, starred_at, synced_at, raw_json) \
+                     VALUES (?1, ?2, ?2, ?3, 1, '{}')",
+                    rusqlite::params![server, id, starred_at],
+                )
+            })
+            .unwrap();
+    }
+
+    fn artist_ids(store: &LibraryStore, server: &str) -> Vec<String> {
+        store
+            .with_read_conn(|c| {
+                let mut stmt = c
+                    .prepare("SELECT id FROM artist WHERE server_id = ?1 ORDER BY id")?;
+                let rows = stmt
+                    .query_map(rusqlite::params![server], |r| r.get::<_, String>(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                Ok(rows)
+            })
+            .unwrap()
+    }
+
+    fn album_ids(store: &LibraryStore, server: &str) -> Vec<String> {
+        store
+            .with_read_conn(|c| {
+                let mut stmt =
+                    c.prepare("SELECT id FROM album WHERE server_id = ?1 ORDER BY id")?;
+                let rows = stmt
+                    .query_map(rusqlite::params![server], |r| r.get::<_, String>(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                Ok(rows)
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn prunes_renamed_away_artist_but_keeps_live_and_confirmed() {
+        let store = LibraryStore::open_in_memory();
+        // ar_new: confirmed this pass (fresh synced_at) + live track → keep.
+        seed_artist(&store, "s1", "ar_new", 100);
+        seed_track(&store, "s1", "tr_1", "ar_new", "al_1", false);
+        // ar_old: stale synced_at, only a soft-deleted track (renamed away) → prune.
+        seed_artist(&store, "s1", "ar_old", 50);
+        seed_track(&store, "s1", "tr_1_old", "ar_old", "al_1", true);
+        // ar_scopeb: stale synced_at but still backs a live track (other scope) → keep.
+        seed_artist(&store, "s1", "ar_scopeb", 50);
+        seed_track(&store, "s1", "tr_2", "ar_scopeb", "al_2", false);
+
+        let report = prune_library_orphans_for_server(&store, "s1").unwrap();
+        assert_eq!(report.artists, 1);
+        assert_eq!(artist_ids(&store, "s1"), vec!["ar_new", "ar_scopeb"]);
+    }
+
+    #[test]
+    fn keeps_album_artist_confirmed_this_pass_without_track_credit() {
+        let store = LibraryStore::open_in_memory();
+        // Various-Artists style row: no track credits its id, but it was just
+        // confirmed by getArtists (shares the freshest synced_at) → keep.
+        seed_artist(&store, "s1", "ar_va", 100);
+        seed_artist(&store, "s1", "ar_real", 100);
+        seed_track(&store, "s1", "tr_1", "ar_real", "al_1", false);
+
+        let report = prune_library_orphans_for_server(&store, "s1").unwrap();
+        assert_eq!(report.artists, 0);
+        assert_eq!(artist_ids(&store, "s1"), vec!["ar_real", "ar_va"]);
+    }
+
+    #[test]
+    fn prunes_orphan_album_but_keeps_starred_and_live() {
+        let store = LibraryStore::open_in_memory();
+        seed_album(&store, "s1", "al_live", None);
+        seed_track(&store, "s1", "tr_1", "ar_1", "al_live", false);
+        seed_album(&store, "s1", "al_orphan", None);
+        seed_track(&store, "s1", "tr_2", "ar_1", "al_orphan", true);
+        seed_album(&store, "s1", "al_starred", Some(1_700_000_000_000));
+
+        let report = prune_library_orphans_for_server(&store, "s1").unwrap();
+        assert_eq!(report.albums, 1);
+        assert_eq!(album_ids(&store, "s1"), vec!["al_live", "al_starred"]);
+    }
+
+    #[test]
+    fn scopes_prune_to_a_single_server() {
+        let store = LibraryStore::open_in_memory();
+        seed_artist(&store, "s1", "ar_fresh", 100);
+        seed_track(&store, "s1", "tr_1", "ar_fresh", "al_1", false);
+        seed_artist(&store, "s1", "ar_ghost", 50);
+        // Another server with its own ghost — must be untouched by scoped prune.
+        seed_artist(&store, "s2", "ar_fresh2", 100);
+        seed_track(&store, "s2", "tr_2", "ar_fresh2", "al_2", false);
+        seed_artist(&store, "s2", "ar_ghost2", 50);
+
+        let report = prune_library_orphans_for_server(&store, "s1").unwrap();
+        assert_eq!(report.artists, 1);
+        assert_eq!(artist_ids(&store, "s1"), vec!["ar_fresh"]);
+        assert_eq!(artist_ids(&store, "s2"), vec!["ar_fresh2", "ar_ghost2"]);
+    }
+
+    #[test]
+    fn global_prune_sweeps_every_server() {
+        let store = LibraryStore::open_in_memory();
+        seed_artist(&store, "s1", "ar_fresh", 100);
+        seed_track(&store, "s1", "tr_1", "ar_fresh", "al_1", false);
+        seed_artist(&store, "s1", "ar_ghost", 50);
+        seed_artist(&store, "s2", "ar_fresh2", 100);
+        seed_track(&store, "s2", "tr_2", "ar_fresh2", "al_2", false);
+        seed_artist(&store, "s2", "ar_ghost2", 50);
+
+        let removed = store
+            .with_conn_mut("test.global", |c| prune_orphan_artists(c, None))
+            .unwrap();
+        assert_eq!(removed, 2);
+        assert_eq!(artist_ids(&store, "s1"), vec!["ar_fresh"]);
+        assert_eq!(artist_ids(&store, "s2"), vec!["ar_fresh2"]);
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -12,7 +12,7 @@ use tauri::Manager;
 ///
 /// Migration checklist (wiring, data backfill, open/swap path):
 /// psysonic-workdocs `ai/agent-rules/08-library-db-migrations.md`.
-pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 17;
+pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 18;
 
 /// One-time data repair after migration 014 (`artist.name_sort`).
 pub(crate) const ARTIST_NAME_SORT_RECONCILE_ID: &str = "artist_name_sort_reconcile_v1";
@@ -23,7 +23,7 @@ pub(crate) const REPLAY_GAIN_PEAK_RECONCILE_ID: &str = "replay_gain_peak_reconci
 /// One-time backfill after migration 016 (`track.library_id` from `raw_json`).
 pub(crate) const LIBRARY_ID_BACKFILL_RECONCILE_ID: &str = "library_id_backfill_reconcile_v1";
 
-/// One-time cleanup of `artist`/`album` browse rows orphaned by pre-fix syncs
+/// One-time cleanup of `artist` browse rows orphaned by pre-fix syncs
 /// (server-side renames left ghosts that opened to "not found"). Ongoing syncs
 /// prune these inline; this clears already-accumulated rows at first open.
 pub(crate) const ORPHAN_BROWSE_RECONCILE_ID: &str = "orphan_browse_rows_reconcile_v1";
@@ -55,6 +55,10 @@ pub(crate) const MIGRATION_016_MULTI_LIBRARY_SCOPE: &str =
     include_str!("../migrations/016_multi_library_scope.sql");
 pub(crate) const MIGRATION_017_LIBRARY_TAG_STATE: &str =
     include_str!("../migrations/017_library_tag_state.sql");
+/// Version 18: additive `idx_artist_synced(server_id, synced_at)` so the orphan
+/// prune's freshness lookup is an index seek instead of a per-server scan.
+pub(crate) const MIGRATION_018_ARTIST_SYNCED_INDEX: &str =
+    include_str!("../migrations/018_artist_synced_index.sql");
 
 /// Embedded migrations. Ordered ascending by `version`; the runner sorts
 /// defensively before applying so the source order can stay readable.
@@ -66,6 +70,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (15, MIGRATION_015_REPLAY_GAIN_PEAK),
     (16, MIGRATION_016_MULTI_LIBRARY_SCOPE),
     (17, MIGRATION_017_LIBRARY_TAG_STATE),
+    (18, MIGRATION_018_ARTIST_SYNCED_INDEX),
 ];
 
 /// Idempotent repair — also runs after the migration runner on every open so
@@ -921,15 +926,14 @@ fn mark_orphan_browse_reconcile_completed(conn: &Connection) -> rusqlite::Result
     Ok(())
 }
 
-/// One-time cleanup of orphaned `artist`/`album` browse rows for existing DBs —
-/// clears ghosts left by server-side renames before inline pruning landed. Runs
-/// once (guarded by `library_data_migration`); ongoing syncs prune inline.
+/// One-time cleanup of orphaned `artist` browse rows for existing DBs — clears
+/// ghosts left by server-side renames before inline pruning landed. Runs once
+/// (guarded by `library_data_migration`); ongoing syncs prune inline.
 fn maybe_reconcile_orphan_browse_rows(conn: &Connection) -> rusqlite::Result<()> {
     if orphan_browse_reconcile_completed(conn)? {
         return Ok(());
     }
-    crate::orphan_cleanup::prune_orphan_artists(conn, None)?;
-    crate::orphan_cleanup::prune_orphan_albums(conn, None)?;
+    crate::orphan_cleanup::prune_orphan_artists_all(conn)?;
     mark_orphan_browse_reconcile_completed(conn)?;
     Ok(())
 }
@@ -1539,22 +1543,6 @@ mod tests {
                      VALUES ('s1', 'ar_old', 'Old', 'old', 1)",
                     [],
                 )?;
-                // Live + orphan + starred albums.
-                conn.execute(
-                    "INSERT INTO album (server_id, id, name, starred_at, synced_at, raw_json) \
-                     VALUES ('s1', 'al_live', 'Live', NULL, 1, '{}')",
-                    [],
-                )?;
-                conn.execute(
-                    "INSERT INTO album (server_id, id, name, starred_at, synced_at, raw_json) \
-                     VALUES ('s1', 'al_orphan', 'Orphan', NULL, 1, '{}')",
-                    [],
-                )?;
-                conn.execute(
-                    "INSERT INTO album (server_id, id, name, starred_at, synced_at, raw_json) \
-                     VALUES ('s1', 'al_starred', 'Fav', 111, 1, '{}')",
-                    [],
-                )?;
                 Ok(())
             })
             .expect("seed");
@@ -1569,12 +1557,6 @@ mod tests {
             })
             .unwrap();
         assert_eq!(artists, 1, "ghost artist pruned, live kept");
-        let albums: i64 = store
-            .with_read_conn(|c| {
-                c.query_row("SELECT COUNT(*) FROM album WHERE server_id = 's1'", [], |r| r.get(0))
-            })
-            .unwrap();
-        assert_eq!(albums, 2, "orphan album pruned, live + starred kept");
 
         // Re-running with the marker set is a no-op even if a new ghost appears.
         store

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -23,6 +23,11 @@ pub(crate) const REPLAY_GAIN_PEAK_RECONCILE_ID: &str = "replay_gain_peak_reconci
 /// One-time backfill after migration 016 (`track.library_id` from `raw_json`).
 pub(crate) const LIBRARY_ID_BACKFILL_RECONCILE_ID: &str = "library_id_backfill_reconcile_v1";
 
+/// One-time cleanup of `artist`/`album` browse rows orphaned by pre-fix syncs
+/// (server-side renames left ghosts that opened to "not found"). Ongoing syncs
+/// prune these inline; this clears already-accumulated rows at first open.
+pub(crate) const ORPHAN_BROWSE_RECONCILE_ID: &str = "orphan_browse_rows_reconcile_v1";
+
 /// Lowest applied schema version the current code can advance from purely
 /// additively. If a DB carries a version below this, the breaking-bump hook
 /// fires (spec §5.7 / P22): the library is treated as incompatible, must be
@@ -646,6 +651,7 @@ fn prepare_write_connection_for_open(conn: &Connection) -> rusqlite::Result<()> 
     maybe_reconcile_artist_name_sort(conn)?;
     maybe_reconcile_replay_gain_peak(conn)?;
     maybe_reconcile_library_id_backfill(conn)?;
+    maybe_reconcile_orphan_browse_rows(conn)?;
     ensure_genre_tags_schema(conn)?;
     checkpoint_wal_conn(conn, "open")?;
     Ok(())
@@ -891,6 +897,40 @@ fn maybe_reconcile_library_id_backfill(conn: &Connection) -> rusqlite::Result<()
     }
     repair_library_id_from_raw_json(conn)?;
     mark_library_id_backfill_reconcile_completed(conn)?;
+    Ok(())
+}
+
+fn orphan_browse_reconcile_completed(conn: &Connection) -> rusqlite::Result<bool> {
+    let completed: Option<Option<i64>> = conn
+        .query_row(
+            "SELECT completed_at FROM library_data_migration WHERE id = ?1",
+            params![ORPHAN_BROWSE_RECONCILE_ID],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(completed.flatten().is_some())
+}
+
+fn mark_orphan_browse_reconcile_completed(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO library_data_migration (id, cursor_rowid, started_at, completed_at) \
+         VALUES (?1, 0, strftime('%s','now'), strftime('%s','now')) \
+         ON CONFLICT(id) DO UPDATE SET completed_at = excluded.completed_at",
+        params![ORPHAN_BROWSE_RECONCILE_ID],
+    )?;
+    Ok(())
+}
+
+/// One-time cleanup of orphaned `artist`/`album` browse rows for existing DBs —
+/// clears ghosts left by server-side renames before inline pruning landed. Runs
+/// once (guarded by `library_data_migration`); ongoing syncs prune inline.
+fn maybe_reconcile_orphan_browse_rows(conn: &Connection) -> rusqlite::Result<()> {
+    if orphan_browse_reconcile_completed(conn)? {
+        return Ok(());
+    }
+    crate::orphan_cleanup::prune_orphan_artists(conn, None)?;
+    crate::orphan_cleanup::prune_orphan_albums(conn, None)?;
+    mark_orphan_browse_reconcile_completed(conn)?;
     Ok(())
 }
 
@@ -1470,6 +1510,91 @@ mod tests {
             })
             .expect("t4 library_id");
         assert_eq!(unchanged, "already-set");
+    }
+
+    #[test]
+    fn orphan_browse_reconcile_prunes_ghosts_once() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn_mut("test.seed", |conn| {
+                conn.execute(
+                    "DELETE FROM library_data_migration WHERE id = ?1",
+                    params![ORPHAN_BROWSE_RECONCILE_ID],
+                )?;
+                // Confirmed-this-pass artist with a live track → keep.
+                conn.execute(
+                    "INSERT INTO artist (server_id, id, name, name_sort, synced_at) \
+                     VALUES ('s1', 'ar_new', 'New', 'new', 100)",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO track (server_id, id, title, artist_id, album, album_id, \
+                       duration_sec, deleted, synced_at, raw_json) \
+                     VALUES ('s1', 'tr_1', 'S', 'ar_new', 'Al', 'al_live', 1, 0, 1, '{}')",
+                    [],
+                )?;
+                // Renamed-away ghost: stale synced_at, no live track → prune.
+                conn.execute(
+                    "INSERT INTO artist (server_id, id, name, name_sort, synced_at) \
+                     VALUES ('s1', 'ar_old', 'Old', 'old', 1)",
+                    [],
+                )?;
+                // Live + orphan + starred albums.
+                conn.execute(
+                    "INSERT INTO album (server_id, id, name, starred_at, synced_at, raw_json) \
+                     VALUES ('s1', 'al_live', 'Live', NULL, 1, '{}')",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO album (server_id, id, name, starred_at, synced_at, raw_json) \
+                     VALUES ('s1', 'al_orphan', 'Orphan', NULL, 1, '{}')",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO album (server_id, id, name, starred_at, synced_at, raw_json) \
+                     VALUES ('s1', 'al_starred', 'Fav', 111, 1, '{}')",
+                    [],
+                )?;
+                Ok(())
+            })
+            .expect("seed");
+
+        store
+            .with_conn("test.reconcile", maybe_reconcile_orphan_browse_rows)
+            .expect("reconcile");
+
+        let artists: i64 = store
+            .with_read_conn(|c| {
+                c.query_row("SELECT COUNT(*) FROM artist WHERE server_id = 's1'", [], |r| r.get(0))
+            })
+            .unwrap();
+        assert_eq!(artists, 1, "ghost artist pruned, live kept");
+        let albums: i64 = store
+            .with_read_conn(|c| {
+                c.query_row("SELECT COUNT(*) FROM album WHERE server_id = 's1'", [], |r| r.get(0))
+            })
+            .unwrap();
+        assert_eq!(albums, 2, "orphan album pruned, live + starred kept");
+
+        // Re-running with the marker set is a no-op even if a new ghost appears.
+        store
+            .with_conn_mut("test.seed_more_ghosts", |conn| {
+                conn.execute(
+                    "INSERT INTO artist (server_id, id, name, name_sort, synced_at) \
+                     VALUES ('s1', 'ar_old2', 'Old2', 'old2', 1)",
+                    [],
+                )
+            })
+            .unwrap();
+        store
+            .with_conn("test.reconcile_again", maybe_reconcile_orphan_browse_rows)
+            .expect("reconcile again");
+        let artists_after: i64 = store
+            .with_read_conn(|c| {
+                c.query_row("SELECT COUNT(*) FROM artist WHERE server_id = 's1'", [], |r| r.get(0))
+            })
+            .unwrap();
+        assert_eq!(artists_after, 2, "guarded: does not re-run after completion");
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/sync/artist_index.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/artist_index.rs
@@ -6,12 +6,17 @@ use psysonic_integration::subsonic::ArtistIndex;
 
 use super::error::SyncError;
 
+/// Persist a `getArtists` body and return how many artist rows it confirmed
+/// (`upsert_index` count). Callers use a non-zero count as the "this was a real,
+/// authoritative `getArtists` pass" signal that gates the orphan prune — an
+/// empty/partial body must not drive a prune, because `backfill_from_tracks`
+/// would still advance the freshest `synced_at` from a lone track.
 pub fn apply_artist_index(
     store: &LibraryStore,
     server_id: &str,
     library_scope: &str,
     index: &ArtistIndex,
-) -> Result<(), SyncError> {
+) -> Result<u32, SyncError> {
     let synced_at = super::now_unix_ms();
     let ignored = crate::artist_sort::ignored_articles_or_default(
         index.ignored_articles.as_deref(),
@@ -21,25 +26,28 @@ pub fn apply_artist_index(
         .set_ignored_articles(server_id, library_scope, ignored)
         .map_err(SyncError::Storage)?;
     let repo = ArtistRepository::new(store);
-    repo.upsert_index(server_id, index, synced_at).map_err(SyncError::Storage)?;
-    repo.backfill_from_tracks(server_id, ignored, synced_at).map_err(SyncError::Storage)?;
-    // Drop `artist`/`album` browse rows this pass no longer confirms and that
-    // have no live track behind them — otherwise a server-side rename leaves a
-    // ghost that opens to "Artist not found" (fixed by matching the fresh
-    // `synced_at` stamp just written above).
-    let pruned = crate::orphan_cleanup::prune_library_orphans_for_server(store, server_id)
+    let confirmed = repo
+        .upsert_index(server_id, index, synced_at)
         .map_err(SyncError::Storage)?;
-    if pruned.artists > 0 || pruned.albums > 0 {
-        crate::app_eprintln!(
-            "[library-sync] pruned {} orphan artist(s), {} orphan album(s)",
-            pruned.artists,
-            pruned.albums
-        );
-    }
+    repo.backfill_from_tracks(server_id, ignored, synced_at).map_err(SyncError::Storage)?;
     if let Some(ms) = index.last_modified_ms {
         sync_state
             .set_artists_last_modified_ms(server_id, library_scope, ms)
             .map_err(SyncError::Storage)?;
     }
-    Ok(())
+    Ok(confirmed)
+}
+
+/// Prune `artist` browse rows the latest `getArtists` pass no longer confirms
+/// and that have no live track — otherwise a server-side rename leaves a ghost
+/// that opens to "Artist not found". Only call after a confirmed pass (see
+/// [`apply_artist_index`]).
+pub fn prune_orphan_artists_after_confirmed_pass(store: &LibraryStore, server_id: &str) {
+    match crate::orphan_cleanup::prune_orphan_artists_for_server(store, server_id) {
+        Ok(pruned) if pruned > 0 => {
+            crate::app_eprintln!("[library-sync] pruned {pruned} orphan artist(s)");
+        }
+        Ok(_) => {}
+        Err(e) => crate::app_eprintln!("[library-sync] orphan artist prune failed: {e}"),
+    }
 }

--- a/src-tauri/crates/psysonic-library/src/sync/artist_index.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/artist_index.rs
@@ -23,6 +23,19 @@ pub fn apply_artist_index(
     let repo = ArtistRepository::new(store);
     repo.upsert_index(server_id, index, synced_at).map_err(SyncError::Storage)?;
     repo.backfill_from_tracks(server_id, ignored, synced_at).map_err(SyncError::Storage)?;
+    // Drop `artist`/`album` browse rows this pass no longer confirms and that
+    // have no live track behind them — otherwise a server-side rename leaves a
+    // ghost that opens to "Artist not found" (fixed by matching the fresh
+    // `synced_at` stamp just written above).
+    let pruned = crate::orphan_cleanup::prune_library_orphans_for_server(store, server_id)
+        .map_err(SyncError::Storage)?;
+    if pruned.artists > 0 || pruned.albums > 0 {
+        crate::app_eprintln!(
+            "[library-sync] pruned {} orphan artist(s), {} orphan album(s)",
+            pruned.artists,
+            pruned.albums
+        );
+    }
     if let Some(ms) = index.last_modified_ms {
         sync_state
             .set_artists_last_modified_ms(server_id, library_scope, ms)

--- a/src-tauri/crates/psysonic-library/src/sync/delta.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/delta.rs
@@ -216,12 +216,21 @@ impl<'a> DeltaSyncRunner<'a> {
         if let Some(ms) = probe.next_artists_watermark {
             let scope = self.library_scope_opt();
             if let Ok(index) = self.subsonic.get_artists(scope).await {
-                super::artist_index::apply_artist_index(
+                let confirmed = super::artist_index::apply_artist_index(
                     self.store,
                     &self.server_id,
                     &self.library_scope,
                     &index,
                 )?;
+                // Only prune after a real `getArtists` confirmation. The DS-8
+                // tombstone pass above has already soft-deleted server-removed
+                // tracks, so a renamed-away artist now has no live track.
+                if confirmed > 0 {
+                    super::artist_index::prune_orphan_artists_after_confirmed_pass(
+                        self.store,
+                        &self.server_id,
+                    );
+                }
             }
             // Advance the watermark to the probed value regardless of the index
             // refresh result — a failed/empty `getArtists` must not force a full

--- a/src-tauri/crates/psysonic-library/src/sync/initial.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial.rs
@@ -289,6 +289,20 @@ impl<'a> InitialSyncRunner<'a> {
                     checked_count: swept,
                 });
             }
+            // Re-run after the sweep so artists/albums whose only tracks were
+            // just soft-deleted here (servers that mint fresh track ids on
+            // rename) are pruned too — the in-pass prune (IS-4) ran before the
+            // sweep and could not see them yet.
+            let pruned =
+                crate::orphan_cleanup::prune_library_orphans_for_server(self.store, &self.server_id)
+                    .map_err(SyncError::Storage)?;
+            if pruned.artists > 0 || pruned.albums > 0 {
+                crate::app_eprintln!(
+                    "[library-sync] IS-7 pruned {} orphan artist(s), {} orphan album(s)",
+                    pruned.artists,
+                    pruned.albums
+                );
+            }
         }
         let local_count = crate::dto::count_local_tracks(self.store, &self.server_id)
             .map_err(SyncError::Storage)?;
@@ -1492,6 +1506,122 @@ mod tests {
             })
             .unwrap();
         assert_eq!(stale_deleted, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn full_resync_prunes_artist_orphaned_by_rename() {
+        let server = MockServer::start().await;
+        // Ingest one song credited to the *new* artist id (post-rename).
+        for page in 0u32..=1 {
+            let body = if page == 0 {
+                json!({
+                    "subsonic-response": {
+                        "status": "ok",
+                        "searchResult3": {
+                            "song": [{
+                                "id": "tr_1",
+                                "title": "Song",
+                                "duration": 200_i64,
+                                "artistId": "ar_new",
+                                "artist": "New Name"
+                            }]
+                        }
+                    }
+                })
+            } else {
+                json!({ "subsonic-response": { "status": "ok", "searchResult3": {} } })
+            };
+            Mock::given(wm_method("GET"))
+                .and(wm_path("/rest/search3.view"))
+                .and(query_param("songOffset", (page * 10).to_string()))
+                .respond_with(ResponseTemplate::new(200).set_body_json(body))
+                .mount(&server)
+                .await;
+        }
+        // getArtists returns only the new artist (the old name is gone server-side).
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getArtists.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "artists": {
+                        "lastModified": 1_716_840_000_000_i64,
+                        "ignoredArticles": "",
+                        "index": [{
+                            "name": "N",
+                            "artist": [{ "id": "ar_new", "name": "New Name", "albumCount": 1 }]
+                        }]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getScanStatus.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "scanStatus": { "scanning": false, "count": 1, "lastScan": "2024-06-01T12:00:00Z" }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = LibraryStore::open_in_memory();
+        let sync_state = SyncStateRepository::new(&store);
+        sync_state.ensure("s1", "").unwrap();
+        // Prior full sync → this run is a resync (arms the orphan sweep).
+        sync_state.set_last_full_sync_at("s1", "", 1).unwrap();
+        // Pre-existing ghost: old artist row + its (now stale) track.
+        store
+            .with_conn_mut("seed", |c| {
+                c.execute(
+                    "INSERT INTO artist (server_id, id, name, name_sort, synced_at) \
+                     VALUES ('s1', 'ar_old', 'Old Name', 'old name', 1)",
+                    [],
+                )?;
+                c.execute(
+                    "INSERT INTO track (server_id, id, title, artist_id, album, duration_sec, \
+                       deleted, synced_at, raw_json, resync_gen) \
+                     VALUES ('s1', 'tr_old', 'Old', 'ar_old', 'Al', 1, 0, 1, '{}', 0)",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let subsonic = test_subsonic(&server.uri());
+        InitialSyncRunner::new(
+            &store,
+            &subsonic,
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK | CapabilityFlags::SCAN_STATUS_AVAILABLE),
+        )
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap();
+
+        // Stale track soft-deleted, ghost artist pruned, new artist kept.
+        let old_track_deleted: i64 = store
+            .with_conn("misc", |c| {
+                c.query_row("SELECT deleted FROM track WHERE id = 'tr_old'", [], |r| r.get(0))
+            })
+            .unwrap();
+        assert_eq!(old_track_deleted, 1);
+
+        let artist_ids: Vec<String> = store
+            .with_read_conn(|c| {
+                let mut stmt =
+                    c.prepare("SELECT id FROM artist WHERE server_id = 's1' ORDER BY id")?;
+                let rows = stmt
+                    .query_map([], |r| r.get::<_, String>(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                Ok(rows)
+            })
+            .unwrap();
+        assert_eq!(artist_ids, vec!["ar_new"]);
     }
 
     // ── Per-batch progress is emitted during ingest ───────────────────

--- a/src-tauri/crates/psysonic-library/src/sync/initial.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial.rs
@@ -262,9 +262,13 @@ impl<'a> InitialSyncRunner<'a> {
             self.persist_cursor(&sync_state, &cursor)?;
         }
 
-        // IS-4 — optional artist/album index pass via `getArtists`.
+        // IS-4 — optional artist/album index pass via `getArtists`. Remember
+        // whether it was a real, confirmed pass so IS-7 can prune orphans only
+        // when authoritative (on a cursor-resume that skips this phase we stay
+        // conservative and let the next sync clean up).
+        let mut artists_confirmed = false;
         if cursor.phase == CursorPhase::ArtistPass {
-            self.run_artist_pass(&sync_state).await?;
+            artists_confirmed = self.run_artist_pass(&sync_state).await?;
             cursor.phase = CursorPhase::Watermarks;
             self.persist_cursor(&sync_state, &cursor)?;
         }
@@ -289,18 +293,17 @@ impl<'a> InitialSyncRunner<'a> {
                     checked_count: swept,
                 });
             }
-            // Re-run after the sweep so artists/albums whose only tracks were
-            // just soft-deleted here (servers that mint fresh track ids on
-            // rename) are pruned too — the in-pass prune (IS-4) ran before the
-            // sweep and could not see them yet.
-            let pruned =
-                crate::orphan_cleanup::prune_library_orphans_for_server(self.store, &self.server_id)
-                    .map_err(SyncError::Storage)?;
-            if pruned.artists > 0 || pruned.albums > 0 {
-                crate::app_eprintln!(
-                    "[library-sync] IS-7 pruned {} orphan artist(s), {} orphan album(s)",
-                    pruned.artists,
-                    pruned.albums
+            // Prune orphaned artist browse rows once, here — after the sweep has
+            // soft-deleted the very tracks a renamed-away artist used to keep
+            // alive (servers that mint fresh track ids on rename). Doing it only
+            // post-sweep (instead of also in IS-4) avoids the double O(N) scan
+            // per full sync; the delta path prunes in DS-9 where there is no
+            // sweep. Gated on a confirmed `getArtists` pass so an empty/partial
+            // body can't mass-prune album-artist-only rows (see B1).
+            if artists_confirmed {
+                super::artist_index::prune_orphan_artists_after_confirmed_pass(
+                    self.store,
+                    &self.server_id,
                 );
             }
         }
@@ -1214,10 +1217,12 @@ impl<'a> InitialSyncRunner<'a> {
 
     // ── IS-4 artist pass (best-effort browse acceleration) ─────────────
 
+    /// Returns `true` when `getArtists` returned an authoritative body (≥ 1
+    /// confirmed artist), which the caller uses to gate the IS-7 orphan prune.
     async fn run_artist_pass(
         &self,
         _sync_state: &SyncStateRepository<'_>,
-    ) -> Result<(), SyncError> {
+    ) -> Result<bool, SyncError> {
         let scope = self.library_scope_opt();
         let artists = retry_with_backoff(
             self,
@@ -1226,15 +1231,17 @@ impl<'a> InitialSyncRunner<'a> {
         )
         .await
         .ok();
-        if let Some(index) = artists {
+        let confirmed = if let Some(index) = artists {
             super::artist_index::apply_artist_index(
                 self.store,
                 &self.server_id,
                 &self.library_scope,
                 &index,
-            )?;
-        }
-        Ok(())
+            )? > 0
+        } else {
+            false
+        };
+        Ok(confirmed)
     }
 
     // ── IS-5 watermarks ────────────────────────────────────────────────
@@ -1622,6 +1629,101 @@ mod tests {
             })
             .unwrap();
         assert_eq!(artist_ids, vec!["ar_new"]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn full_resync_empty_get_artists_keeps_album_artist_rows() {
+        // B1 guard: an empty/partial `getArtists` (transient 200-empty) must not
+        // prune album-artist-only rows just because track ingest + backfill
+        // advanced the freshest `synced_at`.
+        let server = MockServer::start().await;
+        for page in 0u32..=1 {
+            let body = if page == 0 {
+                json!({
+                    "subsonic-response": {
+                        "status": "ok",
+                        "searchResult3": {
+                            "song": [{
+                                "id": "tr_1",
+                                "title": "Song",
+                                "duration": 200_i64,
+                                "artistId": "ar_track",
+                                "artist": "Track Artist"
+                            }]
+                        }
+                    }
+                })
+            } else {
+                json!({ "subsonic-response": { "status": "ok", "searchResult3": {} } })
+            };
+            Mock::given(wm_method("GET"))
+                .and(wm_path("/rest/search3.view"))
+                .and(query_param("songOffset", (page * 10).to_string()))
+                .respond_with(ResponseTemplate::new(200).set_body_json(body))
+                .mount(&server)
+                .await;
+        }
+        // getArtists returns Ok but with an EMPTY index (no confirmation).
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getArtists.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "artists": { "ignoredArticles": "", "index": [] }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getScanStatus.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "scanStatus": { "scanning": false, "count": 1, "lastScan": "2024-06-01T12:00:00Z" }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = LibraryStore::open_in_memory();
+        let sync_state = SyncStateRepository::new(&store);
+        sync_state.ensure("s1", "").unwrap();
+        sync_state.set_last_full_sync_at("s1", "", 1).unwrap();
+        // Album-artist-only row (compilation credit): stale stamp, no crediting
+        // track. A confirmed pass would re-stamp it; an empty pass must leave it.
+        store
+            .with_conn_mut("seed", |c| {
+                c.execute(
+                    "INSERT INTO artist (server_id, id, name, name_sort, synced_at) \
+                     VALUES ('s1', 'ar_va', 'Various', 'various', 1)",
+                    [],
+                )
+            })
+            .unwrap();
+
+        let subsonic = test_subsonic(&server.uri());
+        InitialSyncRunner::new(
+            &store,
+            &subsonic,
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK | CapabilityFlags::SCAN_STATUS_AVAILABLE),
+        )
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap();
+
+        let has_va: i64 = store
+            .with_read_conn(|c| {
+                c.query_row(
+                    "SELECT COUNT(*) FROM artist WHERE server_id = 's1' AND id = 'ar_va'",
+                    [],
+                    |r| r.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(has_va, 1, "empty getArtists must not prune album-artist rows");
     }
 
     // ── Per-batch progress is emitted during ingest ───────────────────

--- a/src/app/musicLibraryCatalogReloadBridge.ts
+++ b/src/app/musicLibraryCatalogReloadBridge.ts
@@ -2,6 +2,7 @@ import { clearArtistBrowseCatalogCache } from '@/lib/library/artistBrowseInfligh
 import { prefetchAlbumBrowseCatalogAfterFilterChange } from '@/lib/library/albumBrowseCatalogPrefetch';
 import { prefetchArtistBrowseCatalogAfterFilterChange } from '@/lib/library/artistBrowseCatalogPrefetch';
 import { registerMusicLibraryCatalogReloadHandler } from '@/store/musicLibraryFilterNotify';
+import { offlineLocalLibrarySyncRevision } from '@/store/offlineLocalLibrarySyncRevision';
 
 /**
  * App-layer seam wiring the store's music-library filter/selection change to the
@@ -16,6 +17,7 @@ import { registerMusicLibraryCatalogReloadHandler } from '@/store/musicLibraryFi
  */
 registerMusicLibraryCatalogReloadHandler((serverId, indexEnabled, version) => {
   clearArtistBrowseCatalogCache();
-  prefetchAlbumBrowseCatalogAfterFilterChange(serverId, version, indexEnabled);
-  prefetchArtistBrowseCatalogAfterFilterChange(serverId, version, indexEnabled);
+  const syncRevision = offlineLocalLibrarySyncRevision(serverId);
+  prefetchAlbumBrowseCatalogAfterFilterChange(serverId, version, indexEnabled, syncRevision);
+  prefetchArtistBrowseCatalogAfterFilterChange(serverId, version, indexEnabled, syncRevision);
 });

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -189,7 +189,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Genres — full catalog via indexed SQL when All libraries is selected; no longer samples first album page on large libraries (PR #1242)',
       'Offline browse — on-disk-only Artists/Albums/Tracks/Genres (pins, favorites-auto, hot-cache); reactive sidebar gates and sync-idle reload; local credit mode and genre scope (PR #1243)',
       'Album detail — album-level favorite heart from album.starred_at; server-backed album rating reconcile on detail (report: HiveMind on Psysonic Discord, PR #1247)',
-      'Library — prune orphaned artist/album browse rows after server-side renames (fixes "Artist not found" ghosts) on full/delta sync + one-time startup reconcile; refresh Artists/Albums catalog on sync-idle (report: Seraphim on Psysonic Discord, PR #1253)',
+      'Library — prune orphaned artist browse rows after server-side renames (fixes "Artist not found" ghosts) on full/delta sync + one-time startup reconcile; refresh Artists/Albums catalog on sync-idle (report: Seraphim on Psysonic Discord, PR #1253)',
     ],
   },
   {

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -189,6 +189,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Genres — full catalog via indexed SQL when All libraries is selected; no longer samples first album page on large libraries (PR #1242)',
       'Offline browse — on-disk-only Artists/Albums/Tracks/Genres (pins, favorites-auto, hot-cache); reactive sidebar gates and sync-idle reload; local credit mode and genre scope (PR #1243)',
       'Album detail — album-level favorite heart from album.starred_at; server-backed album rating reconcile on detail (report: HiveMind on Psysonic Discord, PR #1247)',
+      'Library — prune orphaned artist/album browse rows after server-side renames (fixes "Artist not found" ghosts) on full/delta sync + one-time startup reconcile; refresh Artists/Albums catalog on sync-idle (PR #1253)',
     ],
   },
   {

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -189,7 +189,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Genres — full catalog via indexed SQL when All libraries is selected; no longer samples first album page on large libraries (PR #1242)',
       'Offline browse — on-disk-only Artists/Albums/Tracks/Genres (pins, favorites-auto, hot-cache); reactive sidebar gates and sync-idle reload; local credit mode and genre scope (PR #1243)',
       'Album detail — album-level favorite heart from album.starred_at; server-backed album rating reconcile on detail (report: HiveMind on Psysonic Discord, PR #1247)',
-      'Library — prune orphaned artist/album browse rows after server-side renames (fixes "Artist not found" ghosts) on full/delta sync + one-time startup reconcile; refresh Artists/Albums catalog on sync-idle (PR #1253)',
+      'Library — prune orphaned artist/album browse rows after server-side renames (fixes "Artist not found" ghosts) on full/delta sync + one-time startup reconcile; refresh Artists/Albums catalog on sync-idle (report: Seraphim on Psysonic Discord, PR #1253)',
     ],
   },
   {

--- a/src/features/album/hooks/useAlbumBrowseData.ts
+++ b/src/features/album/hooks/useAlbumBrowseData.ts
@@ -40,6 +40,7 @@ import {
   useOfflineBrowseReloadToken,
 } from '@/features/offline';
 import { useOfflineLocalBrowseReloadKey } from '@/store/localPlaybackBrowseRevision';
+import { useOfflineLocalLibrarySyncRevision } from '@/store/offlineLocalLibrarySyncRevision';
 import {
   fetchAlbumBrowseCatalogChunk,
   mergeAlbumCatalogChunk,
@@ -57,6 +58,7 @@ import {
   albumBrowseCatalogCacheKey,
   albumBrowseCatalogInflight,
   albumBrowseInitialLoadKey,
+  albumBrowseOnlineCatalogKey,
   fetchAlbumBrowseCatalogDeduped,
   readAlbumBrowseCatalogCache,
   storeAlbumBrowseCatalogCache,
@@ -125,6 +127,7 @@ export function useAlbumBrowseData({
     serverId,
     offlineBrowseActive,
   );
+  const librarySyncRevision = useOfflineLocalLibrarySyncRevision(serverId ?? null);
   const [albums, setAlbums] = useState<SubsonicAlbum[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -169,10 +172,13 @@ export function useAlbumBrowseData({
         browseQuery,
         offlineBrowseActive,
       );
-      if (!offlineBrowseActive) return base;
+      // Online index browse re-keys on the library sync revision so a completed
+      // resync surfaces renamed/pruned albums without an app restart; offline
+      // browse already re-keys via its own (sync-driven) reload key.
+      if (!offlineBrowseActive) return albumBrowseOnlineCatalogKey(base, librarySyncRevision);
       return `${base}\0${offlineLocalBrowseReloadKey}`;
     },
-    [serverId, musicLibraryFilterVersion, browseQuery, offlineBrowseActive, offlineLocalBrowseReloadKey],
+    [serverId, musicLibraryFilterVersion, browseQuery, offlineBrowseActive, offlineLocalBrowseReloadKey, librarySyncRevision],
   );
 
   const compFilterActive = compFilter !== 'all';

--- a/src/features/artist/hooks/useArtistsBrowseCatalog.ts
+++ b/src/features/artist/hooks/useArtistsBrowseCatalog.ts
@@ -11,6 +11,7 @@ import {
 } from '@/features/artist/utils/artistBrowseCreditMode';
 import { useOfflineBrowseContext, useOfflineBrowseReloadToken } from '@/features/offline';
 import { useOfflineLocalBrowseReloadKey } from '@/store/localPlaybackBrowseRevision';
+import { useOfflineLocalLibrarySyncRevision } from '@/store/offlineLocalLibrarySyncRevision';
 import {
   fetchOfflineLocalArtistCatalogChunk,
   fetchOfflineLocalStarredArtists,
@@ -28,6 +29,7 @@ import {
   artistBrowseCatalogCacheKey,
   artistBrowseCatalogInflight,
   artistBrowseInitialLoadKey,
+  artistBrowseOnlineCatalogKey,
   fetchArtistBrowseCatalogDeduped,
   readArtistBrowseCatalogCache,
   storeArtistBrowseCatalogCache,
@@ -66,6 +68,7 @@ export function useArtistsBrowseCatalog({
     serverId,
     offlineBrowseActive,
   );
+  const librarySyncRevision = useOfflineLocalLibrarySyncRevision(serverId ?? null);
   const [catalogArtists, setCatalogArtists] = useState<SubsonicArtist[]>([]);
   const [loading, setLoading] = useState(true);
   const [catalogHasMore, setCatalogHasMore] = useState(false);
@@ -87,9 +90,12 @@ export function useArtistsBrowseCatalog({
       starredOnly,
       offlineBrowseActive,
     );
-    if (!offlineBrowseActive) return base;
+    // Offline browse already re-keys via its own reload key (also sync-driven);
+    // online index browse re-keys on the library sync revision so a completed
+    // resync surfaces renamed/pruned artists without an app restart.
+    if (!offlineBrowseActive) return artistBrowseOnlineCatalogKey(base, librarySyncRevision);
     return `${base}\0${offlineLocalBrowseReloadKey}`;
-  }, [serverId, musicLibraryFilterVersion, libraryScopeKey, creditMode, letterFilter, starredOnly, offlineBrowseActive, offlineLocalBrowseReloadKey]);
+  }, [serverId, musicLibraryFilterVersion, libraryScopeKey, creditMode, letterFilter, starredOnly, offlineBrowseActive, offlineLocalBrowseReloadKey, librarySyncRevision]);
 
   useLayoutEffect(() => {
     const cached = readArtistBrowseCatalogCache(catalogLoadKey);

--- a/src/lib/library/albumBrowseCatalogPrefetch.ts
+++ b/src/lib/library/albumBrowseCatalogPrefetch.ts
@@ -8,6 +8,7 @@ import {
   albumBrowseCatalogCacheKey,
   albumBrowseCatalogInflight,
   albumBrowseInitialLoadKey,
+  albumBrowseOnlineCatalogKey,
   fetchAlbumBrowseCatalogDeduped,
   readAlbumBrowseCatalogCache,
 } from './albumBrowseInflight';
@@ -20,11 +21,16 @@ const DEFAULT_PREFETCH_QUERY: AlbumBrowseQuery = {
   compFilter: 'all',
 };
 
-/** Warm the first catalog chunk after the sidebar library filter changes. */
+/**
+ * Warm the first catalog chunk after the sidebar library filter changes.
+ * `librarySyncRevision` is supplied by the caller (app layer) so the warmed key
+ * matches the browse hook's online key without `src/lib` importing `src/store`.
+ */
 export function prefetchAlbumBrowseCatalogAfterFilterChange(
   serverId: string,
   libraryFilterVersion: number,
   indexEnabled: boolean,
+  librarySyncRevision: number,
 ): void {
   if (!serverId) return;
   if (!indexEnabled) return;
@@ -32,7 +38,10 @@ export function prefetchAlbumBrowseCatalogAfterFilterChange(
   const query = DEFAULT_PREFETCH_QUERY;
   if (!albumBrowseBootstrapEligible(query)) return;
 
-  const loadKey = albumBrowseInitialLoadKey(serverId, libraryFilterVersion, query, false);
+  const loadKey = albumBrowseOnlineCatalogKey(
+    albumBrowseInitialLoadKey(serverId, libraryFilterVersion, query, false),
+    librarySyncRevision,
+  );
   if (readAlbumBrowseCatalogCache(loadKey)) return;
 
   const bootKey = albumBrowseCatalogCacheKey(

--- a/src/lib/library/albumBrowseInflight.ts
+++ b/src/lib/library/albumBrowseInflight.ts
@@ -24,6 +24,21 @@ export function albumBrowseInitialLoadKey(
 const inflight = new Map<string, Promise<AlbumBrowsePageResult | null>>();
 const cache = new Map<string, AlbumBrowsePageResult>();
 
+/** Evict every buffered All Albums chunk (e.g. after a library sync changed rows). */
+export function clearAlbumBrowseCatalogCache(): void {
+  inflight.clear();
+  cache.clear();
+}
+
+/**
+ * Suffix the online catalog key with the library sync revision so a completed
+ * resync (renamed/pruned albums) forces a refetch. Shared by the browse hook
+ * and the filter-change prefetch so both address the same cache entry.
+ */
+export function albumBrowseOnlineCatalogKey(base: string, syncRevision: number): string {
+  return `${base}\0syncrev:${syncRevision}`;
+}
+
 export function readAlbumBrowseCatalogCache(
   key: string,
 ): AlbumBrowsePageResult | undefined {

--- a/src/lib/library/albumBrowseInflight.ts
+++ b/src/lib/library/albumBrowseInflight.ts
@@ -1,3 +1,4 @@
+import { librarySyncCatalogKey } from '@/lib/library/browseCatalogSyncKey';
 import type { AlbumBrowsePageResult, AlbumBrowseQuery } from './albumBrowseTypes';
 
 /** Stable key for the initial All Albums catalog chunk (survives Strict Mode remount). */
@@ -30,13 +31,9 @@ export function clearAlbumBrowseCatalogCache(): void {
   cache.clear();
 }
 
-/**
- * Suffix the online catalog key with the library sync revision so a completed
- * resync (renamed/pruned albums) forces a refetch. Shared by the browse hook
- * and the filter-change prefetch so both address the same cache entry.
- */
+/** Online All Albums catalog key, re-keyed on the library sync revision. */
 export function albumBrowseOnlineCatalogKey(base: string, syncRevision: number): string {
-  return `${base}\0syncrev:${syncRevision}`;
+  return librarySyncCatalogKey(base, syncRevision);
 }
 
 export function readAlbumBrowseCatalogCache(

--- a/src/lib/library/artistBrowseCatalogPrefetch.ts
+++ b/src/lib/library/artistBrowseCatalogPrefetch.ts
@@ -9,6 +9,7 @@ import {
   artistBrowseCatalogCacheKey,
   artistBrowseCatalogInflight,
   artistBrowseInitialLoadKey,
+  artistBrowseOnlineCatalogKey,
   fetchArtistBrowseCatalogDeduped,
   readArtistBrowseCatalogCache,
 } from './artistBrowseInflight';
@@ -16,24 +17,32 @@ import {
 const DEFAULT_CREDIT_MODE: ArtistCreditMode = 'album';
 const DEFAULT_LETTER_FILTER = 'ALL';
 
-/** Warm the first artist catalog chunk after the sidebar library filter changes. */
+/**
+ * Warm the first artist catalog chunk after the sidebar library filter changes.
+ * `librarySyncRevision` is supplied by the caller (app layer) so the warmed key
+ * matches the browse hook's online key without `src/lib` importing `src/store`.
+ */
 export function prefetchArtistBrowseCatalogAfterFilterChange(
   serverId: string,
   libraryFilterVersion: number,
   indexEnabled: boolean,
+  librarySyncRevision: number,
 ): void {
   if (!serverId) return;
   if (!indexEnabled) return;
   if (!artistBrowseBootstrapEligible(DEFAULT_LETTER_FILTER, false)) return;
 
-  const loadKey = artistBrowseInitialLoadKey(
-    serverId,
-    libraryFilterVersion,
-    libraryScopeCacheKeyForServer(serverId),
-    DEFAULT_CREDIT_MODE,
-    DEFAULT_LETTER_FILTER,
-    false,
-    false,
+  const loadKey = artistBrowseOnlineCatalogKey(
+    artistBrowseInitialLoadKey(
+      serverId,
+      libraryFilterVersion,
+      libraryScopeCacheKeyForServer(serverId),
+      DEFAULT_CREDIT_MODE,
+      DEFAULT_LETTER_FILTER,
+      false,
+      false,
+    ),
+    librarySyncRevision,
   );
   if (readArtistBrowseCatalogCache(loadKey)) return;
 

--- a/src/lib/library/artistBrowseInflight.ts
+++ b/src/lib/library/artistBrowseInflight.ts
@@ -26,6 +26,15 @@ export function clearArtistBrowseCatalogCache(): void {
   cache.clear();
 }
 
+/**
+ * Suffix the online catalog key with the library sync revision so a completed
+ * resync (renamed/pruned artists) forces a refetch. Shared by the browse hook
+ * and the filter-change prefetch so both address the same cache entry.
+ */
+export function artistBrowseOnlineCatalogKey(base: string, syncRevision: number): string {
+  return `${base}\0syncrev:${syncRevision}`;
+}
+
 const inflight = new Map<string, Promise<ArtistCatalogChunkResult | null>>();
 const cache = new Map<string, ArtistCatalogChunkResult>();
 

--- a/src/lib/library/artistBrowseInflight.ts
+++ b/src/lib/library/artistBrowseInflight.ts
@@ -1,3 +1,4 @@
+import { librarySyncCatalogKey } from '@/lib/library/browseCatalogSyncKey';
 import type { ArtistCatalogChunkResult } from '@/lib/library/browseTextSearch';
 
 /** Stable key for the initial Artists catalog chunk (survives Strict Mode remount). */
@@ -26,13 +27,9 @@ export function clearArtistBrowseCatalogCache(): void {
   cache.clear();
 }
 
-/**
- * Suffix the online catalog key with the library sync revision so a completed
- * resync (renamed/pruned artists) forces a refetch. Shared by the browse hook
- * and the filter-change prefetch so both address the same cache entry.
- */
+/** Online Artists catalog key, re-keyed on the library sync revision. */
 export function artistBrowseOnlineCatalogKey(base: string, syncRevision: number): string {
-  return `${base}\0syncrev:${syncRevision}`;
+  return librarySyncCatalogKey(base, syncRevision);
 }
 
 const inflight = new Map<string, Promise<ArtistCatalogChunkResult | null>>();

--- a/src/lib/library/browseCatalogSyncKey.ts
+++ b/src/lib/library/browseCatalogSyncKey.ts
@@ -1,0 +1,9 @@
+/**
+ * Suffix an online browse-catalog key with the library sync revision so a
+ * completed resync (renamed/pruned rows) forces a refetch. Single source of the
+ * `\0syncrev:` wire format shared by the artist and album browse caches — both
+ * the browse hooks and the filter-change prefetch must address the same entry.
+ */
+export function librarySyncCatalogKey(base: string, syncRevision: number): string {
+  return `${base}\0syncrev:${syncRevision}`;
+}

--- a/src/lib/library/librarySyncQueue.test.ts
+++ b/src/lib/library/librarySyncQueue.test.ts
@@ -4,6 +4,14 @@ import {
   enqueueLibrarySync,
   resetLibrarySyncQueueForTests,
 } from './librarySyncQueue';
+import {
+  readArtistBrowseCatalogCache,
+  storeArtistBrowseCatalogCache,
+} from './artistBrowseInflight';
+import {
+  readAlbumBrowseCatalogCache,
+  storeAlbumBrowseCatalogCache,
+} from './albumBrowseInflight';
 
 function mockSyncStart() {
   const start = vi.fn(async (args: unknown) => {
@@ -72,6 +80,19 @@ describe('librarySyncQueue', () => {
     await expect(enqueueLibrarySync({ serverId: 's1', kind: 'full' })).rejects.toThrow(
       'boom',
     );
+  });
+
+  it('evicts buffered artist/album catalogs on a successful sync-idle', async () => {
+    storeArtistBrowseCatalogCache('artist-key', { artists: [], hasMore: false });
+    storeAlbumBrowseCatalogCache('album-key', { albums: [], hasMore: false });
+    expect(readArtistBrowseCatalogCache('artist-key')).toBeDefined();
+    expect(readAlbumBrowseCatalogCache('album-key')).toBeDefined();
+
+    mockSyncStart();
+    await enqueueLibrarySync({ serverId: 's1', kind: 'full' });
+
+    expect(readArtistBrowseCatalogCache('artist-key')).toBeUndefined();
+    expect(readAlbumBrowseCatalogCache('album-key')).toBeUndefined();
   });
 
   it('routes verify through library_sync_verify_integrity', async () => {

--- a/src/lib/library/librarySyncQueue.ts
+++ b/src/lib/library/librarySyncQueue.ts
@@ -48,9 +48,13 @@ function ensureIdleListener(): Promise<UnlistenFn> {
 
 function onSyncIdle(payload: LibrarySyncIdlePayload): void {
   if (payload.ok) {
-    // A completed sync may have added/renamed/pruned rows, so drop the buffered
-    // browse catalogs; the artist/album pages re-key on the sync revision (see
-    // offlineLocalLibrarySyncRevision) and refetch fresh data.
+    // The re-key on the sync revision (offlineLocalLibrarySyncRevision) is what
+    // actually drives the refetch after a sync added/renamed/pruned rows. These
+    // clears are complementary memory reclamation — they drop inflight promises
+    // and stale buffered chunks so they don't linger. Unlike the genre cache
+    // (keyed per serverId), the artist/album catalog caches have no serverId
+    // scope, so this clears every server's buffer; the only cost is a wasted
+    // refetch of identical data on another server's next render.
     invalidateGenreCatalogCache(payload.serverId);
     clearArtistBrowseCatalogCache();
     clearAlbumBrowseCatalogCache();

--- a/src/lib/library/librarySyncQueue.ts
+++ b/src/lib/library/librarySyncQueue.ts
@@ -8,6 +8,8 @@ import {
 import type { UnlistenFn } from '@tauri-apps/api/event';
 import { libraryDevEnabled, logLibrarySync } from './libraryDevLog';
 import { invalidateGenreCatalogCache } from './genreCatalogCountsCache';
+import { clearArtistBrowseCatalogCache } from './artistBrowseInflight';
+import { clearAlbumBrowseCatalogCache } from './albumBrowseInflight';
 
 export type LibrarySyncQueueKind = 'full' | 'delta' | 'verify';
 
@@ -45,7 +47,14 @@ function ensureIdleListener(): Promise<UnlistenFn> {
 }
 
 function onSyncIdle(payload: LibrarySyncIdlePayload): void {
-  if (payload.ok) invalidateGenreCatalogCache(payload.serverId);
+  if (payload.ok) {
+    // A completed sync may have added/renamed/pruned rows, so drop the buffered
+    // browse catalogs; the artist/album pages re-key on the sync revision (see
+    // offlineLocalLibrarySyncRevision) and refetch fresh data.
+    invalidateGenreCatalogCache(payload.serverId);
+    clearArtistBrowseCatalogCache();
+    clearAlbumBrowseCatalogCache();
+  }
   if (!waitingForIdle || waitingForIdle.serverId !== payload.serverId) return;
   const waiter = waitingForIdle;
   waitingForIdle = null;


### PR DESCRIPTION
## Summary

Fixes the reported bug where an artist that was played then **renamed** persists forever: it stays in the Artists list (clicking it → "Artist not found"), the new name only appears after an app restart, and further resyncs/restarts don't help.

Root cause — two independent gaps:

1. **Rust:** A full resync soft-deletes orphaned *tracks* (`sweep_resync_orphans`), but the `artist`/`album` browse tables were only ever upserted, never pruned (except a full server purge). Subsonic servers derive artist/album ids from tags, so a rename mints a **new** id and drops the old one → the old browse row lingers. The Artists list (default album-credit mode) reads `artist` rows, but artist detail resolves from live tracks by `artist_id` → stale row → "Artist not found".
2. **Frontend:** The online artist/album browse catalog is cached in module-level maps that were only evicted on library-filter changes, never on `library:sync-idle` → the new artist only appeared after a full module reload (app restart).

## Changes

- **`orphan_cleanup` module** (new): prunes `artist` rows the latest `getArtists` pass no longer confirms (older `synced_at` than the freshest row for that server) that also have **no live track** crediting them, and `album` rows with no live track and no favourite (`starred_at` preserved). Correlated per-server so one statement works scoped (sync) or global (open reconcile). Nothing browsable/openable is dropped.
- Prune runs on **every** artist-index refresh (full sync IS-4 **and** delta DS-9) and again **after the IS-7 track sweep** — so both stable-id and fresh-id-on-rename servers are covered, on full **and** partial (delta) resync.
- **One-time reconcile** at DB open (`library_data_migration`-guarded) clears ghosts already accumulated in existing DBs.
- **Frontend:** online artist/album browse re-keys on the library sync revision, and the buffered catalogs are evicted on `library:sync-idle` — renamed/pruned artists surface without an app restart. Prefetch keys threaded from the app layer to keep `src/lib` off `src/store` (dep-cruiser floor).

Note on the "more cache-flush mechanisms" ask in the issue: rather than add manual per-entity flush buttons, this makes the *automatic* sync path reliably delete orphans and refresh browse — which is the underlying need. Happy to add manual flush controls in a follow-up if still wanted.

## Test plan

- [x] `cargo test --workspace` — new `orphan_cleanup` unit tests (renamed-away artist pruned; live/confirmed/other-scope artists kept; orphan album pruned but starred/live kept; scoped vs global), integration test `full_resync_prunes_artist_orphaned_by_rename`, store reconcile test (prunes once, idempotent/guarded).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `npx tsc --noEmit`, `npm run dep:check`, eslint on touched files
- [x] `npx vitest run` — new sync-idle cache-eviction test + artist/album feature suites (85 tests)
- [ ] Manual: play an artist, rename it in tags, resync → old artist gone from list, new artist visible without restart; existing DBs cleared on first open after upgrade.

### Library DB migration
- [x] No schema change (additive DELETEs only); no `LIBRARY_DB_SCHEMA_VERSION` bump
- [x] Data cleanup guarded by `library_data_migration` (`orphan_browse_rows_reconcile_v1`), one-time at open
- [x] Ongoing prune wired into sync paths, not run unconditionally on every open