### PR TITLE
docs(contributing): document frontend layering contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,25 @@ Align early: open an issue or chat thread before sending a PR that renames `invo
 
 ---
 
+## Frontend architecture and layering
+
+The frontend uses a feature-folder architecture (introduced in #1225) with a layering contract that CI enforces through **`npm run dep:check`** (dependency-cruiser). The rule is simple: **a lower layer must never import a higher one.**
+
+```
+lib  →  store / ui  →  cover / music-network  →  features/<x>  →  app
+```
+
+- **`lib/**` is the floor** — feature-free infrastructure (API clients, formatting, i18n, util, media, server, navigation). It must **not** import from `store`, `ui`, `features`, `cover`, `music-network`, or `app`. If a `lib` helper needs auth/server state, pass it in as an argument or keep the helper in the layer that owns that state (`store` or `features`) — do not reach into a store from `lib`.
+- **`store` / `ui`** may import `lib` only.
+- **`cover` / `music-network`** are top-level domains and may import `lib`, `store`, `ui`.
+- **`features/<x>`** may import `lib`, `store`, `ui`, `cover`, `music-network`, and other features — but cross-feature access goes **only** through the `@/features/<x>` barrel, never a deep path.
+- **`app`** (shell + bridges) may import anything.
+- **No import cycles** anywhere under `src/`.
+
+The authoritative rules and rationale live in [`.dependency-cruiser.cjs`](.dependency-cruiser.cjs) (its header documents the layers and the known-violation ratchet). Any **new** layering or cycle violation fails the `dependency-cruiser` job and blocks `ci-ok`, so run **`npm run dep:check`** locally before opening a frontend PR. The known-violations baseline in `.dependency-cruiser-known-violations.json` only ratchets **down** — don't regenerate it to silence a new violation; fix the import instead.
+
+---
+
 ## CI on pull requests to `main`
 
 PRs must target `main`. `next` and `release` are maintainer-driven promotion branches — don't target them directly.


### PR DESCRIPTION
## Summary

Adds a **Frontend architecture and layering** section to `CONTRIBUTING.md`.

Contributors are already told to run `npm run dep:check` before a frontend PR, but the layering **model** it enforces (`lib → store/ui → cover/music-network → features/<x> → app`, `lib` is the floor, cross-feature via the `@/features/<x>` barrel only) was documented **only** in the `.dependency-cruiser.cjs` header. That made it easy to write a `src/lib/**` import of a store with no doc-level signal until the `dependency-cruiser` CI job (or a local `dep:check`) failed — as just happened on #1262, where a new contributor added `useAuthStore` inside `src/lib/api/subsonicPlayQueue.ts`.

The new section states the layer order, spells out that `lib/**` must not import `store`/`ui`/`features`/etc. (with the "pass state in as an argument" guidance), points to `.dependency-cruiser.cjs` as the source of truth, and notes the known-violations baseline only ratchets down.

Docs-only; no code or behaviour change.

## Test plan

- [x] Markdown renders correctly (section, arrow diagram, bullet list, links to `.dependency-cruiser.cjs`)
- [x] No code paths touched — frontend/backend CI unaffected