### PR TITLE
fix(api): align native client UA with the WebView to collapse the duplicate Navidrome session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The Square Corners toggle left the player bar cover and the small cover thumbnails in list rows rounded (queue, playlists, favorites, search, Random Mix). They now go square with everything else; the floating player bar's circular cover stays round by design.
 
+### Duplicate server session on Navidrome
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), reported by TheHomeGuy on the Psysonic Discord, PR [#1322](https://github.com/Psychotoxical/psysonic/pull/1322)**
+
+* Native requests carried a separate User-Agent from the in-app view, so the server listed the app as two logged-in players at once. They now share one identity and show as a single session.
+
 
 ## [1.49.0] - 2026-06-29
 

--- a/src-tauri/crates/psysonic-integration/src/navidrome/client.rs
+++ b/src-tauri/crates/psysonic-integration/src/navidrome/client.rs
@@ -123,7 +123,10 @@ pub fn nd_http_client() -> reqwest::Client {
     // the WebKit-side Subsonic calls end up negotiating most of the time
     // on these setups.
     reqwest::Client::builder()
-        .user_agent(format!("Psysonic/{} (Tauri)", env!("CARGO_PKG_VERSION")))
+        // Shared wire UA (the main WebView's User-Agent once the frontend reports
+        // it at startup) so Navidrome logs these native calls under the same
+        // client as the WebView instead of a second `[Psysonic]` session.
+        .user_agent(psysonic_core::user_agent::subsonic_wire_user_agent())
         .http1_only()
         .pool_max_idle_per_host(0)
         .max_tls_version(reqwest::tls::Version::TLS_1_2)

--- a/src-tauri/crates/psysonic-integration/src/subsonic/client.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/client.rs
@@ -413,7 +413,10 @@ struct MusicFoldersWrapper {
 
 fn default_http_client() -> reqwest::Client {
     reqwest::Client::builder()
-        .user_agent(format!("Psysonic/{} (Tauri)", env!("CARGO_PKG_VERSION")))
+        // Shared wire UA (aligned with the main WebView at startup) so native
+        // Subsonic calls share the WebView's client identity on the server
+        // instead of registering a separate `[Psysonic]` session.
+        .user_agent(psysonic_core::user_agent::subsonic_wire_user_agent())
         .build()
         .unwrap_or_else(|_| reqwest::Client::new())
 }


### PR DESCRIPTION
The native Rust HTTP clients (Navidrome + Subsonic) sent a hardcoded `Psysonic/<ver> (Tauri)` User-Agent, so Navidrome logged them as a second player (`[Psysonic]`) alongside the WebView's own session. Once the client id was fixed to the real version, the two showed up as an apparent double login of the same version.

- `nd_http_client()` and the Subsonic `default_http_client()` now use the shared wire User-Agent (`subsonic_wire_user_agent()`), which the frontend aligns to the main WebView UA at startup — completing the alignment PR #235 started.
- Both clients are built per request, so they pick up the WebView UA once it is reported; Navidrome then attributes native calls to the same client as the WebView.

Test plan:
- `cargo check`/`clippy`/`test --workspace` green (integration crate 125/125).
- Verified against a live Navidrome: a single `psysonic/<ver> [Edge/Windows]` player, the duplicate `[Psysonic]` session gone.