### PR TITLE
fix(library): #1252 Random Albums — artist links + missing tile cover art

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Renaming an artist on the server no longer leaves a stale entry in the local Artists list that opened to "Artist not found" — a sync now prunes artist rows the latest server listing no longer confirms that also have no remaining tracks. Cleanup runs on both full and delta syncs (only after a confirmed artist listing, so a transient empty response can't drop valid entries), plus a one-time pass at startup that clears ghosts already accumulated in existing libraries.
 * Newly added or renamed entries now show up right after a resync instead of only after an app restart: the Artists and Albums pages refresh their cached catalog when a library sync finishes.
 
+### Library — album artist links no longer dead-end at "Artist not found"
+
+**By [@cucadmuh](https://github.com/cucadmuh), reported by tummydummy, PR [#1254](https://github.com/Psychotoxical/psysonic/pull/1254)**
+
+* Clicking the artist beneath an album (most visibly in **Random Albums**) no longer shows "Artist not found" when the server's `getArtist` doesn't recognise that album-artist id — the artist page now falls back to the local library index, which shares the id the card was built from. Artist pages also stay reachable on a brief network hiccup when the library is indexed.
+
 
 ## [1.49.0] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Clicking the artist beneath an album (most visibly in **Random Albums**) no longer shows "Artist not found" when the server's `getArtist` doesn't recognise that album-artist id — the artist page now falls back to the local library index, which shares the id the card was built from. Artist pages also stay reachable on a brief network hiccup when the library is indexed.
 
+### Library — album tiles no longer miss cover art in Random Albums
+
+**By [@cucadmuh](https://github.com/cucadmuh), reported by tummydummy, PR [#1254](https://github.com/Psychotoxical/psysonic/pull/1254)**
+
+* Album tiles for rows that synced without a cover id (surfacing most in **Random Albums**) no longer show a blank cover while the detail page has one — local browse now falls back to the album's first track cover id, so tile and detail resolve the same artwork. The same fallback applies to the detail header's library cover resolution, so the two stay consistent instead of flickering between art and placeholder.
+
 
 ## [1.49.0] - 2026-06-29
 

--- a/src-tauri/crates/psysonic-library/src/advanced_search.rs
+++ b/src-tauri/crates/psysonic-library/src/advanced_search.rs
@@ -44,7 +44,12 @@ const ALBUM_COLUMNS: &str = "a.server_id, a.id, a.name, a.artist, a.artist_id, \
   a.song_count, a.duration_sec, \
   COALESCE(a.year, (SELECT MAX(t.year) FROM track t \
     WHERE t.server_id = a.server_id AND t.album_id = a.id AND t.deleted = 0)), \
-  a.genre, a.cover_art_id, a.starred_at, a.synced_at, a.raw_json";
+  a.genre, \
+  COALESCE(a.cover_art_id, (SELECT t.cover_art_id FROM track t \
+    WHERE t.server_id = a.server_id AND t.album_id = a.id AND t.deleted = 0 \
+      AND NULLIF(TRIM(t.cover_art_id), '') IS NOT NULL \
+    ORDER BY t.id ASC LIMIT 1)), \
+  a.starred_at, a.synced_at, a.raw_json";
 
 const ARTIST_COLUMNS: &str = "ar.server_id, ar.id, ar.name, ar.name_sort, ar.album_count, \
   ar.synced_at, ar.raw_json";
@@ -2666,6 +2671,36 @@ mod tests {
         let resp = run_advanced_search(&store, &r).unwrap();
         assert_eq!(resp.albums.len(), 1);
         assert_eq!(resp.albums[0].id, "al_star");
+    }
+
+    // #1252: an album-table row synced without a cover id must surface its first
+    // track cover in the browse DTO so random/browse tiles resolve the same art
+    // the detail page does. `starred_only` forces the album-table path here.
+    #[test]
+    fn album_table_cover_falls_back_to_track_cover() {
+        let store = LibraryStore::open_in_memory();
+        insert_album(&store, "s1", "al_nocover", "No Cover", None, None);
+        store
+            .with_conn("misc", |c| {
+                c.execute(
+                    "UPDATE album SET starred_at = 100 WHERE server_id = 's1' AND id = 'al_nocover'",
+                    [],
+                )
+            })
+            .unwrap();
+        let mut t = track("s1", "t1", "Song", "Artist", "No Cover");
+        t.album_id = Some("al_nocover".into());
+        t.cover_art_id = Some("mf-track-cover".into());
+        TrackRepository::new(&store).upsert_batch(&[t]).unwrap();
+        let mut r = req("s1", &[EntityKind::Album]);
+        r.starred_only = Some(true);
+        let resp = run_advanced_search(&store, &r).unwrap();
+        let al = resp
+            .albums
+            .iter()
+            .find(|a| a.id == "al_nocover")
+            .expect("album-table row present");
+        assert_eq!(al.cover_art_id.as_deref(), Some("mf-track-cover"));
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/cover_resolve.rs
+++ b/src-tauri/crates/psysonic-library/src/cover_resolve.rs
@@ -110,8 +110,43 @@ pub fn resolve_album_cover_entry(
         None => return Ok(None),
         Some(v) => v,
     };
+    // Album rows synced without a cover id (created from a starred/tag/browse path
+    // rather than getAlbum) would otherwise resolve to the bare album id, which
+    // fails on servers that only serve art under a track/media cover id. Fall back
+    // to the album's first track cover so the detail header and browse tiles agree.
+    let cover_art_id = match cover_art_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(_) => cover_art_id,
+        None => album_track_cover_art_id(store, library_server_id, album_id)?,
+    };
     let distinct = album_has_distinct_disc_covers(store, library_server_id, album_id)?;
     Ok(resolve_album_cover(album_id, cover_art_id.as_deref(), distinct).map(Into::into))
+}
+
+/// First non-empty track cover id for an album — used to fill an `album` row that
+/// synced without a `cover_art_id`. Mirrors the `ALBUM_COLUMNS` COALESCE fallback
+/// in `advanced_search.rs` so browse tiles and cover resolution agree.
+fn album_track_cover_art_id(
+    store: &LibraryStore,
+    library_server_id: &str,
+    album_id: &str,
+) -> Result<Option<String>, String> {
+    store.with_read_conn(|conn| {
+        conn.query_row(
+            "SELECT t.cover_art_id FROM track t
+             WHERE t.server_id = ?1 AND t.album_id = ?2 AND t.deleted = 0
+               AND NULLIF(TRIM(t.cover_art_id), '') IS NOT NULL
+             ORDER BY t.id ASC
+             LIMIT 1",
+            rusqlite::params![library_server_id, album_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .map(Option::flatten)
+    })
 }
 
 /// Album id appears only on `track` rows (no `album` table row) — mirror catalog `fetch_id`.
@@ -372,6 +407,32 @@ mod tests {
             .unwrap();
         assert_eq!(e.cache_entity_id, "ca78bec6");
         assert_eq!(e.fetch_cover_art_id, "al-ca78bec6_60fc987f");
+    }
+
+    // #1252: an album row synced without a cover id (e.g. via a starred/tag path)
+    // must fall back to the album's track cover, not the bare album id, so the
+    // detail header and browse tiles resolve the same fetch id.
+    #[test]
+    fn resolve_album_falls_back_to_track_cover_when_row_cover_null() {
+        let store = LibraryStore::open_in_memory();
+        seed_album(&store, "srv", "al-nocover", None);
+        seed_track(&store, "srv", "tr1", "al-nocover", 1, Some("mf-cover"));
+        let e = resolve_album_cover_entry(&store, "srv", "al-nocover")
+            .unwrap()
+            .unwrap();
+        assert_eq!(e.cache_entity_id, "al-nocover");
+        assert_eq!(e.fetch_cover_art_id, "mf-cover");
+    }
+
+    #[test]
+    fn resolve_album_keeps_row_cover_over_track_cover() {
+        let store = LibraryStore::open_in_memory();
+        seed_album(&store, "srv", "al-rowcover", Some("al-rowcover_art"));
+        seed_track(&store, "srv", "tr1", "al-rowcover", 1, Some("mf-cover"));
+        let e = resolve_album_cover_entry(&store, "srv", "al-rowcover")
+            .unwrap()
+            .unwrap();
+        assert_eq!(e.fetch_cover_art_id, "al-rowcover_art");
     }
 
     #[test]

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -190,7 +190,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Offline browse — on-disk-only Artists/Albums/Tracks/Genres (pins, favorites-auto, hot-cache); reactive sidebar gates and sync-idle reload; local credit mode and genre scope (PR #1243)',
       'Album detail — album-level favorite heart from album.starred_at; server-backed album rating reconcile on detail (report: HiveMind on Psysonic Discord, PR #1247)',
       'Library — prune orphaned artist browse rows after server-side renames (fixes "Artist not found" ghosts) on full/delta sync + one-time startup reconcile; refresh Artists/Albums catalog on sync-idle (report: Seraphim on Psysonic Discord, PR #1253)',
-      'Artist detail — fall back to the local library index when getArtist 404s an album-artist id (fixes Random Albums artist links dead-ending at "Artist not found") (report: tummydummy, PR #1254)',
+      'Artist detail — fall back to the local library index when getArtist 404s an album-artist id (fixes Random Albums artist links dead-ending at "Artist not found"); album browse + detail cover resolution fall back to the album\'s first track cover for rows synced without one (fixes missing Random Albums tile art) (report: tummydummy, PR #1254)',
     ],
   },
   {

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -190,6 +190,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Offline browse — on-disk-only Artists/Albums/Tracks/Genres (pins, favorites-auto, hot-cache); reactive sidebar gates and sync-idle reload; local credit mode and genre scope (PR #1243)',
       'Album detail — album-level favorite heart from album.starred_at; server-backed album rating reconcile on detail (report: HiveMind on Psysonic Discord, PR #1247)',
       'Library — prune orphaned artist browse rows after server-side renames (fixes "Artist not found" ghosts) on full/delta sync + one-time startup reconcile; refresh Artists/Albums catalog on sync-idle (report: Seraphim on Psysonic Discord, PR #1253)',
+      'Artist detail — fall back to the local library index when getArtist 404s an album-artist id (fixes Random Albums artist links dead-ending at "Artist not found") (report: tummydummy, PR #1254)',
     ],
   },
   {

--- a/src/features/artist/hooks/useArtistDetailData.multiScope.test.ts
+++ b/src/features/artist/hooks/useArtistDetailData.multiScope.test.ts
@@ -33,6 +33,7 @@ vi.mock('@/lib/hooks/useConnectionStatus', () => ({
 }));
 
 import { getArtist, getArtistForServer, getArtistInfo, getTopSongs } from '@/lib/api/subsonicArtists';
+import { loadArtistFromLibraryIndex } from '@/features/offline';
 import { search } from '@/lib/api/subsonicSearch';
 import { useArtistDetailData } from './useArtistDetailData';
 
@@ -110,6 +111,38 @@ describe('useArtistDetailData — multi-library selection', () => {
     expect(getArtistForServer).toHaveBeenCalled();
     expect(getArtist).not.toHaveBeenCalled();
     expect(result.current.artist).toMatchObject({ name: 'Network' });
+  });
+
+  it('falls back to the local library index when network getArtist fails', async () => {
+    // Random Albums links an album-artist id that `getArtist` 404s on, but the
+    // artist row exists in the local index the album came from → resolve there
+    // instead of showing "Artist not found".
+    librarySelectionForServerMock.mockReturnValue([]);
+    vi.mocked(getArtistForServer).mockRejectedValue(new Error('artist not found'));
+    vi.mocked(loadArtistFromLibraryIndex).mockResolvedValue({
+      artist: { id: 'art-x', name: 'Album Artist', albumCount: 1, serverId: 'srv-1' },
+      albums: [{ id: 'alb-9', name: 'Comp', artist: 'Album Artist', artistId: 'art-x', songCount: 1, duration: 100 }],
+    });
+
+    const { result } = renderHook(() => useArtistDetailData('art-x'), { wrapper: routerWrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(getArtistForServer).toHaveBeenCalled();
+    expect(loadArtistFromLibraryIndex).toHaveBeenCalledWith('srv-1', 'art-x');
+    expect(result.current.artist).toMatchObject({ id: 'art-x', name: 'Album Artist' });
+    expect(result.current.albums).toHaveLength(1);
+  });
+
+  it('shows nothing to resolve when both network and local index miss', async () => {
+    librarySelectionForServerMock.mockReturnValue([]);
+    vi.mocked(getArtistForServer).mockRejectedValue(new Error('artist not found'));
+    vi.mocked(loadArtistFromLibraryIndex).mockResolvedValue(null);
+
+    const { result } = renderHook(() => useArtistDetailData('ghost'), { wrapper: routerWrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(loadArtistFromLibraryIndex).toHaveBeenCalledWith('srv-1', 'ghost');
+    expect(result.current.artist).toBeNull();
   });
 
   it('falls through to getArtist when multi-scope load returns null', async () => {

--- a/src/features/artist/hooks/useArtistDetailData.ts
+++ b/src/features/artist/hooks/useArtistDetailData.ts
@@ -162,26 +162,31 @@ export function useArtistDetailData(
         setAlbums(nextAlbums);
         setTopSongs(nextSongs);
       } catch (err) {
-        if (!cancelled) {
-          if (preferLocalArtist && serverId && id) {
-            try {
-              const local = preferLocalBytesOnly
-                ? await loadArtistFromLocalPlayback(serverId, id)
-                : await loadArtistFromLibraryIndex(serverId, id);
-              if (cancelled) return;
-              if (local) {
-                setArtist(local.artist);
-                setIsStarred(!!local.artist.starred);
-                setAlbums(local.albums);
-                setTopSongs([]);
-                setLoading(false);
-                return;
-              }
-            } catch { /* ignore */ }
-          }
-          console.error(err);
-          setLoading(false);
+        if (cancelled) return;
+        // Network `getArtist` can fail for an id that is a valid card link but
+        // has no `getArtist` entry — e.g. an album-artist surfaced by Random
+        // Albums whose id resolves the album fine but not the artist. Fall back
+        // to the local library index (the same id space the card came from)
+        // before showing "Artist not found"; this also keeps artist pages
+        // reachable on a transient network hiccup when the library is indexed.
+        if (serverId && id) {
+          try {
+            const local = preferLocalBytesOnly
+              ? await loadArtistFromLocalPlayback(serverId, id)
+              : await loadArtistFromLibraryIndex(serverId, id);
+            if (cancelled) return;
+            if (local) {
+              setArtist(local.artist);
+              setIsStarred(!!local.artist.starred);
+              setAlbums(local.albums);
+              setTopSongs([]);
+              setLoading(false);
+              return;
+            }
+          } catch { /* ignore */ }
         }
+        console.error(err);
+        setLoading(false);
       }
     })();
 


### PR DESCRIPTION
## Summary

Fixes both symptoms of #1252 (reported by @tummydummy) for **Random Albums** (and album-table browse generally).

### 1. "Artist Not Found" on album-artist links
Album cards render the artist beneath the title from **album-level** metadata ids (`album.artists[]` / `album.artistId`). When Random Albums is served from the **local library index**, that id resolves the album fine but can **404 on Subsonic `getArtist`** (e.g. album-artist ids without a `getArtist` entry). The artist page then showed *"Artist not found"* even though the artist exists in the local index the album came from.

`useArtistDetailData`'s online branch previously only fell back to the local index in the offline-preferring case; any other `getArtist` failure went straight to the not-found state. Now **any** failed network `getArtist` retries `loadArtistFromLibraryIndex(serverId, id)` — the same id space the card links from — before giving up. Bonus: artist pages stay reachable on a transient network hiccup when the library is indexed.

- `src/features/artist/hooks/useArtistDetailData.ts` — catch-path fallback broadened from `preferLocalArtist` to any `serverId && id`.

### 2. Missing cover art on album tiles
Album tiles for rows that synced **without a `cover_art_id`** (created via a starred/tag/browse path rather than `getAlbum`) showed a blank cover, while the detail page resolved one — the "cover art flickers on/off as you go back and forth" report.

Root cause: the browse DTO reads `a.cover_art_id` straight from the `album` table (`ALBUM_COLUMNS` → `map_album`), and the library cover resolver read the same column; when NULL both fell back to the bare album id (which fails on servers that only serve art under a media/track cover id), whereas the detail header had a real cover from `getAlbum`.

Fix (mirrors the existing `COALESCE(a.year, <track subquery>)` precedent):
- `advanced_search.rs` `ALBUM_COLUMNS` — `COALESCE(a.cover_art_id, <first non-empty track cover>)` so browse tiles carry a real cover id.
- `cover_resolve.rs` `resolve_album_cover_entry` — same track fallback, so the detail header/library resolution agrees with tiles (no more flicker).

No migration, no DTO/contract change, no locale change. `COALESCE` short-circuits, so the track subquery only runs for rows whose column is NULL.

## Test plan
- [x] `cargo test --workspace cover_resolve::` (incl. new NULL→track-cover + row-cover-precedence cases)
- [x] `cargo test --workspace advanced_search::` (incl. new album-table COALESCE case; 65 pass)
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `npx vitest run src/features/artist/hooks/useArtistDetailData` (artist-link fallback)
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run dep:check`, release-notes bundle
- [ ] Manual: Random Albums on Navidrome — artist links that previously 404'd resolve from the local index; tiles for cover-less rows now show artwork matching the detail page.

Closes #1252.