### PR TITLE
chore(aur): bump PKGBUILD to 1.50.0

### DIFF
--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Psychotoxic <psychotoxic@gmx.de>
 pkgname=psysonic
-pkgver=1.49.0
+pkgver=1.50.0
 pkgrel=1
 pkgdesc="Desktop music player for Subsonic API-compatible servers (Navidrome, Gonic, etc.)"
 arch=('x86_64')


### PR DESCRIPTION
Keeps the in-repo AUR packaging in sync with the published `app-v1.50.0` release.

- Bumps `packages/aur/PKGBUILD` from 1.49.0 to 1.50.0; `pkgrel` stays at 1.
- The `source` URL derives from `$pkgver`, so it now points at the 1.50.0 tag tarball.
- `sha256sums` is `SKIP`, so no checksum regeneration is required.

Test plan: verified the derived source URL resolves (HTTP 200) for the published `app-v1.50.0` tag before bumping. The AUR clone is updated separately and pushed from a Linux host.