### PR TITLE
fix(ui): no cover thumbs on album detail tracklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+### Album detail — no duplicate cover thumbs in tracklist
+
+**By [@cucadmuh](https://github.com/cucadmuh), reported by mikmik on the Psysonic Discord, PR [#1291](https://github.com/Psychotoxical/psysonic/pull/1291)**
+
+* The album detail tracklist no longer shows a small album cover on every row when **Settings → Appearance → Track lists** is enabled — the page already displays the album art above the list, so the per-row thumbs from #1280 duplicated the same image on every line (desktop and mobile).
+
 ### Per-track covers when playing from a playlist
 
 **By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1218](https://github.com/Psychotoxical/psysonic/pull/1218)**, reported by The Cup Slammer on Discord

--- a/src/features/album/components/AlbumTrackListMobile.tsx
+++ b/src/features/album/components/AlbumTrackListMobile.tsx
@@ -4,8 +4,6 @@ import type { SubsonicSong } from '@/lib/api/subsonicTypes';
 import type { Track } from '@/lib/media/trackTypes';
 import { songToTrack } from '@/lib/media/songToTrack';
 import { formatLongDuration } from '@/lib/format/formatDuration';
-import { OptionalBrowseTrackRowCoverThumb } from '@/cover/TrackRowCoverThumb';
-import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
 
 interface Props {
   discNums: number[];
@@ -43,8 +41,6 @@ export function AlbumTrackListMobile({
   onPlaySong,
   onContextMenu,
 }: Props) {
-  const showCovers = useTrackListCoverArtEnabled('pages');
-
   return (
     <div className="tracklist-mobile">
       {discNums.map(discNum => (
@@ -62,7 +58,7 @@ export function AlbumTrackListMobile({
             return (
               <div
                 key={song.id}
-                className={`tracklist-mobile-row${showCovers ? ' tracklist-mobile-row--with-cover' : ''}${isActive ? ' active' : ''}${contextMenuSongId === song.id ? ' context-active' : ''}`}
+                className={`tracklist-mobile-row${isActive ? ' active' : ''}${contextMenuSongId === song.id ? ' context-active' : ''}`}
                 onClick={() => onPlaySong(song)}
                 onContextMenu={e => {
                   e.preventDefault();
@@ -78,7 +74,6 @@ export function AlbumTrackListMobile({
                   ) : (
                     <span className="tracklist-mobile-num">{song.track ?? ''}</span>
                   )}
-                  <OptionalBrowseTrackRowCoverThumb song={song} size="dense" />
                   <span className="tracklist-mobile-title">{song.title}</span>
                 </div>
                 <span className="tracklist-mobile-duration">{formatLongDuration(song.duration)}</span>

--- a/src/features/album/components/TrackRow.tsx
+++ b/src/features/album/components/TrackRow.tsx
@@ -16,8 +16,6 @@ import { formatLastSeen } from '@/lib/format/userMgmtHelpers';
 import i18n from '@/lib/i18n';
 import { offlineActionPolicy, type OfflineActionPolicy } from '@/features/offline';
 import { resolveTrackArtistRefs } from '@/features/playback/utils/playback/trackArtistRefs';
-import { OptionalBrowseTrackRowCoverThumb } from '@/cover/TrackRowCoverThumb';
-import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
 
 type ContextMenuFn = (
   x: number,
@@ -78,7 +76,6 @@ export const TrackRow = React.memo(function TrackRow({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const showBitrate = useThemeStore(s => s.showBitrate);
-  const showCovers = useTrackListCoverArtEnabled('pages');
   const isSelected = useSelectionStore(s => s.selectedIds.has(song.id));
   const isActive = currentTrackId === song.id;
   const isPreviewing = usePreviewStore(s => s.previewingId === song.id);
@@ -109,9 +106,6 @@ export const TrackRow = React.memo(function TrackRow({
       case 'title':
         return (
           <div key="title" className="track-info track-info-suggestion">
-            {showCovers ? (
-              <OptionalBrowseTrackRowCoverThumb song={song} size="dense" className="song-list-row-cover-thumb" />
-            ) : null}
             <button
               type="button"
               className="playlist-suggestion-play-btn"


### PR DESCRIPTION
## Summary

- Album detail track rows no longer show per-track album cover thumbnails when **Settings → Appearance → Track lists** is on — the page already displays the album art above the list, so row thumbs duplicated the same cover on every line (regression from #1280).

## Test plan

- [x] `npm run lint`
- [x] `npm run dep:check`
- [x] `npx tsc --noEmit`
- [ ] Album detail (desktop + mobile): no row thumbs with track-list covers enabled
- [ ] Search / Favorites / Playlists: row thumbs still appear when enabled