### PR TITLE
chore(build): bind Windows cargo-test binaries to Common-Controls v6 manifest

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,20 @@
 fn main() {
+    // Windows/MSVC test binaries only: bind to Common-Controls v6.
+    //
+    // The library test harness (`--lib` unittests) links the wry/tao windowing
+    // runtime and statically imports `TaskDialogIndirect` from comctl32, which
+    // exists only in Common-Controls v6 (WinSxS). The real app binary gets that
+    // manifest from `tauri_build`, but the separate test executable does not, so
+    // it aborts at startup with STATUS_ENTRYPOINT_NOT_FOUND (0xC0000139). Add the
+    // dependency to test targets only — never the app binary (which already has a
+    // manifest via tauri_build) nor non-Windows/CI builds.
+    let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+    if is_windows_msvc {
+        println!(
+            "cargo::rustc-link-arg=/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'"
+        );
+    }
+
     tauri_build::build()
 }

--- a/src-tauri/crates/psysonic-analysis/build.rs
+++ b/src-tauri/crates/psysonic-analysis/build.rs
@@ -1,0 +1,19 @@
+fn main() {
+    // Windows/MSVC test binaries only: bind to Common-Controls v6.
+    //
+    // The `tauri` dev-dependency pulls the wry/tao windowing runtime into this
+    // crate's *test* executables, which statically import `TaskDialogIndirect`
+    // from comctl32. That symbol lives only in Common-Controls v6 (WinSxS); the
+    // bare System32 comctl32.dll is v5.82 and does not export it, so an
+    // unmanifested test exe aborts at startup with STATUS_ENTRYPOINT_NOT_FOUND
+    // (0xC0000139) before any test runs. The app binary avoids this through its
+    // embedded manifest — mirror that here, scoped to test targets only (never
+    // the app, the rlib, or non-Windows/CI builds).
+    let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+    if is_windows_msvc {
+        println!(
+            "cargo::rustc-link-arg=/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'"
+        );
+    }
+}

--- a/src-tauri/crates/psysonic-audio/build.rs
+++ b/src-tauri/crates/psysonic-audio/build.rs
@@ -1,0 +1,19 @@
+fn main() {
+    // Windows/MSVC test binaries only: bind to Common-Controls v6.
+    //
+    // The `tauri` dev-dependency pulls the wry/tao windowing runtime into this
+    // crate's *test* executables, which statically import `TaskDialogIndirect`
+    // from comctl32. That symbol lives only in Common-Controls v6 (WinSxS); the
+    // bare System32 comctl32.dll is v5.82 and does not export it, so an
+    // unmanifested test exe aborts at startup with STATUS_ENTRYPOINT_NOT_FOUND
+    // (0xC0000139) before any test runs. The app binary avoids this through its
+    // embedded manifest — mirror that here, scoped to test targets only (never
+    // the app, the rlib, or non-Windows/CI builds).
+    let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+    if is_windows_msvc {
+        println!(
+            "cargo::rustc-link-arg=/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

On Windows/MSVC the cargo **test** binaries for `psysonic-analysis`, `psysonic-audio` and the top `psysonic` crate crashed at startup with `STATUS_ENTRYPOINT_NOT_FOUND` (0xC0000139) before any test ran, so backend tests could not be run locally on Windows.

- Root cause: those test exes link the wry/tao windowing runtime (via the `tauri` dep) and statically import `TaskDialogIndirect` from comctl32 — a Common-Controls **v6** export. System32 `comctl32.dll` is v5.82 and lacks it; the test exe has no manifest binding it to v6 (the app binary gets one from `tauri_build`).
- Fix: three build scripts declare the Common-Controls v6 dependency on their test binaries via `rustc-link-arg`, gated to windows-msvc.
- The app binary's embedded manifest is **byte-identical** with and without this change (`tauri_build` already embeds the same dependency; the linker dedupes). Non-Windows / CI builds are unaffected.

## Test plan
- [x] `cargo test --workspace` on Windows: no 0xC0000139; all test binaries launch and run (analysis 122, audio 209, library 503, core 30, integration 112, lib 52).
- [x] `cargo build --bin psysonic` links cleanly; embedded manifest verified as a single well-formed entry.
- [ ] Linux/CI: unchanged (the build-script arm is windows-msvc only).