### PR TITLE
chore(audio): satisfy clippy::question_mark on the hi-res spill read

### DIFF
--- a/src-tauri/crates/psysonic-audio/src/hi_res_blend.rs
+++ b/src-tauri/crates/psysonic-audio/src/hi_res_blend.rs
@@ -123,10 +123,8 @@ fn resolve_cached_play_input(engine: &AudioEngine, url: &str) -> Option<PlayInpu
                 .filter(|s| s.url == url)
                 .map(|s| s.path.clone())
         };
-        match spill_path {
-            Some(p) => std::fs::read(&p).ok()?,
-            None => return None,
-        }
+        let path = spill_path?;
+        std::fs::read(&path).ok()?
     };
     Some(PlayInput::Bytes(bytes))
 }


### PR DESCRIPTION
## Summary

- CI's Rust toolchain moved to 1.97, which added `clippy::question_mark` for the spill-path read in `hi_res_blend`. `cargo clippy --workspace --all-targets -- -D warnings` is a required check, so this fails on `main` and blocks every Rust pull request (first seen on #1267).
- Rewrites the `match` as the `?` the lint asks for. Same control flow, no behaviour change.

## Boundary

Not touched.

## Test plan

- `cargo test --workspace` green (one unrelated wall-clock perf test, `upsert_500_rows_completes_well_under_perf_budget`, flaked under full-suite load and passes in isolation).
- The lint cannot be reproduced locally: this box runs Rust 1.96 and the lint ships in 1.97. The rewrite is clippy's own suggestion from the CI log; CI on this PR is the verification.
