### PR TITLE
chore(nix): refresh nixpkgs pin in flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Refresh `flake.lock` nixpkgs pin (`64c08a7` → `e7a3ca8`).
- Keeps flake installs/dev shells aligned with current nixos-unstable (fontconfig 2.18 in WebKit chain; fewer `48-guessfamily.conf` warnings on updated NixOS).

## Test plan
- [x] `./dev.sh` starts and app runs locally
- [ ] `nix build .#psysonic` (CI verify-nix on channel publish also covers this)