### PR TITLE
fix(library): show canonical artist name on artist detail header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The first New Releases page now keeps the local catalogue's logical album de-duplication when fresh network results arrive, including alternate physical copies on one server and matching copies across several servers.
 
+### Artist details — show the artist name, not a featured-guest track credit
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1328](https://github.com/Psychotoxical/psysonic/pull/1328)**
+
+* The artist detail header no longer adopts a per-track "featuring" credit when a single track in the discography is tagged with a guest artist. It shows the artist's own name, matching the artist browse list.
+
 
 ## [1.50.0]
 

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -2140,10 +2140,19 @@ fn fetch_artist_candidates(
         artist_key.map(|_| "artist_key"),
         "AND t.server_id = ? AND t.artist_id = ? AND ck.artist_key IS NULL",
     );
+    // Display name = the canonical `artist.name` for each (server, artist_id) — the
+    // same source the artist browse list uses. Deriving it from the tracks via
+    // `MAX(t.artist)` picked up per-track "feat." credits (one guest feature in a
+    // discography would rename the whole artist header); `COALESCE` keeps the old
+    // track-derived fallback for artist_ids without an indexed artist row.
     let sql = format!(
         "{cte}, \
          grouped AS ( \
-           SELECT t.server_id, t.artist_id, MAX(t.artist) AS artist, \
+           SELECT t.server_id, t.artist_id, \
+                  COALESCE( \
+                    (SELECT ar.name FROM artist ar \
+                      WHERE ar.server_id = t.server_id AND ar.id = t.artist_id), \
+                    MAX(t.artist)) AS artist, \
                   COUNT(DISTINCT t.album_id) AS album_count, MAX(t.synced_at) AS synced_at, \
                   MIN({priority}) AS best_pr \
            {scoped} AND t.artist_id IS NOT NULL AND t.artist_id != '' {key_filter} \
@@ -2811,6 +2820,44 @@ mod tests {
         .unwrap();
         assert_eq!(with_tracks.tracks.len(), 1);
         assert_eq!(with_tracks.tracks[0].id, "t1");
+    }
+
+    #[test]
+    fn artist_detail_name_uses_canonical_artist_not_feature_track_credit() {
+        // Regression: a single guest-feature track in a discography carries a
+        // per-track "feat." credit while sharing the artist's `artist_id`. The
+        // header name must stay the canonical `artist.name`, not `MAX(t.artist)`
+        // which would pick the lexicographically-larger "… feat. …" string and
+        // rename the whole artist. Mirrors the browse list (reads `artist.name`).
+        let store = LibraryStore::open_in_memory();
+        seed_and_rebuild(
+            &store,
+            &[
+                // Plain credit first so the seeded `artist.name` is canonical.
+                track(
+                    "s1", "t-plain", "A Plain Song", Some("Skyclad"), "Album One",
+                    "alb1", Some("skyclad"), 200, "lib-a", None, None, None,
+                ),
+                track(
+                    "s1", "t-feat", "A Guest Song", Some("Skyclad feat. Ten Pole Tudor"),
+                    "Album Two", "alb2", Some("skyclad"), 201, "lib-a", None, None, None,
+                ),
+            ],
+        );
+
+        let response = artist_detail(
+            &store,
+            &LibraryScopeArtistDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                artist_id: "skyclad".into(),
+                server_id: "s1".into(),
+                include_tracks: false,
+                top_tracks_limit: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(response.artist.name, "Skyclad");
     }
 
     #[test]


### PR DESCRIPTION
The artist detail header showed a per-track "feat." credit instead of the artist name (regression from the multi-server artist detail path).

- Root cause: the merged artist name was derived from `MAX(t.artist)` over the artist's tracks, so a single track carrying a per-track featured-guest credit sorts highest and renamed the whole header.
- Fix: source the display name from the canonical `artist` row per `(server_id, id)` — the same source the artist browse list already uses — with a fallback to the track-derived name when no artist row exists.
- Multi-server merge, priority ordering, dedup, and album/track aggregation are unchanged; only the per-candidate name column changes.

Test plan:
- New regression test `artist_detail_name_uses_canonical_artist_not_feature_track_credit` (fails on the old `MAX(t.artist)`, passes with the canonical lookup).
- `cargo test --workspace` green.