### PR TITLE
fix(library): prune orphaned cluster identity keys on rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Album tiles for rows that synced without a cover id (surfacing most in **Random Albums**) no longer show a blank cover while the detail page has one — local browse now falls back to the album's first track cover id, so tile and detail resolve the same artwork. The same fallback applies to the detail header's library cover resolution, so the two stay consistent instead of flickering between art and placeholder.
 
+### Library — multi-library dedup sidecar no longer accumulates dead identity keys
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1255](https://github.com/Psychotoxical/psysonic/pull/1255)**
+
+* The precomputed `library-cluster.db` identity keys used for cross-library dedup are now pruned on rebuild when their track no longer exists (removed, or dropped when a server mints a fresh id on rename). Previously the rebuild only refreshed live tracks and never deleted stale rows, so the sidecar grew with library churn until it was recreated wholesale (server switch / restore / import). The rows were inert (reads only ever join live tracks), so dedup and browse results are unchanged — this just stops the sidecar from bloating.
+
 
 ## [1.49.0] - 2026-06-29
 

--- a/src-tauri/crates/psysonic-library/src/identity/rebuild.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/rebuild.rs
@@ -390,6 +390,50 @@ mod tests {
     }
 
     #[test]
+    fn global_rebuild_prunes_orphans_across_servers() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                track_row("s1", "t1", "T1", Some("A"), "Al", None, 100, "lib"),
+                track_row("s2", "t2", "T2", Some("B"), "Al", None, 120, "lib"),
+            ])
+            .unwrap();
+        rebuild_cluster_keys(&store, None).unwrap();
+        assert!(store
+            .with_read_conn(|c| read_cluster_row(c, "s1", "t1"))
+            .unwrap()
+            .is_some());
+        assert!(store
+            .with_read_conn(|c| read_cluster_row(c, "s2", "t2"))
+            .unwrap()
+            .is_some());
+
+        // Both tracks go to tombstone; a global (server_id = None) rebuild must
+        // prune the orphan on every server via the tuple-scoped DELETE branch.
+        store
+            .with_conn_mut("test.del", |c| {
+                c.execute("UPDATE track SET deleted = 1 WHERE id IN ('t1', 't2')", [])
+            })
+            .unwrap();
+        rebuild_cluster_keys(&store, None).unwrap();
+
+        assert!(
+            store
+                .with_read_conn(|c| read_cluster_row(c, "s1", "t1"))
+                .unwrap()
+                .is_none(),
+            "global rebuild must prune s1 orphan"
+        );
+        assert!(
+            store
+                .with_read_conn(|c| read_cluster_row(c, "s2", "t2"))
+                .unwrap()
+                .is_none(),
+            "global rebuild must prune s2 orphan"
+        );
+    }
+
+    #[test]
     fn per_server_rebuild_leaves_other_server_keys() {
         let store = LibraryStore::open_in_memory();
         TrackRepository::new(&store)

--- a/src-tauri/crates/psysonic-library/src/identity/rebuild.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/rebuild.rs
@@ -120,6 +120,31 @@ pub fn rebuild_cluster_keys(
         drop(rows);
         drop(stmt);
         drop(upsert);
+        // Prune keys whose track no longer exists (soft-deleted via tombstone, or
+        // dropped when a server mints a fresh id on rename). The UPSERT above only
+        // refreshes live rows; without this, orphaned keys accumulate forever and
+        // are only reclaimed when the whole sidecar is dropped (swap/restore/import).
+        // Reads join `cluster.track_cluster_key` against `track WHERE deleted = 0`,
+        // so these rows are inert — this is bloat cleanup, scoped to the rebuilt
+        // server(s) so a single-server rebuild never touches other servers' keys.
+        if let Some(sid) = server_id {
+            tx.execute(
+                "DELETE FROM cluster.track_cluster_key \
+                 WHERE server_id = ?1 \
+                   AND track_id NOT IN (\
+                     SELECT id FROM track WHERE deleted = 0 AND server_id = ?1\
+                   )",
+                params![sid],
+            )?;
+        } else {
+            tx.execute(
+                "DELETE FROM cluster.track_cluster_key \
+                 WHERE (server_id, track_id) NOT IN (\
+                   SELECT server_id, id FROM track WHERE deleted = 0\
+                 )",
+                [],
+            )?;
+        }
         set_cluster_meta(&tx)?;
         tx.commit()?;
         Ok(upserted)
@@ -319,6 +344,86 @@ mod tests {
             .unwrap();
 
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn rebuild_prunes_orphaned_cluster_keys() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                track_row("s1", "t1", "T1", Some("A"), "Al", None, 100, "lib"),
+                track_row("s1", "t2", "T2", Some("B"), "Al", None, 120, "lib"),
+            ])
+            .unwrap();
+        rebuild_cluster_keys(&store, Some("s1")).unwrap();
+        assert!(store
+            .with_read_conn(|c| read_cluster_row(c, "s1", "t2"))
+            .unwrap()
+            .is_some());
+
+        // Soft-delete t2 (tombstone) → its stale cluster key must be pruned on
+        // the next rebuild, not linger forever.
+        store
+            .with_conn_mut("test.soft_delete", |c| {
+                c.execute(
+                    "UPDATE track SET deleted = 1 WHERE server_id = 's1' AND id = 't2'",
+                    [],
+                )
+            })
+            .unwrap();
+        rebuild_cluster_keys(&store, Some("s1")).unwrap();
+
+        assert!(
+            store
+                .with_read_conn(|c| read_cluster_row(c, "s1", "t1"))
+                .unwrap()
+                .is_some(),
+            "live track key must remain"
+        );
+        assert!(
+            store
+                .with_read_conn(|c| read_cluster_row(c, "s1", "t2"))
+                .unwrap()
+                .is_none(),
+            "orphaned cluster key must be pruned"
+        );
+    }
+
+    #[test]
+    fn per_server_rebuild_leaves_other_server_keys() {
+        let store = LibraryStore::open_in_memory();
+        TrackRepository::new(&store)
+            .upsert_batch(&[
+                track_row("s1", "t1", "T1", Some("A"), "Al", None, 100, "lib"),
+                track_row("s2", "t2", "T2", Some("B"), "Al", None, 120, "lib"),
+            ])
+            .unwrap();
+        rebuild_cluster_keys(&store, None).unwrap();
+
+        // Both tracks go to tombstone, but we rebuild only s1: s1's orphan is
+        // pruned while s2's key is untouched (single global norm stamp, but the
+        // prune is scoped to the rebuilt server).
+        store
+            .with_conn_mut("test.del", |c| {
+                c.execute("UPDATE track SET deleted = 1 WHERE id IN ('t1', 't2')", [])
+            })
+            .unwrap();
+        rebuild_cluster_keys(&store, Some("s1")).unwrap();
+
+        assert!(
+            store
+                .with_read_conn(|c| read_cluster_row(c, "s1", "t1"))
+                .unwrap()
+                .is_none(),
+            "rebuilt server's orphan must be pruned"
+        );
+        assert!(
+            store
+                .with_read_conn(|c| read_cluster_row(c, "s2", "t2"))
+                .unwrap()
+                .is_some(),
+            "single-server rebuild must not prune another server's keys"
+        );
     }
 
     #[test]

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -191,6 +191,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Album detail — album-level favorite heart from album.starred_at; server-backed album rating reconcile on detail (report: HiveMind on Psysonic Discord, PR #1247)',
       'Library — prune orphaned artist browse rows after server-side renames (fixes "Artist not found" ghosts) on full/delta sync + one-time startup reconcile; refresh Artists/Albums catalog on sync-idle (report: Seraphim on Psysonic Discord, PR #1253)',
       'Artist detail — fall back to the local library index when getArtist 404s an album-artist id (fixes Random Albums artist links dead-ending at "Artist not found"); album browse + detail cover resolution fall back to the album\'s first track cover for rows synced without one (fixes missing Random Albums tile art) (report: tummydummy, PR #1254)',
+      'Library — prune orphaned identity keys from the multi-library dedup sidecar (library-cluster.db) on rebuild so it no longer bloats with rows for removed/renamed tracks (PR #1255)',
     ],
   },
   {


### PR DESCRIPTION
## Summary

`library-cluster.db` (the multi-library dedup sidecar, attached as schema `cluster`) stores one `track_cluster_key` row per track, keyed by `(server_id, track_id)` and derived from the track's normalized `artist`/`title`/`album`/`album_artist`.

`rebuild_cluster_keys` (run on every sync-idle via `libraryClusterRebuild`, plus on `norm_version` bump and lazily before multi-library reads) only **UPSERTs keys for live tracks** (`track WHERE deleted = 0`) and never deleted anything. So keys for tracks that went to tombstone — or were dropped when a server mints a fresh track id on rename — **lingered in the sidecar forever**, reclaimed only when the whole file is dropped (swap / restore / import).

Every consumer joins `cluster.track_cluster_key` against `track WHERE deleted = 0`, so these orphan rows were **inert** (they can't affect dedup or browse results) — but they accumulate as pure sidecar bloat with library churn / mass renames.

The rebuild now prunes cluster rows with no matching live track, **scoped to the rebuilt server(s)** so a single-server rebuild (the per-sync path) never touches another server's keys. Text-metadata renames on a live track keep self-healing via the existing UPSERT; this only removes truly dead rows.

- `identity/rebuild.rs` — post-UPSERT `DELETE` of orphaned keys (single-column scoped `NOT IN` when a server is given; row-value tuple `NOT IN` for the global rebuild).
- Tests: soft-deleted track's key is pruned on next rebuild; single-server rebuild leaves another server's keys intact.

No schema change, no migration (sidecar is fully rebuildable), no contract/locale change.

## Test plan
- [x] `cargo test --workspace identity::` (17 pass, incl. 2 new prune cases)
- [x] `cargo test --workspace scope_merge::` (cluster consumer; 9 pass)
- [x] `cargo clippy --workspace --all-targets` (clean)
- [ ] Manual: multi-library setup, rename/remove tracks on a server, resync → orphaned rows drop out of `library-cluster.db`; cross-library dedup/browse unchanged.