### PR TITLE
fix(library): heal stale album-artist reference on resync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Album tiles for rows that synced without a cover id (surfacing most in **Random Albums**) no longer show a blank cover while the detail page has one — local browse now falls back to the album's first track cover id, so tile and detail resolve the same artwork. The same fallback applies to the detail header's library cover resolution, so the two stay consistent instead of flickering between art and placeholder.
 
+### Library — renamed album artist links now heal on resync
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1256](https://github.com/Psychotoxical/psysonic/pull/1256)**
+
+* When an artist is renamed on the server (minting a new artist id), the album's stored artist link no longer stays stuck on the old id and dead-ending at "Artist not found". Album metadata now follows the server's `getAlbum` for the artist reference, so a resync updates it instead of keeping the pre-rename id indefinitely. Complements the earlier ghost-row prune (#1253) and the local-index fallback (#1254), which did not clear the stale reference itself.
+
 
 ## [1.49.0] - 2026-06-29
 

--- a/src-tauri/crates/psysonic-library/src/sync/album_metadata.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/album_metadata.rs
@@ -17,8 +17,13 @@ fn album_starred_at_from_raw(raw_album: &Value) -> Option<Option<i64>> {
 }
 
 /// Upsert `album` row metadata from a `#getAlbum` response. When `starred` is
-/// present in `raw_album`, it overwrites `album.starred_at`; omitted keys are
-/// left untouched on conflict.
+/// present in `raw_album`, it overwrites `album.starred_at`.
+///
+/// `name`, `artist` and `artist_id` follow `getAlbum` authoritatively — they are
+/// overwritten even when the response omits them (writes NULL), so a server-side
+/// artist rename heals on resync instead of the old id sticking via `COALESCE`
+/// and leaving the album-artist link dead-ending at "Artist not found". Other
+/// nullable columns keep their prior value when the response omits them.
 pub(crate) fn upsert_album_from_get_album(
     store: &LibraryStore,
     server_id: &str,
@@ -41,8 +46,8 @@ pub(crate) fn upsert_album_from_get_album(
                  ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
                  ON CONFLICT(server_id, id) DO UPDATE SET
                    name = excluded.name,
-                   artist = COALESCE(excluded.artist, album.artist),
-                   artist_id = COALESCE(excluded.artist_id, album.artist_id),
+                   artist = excluded.artist,
+                   artist_id = excluded.artist_id,
                    song_count = COALESCE(excluded.song_count, album.song_count),
                    duration_sec = COALESCE(excluded.duration_sec, album.duration_sec),
                    year = COALESCE(excluded.year, album.year),
@@ -119,5 +124,79 @@ mod tests {
             })
             .unwrap();
         assert!(starred.is_some());
+    }
+
+    fn album_artist(store: &LibraryStore) -> (Option<String>, Option<String>) {
+        store
+            .with_conn("read", |c| {
+                c.query_row(
+                    "SELECT artist, artist_id FROM album WHERE server_id = 's1' AND id = 'al1'",
+                    [],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+            })
+            .unwrap()
+    }
+
+    fn seed_album_with_artist(store: &LibraryStore, artist: &str, artist_id: &str) {
+        store
+            .with_conn_mut("seed", |c| {
+                c.execute(
+                    "INSERT INTO album (server_id, id, name, artist, artist_id, synced_at, raw_json) \
+                     VALUES ('s1', 'al1', 'Album', ?1, ?2, 1, '{}')",
+                    params![artist, artist_id],
+                )
+            })
+            .unwrap();
+    }
+
+    fn get_album_with_artist(artist: Option<&str>, artist_id: Option<&str>) -> Album {
+        Album {
+            id: "al1".into(),
+            name: "Album".into(),
+            artist: artist.map(str::to_string),
+            artist_id: artist_id.map(str::to_string),
+            song_count: None,
+            duration: None,
+            year: None,
+            genre: None,
+            cover_art: None,
+            song: vec![],
+        }
+    }
+
+    // A server-side artist rename mints a new artist id; the fresh getAlbum must
+    // overwrite the album's stale artist ref so the card link stops dead-ending
+    // at "Artist not found" (previously COALESCE kept the pre-rename id).
+    #[test]
+    fn upsert_refreshes_album_artist_ref_on_rename() {
+        let store = LibraryStore::open_in_memory();
+        seed_album_with_artist(&store, "Old Name", "ar_old");
+        let album = get_album_with_artist(Some("New Name"), Some("ar_new"));
+        let raw = serde_json::json!({ "id": "al1", "name": "Album" });
+
+        upsert_album_from_get_album(&store, "s1", &album, &raw, 2).unwrap();
+
+        let (artist, artist_id) = album_artist(&store);
+        assert_eq!(artist.as_deref(), Some("New Name"));
+        assert_eq!(artist_id.as_deref(), Some("ar_new"));
+    }
+
+    // When the server no longer exposes an album-level artist id (e.g. only the
+    // structured `artists[]` in raw_json), the stale column value must not stick.
+    #[test]
+    fn upsert_clears_stale_album_artist_id_when_server_drops_it() {
+        let store = LibraryStore::open_in_memory();
+        seed_album_with_artist(&store, "Old", "ar_old");
+        let album = get_album_with_artist(None, None);
+        let raw = serde_json::json!({ "id": "al1", "name": "Album" });
+
+        upsert_album_from_get_album(&store, "s1", &album, &raw, 2).unwrap();
+
+        let (_, artist_id) = album_artist(&store);
+        assert!(
+            artist_id.is_none(),
+            "stale artist_id must not persist when getAlbum omits it"
+        );
     }
 }

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -191,6 +191,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Album detail — album-level favorite heart from album.starred_at; server-backed album rating reconcile on detail (report: HiveMind on Psysonic Discord, PR #1247)',
       'Library — prune orphaned artist browse rows after server-side renames (fixes "Artist not found" ghosts) on full/delta sync + one-time startup reconcile; refresh Artists/Albums catalog on sync-idle (report: Seraphim on Psysonic Discord, PR #1253)',
       'Artist detail — fall back to the local library index when getArtist 404s an album-artist id (fixes Random Albums artist links dead-ending at "Artist not found"); album browse + detail cover resolution fall back to the album\'s first track cover for rows synced without one (fixes missing Random Albums tile art) (report: tummydummy, PR #1254)',
+      'Library — follow getAlbum authoritatively for album artist reference so a server-side artist rename heals on resync instead of dead-ending at "Artist not found" (PR #1256)',
     ],
   },
   {


### PR DESCRIPTION
## Summary

Follow-up to the root cause found while investigating #1252: the album-artist link that dead-ends at **"Artist not found"** is, in part, a **rename artifact** that #1253/#1254 did not address.

`upsert_album_from_get_album` updated the `album` row's `artist`/`artist_id` with `COALESCE(excluded.*, album.*)`. That keeps the previous value whenever the fresh `getAlbum` omits it — so when a server-side rename mints a **new** artist id, the album row keeps pointing at the **pre-rename** id indefinitely. `deriveAlbumArtistRefs` falls back to that stale `artistId` (when the server exposes no structured `artists[]`), and the link 404s on `getArtist`.

Neither path fixed this:
- **#1253** pruned stale rows in the `artist` **table**, not the `artist_id` **references** embedded in album rows.
- A full resync re-fetched `getAlbum` for every album but `COALESCE` still "stuck" the old id.
- **#1254**'s local-index fallback misses once the old id is gone (e.g. pruned by #1253).

### Fix
Follow `getAlbum` authoritatively for `name`/`artist`/`artist_id` — overwrite even when the response omits them — matching how the **track** upsert already writes `artist_id = excluded.artist_id`. Stale references now heal on the next resync.

Dropping a stale id to NULL does not blank the UI: the read-side browse queries already `COALESCE(a.artist, <track-derived artist>)`, and `deriveAlbumArtistRefs` prefers the refreshed `raw_json` `artists[]`/`displayArtist`. `getAlbum` is the sole writer of these columns in prod, so there is no partial-update path relying on the old sticky behavior. Other nullable columns (`year`, `genre`, `cover_art_id`, …) keep their `COALESCE` guard.

- `sync/album_metadata.rs` — `artist`/`artist_id` now `= excluded.*` on conflict; doc comment updated.
- Tests: rename overwrites the stale ref (`ar_old` → `ar_new`); a `getAlbum` that omits the id clears the stale value instead of sticking.

Existing DBs heal on the next full resync (no offline migration possible — the new id is only known from the server). No schema change, no contract/locale change.

## Test plan
- [x] `cargo test --workspace album_metadata::` (3 pass, incl. 2 new)
- [x] `cargo test --workspace sync::` (library binary: 136 pass)
- [x] `cargo test --workspace advanced_search::` (65 pass; browse read-side)
- [x] `cargo clippy --workspace --all-targets` (clean)
- [ ] Manual: rename an album artist on the server, resync → the album card's artist link resolves to the new artist instead of "Artist not found".