### PR TITLE
chore(deps): resolve Dependabot security alerts

### DIFF
--- a/nix/upstream-sources.json
+++ b/nix/upstream-sources.json
@@ -1,3 +1,3 @@
 {
-  "npmDepsHash": "sha256-jyNFcFi8VrgcFe1TW4tuXDErYyUBwH8/bZK0DNTFGk8="
+  "npmDepsHash": "sha256-r7Pe7YRJvRhigg4vmfLbnLdWr5EKGAeAC53vbs3V2uw="
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@tauri-apps/plugin-store": "^2",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "@tauri-apps/plugin-window-state": "^2.4.1",
-        "axios": "^1.16.0",
+        "axios": "^1.18.1",
         "i18next": "^26.0.8",
         "lucide-react": "^1.17.0",
         "md5": "^2.3.0",
@@ -2808,9 +2808,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -2878,9 +2878,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@tauri-apps/plugin-store": "^2",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@tauri-apps/plugin-window-state": "^2.4.1",
-    "axios": "^1.16.0",
+    "axios": "^1.18.1",
     "i18next": "^26.0.8",
     "lucide-react": "^1.17.0",
     "md5": "^2.3.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -536,6 +536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,7 +2383,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5117,11 +5126,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5136,9 +5146,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
## Summary

- upgrade Axios from 1.17.0 to 1.18.1, resolving open runtime alerts #27, #28, and #30-#37
- upgrade transitive brace-expansion from 5.0.6 to 5.0.7, resolving alert #29
- upgrade transitive serde_with from 3.19.0 to 3.21.0 through the Tauri dependency graph, resolving alert #26
- keep the change dependency-only; there is no user-visible behavior or Tauri command/event contract change

## Verification

- `npm ci`
- `npm audit --audit-level=low` (0 vulnerabilities)
- `npm run lint`
- `npm run dep:check`
- `npm test` (489 files, 3385 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npm run test:coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace --all-targets`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`

## Notes

- Axios usage is limited to the standard request APIs covered by the existing frontend suite; no migration changes were required.
- `serde_with` 3.21.0 requires Rust 1.88; the workspace minimum is Rust 1.95.
- No changelog or Settings credits entry: this is security maintenance with no user-visible feature change.