### PR TITLE
fix(ui): reserve shadow room in album rails so themes need no overflow hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The Discord community banner rendered its icon at an enormous size on Windows, pushing the message out of the bar. The icon now has a fixed size on every platform.
 
+### Themes — album rails no longer cut off card shadows
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), reported by Asra on the Psysonic Discord, PR [#1300](https://github.com/Psychotoxical/psysonic/pull/1300)**
+
+* Horizontal album rails clipped an outer card shadow at the edges, which only themes that use a real drop shadow ran into. Working around it meant overriding the rail's `overflow`, and that disabled the rail's `<` / `>` scroll arrows. Rails now reserve room for the shadow inside the rail itself, so the arrows keep working; a theme that needs more room can raise `--rail-shadow-room` instead of touching `overflow`.
+
 
 ## [1.49.0] - 2026-06-29
 

--- a/src/styles/components/album-row-container.css
+++ b/src/styles/components/album-row-container.css
@@ -51,7 +51,15 @@
   display: flex;
   gap: var(--space-4);
   overflow-x: auto;
-  padding-bottom: var(--space-4);
+  /* The rail scrolls, so it clips: `overflow-x: auto` makes `overflow-y` compute
+     to `auto` too. An outer card shadow would be cut off at the edges. Padding
+     gives it room to paint *inside* the clip box; the matching negative margin
+     keeps the rail's content box exactly where it was, so nothing shifts.
+     Without this, a theme with a drop shadow is pushed into overriding `overflow`
+     — which removes the scroll container the nav arrows drive, disabling them. */
+  padding: var(--rail-shadow-room) var(--rail-shadow-room)
+    max(var(--space-4), var(--rail-shadow-room));
+  margin: calc(-1 * var(--rail-shadow-room)) calc(-1 * var(--rail-shadow-room)) 0;
   scroll-snap-type: none;
   scroll-behavior: smooth;
   /* Hide scrollbar for Webkit */

--- a/src/styles/themes/global-base-settings.css
+++ b/src/styles/themes/global-base-settings.css
@@ -35,5 +35,13 @@
   /* Layout */
   --sidebar-width: 220px;
   --player-height: 88px;
+
+  /* Room reserved inside a horizontal card rail's clip box so an outer card
+     shadow has somewhere to paint. A rail scrolls, so it must clip (its
+     `overflow-x: auto` makes `overflow-y` compute to `auto`), and a drop shadow
+     would otherwise be cut off at the edges. Raise this in a theme that uses a
+     larger shadow or glow — never override `overflow` on the rail itself, which
+     would remove its scrollability and disable its nav arrows. */
+  --rail-shadow-room: 8px;
 }
 


### PR DESCRIPTION
## Summary
- Album rails clip outer card shadows: `overflow-x: auto` makes `overflow-y` compute to `auto`, so a drop shadow is cut off at the edges. The default theme never hit this (rail cards use inset shadows only); a community theme with a real shadow did.
- The only workaround was overriding `overflow` on `.album-grid` — which removes the scroll container the `<` / `>` nav arrows drive, leaving them permanently disabled.
- Reserve the room inside the clip box instead: pad the rail, cancel the padding with a matching negative margin so the content box does not move. Same technique `.page-sticky-header` already uses.
- The amount is a `--rail-shadow-room` token, so a theme with a larger shadow raises that instead of touching `overflow`.

## Test plan
- [x] `npm run build` (tsc + vite) — emitted rule verified in the bundled CSS, and it still wins over the legacy `.album-grid` grid rule in `themes/album-grid.css` (`components/` imports after `themes/`).
- [x] Layout neutrality by construction: `padding-top`/`left`/`right` cancelled by the negative margin; wrapper height unchanged. The 8px bleed lands inside `.content-body`'s 24px padding, which is `overflow-x: hidden`, so no horizontal scrollbar.
- [x] Visual pass on Home / Favorites / Statistics rails.

Known limitation: some engines ignore a flex scroll container's end padding at the far-right scroll position, so the last card's right-side shadow can still touch the edge there. Cosmetic, and unrelated to the vertical clipping this fixes.