### PR TITLE
fix(tray): second-instance restore stays generic over Runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+### Tray — release build compile after #1296
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1298](https://github.com/Psychotoxical/psysonic/pull/1298)**
+
+* Fixes `E0308` in release `on_second_instance`: second-launch tray restore again uses inline resume/show/unminimize/focus so it stays generic over `tauri::Runtime` (Nix/release builds no longer fail on `restore_main_window(&WebviewWindow<R>)`).
+
 ### Tray — sidebar missing after cold start minimized to tray
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#1296](https://github.com/Psychotoxical/psysonic/pull/1296)**

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,11 +53,14 @@ fn on_second_instance<R: tauri::Runtime>(
         let window = app.get_webview_window("main").expect("no main window");
         // The window may have been hidden via the close-to-tray path,
         // which injects PAUSE_RENDERING_JS (sets `__psyHidden=true`,
-        // pauses CSS animations). Tray restore uses `restore_main_window`
-        // — second-launch restore must do the same, otherwise the webview
-        // comes back with rendering still paused and navigation looks blank
-        // (issue #497).
-        let _ = crate::lib_commands::ui::mini::restore_main_window(&window);
+        // pauses CSS animations). Tray-icon restore mirrors this with
+        // RESUME_RENDERING_JS — second-launch restore must do the same,
+        // otherwise the webview comes back with rendering still paused
+        // and navigation looks blank (issue #497).
+        let _ = window.eval(RESUME_RENDERING_JS);
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1296: release builds failed to compile because `on_second_instance<R: Runtime>` passed `&WebviewWindow<R>` into `restore_main_window(&WebviewWindow)` (concrete Wry). Restore the inline `RESUME_RENDERING_JS` + `show` + `unminimize` + `set_focus` path from issue #497.

## Test plan

- [ ] `cd src-tauri && cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `nix-build` / release profile compiles on NixOS
- [ ] (optional) second launch while app is in tray still restores the window