### PR TITLE
fix(themes): square corners for player bar cover and list thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The queue cover-art setting and the track-list setting's title showed English text in every language except Russian — both are translated in all languages now, and the German description states more precisely which pages show the thumbnails.
 
+### Square corners — player bar and list thumbnails included
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), reported by JU3RG on the Psysonic Discord, PR [#1320](https://github.com/Psychotoxical/psysonic/pull/1320)**
+
+* The Square Corners toggle left the player bar cover and the small cover thumbnails in list rows rounded (queue, playlists, favorites, search, Random Mix). They now go square with everything else; the floating player bar's circular cover stays round by design.
+
 
 ## [1.49.0] - 2026-06-29
 

--- a/src/styles/components/square-corners.css
+++ b/src/styles/components/square-corners.css
@@ -5,8 +5,8 @@
  *   corners off the grid cards (album / playlist / artist / song / "because")
  *   and their cover artwork, for users who prefer a sharp, boxy look.
  *
- *   Scope is deliberately limited to cards + their covers — buttons, inputs,
- *   dialogs and the player bar keep whatever radius the active theme defines.
+ *   Scope is deliberately limited to cards + covers — buttons, inputs and
+ *   dialogs keep whatever radius the active theme defines.
  *   `!important` is required because some themes set card radii with their own
  *   `!important` (see e.g. `.artist-card-avatar-initial`).
  *
@@ -67,4 +67,23 @@ html[data-square-corners] :is(
   .mp-album-cover
 ) {
   border-radius: 0 !important;
+}
+
+/* Player bar cover and the list-row cover thumbs (queue, playlists,
+ *  favorites, search — every list surface shares `.track-row-cover-thumb`).
+ *  The wrap clips the art (`overflow: hidden`), so it must lose its radius
+ *  too or the corners stay visually rounded. */
+html[data-square-corners] :is(
+  .player-album-art,
+  .player-album-art-placeholder,
+  .player-album-art-wrap,
+  .track-row-cover-thumb
+) {
+  border-radius: 0 !important;
+}
+
+/* The floating player bar's cover is a deliberate circular disc, not a card
+ *  corner — it stays round, same rule as the avatar placeholder circle. */
+html[data-square-corners] .player-bar.floating .player-album-art-wrap {
+  border-radius: 50% !important;
 }


### PR DESCRIPTION
## Summary
- The Square Corners toggle skipped the player bar cover and the small cover thumbnails in list rows (queue panel, mini player queue, fullscreen Up next, playlists, favorites, search, Random Mix) - they kept their rounded corners.
- All of them now go square with the toggle; the floating player bar's circular disc cover stays round on purpose (a deliberate shape, like the avatar placeholder circle).

## Test plan
- [x] `npm run lint`, `npm run dep:check`, `npx tsc --noEmit`, `npx vitest run` (2890 passed)
- [ ] Manual smoke: enable Square Corners, check the docked player bar cover, queue rows, and a playlist table; floating bar cover stays circular