### PR TITLE
fix(library): repair multi-server scope fallback and add diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#1331](https://github.com/Psychotoxical/psysonic/pull/1331)**
 
 * Existing profiles that retained an empty Library server selection recover the configured active server when another server is added. Music-folder discovery and New Releases no longer collapse to an empty result in that legacy state.
+* Artist browse no longer waits for a full identity rebuild on the first launch after upgrading an existing large library.
 
 
 ## [1.50.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#1331](https://github.com/Psychotoxical/psysonic/pull/1331)**
 
-* **Settings → System → Logging** and **PsyLab → Logs** offer three persisted debug-depth levels while Debug logging is enabled. Deeper levels add structured multi-server scope, reachability, music-folder and New Releases diagnostics, with credentials and sensitive URL data redacted.
+* **Settings → System → Logging** and **PsyLab → Logs** offer basic and verbose debug-depth levels while Debug logging is enabled. Verbose mode adds structured multi-server scope, reachability, music-folder and New Releases diagnostics, with credentials and sensitive URL data redacted.
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Context menus, ratings, favourites, sharing, offline pins, device sync and Orbit carry the item's owner through the complete action. Creating an Orbit session from a multi-server scope now asks which server should host it, temporarily keeps only that server in the library scope and shared queue, then restores the previous scope when the session ends.
 * Sharing a mixed-server queue opens a compact server picker directly below the share button; choosing a server copies its tracks immediately, while single-server queues still copy without an extra prompt. Unavailable servers are marked with an explanatory warning.
 
+### Debug logging — selectable multi-server diagnostics
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1331](https://github.com/Psychotoxical/psysonic/pull/1331)**
+
+* **Settings → System → Logging** and **PsyLab → Logs** offer three persisted debug-depth levels while Debug logging is enabled. Deeper levels add structured multi-server scope, reachability, music-folder and New Releases diagnostics, with credentials and sensitive URL data redacted.
+
 ## Changed
 
 ### Library index — designed for several live servers at once
@@ -94,6 +100,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1328](https://github.com/Psychotoxical/psysonic/pull/1328)**
 
 * The artist detail header no longer adopts a per-track "featuring" credit when a single track in the discography is tagged with a guest artist. It shows the artist's own name, matching the artist browse list.
+
+### Multi-server library scope — recover empty persisted selections
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1331](https://github.com/Psychotoxical/psysonic/pull/1331)**
+
+* Existing profiles that retained an empty Library server selection recover the configured active server when another server is added. Music-folder discovery and New Releases no longer collapse to an empty result in that legacy state.
 
 
 ## [1.50.0]

--- a/src-tauri/crates/psysonic-library/src/advanced_search.rs
+++ b/src-tauri/crates/psysonic-library/src/advanced_search.rs
@@ -3712,7 +3712,7 @@ mod tests {
     }
 
     #[test]
-    fn index_artists_layer1_scope_excludes_artists_from_other_libraries() {
+    fn single_scope_artists_do_not_block_on_cluster_key_rebuild() {
         let store = LibraryStore::open_in_memory();
         insert_artist_with_album_count(&store, "s1", "ar_in", "In Sampler", Some(1));
         insert_artist_with_album_count(&store, "s1", "ar_out", "Outside", Some(1));
@@ -3743,12 +3743,40 @@ mod tests {
         );
         t_out.artist_id = Some("ar_out".into());
         TrackRepository::new(&store).upsert_batch(&[t_in, t_out]).unwrap();
+        crate::identity::rebuild_cluster_keys(&store, None).unwrap();
+        store
+            .with_conn_mut("test.stale_identity", |conn| {
+                conn.execute(
+                    "UPDATE cluster.cluster_meta SET value = 'stale' WHERE key = 'norm_version'",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
         let mut r = req("s1", &[EntityKind::Artist]);
         r.library_scopes = Some(vec![scope_pair("s1", "sampler")]);
         r.artist_credit_mode = Some(ArtistCreditMode::Album);
         let resp = run_advanced_search(&store, &r).unwrap();
         let ids: Vec<&str> = resp.artists.iter().map(|a| a.id.as_str()).collect();
         assert_eq!(ids, vec!["ar_in"]);
+        assert!(
+            store
+                .with_read_conn(crate::identity::cluster_rebuild_needed)
+                .unwrap(),
+            "single-scope album artists must not trigger identity maintenance"
+        );
+
+        r.artist_credit_mode = Some(ArtistCreditMode::Track);
+        let resp = run_advanced_search(&store, &r).unwrap();
+        let ids: Vec<&str> = resp.artists.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, vec!["ar_in"]);
+        assert!(
+            store
+                .with_read_conn(crate::identity::cluster_rebuild_needed)
+                .unwrap(),
+            "single-scope track artists must not trigger identity maintenance"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -773,7 +773,7 @@ pub(crate) fn list_artists_layer1_filtered(
     skip_totals: bool,
 ) -> Result<(Vec<LibraryArtistDto>, u32), String> {
     let scopes = non_empty_scopes(scopes)?;
-    ensure_cluster_keys_for_all_scopes(store, scopes)?;
+    ensure_cluster_keys_for_scopes(store, scopes)?;
     let (cte, scope_binds) = scope_cte_sql(scopes);
     let scoped = if scopes.len() == 1 {
         scoped_track_join_layer1()
@@ -873,7 +873,7 @@ pub(crate) fn list_index_artists_layer1_filtered(
     skip_totals: bool,
 ) -> Result<(Vec<LibraryArtistDto>, u32), String> {
     let scopes = non_empty_scopes(scopes)?;
-    ensure_cluster_keys_for_all_scopes(store, scopes)?;
+    ensure_cluster_keys_for_scopes(store, scopes)?;
     let (cte, scope_binds) = scope_cte_sql(scopes);
     let scoped_from = "FROM scope s \
          CROSS JOIN track t ON t.server_id = s.server_id AND t.library_id = s.library_id";

--- a/src/app/ConnectionIndicator.tsx
+++ b/src/app/ConnectionIndicator.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -17,6 +17,11 @@ import { applyListReorderById } from '@/lib/util/listReorder';
 import { deriveEffectiveLibraryBrowseServerIds } from '@/lib/library/libraryBrowseScope';
 import { useUnavailableServerIds } from '@/lib/network/serverReachability';
 import { ServerChoiceWarning } from '@/ui/ServerChoiceList';
+import {
+  describeMultiServerError,
+  emitMultiServerDebug,
+  summarizeMultiServerProfiles,
+} from '@/lib/library/multiServerDebug';
 
 interface Props {
   status: ConnectionStatus;
@@ -54,15 +59,21 @@ export default function ConnectionIndicator({ status, isLan, serverName }: Props
 
   const multi = servers.length > 1;
   const multiLibraryScope = libraryBrowseServerIds.length > 1;
-  const effectiveLibraryServerIds = deriveEffectiveLibraryBrowseServerIds({
+  const effectiveLibraryServerIds = useMemo(() => deriveEffectiveLibraryBrowseServerIds({
     servers,
     activeServerId,
     libraryBrowseServerIds,
-  }, unavailableServerIds);
+  }, unavailableServerIds), [activeServerId, libraryBrowseServerIds, servers, unavailableServerIds]);
   const unavailableSelection = multiLibraryScope
     && effectiveLibraryServerIds.length < libraryBrowseServerIds.length;
   const applyServerReorder = useCallback((draggedId: string, target: { id: string; before: boolean }) => {
     const next = applyListReorderById(serversRef.current, draggedId, target);
+    emitMultiServerDebug('connection_server_reorder', {
+      draggedId,
+      target,
+      previousOrder: serversRef.current.map(server => server.id),
+      nextOrder: next?.map(server => server.id) ?? null,
+    });
     if (next) setServers(next);
   }, [setServers]);
   const { isDragging, setContainer, onMouseMove, dropEdge } = useListReorderDnd({
@@ -90,6 +101,50 @@ export default function ConnectionIndicator({ status, isLan, serverName }: Props
   }, [menuOpen, updateMenuPosition]);
 
   useEffect(() => {
+    emitMultiServerDebug('connection_indicator_snapshot', {
+      status,
+      isLan,
+      displayedServerName: serverName,
+      activeServerId,
+      menuOpen,
+      switchingId,
+      configuredServerIds: libraryBrowseServerIds,
+      effectiveServerIds: effectiveLibraryServerIds,
+      unavailableServerIds: [...unavailableServerIds],
+      multiProfile: multi,
+      multiLibraryScope,
+      unavailableSelection,
+      servers: summarizeMultiServerProfiles(servers),
+      queueLed: {
+        ledVariant,
+        localQueueSyncPaused,
+        queueHandoffReason,
+        pullInFlight,
+        syncRingVisible,
+      },
+    });
+  }, [
+    activeServerId,
+    effectiveLibraryServerIds,
+    isLan,
+    ledVariant,
+    libraryBrowseServerIds,
+    localQueueSyncPaused,
+    menuOpen,
+    multi,
+    multiLibraryScope,
+    pullInFlight,
+    queueHandoffReason,
+    serverName,
+    servers,
+    status,
+    switchingId,
+    syncRingVisible,
+    unavailableSelection,
+    unavailableServerIds,
+  ]);
+
+  useEffect(() => {
     if (!menuOpen) return;
     const onDown = (e: MouseEvent) => {
       const target = e.target as Node;
@@ -114,6 +169,12 @@ export default function ConnectionIndicator({ status, isLan, serverName }: Props
   };
 
   const onMetaClick = () => {
+    emitMultiServerDebug('connection_indicator_click', {
+      multiProfile: multi,
+      menuOpen,
+      activeServerId,
+      configuredServerIds: libraryBrowseServerIds,
+    });
     if (!multi) {
       goServerSettings();
       return;
@@ -128,21 +189,45 @@ export default function ConnectionIndicator({ status, isLan, serverName }: Props
   };
 
   const onPickServer = async (srv: ServerProfile) => {
+    emitMultiServerDebug('connection_server_pick_start', {
+      pickedServerId: srv.id,
+      activeServerId,
+      configuredServerIds: libraryBrowseServerIds,
+      alreadyActive: srv.id === activeServerId,
+    });
     if (srv.id === activeServerId) {
       setLibraryBrowseServerExclusive(srv.id);
       setMenuOpen(false);
+      emitMultiServerDebug('connection_server_pick_done', {
+        pickedServerId: srv.id,
+        switched: false,
+        action: 'exclusive_scope_only',
+      });
       return;
     }
     setSwitchingId(srv.id);
-    const ok = await switchActiveServer(srv);
-    setSwitchingId(null);
-    setMenuOpen(false);
-    if (!ok) {
-      showToast(t('connection.switchFailed'), 5000, 'error');
-      return;
+    try {
+      const ok = await switchActiveServer(srv);
+      setSwitchingId(null);
+      setMenuOpen(false);
+      emitMultiServerDebug('connection_server_pick_done', {
+        pickedServerId: srv.id,
+        switched: ok,
+        resultingActiveServerId: useAuthStore.getState().activeServerId,
+      });
+      if (!ok) {
+        showToast(t('connection.switchFailed'), 5000, 'error');
+        return;
+      }
+      setLibraryBrowseServerExclusive(srv.id);
+      navigate('/');
+    } catch (error) {
+      emitMultiServerDebug('connection_server_pick_error', {
+        pickedServerId: srv.id,
+        error: describeMultiServerError(error),
+      });
+      throw error;
     }
-    setLibraryBrowseServerExclusive(srv.id);
-    navigate('/');
   };
 
   const label = multiLibraryScope ? t('connection.multiServer') : (isLan ? 'LAN' : t('connection.extern'));
@@ -285,6 +370,13 @@ export default function ConnectionIndicator({ status, isLan, serverName }: Props
                     disabled={finalIncluded}
                     onClick={event => {
                       event.stopPropagation();
+                      emitMultiServerDebug('connection_scope_membership_change', {
+                        serverId: srv.id,
+                        selected: !included,
+                        configuredServerIds: libraryBrowseServerIds,
+                        finalIncluded,
+                        unavailable: unavailableServerIds.has(srv.id),
+                      });
                       setLibraryBrowseServerSelected(srv.id, !included);
                     }}
                   >

--- a/src/app/hooks/useLibraryServerReachability.ts
+++ b/src/app/hooks/useLibraryServerReachability.ts
@@ -2,10 +2,18 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useAuthStore } from '@/store/authStore';
 import { ensureConnectUrlResolved, invalidateReachableEndpointCache } from '@/lib/server/serverEndpoint';
 import {
+  getServerReachabilitySnapshot,
+  getUnavailableServerIds,
+  useServerReachabilitySnapshot,
   useUnavailableServerIds,
 } from '@/lib/network/serverReachability';
 import { deriveEffectiveLibraryBrowseServerIds } from '@/lib/library/libraryBrowseScope';
 import { bootstrapIndexedServer } from '@/lib/library/librarySession';
+import {
+  describeMultiServerError,
+  emitMultiServerDebug,
+  summarizeMultiServerProfiles,
+} from '@/lib/library/multiServerDebug';
 import { usePerfProbeFlags } from '@/lib/perf/perfFlags';
 import { useLibraryIndexStore } from '@/store/libraryIndexStore';
 import { switchActiveServer } from '@/utils/server/switchActiveServer';
@@ -19,6 +27,7 @@ export function useLibraryServerReachability(): void {
   const activeServerId = useAuthStore(state => state.activeServerId);
   const libraryBrowseServerIds = useAuthStore(state => state.libraryBrowseServerIds);
   const unavailableServerIds = useUnavailableServerIds();
+  const reachabilitySnapshot = useServerReachabilitySnapshot();
   const perfFlags = usePerfProbeFlags();
   const selectedProfiles = useMemo(() => {
     const selected = new Set(libraryBrowseServerIds);
@@ -39,8 +48,61 @@ export function useLibraryServerReachability(): void {
   desiredActiveServerIdRef.current = desiredActiveServerId;
 
   useEffect(() => {
-    if (!isLoggedIn || !desiredActiveServerId || activeSwitchInFlightRef.current) return;
+    emitMultiServerDebug('reachability_scope_snapshot', {
+      isLoggedIn,
+      activeServerId,
+      configuredServerIds: libraryBrowseServerIds,
+      effectiveServerIds: effectiveLibraryServerIds,
+      desiredActiveServerId,
+      unavailableServerIds: [...unavailableServerIds],
+      reachability: Object.fromEntries(servers.map(server => [
+        server.id,
+        reachabilitySnapshot.get(server.id) ?? 'unknown',
+      ])),
+      selectedProfiles: summarizeMultiServerProfiles(selectedProfiles),
+      allProfiles: summarizeMultiServerProfiles(servers),
+      backgroundPollingDisabled: perfFlags.disableBackgroundPolling,
+    });
+  }, [
+    activeServerId,
+    desiredActiveServerId,
+    effectiveLibraryServerIds,
+    isLoggedIn,
+    libraryBrowseServerIds,
+    perfFlags.disableBackgroundPolling,
+    reachabilitySnapshot,
+    selectedProfiles,
+    servers,
+    unavailableServerIds,
+  ]);
+
+  useEffect(() => {
+    const state = useAuthStore.getState();
+    const currentEffectiveServerIds = deriveEffectiveLibraryBrowseServerIds(
+      state,
+      getUnavailableServerIds(),
+    );
+    if (!isLoggedIn || !desiredActiveServerId || activeSwitchInFlightRef.current) {
+      emitMultiServerDebug('active_scope_alignment_skip', {
+        reason: !isLoggedIn
+          ? 'not_logged_in'
+          : !desiredActiveServerId
+            ? 'no_effective_server'
+            : 'switch_already_in_flight',
+        activeServerId: state.activeServerId,
+        desiredActiveServerId,
+        configuredServerIds: state.libraryBrowseServerIds,
+        effectiveServerIds: currentEffectiveServerIds,
+      });
+      return;
+    }
     activeSwitchInFlightRef.current = true;
+    emitMultiServerDebug('active_scope_alignment_start', {
+      activeServerId: state.activeServerId,
+      desiredActiveServerId,
+      configuredServerIds: state.libraryBrowseServerIds,
+      effectiveServerIds: currentEffectiveServerIds,
+    });
 
     void (async () => {
       try {
@@ -49,12 +111,45 @@ export function useLibraryServerReachability(): void {
           const state = useAuthStore.getState();
           if (!targetId || state.activeServerId === targetId) return;
           const target = state.servers.find(server => server.id === targetId);
-          if (!target) return;
-          const switched = await switchActiveServer(target);
-          if (!switched && desiredActiveServerIdRef.current === targetId) return;
+          if (!target) {
+            emitMultiServerDebug('active_scope_alignment_abort', {
+              reason: 'target_profile_missing',
+              targetId,
+              currentActiveServerId: state.activeServerId,
+              savedServerIds: state.servers.map(server => server.id),
+            });
+            return;
+          }
+          const switchStartedAt = performance.now();
+          emitMultiServerDebug('active_scope_switch_start', {
+            targetId,
+            currentActiveServerId: state.activeServerId,
+          });
+          try {
+            const switched = await switchActiveServer(target);
+            emitMultiServerDebug('active_scope_switch_done', {
+              targetId,
+              switched,
+              durationMs: Math.round(performance.now() - switchStartedAt),
+              resultingActiveServerId: useAuthStore.getState().activeServerId,
+              latestDesiredActiveServerId: desiredActiveServerIdRef.current,
+            });
+            if (!switched && desiredActiveServerIdRef.current === targetId) return;
+          } catch (error) {
+            emitMultiServerDebug('active_scope_switch_error', {
+              targetId,
+              durationMs: Math.round(performance.now() - switchStartedAt),
+              error: describeMultiServerError(error),
+            });
+            throw error;
+          }
         }
       } finally {
         activeSwitchInFlightRef.current = false;
+        emitMultiServerDebug('active_scope_alignment_finish', {
+          activeServerId: useAuthStore.getState().activeServerId,
+          desiredActiveServerId: desiredActiveServerIdRef.current,
+        });
       }
     })();
   }, [desiredActiveServerId, isLoggedIn, libraryBrowsePriorityKey]);
@@ -69,7 +164,19 @@ export function useLibraryServerReachability(): void {
         if (unavailableServerIds.has(serverId)) continue;
         const recovered = state.servers.find(server => server.id === serverId);
         if (recovered && useLibraryIndexStore.getState().isIndexEnabled(recovered.id)) {
-          void bootstrapIndexedServer(recovered);
+          const bootstrapStartedAt = performance.now();
+          emitMultiServerDebug('recovered_server_bootstrap_start', { serverId });
+          void bootstrapIndexedServer(recovered)
+            .then(result => emitMultiServerDebug('recovered_server_bootstrap_done', {
+              serverId,
+              result,
+              durationMs: Math.round(performance.now() - bootstrapStartedAt),
+            }))
+            .catch(error => emitMultiServerDebug('recovered_server_bootstrap_error', {
+              serverId,
+              durationMs: Math.round(performance.now() - bootstrapStartedAt),
+              error: describeMultiServerError(error),
+            }));
         }
       }
     }
@@ -81,6 +188,13 @@ export function useLibraryServerReachability(): void {
       state,
       unavailableServerIds,
     ).join('\u0000');
+    emitMultiServerDebug('reachability_effective_scope_change', {
+      previousUnavailableServerIds: [...previousUnavailableServerIds],
+      unavailableServerIds: [...unavailableServerIds],
+      previousEffectiveServerIds: previousEffectiveScopeKey ? previousEffectiveScopeKey.split('\u0000') : [],
+      effectiveServerIds: effectiveScopeKey ? effectiveScopeKey.split('\u0000') : [],
+      scopeVersionWillBump: previousEffectiveScopeKey !== effectiveScopeKey,
+    });
     if (previousEffectiveScopeKey === effectiveScopeKey) return;
     useAuthStore.setState(state => ({
       libraryBrowseScopeVersion: state.libraryBrowseScopeVersion + 1,
@@ -88,13 +202,45 @@ export function useLibraryServerReachability(): void {
   }, [isLoggedIn, unavailableServerIds]);
 
   useEffect(() => {
-    if (!isLoggedIn || perfFlags.disableBackgroundPolling || selectedProfiles.length === 0) return;
+    if (!isLoggedIn || perfFlags.disableBackgroundPolling || selectedProfiles.length === 0) {
+      emitMultiServerDebug('reachability_polling_skip', {
+        reason: !isLoggedIn
+          ? 'not_logged_in'
+          : perfFlags.disableBackgroundPolling
+            ? 'background_polling_disabled'
+            : 'no_selected_profiles',
+        selectedServerIds: selectedProfiles.map(server => server.id),
+      });
+      return;
+    }
     let cancelled = false;
 
     const probeSelectedServers = async () => {
       for (const server of selectedProfiles) {
         if (cancelled) return;
-        await ensureConnectUrlResolved(server);
+        const probeStartedAt = performance.now();
+        emitMultiServerDebug('reachability_probe_start', {
+          serverId: server.id,
+          currentReachability: getServerReachabilitySnapshot().get(server.id) ?? 'unknown',
+        });
+        try {
+          const result = await ensureConnectUrlResolved(server);
+          emitMultiServerDebug('reachability_probe_done', {
+            serverId: server.id,
+            durationMs: Math.round(performance.now() - probeStartedAt),
+            ok: result.ok,
+            ...(result.ok
+              ? { endpointKind: result.endpoint.kind, serverType: result.ping.type ?? null }
+              : { reason: result.reason }),
+          });
+        } catch (error) {
+          emitMultiServerDebug('reachability_probe_error', {
+            serverId: server.id,
+            durationMs: Math.round(performance.now() - probeStartedAt),
+            error: describeMultiServerError(error),
+          });
+          throw error;
+        }
       }
     };
     const handleOnline = () => {
@@ -109,6 +255,9 @@ export function useLibraryServerReachability(): void {
       cancelled = true;
       clearInterval(interval);
       window.removeEventListener('online', handleOnline);
+      emitMultiServerDebug('reachability_polling_cleanup', {
+        selectedServerIds: selectedProfiles.map(server => server.id),
+      });
     };
   }, [isLoggedIn, perfFlags.disableBackgroundPolling, selectedProfiles]);
 }

--- a/src/app/hooks/useLibraryServerReachability.ts
+++ b/src/app/hooks/useLibraryServerReachability.ts
@@ -26,8 +26,11 @@ export function useLibraryServerReachability(): void {
   const servers = useAuthStore(state => state.servers);
   const activeServerId = useAuthStore(state => state.activeServerId);
   const libraryBrowseServerIds = useAuthStore(state => state.libraryBrowseServerIds);
+  const loggingMode = useAuthStore(state => state.loggingMode);
+  const debugLoggingDepth = useAuthStore(state => state.debugLoggingDepth);
   const unavailableServerIds = useUnavailableServerIds();
-  const reachabilitySnapshot = useServerReachabilitySnapshot();
+  const verboseDiagnosticsEnabled = loggingMode === 'debug' && debugLoggingDepth === 3;
+  const reachabilitySnapshot = useServerReachabilitySnapshot(verboseDiagnosticsEnabled);
   const perfFlags = usePerfProbeFlags();
   const selectedProfiles = useMemo(() => {
     const selected = new Set(libraryBrowseServerIds);
@@ -48,6 +51,7 @@ export function useLibraryServerReachability(): void {
   desiredActiveServerIdRef.current = desiredActiveServerId;
 
   useEffect(() => {
+    if (!verboseDiagnosticsEnabled) return;
     emitMultiServerDebug('reachability_scope_snapshot', {
       isLoggedIn,
       activeServerId,
@@ -74,6 +78,7 @@ export function useLibraryServerReachability(): void {
     selectedProfiles,
     servers,
     unavailableServerIds,
+    verboseDiagnosticsEnabled,
   ]);
 
   useEffect(() => {

--- a/src/app/hooks/useMusicFoldersDiscovery.test.tsx
+++ b/src/app/hooks/useMusicFoldersDiscovery.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuthStore } from '@/store/authStore';
+import { resetAuthStore } from '@/test/helpers/storeReset';
+import { useMusicFoldersDiscovery } from './useMusicFoldersDiscovery';
+
+const getMusicFoldersForServerMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api/subsonicLibrary', () => ({
+  getMusicFoldersForServer: getMusicFoldersForServerMock,
+}));
+
+beforeEach(() => {
+  resetAuthStore();
+  getMusicFoldersForServerMock.mockReset().mockResolvedValue([
+    { id: 'music', name: 'Music' },
+  ]);
+});
+
+describe('useMusicFoldersDiscovery', () => {
+  it('discovers folders for the active fallback when persisted membership is invalid', async () => {
+    useAuthStore.setState({
+      servers: [
+        { id: 'first', name: 'First', url: 'https://first.test', username: 'u', password: 'p' },
+        { id: 'active', name: 'Active', url: 'https://active.test', username: 'u', password: 'p' },
+      ],
+      activeServerId: 'active',
+      libraryBrowseServerIds: ['missing'],
+      isLoggedIn: true,
+    });
+
+    renderHook(() => useMusicFoldersDiscovery());
+
+    await waitFor(() => expect(getMusicFoldersForServerMock).toHaveBeenCalledWith('active'));
+    await waitFor(() => expect(useAuthStore.getState().musicFoldersByServer.active).toEqual([
+      { id: 'music', name: 'Music' },
+    ]));
+    expect(getMusicFoldersForServerMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/hooks/useMusicFoldersDiscovery.ts
+++ b/src/app/hooks/useMusicFoldersDiscovery.ts
@@ -1,36 +1,121 @@
 import { useEffect, useMemo } from 'react';
 import { getMusicFoldersForServer } from '@/lib/api/subsonicLibrary';
+import { deriveLibraryBrowseServerIdsWithFallback } from '@/lib/library/libraryBrowseScope';
+import {
+  describeMultiServerError,
+  emitMultiServerDebug,
+  summarizeMultiServerProfiles,
+  summarizeMusicFoldersByServer,
+} from '@/lib/library/multiServerDebug';
 import { useAuthStore } from '@/store/authStore';
 
-/** Refreshes folder lists for the servers selected in Switch server. */
+/** Refreshes folder lists for the configured Library scope or its active-server fallback. */
 export function useMusicFoldersDiscovery(): void {
   const isLoggedIn = useAuthStore(state => state.isLoggedIn);
   const servers = useAuthStore(state => state.servers);
-  const selectedServerIds = useAuthStore(state => state.libraryBrowseServerIds);
+  const activeServerId = useAuthStore(state => state.activeServerId);
+  const configuredServerIds = useAuthStore(state => state.libraryBrowseServerIds);
   const setMusicFoldersForServer = useAuthStore(state => state.setMusicFoldersForServer);
+  const selectedServerIds = useMemo(() => deriveLibraryBrowseServerIdsWithFallback({
+    servers,
+    activeServerId,
+    libraryBrowseServerIds: configuredServerIds,
+  }), [activeServerId, configuredServerIds, servers]);
   const selectedKey = useMemo(() => selectedServerIds.join('\u0000'), [selectedServerIds]);
 
   useEffect(() => {
-    if (!isLoggedIn || selectedServerIds.length === 0) return;
+    const stateAtStart = useAuthStore.getState();
+    emitMultiServerDebug('folders_discovery_effect', {
+      isLoggedIn,
+      activeServerId,
+      configuredServerIds,
+      resolvedServerIds: selectedServerIds,
+      selectedKey,
+      servers: summarizeMultiServerProfiles(servers),
+      existingFolders: summarizeMusicFoldersByServer(stateAtStart.musicFoldersByServer),
+    });
+    if (!isLoggedIn || selectedServerIds.length === 0) {
+      emitMultiServerDebug('folders_discovery_skip', {
+        reason: !isLoggedIn ? 'not_logged_in' : 'no_resolved_servers',
+        activeServerId,
+        configuredServerIds,
+        resolvedServerIds: selectedServerIds,
+      });
+      return;
+    }
     const savedIds = new Set(servers.map(server => server.id));
     let cancelled = false;
 
     for (const serverId of selectedServerIds) {
-      if (!savedIds.has(serverId)) continue;
+      if (!savedIds.has(serverId)) {
+        emitMultiServerDebug('folders_discovery_server_skip', {
+          serverId,
+          reason: 'profile_missing',
+          savedServerIds: [...savedIds],
+        });
+        continue;
+      }
+      const requestStartedAt = performance.now();
+      emitMultiServerDebug('folders_discovery_request_start', {
+        serverId,
+        previousFolders: summarizeMusicFoldersByServer({
+          [serverId]: stateAtStart.musicFoldersByServer[serverId] ?? [],
+        })[serverId],
+      });
       void getMusicFoldersForServer(serverId)
         .then(folders => {
-          if (cancelled) return;
+          if (cancelled) {
+            emitMultiServerDebug('folders_discovery_request_stale', {
+              serverId,
+              durationMs: Math.round(performance.now() - requestStartedAt),
+              folderCount: folders.length,
+              reason: 'effect_cancelled',
+            });
+            return;
+          }
           const state = useAuthStore.getState();
-          if (!state.servers.some(server => server.id === serverId)) return;
+          if (!state.servers.some(server => server.id === serverId)) {
+            emitMultiServerDebug('folders_discovery_request_stale', {
+              serverId,
+              durationMs: Math.round(performance.now() - requestStartedAt),
+              folderCount: folders.length,
+              reason: 'profile_removed',
+            });
+            return;
+          }
           setMusicFoldersForServer(serverId, folders);
+          emitMultiServerDebug('folders_discovery_request_done', {
+            serverId,
+            durationMs: Math.round(performance.now() - requestStartedAt),
+            folderCount: folders.length,
+            folders: folders.map(folder => ({ id: folder.id, name: folder.name })),
+            activeServerId: state.activeServerId,
+            configuredServerIds: state.libraryBrowseServerIds,
+          });
         })
-        .catch(() => {
+        .catch(error => {
           // Preserve the last successful list while a server is temporarily unavailable.
+          emitMultiServerDebug('folders_discovery_request_error', {
+            serverId,
+            durationMs: Math.round(performance.now() - requestStartedAt),
+            error: describeMultiServerError(error),
+          });
         });
     }
 
     return () => {
       cancelled = true;
+      emitMultiServerDebug('folders_discovery_cleanup', {
+        resolvedServerIds: selectedServerIds,
+      });
     };
-  }, [isLoggedIn, selectedKey, selectedServerIds, servers, setMusicFoldersForServer]);
+  }, [
+    activeServerId,
+    configuredServerIds,
+    isLoggedIn,
+    selectedKey,
+    selectedServerIds,
+    servers,
+    setMusicFoldersForServer,
+  ]);
 }

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -209,6 +209,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Playlist cards — Play next and Add to queue from the right-click menu, matching album cards (PR #1307)',
       'Playlists browse — scoped header search by playlist name (PR #1308)',
       'True simultaneous multi-server support — unified catalogue, mixed-server playback, owner-safe actions, source fallback, and incremental indexing (PR #1326)',
+      'Multi-server scope recovery and redacted selectable-depth diagnostics for reachability, music folders, and New Releases (PR #1331)',
     ],
   },
   {

--- a/src/features/album/hooks/useHotNewReleaseOverlay.ts
+++ b/src/features/album/hooks/useHotNewReleaseOverlay.ts
@@ -4,6 +4,10 @@ import {
   fetchHotNewReleases,
   type ResolvedHotNewRelease,
 } from '@/features/album/utils/hotNewReleases';
+import {
+  describeMultiServerError,
+  emitMultiServerDebug,
+} from '@/lib/library/multiServerDebug';
 
 /** Network-only first-page overlay; stale results are discarded when scope changes. */
 export function useHotNewReleaseOverlay(
@@ -18,11 +22,47 @@ export function useHotNewReleaseOverlay(
 
   useEffect(() => {
     let cancelled = false;
-    if (!active || scopes.length === 0) return () => { cancelled = true; };
-    void fetchHotNewReleases(scopes).then(result => {
-      if (!cancelled) setResult({ scopeFingerprint, albums: result });
-    });
-    return () => { cancelled = true; };
+    if (!active || scopes.length === 0) {
+      emitMultiServerDebug('new_releases_hot_overlay_skip', {
+        reason: !active ? 'inactive' : 'empty_scope',
+        active,
+        scopes,
+        scopeFingerprint,
+      });
+      return () => { cancelled = true; };
+    }
+    const startedAt = performance.now();
+    emitMultiServerDebug('new_releases_hot_overlay_start', { scopes, scopeFingerprint });
+    void fetchHotNewReleases(scopes)
+      .then(result => {
+        emitMultiServerDebug('new_releases_hot_overlay_done', {
+          scopes,
+          scopeFingerprint,
+          cancelled,
+          durationMs: Math.round(performance.now() - startedAt),
+          albumCount: result.length,
+          sampleAlbums: result.slice(0, 10).map(resolved => ({
+            serverId: resolved.album.serverId,
+            id: resolved.album.id,
+            name: resolved.album.name,
+            representativeServerId: resolved.representativeServerId ?? null,
+            representativeId: resolved.representativeId ?? null,
+            group: resolved.group,
+          })),
+        });
+        if (!cancelled) setResult({ scopeFingerprint, albums: result });
+      })
+      .catch(error => emitMultiServerDebug('new_releases_hot_overlay_error', {
+        scopes,
+        scopeFingerprint,
+        cancelled,
+        durationMs: Math.round(performance.now() - startedAt),
+        error: describeMultiServerError(error),
+      }));
+    return () => {
+      cancelled = true;
+      emitMultiServerDebug('new_releases_hot_overlay_cleanup', { scopes, scopeFingerprint });
+    };
   }, [active, scopeFingerprint, scopes]);
 
   return result;

--- a/src/features/album/pages/NewReleases.tsx
+++ b/src/features/album/pages/NewReleases.tsx
@@ -40,6 +40,12 @@ import { filterAlbumsByGenres } from '@/lib/library/albumBrowseFilters';
 import { useScopedBrowseSearchQuery } from '@/store/liveSearchScopeStore';
 import { deriveLibraryBrowseScope } from '@/lib/library/libraryBrowseScope';
 import { loadLocalNewReleases } from '@/lib/library/newReleasesLocal';
+import {
+  describeMultiServerError,
+  emitMultiServerDebug,
+  summarizeMultiServerProfiles,
+  summarizeMusicFoldersByServer,
+} from '@/lib/library/multiServerDebug';
 import { mergeHotNewReleases } from '@/features/album/utils/hotNewReleases';
 import { useHotNewReleaseOverlay } from '@/features/album/hooks/useHotNewReleaseOverlay';
 
@@ -140,6 +146,69 @@ export default function NewReleases() {
       : albums;
   }, [textSearchActive, textSearchAlbums, albums, hotAlbums, genreFiltered, selectedGenres, scopedSearchQuery]);
 
+  useEffect(() => {
+    emitMultiServerDebug('new_releases_page_snapshot', {
+      pathname: location.pathname,
+      activeServerId: auth.activeServerId,
+      pageServerId: serverId,
+      indexEnabled,
+      configuredServerIds: auth.libraryBrowseServerIds,
+      unavailableServerIds: [...unavailableServerIds],
+      servers: summarizeMultiServerProfiles(auth.servers),
+      foldersByServer: summarizeMusicFoldersByServer(auth.musicFoldersByServer),
+      selectionByServer: auth.libraryBrowseSelectionByServer,
+      releaseScope: {
+        anchorServerId,
+        pairs: releaseScopes,
+        fingerprint: releaseScopeFingerprint,
+      },
+      restore: {
+        initialAlbumCount: initialAlbums?.length ?? null,
+        initialHasMore,
+        restoringSession: restoringSessionRef.current,
+      },
+      pageState: {
+        loading,
+        albumCount: albums.length,
+        displayAlbumCount: displayAlbums.length,
+        hasMore,
+        genreCount: genreCounts.length,
+        selectedGenres,
+        scopedSearchQuery,
+        textSearchActive,
+        textSearchLoading,
+        hotOverlayCount: hotAlbums.length,
+        hotOverlayFingerprint: hotOverlay.scopeFingerprint,
+      },
+    });
+  }, [
+    albums.length,
+    anchorServerId,
+    auth.activeServerId,
+    auth.libraryBrowseSelectionByServer,
+    auth.libraryBrowseServerIds,
+    auth.musicFoldersByServer,
+    auth.servers,
+    displayAlbums.length,
+    genreCounts.length,
+    hasMore,
+    hotAlbums.length,
+    hotOverlay.scopeFingerprint,
+    indexEnabled,
+    initialAlbums,
+    initialHasMore,
+    loading,
+    location.pathname,
+    releaseScopeFingerprint,
+    releaseScopes,
+    scopedSearchQuery,
+    selectedGenres,
+    serverId,
+    textSearchActive,
+    textSearchLoading,
+    unavailableServerIds,
+  ]);
+
   const loadingGrid = textSearchActive ? textSearchLoading : loading;
   const gridHasMore = textSearchActive ? false : (!genreFiltered && hasMore);
 
@@ -206,29 +275,80 @@ export default function NewReleases() {
   };
 
   const load = useCallback(async (offset: number, append = false, genres: string[] = []) => {
-    await runLoad(async () => {
-      const data = await loadLocalNewReleases(
-        anchorServerId ?? '', releaseScopes, PAGE_SIZE, offset, genres,
-      );
-      if (append) setAlbums(prev => [...prev, ...data.albums]);
-      else setAlbums(data.albums);
-      setHasMore(data.hasMore);
-      if (!append) setGenreCounts(data.genreCounts.map(row => ({ genre: row.value, count: row.albumCount })));
+    const pageLoadStartedAt = performance.now();
+    emitMultiServerDebug('new_releases_page_load_start', {
+      anchorServerId,
+      releaseScopes,
+      releaseScopeFingerprint,
+      offset,
+      append,
+      genres,
     });
-  }, [anchorServerId, releaseScopes, runLoad]);
+    try {
+      await runLoad(async () => {
+        const data = await loadLocalNewReleases(
+          anchorServerId ?? '', releaseScopes, PAGE_SIZE, offset, genres,
+        );
+        emitMultiServerDebug('new_releases_page_load_apply', {
+          anchorServerId,
+          releaseScopeFingerprint,
+          offset,
+          append,
+          genres,
+          durationMs: Math.round(performance.now() - pageLoadStartedAt),
+          albumCount: data.albums.length,
+          hasMore: data.hasMore,
+          genreCount: data.genreCounts.length,
+        });
+        if (append) setAlbums(prev => [...prev, ...data.albums]);
+        else setAlbums(data.albums);
+        setHasMore(data.hasMore);
+        if (!append) setGenreCounts(data.genreCounts.map(row => ({ genre: row.value, count: row.albumCount })));
+      });
+    } catch (error) {
+      emitMultiServerDebug('new_releases_page_load_error', {
+        anchorServerId,
+        releaseScopes,
+        releaseScopeFingerprint,
+        offset,
+        append,
+        genres,
+        durationMs: Math.round(performance.now() - pageLoadStartedAt),
+        error: describeMultiServerError(error),
+      });
+      throw error;
+    }
+  }, [anchorServerId, releaseScopeFingerprint, releaseScopes, runLoad]);
 
   const loadFiltered = useCallback(async (genres: string[]) => {
     await load(0, false, genres);
   }, [load]);
 
   useEffect(() => {
-    if (restoringSessionRef.current || scopedSearchQuery) return;
-    if (genreFiltered) loadFiltered(selectedGenres);
+    if (restoringSessionRef.current || scopedSearchQuery) {
+      emitMultiServerDebug('new_releases_page_load_effect_skip', {
+        reason: restoringSessionRef.current ? 'restoring_session' : 'scoped_search_active',
+        scopedSearchQuery,
+        releaseScopeFingerprint,
+        anchorServerId,
+        releaseScopes,
+      });
+      return;
+    }
+    emitMultiServerDebug('new_releases_page_load_effect_run', {
+      genreFiltered,
+      selectedGenres,
+      releaseScopeFingerprint,
+      anchorServerId,
+      releaseScopes,
+      musicLibraryFilterVersion,
+    });
+    if (genreFiltered) void loadFiltered(selectedGenres);
     else {
       resetPage();
       void load(0, false, selectedGenres);
     }
-  }, [genreFiltered, selectedGenres, load, loadFiltered, resetPage, scopedSearchQuery, releaseScopeFingerprint, musicLibraryFilterVersion]);
+  }, [anchorServerId, genreFiltered, selectedGenres, load, loadFiltered, resetPage, scopedSearchQuery, releaseScopeFingerprint, releaseScopes, musicLibraryFilterVersion]);
 
   const loadMore = useCallback(() => {
     if (!gridHasMore || genreFiltered || textSearchActive || isBlocked()) return;

--- a/src/features/settings/components/SystemTab.tsx
+++ b/src/features/settings/components/SystemTab.tsx
@@ -265,33 +265,32 @@ export function SystemTab() {
                   />
                 </div>
               </SettingsField>
-              <SettingsField
-                label={t('settings.debugLoggingDepth')}
-                desc={t('settings.debugLoggingDepthDesc')}
-                row
-              >
-                <div style={{ minWidth: 160 }}>
-                  <CustomSelect
-                    value={String(auth.debugLoggingDepth)}
-                    onChange={(v) => auth.setDebugLoggingDepth(Number(v) as DebugLoggingDepth)}
-                    options={[
-                      { value: '1', label: '1' },
-                      { value: '2', label: '2' },
-                      { value: '3', label: '3' },
-                    ]}
-                    disabled={auth.loggingMode !== 'debug'}
-                    ariaLabel={t('settings.debugLoggingDepth')}
-                  />
-                </div>
-                {auth.loggingMode === 'debug' && (
+              {auth.loggingMode === 'debug' && (
+                <SettingsField
+                  label={t('settings.debugLoggingDepth')}
+                  desc={t('settings.debugLoggingDepthDesc')}
+                  row
+                >
+                  <div style={{ minWidth: 160 }}>
+                    <CustomSelect
+                      value={String(auth.debugLoggingDepth)}
+                      onChange={(v) => auth.setDebugLoggingDepth(Number(v) as DebugLoggingDepth)}
+                      options={[
+                        { value: '1', label: '1' },
+                        { value: '2', label: '2' },
+                        { value: '3', label: '3' },
+                      ]}
+                      ariaLabel={t('settings.debugLoggingDepth')}
+                    />
+                  </div>
                   <div>
                     <button className="btn btn-surface" onClick={exportRuntimeLogs}>
                       <Download size={14} />
                       {t('settings.loggingExport')}
                     </button>
                   </div>
-                )}
-              </SettingsField>
+                </SettingsField>
+              )}
             </SettingsSubCard>
           </SettingsGroup>
         </div>

--- a/src/features/settings/components/SystemTab.tsx
+++ b/src/features/settings/components/SystemTab.tsx
@@ -9,7 +9,12 @@ import { AppWindow, ChevronDown, Download, ExternalLink, Globe, HardDrive, Info,
 import { version as appVersion } from '@/../package.json';
 import i18n from '@/lib/i18n';
 import { useAuthStore } from '@/store/authStore';
-import type { ClockFormat, LinuxWaylandTextRenderProfile, LoggingMode } from '@/store/authStoreTypes';
+import type {
+  ClockFormat,
+  DebugLoggingDepth,
+  LinuxWaylandTextRenderProfile,
+  LoggingMode,
+} from '@/store/authStoreTypes';
 import { IS_LINUX } from '@/lib/util/platform';
 import { showToast } from '@/lib/dom/toast';
 import { AboutPsysonicBrandHeader } from '@/features/settings/components/AboutPsysonicLol';
@@ -247,16 +252,37 @@ export function SystemTab() {
         <div className="settings-card">
           <SettingsGroup>
             <SettingsSubCard>
-              <SettingsField desc={t('settings.loggingModeDesc')}>
-                <CustomSelect
-                  value={auth.loggingMode}
-                  onChange={(v) => auth.setLoggingMode(v as LoggingMode)}
-                  options={[
-                    { value: 'off', label: t('settings.loggingModeOff') },
-                    { value: 'normal', label: t('settings.loggingModeNormal') },
-                    { value: 'debug', label: t('settings.loggingModeDebug') },
-                  ]}
-                />
+              <SettingsField label={t('settings.loggingTitle')} desc={t('settings.loggingModeDesc')} row>
+                <div style={{ minWidth: 160 }}>
+                  <CustomSelect
+                    value={auth.loggingMode}
+                    onChange={(v) => auth.setLoggingMode(v as LoggingMode)}
+                    options={[
+                      { value: 'off', label: t('settings.loggingModeOff') },
+                      { value: 'normal', label: t('settings.loggingModeNormal') },
+                      { value: 'debug', label: t('settings.loggingModeDebug') },
+                    ]}
+                  />
+                </div>
+              </SettingsField>
+              <SettingsField
+                label={t('settings.debugLoggingDepth')}
+                desc={t('settings.debugLoggingDepthDesc')}
+                row
+              >
+                <div style={{ minWidth: 160 }}>
+                  <CustomSelect
+                    value={String(auth.debugLoggingDepth)}
+                    onChange={(v) => auth.setDebugLoggingDepth(Number(v) as DebugLoggingDepth)}
+                    options={[
+                      { value: '1', label: '1' },
+                      { value: '2', label: '2' },
+                      { value: '3', label: '3' },
+                    ]}
+                    disabled={auth.loggingMode !== 'debug'}
+                    ariaLabel={t('settings.debugLoggingDepth')}
+                  />
+                </div>
                 {auth.loggingMode === 'debug' && (
                   <div>
                     <button className="btn btn-surface" onClick={exportRuntimeLogs}>

--- a/src/features/settings/components/SystemTab.tsx
+++ b/src/features/settings/components/SystemTab.tsx
@@ -277,7 +277,6 @@ export function SystemTab() {
                       onChange={(v) => auth.setDebugLoggingDepth(Number(v) as DebugLoggingDepth)}
                       options={[
                         { value: '1', label: '1' },
-                        { value: '2', label: '2' },
                         { value: '3', label: '3' },
                       ]}
                       ariaLabel={t('settings.debugLoggingDepth')}

--- a/src/features/settings/components/settingsTabs.ts
+++ b/src/features/settings/components/settingsTabs.ts
@@ -73,7 +73,7 @@ export const SETTINGS_INDEX: SearchIndexEntry[] = [
   { tab: 'system',         titleKey: 'settings.language',                 keywords: 'language locale translation i18n' },
   { tab: 'system',         titleKey: 'settings.behavior',                 keywords: 'behavior tray minimize close start minimized launch hidden smooth scroll linux' },
   { tab: 'system',         titleKey: 'settings.backupTitle',              keywords: 'backup export import settings restore' },
-  { tab: 'system',         titleKey: 'settings.loggingTitle',             keywords: 'log logs diagnostic debug verbose' },
+  { tab: 'system',         titleKey: 'settings.loggingTitle',             keywords: 'log logs diagnostic debug verbose depth detail trace' },
   { tab: 'system',         titleKey: 'settings.aboutTitle',               keywords: 'about version update changelog release notes' },
   { tab: 'system',         titleKey: 'settings.aboutContributorsLabel',   keywords: 'contributors credits maintainers' },
   { tab: 'system',         titleKey: 'licenses.title',                    keywords: 'licenses license open source attribution copyright third party dependencies oss' },

--- a/src/features/sidebar/components/Sidebar.tsx
+++ b/src/features/sidebar/components/Sidebar.tsx
@@ -37,6 +37,11 @@ import {
 } from '@/lib/library/libraryBrowseScope';
 import { serverListDisplayLabel } from '@/lib/server/serverDisplayName';
 import { useUnavailableServerIds } from '@/lib/network/serverReachability';
+import {
+  emitMultiServerDebug,
+  summarizeMultiServerProfiles,
+  summarizeMusicFoldersByServer,
+} from '@/lib/library/multiServerDebug';
 
 const EMPTY_LIBRARY_IDS: string[] = [];
 
@@ -224,6 +229,57 @@ export default function Sidebar({
     isLoggedIn,
     pathname: location.pathname,
   });
+
+  useEffect(() => {
+    const visibilityBlockers = [
+      ...(isCollapsed ? ['sidebar_collapsed'] : []),
+      ...(!isLoggedIn ? ['not_logged_in'] : []),
+      ...(isServerOffline ? ['offline_mode'] : []),
+      ...(libraryGroups.length <= 1 && selectableLibraryCount <= 1
+        ? ['single_group_with_at_most_one_folder']
+        : []),
+    ];
+    emitMultiServerDebug('sidebar_library_snapshot', {
+      pathname: location.pathname,
+      activeServerId: serverId,
+      isCollapsed,
+      isLoggedIn,
+      isServerOffline,
+      configuredServerIds: libraryBrowseServerIds,
+      effectiveServerIds: effectiveLibraryBrowseServerIds,
+      unavailableServerIds: [...unavailableServerIds],
+      libraryBrowseScopeVersion,
+      servers: summarizeMultiServerProfiles(servers),
+      foldersByServer: summarizeMusicFoldersByServer(musicFoldersByServer),
+      activeMusicFolders: musicFolders.map(folder => ({ id: folder.id, name: folder.name })),
+      selectionByServer: libraryBrowseSelectionByServer,
+      libraryGroups,
+      selectableLibraryCount,
+      showLibraryPicker,
+      visibilityBlockers,
+      newReleasesScope,
+      newReleasesUnreadCount,
+    });
+  }, [
+    effectiveLibraryBrowseServerIds,
+    isCollapsed,
+    isLoggedIn,
+    isServerOffline,
+    libraryBrowseScopeVersion,
+    libraryBrowseSelectionByServer,
+    libraryBrowseServerIds,
+    libraryGroups,
+    location.pathname,
+    musicFolders,
+    musicFoldersByServer,
+    newReleasesScope,
+    newReleasesUnreadCount,
+    selectableLibraryCount,
+    serverId,
+    servers,
+    showLibraryPicker,
+    unavailableServerIds,
+  ]);
   const { perfProbeOpen, setPerfProbeOpen } = useSidebarPerfProbe();
   const perfFlags = usePerfProbeFlags();
 
@@ -231,7 +287,19 @@ export default function Sidebar({
 
 
   const onLibrarySelectionChange = (selectedServerId: string, libraryIds: string[]) => {
-    if (isServerOffline) return;
+    if (isServerOffline) {
+      emitMultiServerDebug('sidebar_library_selection_skip', {
+        selectedServerId,
+        libraryIds,
+        reason: 'offline_mode',
+      });
+      return;
+    }
+    emitMultiServerDebug('sidebar_library_selection_change', {
+      selectedServerId,
+      previousLibraryIds: libraryBrowseSelectionByServer[selectedServerId] ?? [],
+      libraryIds,
+    });
     setLibraryBrowseSelectionForServer(selectedServerId, libraryIds);
   };
 

--- a/src/features/sidebar/components/perfProbe/SidebarPerfProbeLogsTab.tsx
+++ b/src/features/sidebar/components/perfProbe/SidebarPerfProbeLogsTab.tsx
@@ -288,16 +288,17 @@ export default function SidebarPerfProbeLogsTab() {
             options={LOGGING_MODE_OPTIONS}
           />
         </label>
-        <label className="perf-logs__control">
-          <span className="perf-logs__control-label">{t('settings.debugLoggingDepth')}</span>
-          <CustomSelect
-            value={String(debugLoggingDepth)}
-            onChange={changeDebugDepth}
-            options={DEBUG_DEPTH_OPTIONS}
-            disabled={loggingMode !== 'debug'}
-            ariaLabel={t('settings.debugLoggingDepth')}
-          />
-        </label>
+        {loggingMode === 'debug' && (
+          <label className="perf-logs__control">
+            <span className="perf-logs__control-label">{t('settings.debugLoggingDepth')}</span>
+            <CustomSelect
+              value={String(debugLoggingDepth)}
+              onChange={changeDebugDepth}
+              options={DEBUG_DEPTH_OPTIONS}
+              ariaLabel={t('settings.debugLoggingDepth')}
+            />
+          </label>
+        )}
         <label className="perf-logs__control">
           <span className="perf-logs__control-label">Keep</span>
           <CustomSelect

--- a/src/features/sidebar/components/perfProbe/SidebarPerfProbeLogsTab.tsx
+++ b/src/features/sidebar/components/perfProbe/SidebarPerfProbeLogsTab.tsx
@@ -42,7 +42,6 @@ const LOGGING_MODE_OPTIONS: { value: LoggingMode; label: string }[] = [
 ];
 const DEBUG_DEPTH_OPTIONS = [
   { value: '1', label: '1' },
-  { value: '2', label: '2' },
   { value: '3', label: '3' },
 ];
 

--- a/src/features/sidebar/components/perfProbe/SidebarPerfProbeLogsTab.tsx
+++ b/src/features/sidebar/components/perfProbe/SidebarPerfProbeLogsTab.tsx
@@ -8,13 +8,14 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from 'react';
 import { Copy, Download, Pause, Play, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import { save as saveDialog } from '@tauri-apps/plugin-dialog';
 import { writeFile } from '@tauri-apps/plugin-fs';
 import { getLoggingMode, tailRuntimeLogs, type RuntimeLogLine } from '@/lib/api/runtimeLogs';
 import { setLoggingMode as setBackendLoggingMode } from '@/lib/api/platformShell';
 import { useAuthStore } from '@/store/authStore';
-import type { LoggingMode } from '@/store/authStoreTypes';
+import type { DebugLoggingDepth, LoggingMode } from '@/store/authStoreTypes';
 import CustomSelect from '@/ui/CustomSelect';
 import { filterLogLines } from '@/lib/perf/filterLogLines';
 import { sanitizeLogLine } from '@/lib/perf/sanitizeLogLine';
@@ -34,10 +35,15 @@ const LINE_CAP_OPTIONS = [
   { value: '2000', label: '2000 lines' },
   { value: '5000', label: '5000 lines' },
 ];
-const DEPTH_OPTIONS: { value: LoggingMode; label: string }[] = [
+const LOGGING_MODE_OPTIONS: { value: LoggingMode; label: string }[] = [
   { value: 'off', label: 'Off' },
   { value: 'normal', label: 'Normal' },
   { value: 'debug', label: 'Debug' },
+];
+const DEBUG_DEPTH_OPTIONS = [
+  { value: '1', label: '1' },
+  { value: '2', label: '2' },
+  { value: '3', label: '3' },
 ];
 
 /**
@@ -47,8 +53,11 @@ const DEPTH_OPTIONS: { value: LoggingMode; label: string }[] = [
  * ordered include/exclude word filter.
  */
 export default function SidebarPerfProbeLogsTab() {
+  const { t } = useTranslation();
   const loggingMode = useAuthStore(s => s.loggingMode);
   const setLoggingMode = useAuthStore(s => s.setLoggingMode);
+  const debugLoggingDepth = useAuthStore(s => s.debugLoggingDepth);
+  const setDebugLoggingDepth = useAuthStore(s => s.setDebugLoggingDepth);
 
   const [lines, setLines] = useState<RuntimeLogLine[]>([]);
   const [paused, setPaused] = useState(false);
@@ -185,6 +194,10 @@ export default function SidebarPerfProbeLogsTab() {
     void setBackendLoggingMode({ mode }).catch(() => {});
   };
 
+  const changeDebugDepth = (depth: string) => {
+    setDebugLoggingDepth(Number(depth) as DebugLoggingDepth);
+  };
+
   const clear = () => {
     setLines([]);
     setOverflowed(false);
@@ -268,11 +281,21 @@ export default function SidebarPerfProbeLogsTab() {
     <div className="perf-logs">
       <div className="perf-logs__controls">
         <label className="perf-logs__control">
-          <span className="perf-logs__control-label">Depth</span>
+          <span className="perf-logs__control-label">{t('settings.loggingTitle')}</span>
           <CustomSelect
             value={loggingMode}
             onChange={v => changeDepth(v as LoggingMode)}
-            options={DEPTH_OPTIONS}
+            options={LOGGING_MODE_OPTIONS}
+          />
+        </label>
+        <label className="perf-logs__control">
+          <span className="perf-logs__control-label">{t('settings.debugLoggingDepth')}</span>
+          <CustomSelect
+            value={String(debugLoggingDepth)}
+            onChange={changeDebugDepth}
+            options={DEBUG_DEPTH_OPTIONS}
+            disabled={loggingMode !== 'debug'}
+            ariaLabel={t('settings.debugLoggingDepth')}
           />
         </label>
         <label className="perf-logs__control">

--- a/src/features/sidebar/hooks/useSidebarNewReleasesUnread.ts
+++ b/src/features/sidebar/hooks/useSidebarNewReleasesUnread.ts
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { LibraryScopePair } from '@/lib/api/library/scopeReads';
 import { loadLocalNewReleases } from '@/lib/library/newReleasesLocal';
 import {
+  describeMultiServerError,
+  emitMultiServerDebug,
+} from '@/lib/library/multiServerDebug';
+import {
   NEW_RELEASES_RESET_DELAY_MS,
   NEW_RELEASES_SEEN_MAX_IDS,
   NEW_RELEASES_UNREAD_POLL_MS,
@@ -59,10 +63,33 @@ export function useSidebarNewReleasesUnread({
     const isCurrent = () => seq === newReleasesRefreshSeqRef.current;
 
     if (!isLoggedIn || !anchorServerId || scopes.length === 0) {
+      emitMultiServerDebug('new_releases_unread_skip', {
+        seq,
+        markAsSeen,
+        reason: !isLoggedIn
+          ? 'not_logged_in'
+          : !anchorServerId
+            ? 'missing_anchor_server'
+            : 'empty_scope_pairs',
+        anchorServerId,
+        scopes,
+        scopeFingerprint,
+        pathname,
+      });
       if (isCurrent()) setNewReleasesUnreadCount(0);
       return;
     }
 
+    const startedAt = performance.now();
+    emitMultiServerDebug('new_releases_unread_start', {
+      seq,
+      markAsSeen,
+      anchorServerId,
+      scopes,
+      scopeFingerprint,
+      pathname,
+      storageKey: scopedSeenStorageKey,
+    });
     try {
       const newest = await loadLocalNewReleases(
         anchorServerId,
@@ -75,7 +102,15 @@ export function useSidebarNewReleasesUnread({
         // poll and starves the Home New/Latest rails.
         false,
       );
-      if (!isCurrent()) return;
+      if (!isCurrent()) {
+        emitMultiServerDebug('new_releases_unread_stale', {
+          seq,
+          durationMs: Math.round(performance.now() - startedAt),
+          newestCount: newest.albums.length,
+          currentSeq: newReleasesRefreshSeqRef.current,
+        });
+        return;
+      }
       const newestIds = newest.albums.map(a => a.id).filter(Boolean);
       const seenIds = readSeenNewReleaseIds();
 
@@ -83,6 +118,15 @@ export function useSidebarNewReleasesUnread({
         // First bootstrap for this server/scope: baseline is "already seen".
         writeSeenNewReleaseIds(newestIds);
         if (isCurrent()) setNewReleasesUnreadCount(0);
+        emitMultiServerDebug('new_releases_unread_done', {
+          seq,
+          action: 'bootstrap_seen_baseline',
+          durationMs: Math.round(performance.now() - startedAt),
+          newestCount: newestIds.length,
+          seenCountBefore: 0,
+          unreadCount: 0,
+          sampleNewestIds: newestIds.slice(0, 10),
+        });
         return;
       }
 
@@ -91,6 +135,15 @@ export function useSidebarNewReleasesUnread({
         // cannot silently discard freshly "read" albums (fixes badge coming back).
         writeSeenNewReleaseIds(mergeSeenNewReleaseIdsCap(seenIds, newestIds, NEW_RELEASES_SEEN_MAX_IDS));
         if (isCurrent()) setNewReleasesUnreadCount(0);
+        emitMultiServerDebug('new_releases_unread_done', {
+          seq,
+          action: 'mark_as_seen',
+          durationMs: Math.round(performance.now() - startedAt),
+          newestCount: newestIds.length,
+          seenCountBefore: seenIds.length,
+          unreadCount: 0,
+          sampleNewestIds: newestIds.slice(0, 10),
+        });
         return;
       }
 
@@ -98,14 +151,34 @@ export function useSidebarNewReleasesUnread({
       const unread = newestIds.reduce((count, id) => count + (seenSet.has(id) ? 0 : 1), 0);
 
       if (isCurrent()) setNewReleasesUnreadCount(unread);
-    } catch {
+      emitMultiServerDebug('new_releases_unread_done', {
+        seq,
+        action: 'count_unread',
+        durationMs: Math.round(performance.now() - startedAt),
+        newestCount: newestIds.length,
+        seenCountBefore: seenIds.length,
+        unreadCount: unread,
+        sampleNewestIds: newestIds.slice(0, 10),
+      });
+    } catch (error) {
       // Keep previous value on transient network/API errors.
+      emitMultiServerDebug('new_releases_unread_error', {
+        seq,
+        durationMs: Math.round(performance.now() - startedAt),
+        anchorServerId,
+        scopes,
+        scopeFingerprint,
+        error: describeMultiServerError(error),
+      });
     }
   }, [
     anchorServerId,
     isLoggedIn,
+    pathname,
     readSeenNewReleaseIds,
+    scopeFingerprint,
     scopes,
+    scopedSeenStorageKey,
     writeSeenNewReleaseIds,
   ]);
 
@@ -121,13 +194,22 @@ export function useSidebarNewReleasesUnread({
     if (refreshDebounceRef.current != null) {
       window.clearTimeout(refreshDebounceRef.current);
     }
+    emitMultiServerDebug('new_releases_unread_schedule', {
+      seq,
+      markAsSeen,
+      pendingMarkAsSeen: pendingMarkAsSeenRef.current,
+      pathname,
+      anchorServerId,
+      scopes,
+      scopeFingerprint,
+    });
     refreshDebounceRef.current = window.setTimeout(() => {
       refreshDebounceRef.current = null;
       const mark = pendingMarkAsSeenRef.current;
       pendingMarkAsSeenRef.current = false;
       void refreshNewReleasesUnread(seq, mark);
     }, NEW_RELEASES_UNREAD_DEBOUNCE_MS);
-  }, [refreshNewReleasesUnread]);
+  }, [anchorServerId, pathname, refreshNewReleasesUnread, scopeFingerprint, scopes]);
 
   useEffect(() => {
     const onNewReleasesPage = pathname.startsWith('/new-releases');

--- a/src/lib/api/debugLog.ts
+++ b/src/lib/api/debugLog.ts
@@ -4,10 +4,20 @@
  * from a handful of instrumentation helpers across the app. The command is
  * `Result`-wrapped, so the generated binding would leak a rejection to an
  * unhandled promise on a fire-and-forget call; the `.catch` swallows it,
- * matching the prior `void invoke(...).catch(() => {})` call sites.
+ * matching the prior `void invoke(...).catch(() => {})` call sites. Calls that
+ * omit `depth` remain level 1 for backward compatibility.
  */
 import { commands } from '@/generated/bindings';
+import {
+  isDebugLoggingDepthEnabled,
+  type DebugLoggingDepth,
+} from '@/lib/perf/debugLoggingMode';
 
-export function frontendDebugLog(scope: string, message: string): void {
+export function frontendDebugLog(
+  scope: string,
+  message: string,
+  depth: DebugLoggingDepth = 1,
+): void {
+  if (!isDebugLoggingDepthEnabled(depth)) return;
   void commands.frontendDebugLog(scope, message).catch(() => {});
 }

--- a/src/lib/library/multiServerDebug.test.ts
+++ b/src/lib/library/multiServerDebug.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { onInvoke } from '@/test/mocks/tauri';
+import { useAuthStore } from '@/store/authStore';
+import { resetAuthStore } from '@/test/helpers/storeReset';
+import { frontendDebugLog } from '@/lib/api/debugLog';
+import {
+  describeMultiServerError,
+  emitMultiServerDebug,
+  summarizeMultiServerProfiles,
+  summarizeMusicFoldersByServer,
+} from './multiServerDebug';
+
+beforeEach(resetAuthStore);
+
+describe('multiServerDebug', () => {
+  it('writes structured multi-server diagnostics only at debug depth 3', () => {
+    const captured: Array<{ scope: string; message: string }> = [];
+    onInvoke('frontend_debug_log', args => {
+      captured.push(args as { scope: string; message: string });
+      return undefined;
+    });
+
+    emitMultiServerDebug('normal_skip', { value: 1 });
+    useAuthStore.setState({ loggingMode: 'debug' });
+    emitMultiServerDebug('depth_one_skip', { value: 2 });
+    useAuthStore.setState({ debugLoggingDepth: 3 });
+    emitMultiServerDebug('scope_snapshot', { activeServerId: 'a' });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.scope).toBe('multi-server');
+    expect(JSON.parse(captured[0]?.message ?? '{}')).toMatchObject({
+      step: 'scope_snapshot',
+      details: { activeServerId: 'a' },
+    });
+  });
+
+  it('treats frontend diagnostics without an explicit depth as level 1', () => {
+    const captured: Array<{ scope: string; message: string }> = [];
+    onInvoke('frontend_debug_log', args => {
+      captured.push(args as { scope: string; message: string });
+      return undefined;
+    });
+    useAuthStore.setState({ loggingMode: 'debug', debugLoggingDepth: 1 });
+
+    frontendDebugLog('existing', 'level-one');
+    frontendDebugLog('deeper', 'level-two', 2);
+
+    expect(captured).toEqual([{ scope: 'existing', message: 'level-one' }]);
+  });
+
+  it('summarizes profiles and folders without credential fields or full URLs', () => {
+    expect(summarizeMultiServerProfiles([{
+      id: 'profile-a',
+      name: 'Home',
+      url: 'https://music.example.test',
+      alternateUrl: 'http://192.168.1.2:4533',
+    }])).toEqual([{
+      position: 0,
+      profileId: 'profile-a',
+      name: 'Home',
+      indexKey: 'music.example.test',
+      hasPrimaryUrl: true,
+      hasAlternateUrl: true,
+    }]);
+    expect(summarizeMusicFoldersByServer({
+      'profile-a': [{ id: 'music', name: 'Music' }],
+    })).toEqual({
+      'profile-a': [{ id: 'music', name: 'Music' }],
+    });
+  });
+
+  it('redacts credentials and query parameters from diagnostic URLs and errors', () => {
+    expect(summarizeMultiServerProfiles([{
+      id: 'profile-a',
+      url: 'https://user:secret@music.example.test/subsonic?token=hidden',
+    }])[0]?.indexKey).toBe('music.example.test/subsonic');
+
+    expect(describeMultiServerError(new Error(
+      'GET https://user:secret@music.example.test/rest/ping?token=hidden failed authorization=secret',
+    ))).toBe(
+      'Error: GET https://music.example.test/rest/ping failed authorization=[redacted]',
+    );
+  });
+});

--- a/src/lib/library/multiServerDebug.test.ts
+++ b/src/lib/library/multiServerDebug.test.ts
@@ -34,7 +34,7 @@ describe('multiServerDebug', () => {
     });
   });
 
-  it('treats frontend diagnostics without an explicit depth as level 1', () => {
+  it('treats frontend diagnostics without an explicit depth as basic level 1', () => {
     const captured: Array<{ scope: string; message: string }> = [];
     onInvoke('frontend_debug_log', args => {
       captured.push(args as { scope: string; message: string });
@@ -43,7 +43,7 @@ describe('multiServerDebug', () => {
     useAuthStore.setState({ loggingMode: 'debug', debugLoggingDepth: 1 });
 
     frontendDebugLog('existing', 'level-one');
-    frontendDebugLog('deeper', 'level-two', 2);
+    frontendDebugLog('deeper', 'level-three', 3);
 
     expect(captured).toEqual([{ scope: 'existing', message: 'level-one' }]);
   });

--- a/src/lib/library/multiServerDebug.ts
+++ b/src/lib/library/multiServerDebug.ts
@@ -1,0 +1,84 @@
+import { frontendDebugLog } from '@/lib/api/debugLog';
+import {
+  isDebugLoggingDepthEnabled,
+  isDebugLoggingModeActive,
+} from '@/lib/perf/debugLoggingMode';
+import { serverProfileBaseUrl } from '@/lib/server/serverBaseUrl';
+
+type DiagnosticServer = {
+  id: string;
+  name?: string;
+  url?: string;
+  alternateUrl?: string;
+};
+
+type DiagnosticFolder = {
+  id: string;
+  name?: string;
+};
+
+let sequence = 0;
+const startedAt = typeof performance !== 'undefined' ? performance.now() : 0;
+
+function diagnosticIndexKey(url: string): string {
+  try {
+    const parsed = new URL(serverProfileBaseUrl({ url }));
+    const path = parsed.pathname === '/' ? '' : parsed.pathname.replace(/\/$/, '');
+    return `${parsed.host}${path}`;
+  } catch {
+    return '[invalid-url]';
+  }
+}
+
+function redactDiagnosticText(value: string): string {
+  return value
+    .replace(/https?:\/\/[^\s"'<>]+/gi, raw => {
+      try {
+        const parsed = new URL(raw);
+        const path = parsed.pathname === '/' ? '' : parsed.pathname;
+        return `${parsed.protocol}//${parsed.host}${path}`;
+      } catch {
+        return '[redacted-url]';
+      }
+    })
+    .replace(/\b(password|token|api[_-]?key|authorization)=([^\s&]+)/gi, '$1=[redacted]');
+}
+
+export function describeMultiServerError(error: unknown): string {
+  return redactDiagnosticText(error instanceof Error ? `${error.name}: ${error.message}` : String(error));
+}
+
+export function summarizeMultiServerProfiles(servers: readonly DiagnosticServer[]) {
+  return servers.map((server, position) => ({
+    position,
+    profileId: server.id,
+    name: server.name ?? '',
+    indexKey: server.url ? diagnosticIndexKey(server.url) : '',
+    hasPrimaryUrl: Boolean(server.url),
+    hasAlternateUrl: Boolean(server.alternateUrl),
+  }));
+}
+
+export function summarizeMusicFoldersByServer(
+  foldersByServer: Record<string, readonly DiagnosticFolder[]>,
+) {
+  return Object.fromEntries(Object.entries(foldersByServer).map(([serverId, folders]) => [
+    serverId,
+    folders.map(folder => ({ id: folder.id, name: folder.name ?? '' })),
+  ]));
+}
+
+/** High-detail multi-server diagnostics, available at debug depth 3. */
+export function emitMultiServerDebug(
+  step: string,
+  details: Record<string, unknown> = {},
+): void {
+  if (!isDebugLoggingModeActive() || !isDebugLoggingDepthEnabled(3)) return;
+  sequence += 1;
+  frontendDebugLog('multi-server', JSON.stringify({
+    step,
+    sequence,
+    elapsedMs: startedAt ? Math.round(performance.now() - startedAt) : 0,
+    details,
+  }), 3);
+}

--- a/src/lib/library/newReleasesLocal.test.ts
+++ b/src/lib/library/newReleasesLocal.test.ts
@@ -45,4 +45,23 @@ describe('loadLocalNewReleases', () => {
     });
     expect(libraryScopeListMainstageAlbums).not.toHaveBeenCalled();
   });
+
+  it('reads the whole fallback server when defensive scope pairs are empty', async () => {
+    libraryScopeListMainstageAlbums.mockResolvedValue({
+      albums: [],
+      hasMore: false,
+      genreCounts: [],
+    });
+
+    await loadLocalNewReleases('server-a', [], 30);
+
+    expect(libraryScopeListMainstageAlbums).toHaveBeenCalledWith('server-a', {
+      scopes: [{ serverId: 'server-a', libraryId: null }],
+      feed: 'newReleases',
+      limit: 30,
+      offset: 0,
+      genres: [],
+      includeGenreCounts: true,
+    });
+  });
 });

--- a/src/lib/library/newReleasesLocal.ts
+++ b/src/lib/library/newReleasesLocal.ts
@@ -1,6 +1,7 @@
 import { libraryScopeListMainstageAlbums, type LibraryScopePair } from '@/lib/api/library/scopeReads';
 import { albumToAlbum } from '@/lib/library/advancedSearchLocal';
 import type { GenreAlbumCountRow } from '@/lib/api/library/dto';
+import { describeMultiServerError, emitMultiServerDebug } from '@/lib/library/multiServerDebug';
 
 export async function loadLocalNewReleases(
   anchorServerId: string,
@@ -10,18 +11,77 @@ export async function loadLocalNewReleases(
   genres: string[] = [],
   includeGenreCounts = true,
 ): Promise<{ albums: ReturnType<typeof albumToAlbum>[]; hasMore: boolean; genreCounts: GenreAlbumCountRow[] }> {
-  if (!anchorServerId || scopes.length === 0) return { albums: [], hasMore: false, genreCounts: [] };
-  const response = await libraryScopeListMainstageAlbums(anchorServerId, {
-    scopes,
-    feed: 'newReleases',
+  if (!anchorServerId) {
+    emitMultiServerDebug('new_releases_local_skip', {
+      reason: 'missing_anchor_server',
+      inputScopes: scopes,
+      limit,
+      offset,
+      genres,
+      includeGenreCounts,
+    });
+    return { albums: [], hasMore: false, genreCounts: [] };
+  }
+  const effectiveScopes = scopes.length > 0
+    ? scopes
+    : [{ serverId: anchorServerId, libraryId: null }];
+  const startedAt = performance.now();
+  emitMultiServerDebug('new_releases_local_request_start', {
+    anchorServerId,
+    inputScopes: scopes,
+    effectiveScopes,
+    defensiveFallbackUsed: scopes.length === 0,
     limit,
     offset,
     genres,
     includeGenreCounts,
   });
-  return {
-    albums: response.albums.map(albumToAlbum),
-    hasMore: response.hasMore,
-    genreCounts: response.genreCounts,
-  };
+  try {
+    const response = await libraryScopeListMainstageAlbums(anchorServerId, {
+      scopes: effectiveScopes,
+      feed: 'newReleases',
+      limit,
+      offset,
+      genres,
+      includeGenreCounts,
+    });
+    const albums = response.albums.map(albumToAlbum);
+    const ownerCounts = Object.fromEntries([...new Set(albums.map(album => album.serverId ?? ''))]
+      .filter(Boolean)
+      .map(serverId => [serverId, albums.filter(album => album.serverId === serverId).length]));
+    emitMultiServerDebug('new_releases_local_request_done', {
+      anchorServerId,
+      effectiveScopes,
+      defensiveFallbackUsed: scopes.length === 0,
+      durationMs: Math.round(performance.now() - startedAt),
+      albumCount: albums.length,
+      ownerCounts,
+      hasMore: response.hasMore,
+      genreCount: response.genreCounts?.length ?? 0,
+      sampleAlbums: response.albums.slice(0, 10).map(album => ({
+        serverId: album.serverId,
+        id: album.id,
+        name: album.name,
+        year: album.year ?? null,
+        syncedAt: album.syncedAt,
+        createdMs: album.rawJson && typeof album.rawJson === 'object'
+          ? (album.rawJson as Record<string, unknown>).createdMs ?? null
+          : null,
+      })),
+    });
+    return {
+      albums,
+      hasMore: response.hasMore,
+      genreCounts: response.genreCounts,
+    };
+  } catch (error) {
+    emitMultiServerDebug('new_releases_local_request_error', {
+      anchorServerId,
+      effectiveScopes,
+      defensiveFallbackUsed: scopes.length === 0,
+      durationMs: Math.round(performance.now() - startedAt),
+      error: describeMultiServerError(error),
+    });
+    throw error;
+  }
 }

--- a/src/lib/network/serverReachability.test.ts
+++ b/src/lib/network/serverReachability.test.ts
@@ -1,3 +1,4 @@
+import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   getActiveServerReachable,
@@ -8,6 +9,7 @@ import {
   getServerReachabilitySnapshot,
   publishServerConnectionStatus,
   resetServerReachabilitySnapshot,
+  useServerReachabilitySnapshot,
 } from './serverReachability';
 
 beforeEach(() => {
@@ -33,5 +35,23 @@ describe('publishServerConnectionStatus', () => {
     expect(getServerReachabilitySnapshot().get('b')).toBe('available');
     expect(getActiveServerReachable()).toBeNull();
     expect(getConnectionStatus()).toBe('checking');
+  });
+
+  it('subscribes to the full snapshot only while explicitly enabled', () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useServerReachabilitySnapshot(enabled),
+      { initialProps: { enabled: false } },
+    );
+    const disabledSnapshot = result.current;
+
+    act(() => publishServerConnectionStatus('a', 'online'));
+    expect(result.current).toBe(disabledSnapshot);
+    expect(result.current.size).toBe(0);
+
+    rerender({ enabled: true });
+    expect(result.current.get('a')).toBe('available');
+
+    act(() => publishServerConnectionStatus('a', 'offline'));
+    expect(result.current.get('a')).toBe('unavailable');
   });
 });

--- a/src/lib/network/serverReachability.ts
+++ b/src/lib/network/serverReachability.ts
@@ -11,6 +11,7 @@ const reachabilityByServer = new Map<string, ServerReachability>();
 const listeners = new Set<() => void>();
 let unavailableServerIds: ReadonlySet<string> = new Set();
 let reachabilitySnapshot: ReadonlyMap<string, ServerReachability> = new Map();
+const disabledReachabilitySnapshot: ReadonlyMap<string, ServerReachability> = new Map();
 
 function publish(): void {
   reachabilitySnapshot = new Map(reachabilityByServer);
@@ -67,12 +68,26 @@ function subscribe(listener: () => void): () => void {
   return () => listeners.delete(listener);
 }
 
+function subscribeDisabled(): () => void {
+  return () => {};
+}
+
+function getDisabledReachabilitySnapshot(): ReadonlyMap<string, ServerReachability> {
+  return disabledReachabilitySnapshot;
+}
+
 export function useUnavailableServerIds(): ReadonlySet<string> {
   return useSyncExternalStore(subscribe, getUnavailableServerIds, getUnavailableServerIds);
 }
 
-export function useServerReachabilitySnapshot(): ReadonlyMap<string, ServerReachability> {
-  return useSyncExternalStore(subscribe, getServerReachabilitySnapshot, getServerReachabilitySnapshot);
+export function useServerReachabilitySnapshot(
+  enabled = true,
+): ReadonlyMap<string, ServerReachability> {
+  return useSyncExternalStore(
+    enabled ? subscribe : subscribeDisabled,
+    enabled ? getServerReachabilitySnapshot : getDisabledReachabilitySnapshot,
+    enabled ? getServerReachabilitySnapshot : getDisabledReachabilitySnapshot,
+  );
 }
 
 export function resetServerReachabilitySnapshot(): void {

--- a/src/lib/perf/debugLoggingMode.ts
+++ b/src/lib/perf/debugLoggingMode.ts
@@ -1,19 +1,33 @@
 /**
- * Lib-safe gate for "Settings → Logging → Debug" mode.
+ * Lib-safe gate for "Settings → Logging → Debug" mode and detail depth.
  *
- * The source of truth is the auth store's `loggingMode` (a higher layer), so it
- * is *injected* here via `setDebugLoggingModeSource` (called from the store at
- * module load) instead of importing the store — that keeps `src/lib` at the
- * dependency floor. Instrumentation helpers under `src/lib` (album/artist browse
- * traces, etc.) read the gate through `isDebugLoggingModeActive`. Defaults to
- * off until the store wires the source.
+ * The source of truth is the auth store's `loggingMode` and
+ * `debugLoggingDepth` (a higher layer), so both are injected here at module load
+ * instead of importing the store. That keeps `src/lib` at the dependency floor.
+ * Instrumentation helpers read the mode and depth gates independently; defaults
+ * are off and depth 1 until the store wires the sources.
  */
+export type DebugLoggingDepth = 1 | 2 | 3;
+
 let debugLoggingModeSource: () => boolean = () => false;
+let debugLoggingDepthSource: () => DebugLoggingDepth = () => 1;
 
 export function setDebugLoggingModeSource(source: () => boolean): void {
   debugLoggingModeSource = source;
 }
 
+export function setDebugLoggingDepthSource(source: () => DebugLoggingDepth): void {
+  debugLoggingDepthSource = source;
+}
+
 export function isDebugLoggingModeActive(): boolean {
   return debugLoggingModeSource();
+}
+
+export function isDebugLoggingDepthEnabled(requiredDepth: DebugLoggingDepth = 1): boolean {
+  return debugLoggingDepthSource() >= requiredDepth;
+}
+
+export function sanitizeDebugLoggingDepth(value: unknown): DebugLoggingDepth {
+  return value === 2 || value === 3 ? value : 1;
 }

--- a/src/lib/perf/debugLoggingMode.ts
+++ b/src/lib/perf/debugLoggingMode.ts
@@ -7,7 +7,7 @@
  * Instrumentation helpers read the mode and depth gates independently; defaults
  * are off and depth 1 until the store wires the sources.
  */
-export type DebugLoggingDepth = 1 | 2 | 3;
+export type DebugLoggingDepth = 1 | 3;
 
 let debugLoggingModeSource: () => boolean = () => false;
 let debugLoggingDepthSource: () => DebugLoggingDepth = () => 1;
@@ -29,5 +29,5 @@ export function isDebugLoggingDepthEnabled(requiredDepth: DebugLoggingDepth = 1)
 }
 
 export function sanitizeDebugLoggingDepth(value: unknown): DebugLoggingDepth {
-  return value === 2 || value === 3 ? value : 1;
+  return value === 3 ? value : 1;
 }

--- a/src/locales/bg/settings.ts
+++ b/src/locales/bg/settings.ts
@@ -590,6 +590,8 @@ export const settings = {
   loggingModeOff: 'Изключено',
   loggingModeNormal: 'Нормално',
   loggingModeDebug: 'Отстраняване на грешки',
+  debugLoggingDepth: 'Дълбочина на отстраняване',
+  debugLoggingDepthDesc: 'Управлява подробността на диагностиката на интерфейса в режим за отстраняване на грешки. Съществуващите трасета използват ниво 1, а подробните multi-server трасета — ниво 3.',
   loggingExport: 'Изнеси дневниците',
   loggingExportSuccess: 'Дневниците са изнесени ({{count}} реда).',
   loggingExportError: 'Изнасянето на дневниците се провали.',

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -574,6 +574,8 @@ export const settings = {
   loggingModeOff: 'Aus',
   loggingModeNormal: 'Normal',
   loggingModeDebug: 'Debug',
+  debugLoggingDepth: 'Debug-Tiefe',
+  debugLoggingDepthDesc: 'Steuert die Detailtiefe der Frontend-Diagnose im Debug-Modus. Bestehende Traces verwenden Stufe 1, umfangreiche Multi-Server-Traces Stufe 3.',
   loggingExport: 'Protokolle exportieren',
   loggingExportSuccess: 'Protokolle exportiert ({{count}} Zeilen).',
   loggingExportError: 'Protokolle konnten nicht exportiert werden.',

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -590,6 +590,8 @@ export const settings = {
   loggingModeOff: 'Off',
   loggingModeNormal: 'Normal',
   loggingModeDebug: 'Debug',
+  debugLoggingDepth: 'Debug depth',
+  debugLoggingDepthDesc: 'Controls frontend diagnostic detail while Debug logging is active. Existing traces use level 1; high-volume multi-server traces use level 3.',
   loggingExport: 'Export logs',
   loggingExportSuccess: 'Logs exported ({{count}} lines).',
   loggingExportError: 'Could not export logs.',

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -545,6 +545,8 @@ export const settings = {
   loggingModeOff: 'Apagado',
   loggingModeNormal: 'Normal',
   loggingModeDebug: 'Depuración',
+  debugLoggingDepth: 'Profundidad de depuración',
+  debugLoggingDepthDesc: 'Controla el detalle del diagnóstico de la interfaz en modo Depuración. Las trazas existentes usan el nivel 1; las trazas detalladas de varios servidores usan el nivel 3.',
   loggingExport: 'Exportar logs',
   loggingExportSuccess: 'Logs exportados ({{count}} líneas).',
   loggingExportError: 'No se pudieron exportar los logs.',

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -561,6 +561,8 @@ export const settings = {
   loggingModeOff: 'Désactivé',
   loggingModeNormal: 'Normal',
   loggingModeDebug: 'Débogage',
+  debugLoggingDepth: 'Profondeur du débogage',
+  debugLoggingDepthDesc: 'Contrôle le niveau de détail des diagnostics de l’interface en mode Débogage. Les traces existantes utilisent le niveau 1, les traces multi-serveurs détaillées le niveau 3.',
   loggingExport: 'Exporter les journaux',
   loggingExportSuccess: 'Journaux exportés ({{count}} lignes).',
   loggingExportError: 'Impossible d\'exporter les journaux.',

--- a/src/locales/hu/settings.ts
+++ b/src/locales/hu/settings.ts
@@ -590,6 +590,8 @@ export const settings = {
   loggingModeOff: 'Ki',
   loggingModeNormal: 'Normál',
   loggingModeDebug: 'Hibakeresés',
+  debugLoggingDepth: 'Hibakeresési mélység',
+  debugLoggingDepthDesc: 'A felületi diagnosztika részletességét szabályozza Hibakeresés módban. A meglévő nyomkövetések az 1., a részletes többkiszolgálós nyomkövetések a 3. szintet használják.',
   loggingExport: 'Naplók exportálása',
   loggingExportSuccess: 'Naplók exportálva ({{count}} sor).',
   loggingExportError: 'Nem sikerült exportálni a naplókat.',

--- a/src/locales/it/settings.ts
+++ b/src/locales/it/settings.ts
@@ -590,6 +590,8 @@ export const settings = {
   loggingModeOff: 'Disattivato',
   loggingModeNormal: 'Normale',
   loggingModeDebug: 'Debug',
+  debugLoggingDepth: 'Profondità debug',
+  debugLoggingDepthDesc: 'Controlla il dettaglio della diagnostica dell’interfaccia in modalità Debug. Le tracce esistenti usano il livello 1; le tracce multi-server dettagliate usano il livello 3.',
   loggingExport: 'Esporta log',
   loggingExportSuccess: 'Log esportati ({{count}} righe).',
   loggingExportError: 'Impossibile esportare i log.',

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -584,6 +584,8 @@ export const settings = {
   loggingModeOff: 'オフ',
   loggingModeNormal: '通常',
   loggingModeDebug: 'デバッグ',
+  debugLoggingDepth: 'デバッグ深度',
+  debugLoggingDepthDesc: 'デバッグモード中のフロントエンド診断の詳細度を制御します。既存のトレースはレベル1、詳細なマルチサーバートレースはレベル3を使用します。',
   loggingExport: 'ログをエクスポート',
   loggingExportSuccess: 'ログをエクスポートしました ({{count}} 行)。',
   loggingExportError: 'ログをエクスポートできませんでした。',

--- a/src/locales/nb/settings.ts
+++ b/src/locales/nb/settings.ts
@@ -532,6 +532,8 @@ export const settings = {
   loggingModeOff: 'Av',
   loggingModeNormal: 'Normal',
   loggingModeDebug: 'Debug',
+  debugLoggingDepth: 'Feilsøkingsdybde',
+  debugLoggingDepthDesc: 'Styrer detaljnivået for diagnostikk i grensesnittet når Debug er aktiv. Eksisterende sporing bruker nivå 1, mens detaljert flerserversporing bruker nivå 3.',
   loggingExport: 'Eksporter logger',
   loggingExportSuccess: 'Logger eksportert ({{count}} linjer).',
   loggingExportError: 'Kunne ikke eksportere logger.',

--- a/src/locales/nl/settings.ts
+++ b/src/locales/nl/settings.ts
@@ -561,6 +561,8 @@ export const settings = {
   loggingModeOff: 'Uit',
   loggingModeNormal: 'Normaal',
   loggingModeDebug: 'Debug',
+  debugLoggingDepth: 'Debugdiepte',
+  debugLoggingDepthDesc: 'Bepaalt de detaillering van frontenddiagnostiek in de debugmodus. Bestaande traces gebruiken niveau 1; uitgebreide multi-servertraces gebruiken niveau 3.',
   loggingExport: 'Logs exporteren',
   loggingExportSuccess: 'Logs geëxporteerd ({{count}} regels).',
   loggingExportError: 'Kon logs niet exporteren.',

--- a/src/locales/pl/settings.ts
+++ b/src/locales/pl/settings.ts
@@ -590,6 +590,8 @@ export const settings = {
   loggingModeOff: 'Wyłączony',
   loggingModeNormal: 'Normalny',
   loggingModeDebug: 'Debugowanie',
+  debugLoggingDepth: 'Głębokość debugowania',
+  debugLoggingDepthDesc: 'Steruje szczegółowością diagnostyki interfejsu w trybie debugowania. Istniejące ślady używają poziomu 1, a szczegółowe ślady wielu serwerów poziomu 3.',
   loggingExport: 'Eksportuj dzienniki',
   loggingExportSuccess: 'Dzienniki zostały wyeksportowane ({{count}} linii).',
   loggingExportError: 'Nie można wyeksportować dzienników.',

--- a/src/locales/ro/settings.ts
+++ b/src/locales/ro/settings.ts
@@ -548,6 +548,8 @@ export const settings = {
   loggingModeOff: 'Oprit',
   loggingModeNormal: 'Normal',
   loggingModeDebug: 'Debug',
+  debugLoggingDepth: 'Profunzime depanare',
+  debugLoggingDepthDesc: 'Controlează nivelul de detaliu al diagnosticelor interfeței în modul Debug. Trasările existente folosesc nivelul 1, iar trasările detaliate multi-server nivelul 3.',
   loggingExport: 'Exportă log-uri',
   loggingExportSuccess: 'Log-uri exportate ({{count}} linii).',
   loggingExportError: 'Nu s-au putut exporta log-urile.',

--- a/src/locales/ru/settings.ts
+++ b/src/locales/ru/settings.ts
@@ -606,6 +606,8 @@ export const settings = {
   loggingModeOff: 'Выключено',
   loggingModeNormal: 'Обычное',
   loggingModeDebug: 'Дебаг',
+  debugLoggingDepth: 'Глубина дебага',
+  debugLoggingDepthDesc: 'Управляет подробностью диагностики интерфейса в режиме «Дебаг». Существующие трассировки используют уровень 1, подробная multi-server диагностика — уровень 3.',
   loggingExport: 'Экспорт логов',
   loggingExportSuccess: 'Логи экспортированы ({{count}} строк).',
   loggingExportError: 'Не удалось экспортировать логи.',

--- a/src/locales/zh/settings.ts
+++ b/src/locales/zh/settings.ts
@@ -532,6 +532,8 @@ export const settings = {
   loggingModeOff: '关闭',
   loggingModeNormal: '普通',
   loggingModeDebug: '调试',
+  debugLoggingDepth: '调试深度',
+  debugLoggingDepthDesc: '控制调试模式下前端诊断的详细程度。现有跟踪使用级别 1；详细的多服务器跟踪使用级别 3。',
   loggingExport: '导出日志',
   loggingExportSuccess: '日志已导出（{{count}} 行）。',
   loggingExportError: '无法导出日志。',

--- a/src/store/authMusicLibraryActions.ts
+++ b/src/store/authMusicLibraryActions.ts
@@ -5,6 +5,7 @@ import {
   scheduleMusicLibraryFilterVersionBump,
 } from './musicLibraryFilterNotify';
 import { deriveLibraryBrowseServerIdsWithFallback } from '@/lib/library/libraryBrowseScope';
+import { emitMultiServerDebug } from '@/lib/library/multiServerDebug';
 
 type SetState = (
   partial: Partial<AuthState> | ((state: AuthState) => Partial<AuthState>),
@@ -123,7 +124,15 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
 
     setMusicFoldersForServer: (serverId, folders) => {
       const s = get();
-      if (!s.servers.some(server => server.id === serverId)) return;
+      if (!s.servers.some(server => server.id === serverId)) {
+        emitMultiServerDebug('folders_store_update_skip', {
+          serverId,
+          reason: 'profile_missing',
+          folderCount: folders.length,
+          savedServerIds: s.servers.map(server => server.id),
+        });
+        return;
+      }
       const previousFolders = s.musicFoldersByServer[serverId] ?? [];
       const foldersChanged = folders.length !== previousFolders.length
         || folders.some((folder, index) => {
@@ -152,48 +161,128 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
           ? { libraryBrowseScopeVersion: state.libraryBrowseScopeVersion + 1 }
           : {}),
       }));
+      const next = get();
+      emitMultiServerDebug('folders_store_update', {
+        serverId,
+        activeServerId: next.activeServerId,
+        configuredServerIds: next.libraryBrowseServerIds,
+        previousFolders: previousFolders.map(folder => ({ id: folder.id, name: folder.name })),
+        folders: folders.map(folder => ({ id: folder.id, name: folder.name })),
+        foldersChanged,
+        previousBrowseSelection: previousBrowseSelection ?? [],
+        browseSelection: next.libraryBrowseSelectionByServer[serverId] ?? [],
+        browseScopeChanged,
+        libraryBrowseScopeVersion: next.libraryBrowseScopeVersion,
+      });
     },
 
     setLibraryBrowseServerExclusive: (serverId) => {
       const s = get();
-      if (!s.servers.some(server => server.id === serverId)) return;
-      if (s.libraryBrowseServerIds.length === 1 && s.libraryBrowseServerIds[0] === serverId) return;
+      if (!s.servers.some(server => server.id === serverId)) {
+        emitMultiServerDebug('library_scope_exclusive_skip', {
+          serverId,
+          reason: 'profile_missing',
+          configuredServerIds: s.libraryBrowseServerIds,
+        });
+        return;
+      }
+      if (s.libraryBrowseServerIds.length === 1 && s.libraryBrowseServerIds[0] === serverId) {
+        emitMultiServerDebug('library_scope_exclusive_skip', {
+          serverId,
+          reason: 'already_exclusive',
+          configuredServerIds: s.libraryBrowseServerIds,
+        });
+        return;
+      }
       set(state => ({
         libraryBrowseServerIds: [serverId],
         libraryBrowseScopeVersion: state.libraryBrowseScopeVersion + 1,
       }));
+      emitMultiServerDebug('library_scope_exclusive_set', {
+        serverId,
+        previousServerIds: s.libraryBrowseServerIds,
+        configuredServerIds: get().libraryBrowseServerIds,
+        libraryBrowseScopeVersion: get().libraryBrowseScopeVersion,
+      });
     },
 
     setLibraryBrowseServerSelected: (serverId, selected) => {
       const s = get();
-      if (!s.servers.some(server => server.id === serverId)) return;
+      if (!s.servers.some(server => server.id === serverId)) {
+        emitMultiServerDebug('library_scope_membership_skip', {
+          serverId,
+          selected,
+          reason: 'profile_missing',
+          configuredServerIds: s.libraryBrowseServerIds,
+        });
+        return;
+      }
       const current = new Set(s.libraryBrowseServerIds);
       if (selected) current.add(serverId);
       else current.delete(serverId);
-      if (current.size === 0 && s.servers.length > 0) return;
+      if (current.size === 0 && s.servers.length > 0) {
+        emitMultiServerDebug('library_scope_membership_skip', {
+          serverId,
+          selected,
+          reason: 'cannot_remove_final_server',
+          configuredServerIds: s.libraryBrowseServerIds,
+        });
+        return;
+      }
       const next = deriveLibraryBrowseServerIdsWithFallback({
         servers: s.servers,
         activeServerId: s.activeServerId,
         libraryBrowseServerIds: [...current],
       });
       if (next.length === s.libraryBrowseServerIds.length
-        && next.every((id, index) => id === s.libraryBrowseServerIds[index])) return;
+        && next.every((id, index) => id === s.libraryBrowseServerIds[index])) {
+        emitMultiServerDebug('library_scope_membership_skip', {
+          serverId,
+          selected,
+          reason: 'unchanged',
+          configuredServerIds: s.libraryBrowseServerIds,
+        });
+        return;
+      }
       set(state => ({
         libraryBrowseServerIds: next,
         libraryBrowseScopeVersion: state.libraryBrowseScopeVersion + 1,
       }));
+      emitMultiServerDebug('library_scope_membership_set', {
+        serverId,
+        selected,
+        previousServerIds: s.libraryBrowseServerIds,
+        configuredServerIds: next,
+        libraryBrowseScopeVersion: get().libraryBrowseScopeVersion,
+      });
     },
 
     setLibraryBrowseSelectionForServer: (serverId, libraryIds) => {
       const s = get();
-      if (!s.libraryBrowseServerIds.includes(serverId)) return;
+      if (!s.libraryBrowseServerIds.includes(serverId)) {
+        emitMultiServerDebug('library_folder_selection_skip', {
+          serverId,
+          requestedLibraryIds: libraryIds,
+          reason: 'server_not_in_scope',
+          configuredServerIds: s.libraryBrowseServerIds,
+        });
+        return;
+      }
       const folders = s.musicFoldersByServer[serverId] ?? [];
       const knownFolderIds = new Set(folders.map(folder => folder.id));
       const unique = [...new Set(libraryIds)].filter(id => folders.length === 0 || knownFolderIds.has(id));
       const selection = collapseServerSelection(folders, unique);
       const previous = s.libraryBrowseSelectionByServer[serverId] ?? [];
       if (selection.length === previous.length
-        && selection.every((id, index) => id === previous[index])) return;
+        && selection.every((id, index) => id === previous[index])) {
+        emitMultiServerDebug('library_folder_selection_skip', {
+          serverId,
+          requestedLibraryIds: libraryIds,
+          normalizedLibraryIds: selection,
+          reason: 'unchanged',
+        });
+        return;
+      }
       set(state => ({
         libraryBrowseSelectionByServer: {
           ...state.libraryBrowseSelectionByServer,
@@ -201,6 +290,14 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
         },
         libraryBrowseScopeVersion: state.libraryBrowseScopeVersion + 1,
       }));
+      emitMultiServerDebug('library_folder_selection_set', {
+        serverId,
+        requestedLibraryIds: libraryIds,
+        previousLibraryIds: previous,
+        normalizedLibraryIds: selection,
+        availableFolderIds: folders.map(folder => folder.id),
+        libraryBrowseScopeVersion: get().libraryBrowseScopeVersion,
+      });
     },
 
     setMusicLibraryFilter: (folderId) => {

--- a/src/store/authPlumbingActions.ts
+++ b/src/store/authPlumbingActions.ts
@@ -1,23 +1,57 @@
 import type { AuthState } from './authStoreTypes';
+import {
+  emitMultiServerDebug,
+  summarizeMultiServerProfiles,
+  summarizeMusicFoldersByServer,
+} from '@/lib/library/multiServerDebug';
 
 type SetState = (
   partial: Partial<AuthState> | ((state: AuthState) => Partial<AuthState>),
 ) => void;
+type GetState = () => AuthState;
 
 /**
  * Persistent plumbing settings that don't fit a more specific domain:
  * runtime logging level, Navidrome `getNowPlaying` toggle, audiobook
  * exclusion, genre blacklist.
  */
-export function createPlumbingSettingsActions(set: SetState): Pick<
+export function createPlumbingSettingsActions(set: SetState, get: GetState): Pick<
   AuthState,
   | 'setLoggingMode'
+  | 'setDebugLoggingDepth'
   | 'setNowPlayingEnabled'
   | 'setExcludeAudiobooks'
   | 'setCustomGenreBlacklist'
 > {
   return {
-    setLoggingMode: (v) => set({ loggingMode: v }),
+    setLoggingMode: (v) => {
+      set({ loggingMode: v });
+      const state = get();
+      emitMultiServerDebug('debug_logging_mode_changed', {
+        loggingMode: v,
+        activeServerId: state.activeServerId,
+        isLoggedIn: state.isLoggedIn,
+        configuredServerIds: state.libraryBrowseServerIds,
+        servers: summarizeMultiServerProfiles(state.servers),
+        foldersByServer: summarizeMusicFoldersByServer(state.musicFoldersByServer),
+        selectionByServer: state.libraryBrowseSelectionByServer,
+        libraryBrowseScopeVersion: state.libraryBrowseScopeVersion,
+      });
+    },
+    setDebugLoggingDepth: (v) => {
+      set({ debugLoggingDepth: v });
+      const state = get();
+      emitMultiServerDebug('debug_logging_depth_changed', {
+        debugLoggingDepth: v,
+        activeServerId: state.activeServerId,
+        isLoggedIn: state.isLoggedIn,
+        configuredServerIds: state.libraryBrowseServerIds,
+        servers: summarizeMultiServerProfiles(state.servers),
+        foldersByServer: summarizeMusicFoldersByServer(state.musicFoldersByServer),
+        selectionByServer: state.libraryBrowseSelectionByServer,
+        libraryBrowseScopeVersion: state.libraryBrowseScopeVersion,
+      });
+    },
     setNowPlayingEnabled: (v) => set({ nowPlayingEnabled: v }),
     setExcludeAudiobooks: (v) => set({ excludeAudiobooks: v }),
     setCustomGenreBlacklist: (v) => set({ customGenreBlacklist: v }),

--- a/src/store/authServerProfileActions.ts
+++ b/src/store/authServerProfileActions.ts
@@ -3,10 +3,15 @@ import { generateId } from './authStoreHelpers';
 import { getQueueServerId, clearQueueServerForPlayback } from './playbackEngineBridge';
 import { resolveServerIdForIndexKey } from '@/lib/server/serverLookup';
 import { deriveLibraryBrowseServerIdsWithFallback } from '@/lib/library/libraryBrowseScope';
+import {
+  emitMultiServerDebug,
+  summarizeMultiServerProfiles,
+} from '@/lib/library/multiServerDebug';
 
 type SetState = (
   partial: Partial<AuthState> | ((state: AuthState) => Partial<AuthState>),
 ) => void;
+type GetState = () => AuthState;
 
 /**
  * Server profile + connection lifecycle. `removeServer` is the
@@ -15,7 +20,7 @@ type SetState = (
  * the active id to the next available server (or null) so the rest of
  * the app doesn't end up reading stale state.
  */
-export function createServerProfileActions(set: SetState): Pick<
+export function createServerProfileActions(set: SetState, get: GetState): Pick<
   AuthState,
   | 'addServer'
   | 'updateServer'
@@ -30,10 +35,28 @@ export function createServerProfileActions(set: SetState): Pick<
   return {
     addServer: (profile) => {
       const id = generateId();
-      set(s => ({
-        servers: [...s.servers, { ...profile, id }],
-        ...(s.servers.length === 0 ? { libraryBrowseServerIds: [id] } : {}),
-      }));
+      set(s => {
+        const servers = [...s.servers, { ...profile, id }];
+        const libraryBrowseServerIds = deriveLibraryBrowseServerIdsWithFallback({
+          servers,
+          activeServerId: s.activeServerId,
+          libraryBrowseServerIds: s.libraryBrowseServerIds,
+        });
+        const scopeChanged = libraryBrowseServerIds.length !== s.libraryBrowseServerIds.length
+          || libraryBrowseServerIds.some((serverId, index) => serverId !== s.libraryBrowseServerIds[index]);
+        return {
+          servers,
+          libraryBrowseServerIds,
+          ...(scopeChanged
+            ? { libraryBrowseScopeVersion: s.libraryBrowseScopeVersion + 1 }
+            : {}),
+        };
+      });
+      emitMultiServerDebug('server_profile_added', {
+        addedServerId: id,
+        servers: summarizeMultiServerProfiles(get().servers),
+        configuredServerIds: get().libraryBrowseServerIds,
+      });
       return id;
     },
 
@@ -90,19 +113,41 @@ export function createServerProfileActions(set: SetState): Pick<
       });
     },
 
-    setServers: (servers) => set(s => ({
-      servers,
-      libraryBrowseServerIds: deriveLibraryBrowseServerIdsWithFallback({
+    setServers: (servers) => {
+      const before = get();
+      set(s => ({
         servers,
-        activeServerId: s.activeServerId,
-        libraryBrowseServerIds: s.libraryBrowseServerIds,
-      }),
-      libraryBrowseScopeVersion: s.libraryBrowseScopeVersion + 1,
-    })),
-    setActiveServer: (id) => set(s => ({
-      activeServerId: id,
-      musicFolders: s.musicFoldersByServer[id] ?? [],
-    })),
+        libraryBrowseServerIds: deriveLibraryBrowseServerIdsWithFallback({
+          servers,
+          activeServerId: s.activeServerId,
+          libraryBrowseServerIds: s.libraryBrowseServerIds,
+        }),
+        libraryBrowseScopeVersion: s.libraryBrowseScopeVersion + 1,
+      }));
+      const after = get();
+      emitMultiServerDebug('server_profiles_set', {
+        previousServers: summarizeMultiServerProfiles(before.servers),
+        servers: summarizeMultiServerProfiles(after.servers),
+        activeServerId: after.activeServerId,
+        previousConfiguredServerIds: before.libraryBrowseServerIds,
+        configuredServerIds: after.libraryBrowseServerIds,
+        libraryBrowseScopeVersion: after.libraryBrowseScopeVersion,
+      });
+    },
+    setActiveServer: (id) => {
+      const before = get();
+      set(s => ({
+        activeServerId: id,
+        musicFolders: s.musicFoldersByServer[id] ?? [],
+      }));
+      const after = get();
+      emitMultiServerDebug('active_server_set', {
+        previousActiveServerId: before.activeServerId,
+        activeServerId: after.activeServerId,
+        configuredServerIds: after.libraryBrowseServerIds,
+        activeFolders: after.musicFolders.map(folder => ({ id: folder.id, name: folder.name })),
+      });
+    },
     setLoggedIn: (v) => set({ isLoggedIn: v }),
     setConnecting: (v) => set({ isConnecting: v }),
     setConnectionError: (e) => set({ connectionError: e }),

--- a/src/store/authStore.servers.test.ts
+++ b/src/store/authStore.servers.test.ts
@@ -41,6 +41,33 @@ describe('addServer / updateServer', () => {
     expect(s.libraryBrowseServerIds).toEqual([id]);
   });
 
+  it('repairs an empty Library scope when a second server is added', () => {
+    useAuthStore.setState({
+      servers: [{
+        id: 'legacy',
+        name: 'Legacy',
+        url: 'https://legacy.test',
+        username: 'u',
+        password: 'p',
+      }],
+      activeServerId: 'legacy',
+      libraryBrowseServerIds: [],
+      libraryBrowseScopeVersion: 7,
+    });
+
+    useAuthStore.getState().addServer({
+      name: 'Second',
+      url: 'https://second.test',
+      username: 'u',
+      password: 'p',
+    });
+
+    const state = useAuthStore.getState();
+    expect(state.servers).toHaveLength(2);
+    expect(state.libraryBrowseServerIds).toEqual(['legacy']);
+    expect(state.libraryBrowseScopeVersion).toBe(8);
+  });
+
   it('updateServer patches the matching server only', () => {
     const { a, b } = addThree();
     useAuthStore.getState().updateServer(a, { name: 'A-renamed', url: 'https://a-new.test' });

--- a/src/store/authStore.settings.test.ts
+++ b/src/store/authStore.settings.test.ts
@@ -227,6 +227,13 @@ describe('discord cover source setters', () => {
       expect(useAuthStore.getState().loggingMode).toBe(mode);
     }
   });
+
+  it('setDebugLoggingDepth accepts levels 1 / 2 / 3', () => {
+    for (const depth of [1, 2, 3] as const) {
+      useAuthStore.getState().setDebugLoggingDepth(depth);
+      expect(useAuthStore.getState().debugLoggingDepth).toBe(depth);
+    }
+  });
 });
 
 describe('per-server bookkeeping setters', () => {

--- a/src/store/authStore.settings.test.ts
+++ b/src/store/authStore.settings.test.ts
@@ -228,8 +228,8 @@ describe('discord cover source setters', () => {
     }
   });
 
-  it('setDebugLoggingDepth accepts levels 1 / 2 / 3', () => {
-    for (const depth of [1, 2, 3] as const) {
+  it('setDebugLoggingDepth accepts basic and verbose levels', () => {
+    for (const depth of [1, 3] as const) {
       useAuthStore.getState().setDebugLoggingDepth(depth);
       expect(useAuthStore.getState().debugLoggingDepth).toBe(depth);
     }

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -24,7 +24,10 @@ import { syncAllServerHttpContexts } from '@/lib/server/syncServerHttpContext';
 import type { AuthState } from './authStoreTypes';
 import { getCachedConnectBaseUrl } from '@/lib/server/serverEndpoint';
 import { serverProfileBaseUrl } from '@/lib/server/serverBaseUrl';
-import { setDebugLoggingModeSource } from '@/lib/perf/debugLoggingMode';
+import {
+  setDebugLoggingDepthSource,
+  setDebugLoggingModeSource,
+} from '@/lib/perf/debugLoggingMode';
 import { createDiscordBannerActions } from './authDiscordBannerActions';
 import { setLibraryBrowseScopeSource } from '@/lib/library/libraryBrowseScope';
 
@@ -92,6 +95,7 @@ export const useAuthStore = create<AuthState>()(
       linuxWaylandTextRenderProfile: 'sharp',
       linuxWebkitInputForceRepaint: false,
       loggingMode: 'normal',
+      debugLoggingDepth: 1,
       nowPlayingEnabled: false,
       lyricsServerFirst: true,
       enableNeteaselyrics: false,
@@ -150,7 +154,7 @@ export const useAuthStore = create<AuthState>()(
       isConnecting: false,
       connectionError: null,
 
-      ...createServerProfileActions(set),
+      ...createServerProfileActions(set, get),
       ...createMusicNetworkActions(set),
       ...createAudioSettingsActions(set),
       ...createCacheStorageActions(set),
@@ -159,7 +163,7 @@ export const useAuthStore = create<AuthState>()(
       ...createLyricsSettingsActions(set),
       ...createTrackPreviewActions(set),
       ...createDiscoveryActions(set),
-      ...createPlumbingSettingsActions(set),
+      ...createPlumbingSettingsActions(set, get),
       ...createSkipStarActions(set, get),
       ...createMusicLibraryActions(set, get),
       ...createPerServerCapabilityActions(set),
@@ -207,4 +211,5 @@ export const useAuthStore = create<AuthState>()(
 // Wire the lib-safe debug-logging gate to the auth store's `loggingMode`
 // (store → lib injection; keeps `src/lib` instrumentation free of store imports).
 setDebugLoggingModeSource(() => useAuthStore.getState().loggingMode === 'debug');
+setDebugLoggingDepthSource(() => useAuthStore.getState().debugLoggingDepth);
 setLibraryBrowseScopeSource(() => useAuthStore.getState());

--- a/src/store/authStoreRehydrate.test.ts
+++ b/src/store/authStoreRehydrate.test.ts
@@ -44,7 +44,7 @@ describe('computeAuthStoreRehydration — queueDurationDisplayMode', () => {
 describe('computeAuthStoreRehydration — debugLoggingDepth', () => {
   beforeEach(resetAuthStore);
 
-  it.each([1, 2, 3] as const)('preserves valid depth %s', (depth) => {
+  it.each([1, 3] as const)('preserves valid depth %s', (depth) => {
     const patch = computeAuthStoreRehydration({
       ...useAuthStore.getState(),
       debugLoggingDepth: depth,
@@ -52,7 +52,7 @@ describe('computeAuthStoreRehydration — debugLoggingDepth', () => {
     expect(patch.debugLoggingDepth).toBe(depth);
   });
 
-  it.each([0, 4, '3', null, undefined] as const)(
+  it.each([0, 2, 4, '3', null, undefined] as const)(
     'maps invalid or missing depth %j to level 1',
     (depth) => {
       const state = { ...useAuthStore.getState(), debugLoggingDepth: depth } as unknown as AuthState;

--- a/src/store/authStoreRehydrate.test.ts
+++ b/src/store/authStoreRehydrate.test.ts
@@ -41,6 +41,27 @@ describe('computeAuthStoreRehydration — queueDurationDisplayMode', () => {
   );
 });
 
+describe('computeAuthStoreRehydration — debugLoggingDepth', () => {
+  beforeEach(resetAuthStore);
+
+  it.each([1, 2, 3] as const)('preserves valid depth %s', (depth) => {
+    const patch = computeAuthStoreRehydration({
+      ...useAuthStore.getState(),
+      debugLoggingDepth: depth,
+    });
+    expect(patch.debugLoggingDepth).toBe(depth);
+  });
+
+  it.each([0, 4, '3', null, undefined] as const)(
+    'maps invalid or missing depth %j to level 1',
+    (depth) => {
+      const state = { ...useAuthStore.getState(), debugLoggingDepth: depth } as unknown as AuthState;
+      const patch = computeAuthStoreRehydration(state);
+      expect(patch.debugLoggingDepth).toBe(1);
+    },
+  );
+});
+
 describe('computeAuthStoreRehydration — Library browse scope', () => {
   beforeEach(() => {
     resetAuthStore();
@@ -66,6 +87,26 @@ describe('computeAuthStoreRehydration — Library browse scope', () => {
 
     expect(patch.libraryBrowseServerIds).toEqual(['b']);
     expect(patch.musicFoldersByServer).toEqual({ a: [{ id: 'a1', name: 'A1' }] });
+  });
+
+  it('attaches a legacy one-server profile when the persisted scope field is absent', () => {
+    const base = useAuthStore.getState();
+    const { libraryBrowseServerIds: _missing, ...legacy } = base;
+    const server = {
+      id: 'legacy',
+      name: 'Legacy',
+      url: 'https://legacy.test',
+      username: 'u',
+      password: 'p',
+    };
+
+    const patch = computeAuthStoreRehydration({
+      ...legacy,
+      servers: [server],
+      activeServerId: server.id,
+    } as AuthState);
+
+    expect(patch.libraryBrowseServerIds).toEqual([server.id]);
   });
 });
 

--- a/src/store/authStoreRehydrate.ts
+++ b/src/store/authStoreRehydrate.ts
@@ -29,6 +29,7 @@ import type {
 } from './authStoreTypes';
 import { migrateLegacyLastfm, sanitizeAccounts } from '../music-network';
 import { deriveLibraryBrowseServerIdsWithFallback } from '@/lib/library/libraryBrowseScope';
+import { sanitizeDebugLoggingDepth } from '@/lib/perf/debugLoggingMode';
 
 /**
  * Computes the post-rehydration patch for the auth store. Runs all
@@ -298,6 +299,9 @@ export function computeAuthStoreRehydration(state: AuthState): Partial<AuthState
     musicFoldersByServer,
     libraryBrowseSelectionByServer,
     libraryBrowseScopeVersion: 0,
+    debugLoggingDepth: sanitizeDebugLoggingDepth(
+      (state as { debugLoggingDepth?: unknown }).debugLoggingDepth,
+    ),
     musicFolders: state.activeServerId ? (musicFoldersByServer[state.activeServerId] ?? []) : [],
     ...(state.startMinimizedToTray && state.showTrayIcon === false
       ? { startMinimizedToTray: false as const }

--- a/src/store/authStoreTypes.ts
+++ b/src/store/authStoreTypes.ts
@@ -1,5 +1,6 @@
 import type { HiResCrossfadeResampleHz } from '@/lib/audio/hiResCrossfadeResample';
 import type { EntityRatingSupportLevel } from '@/lib/api/subsonicTypes';
+import type { DebugLoggingDepth } from '@/lib/perf/debugLoggingMode';
 import type {
   AudiomusePluginProbeResult,
   InstantMixProbeResult,
@@ -87,6 +88,7 @@ export type DurationMode = 'total' | 'remaining' | 'eta';
  */
 export type QueueDisplayMode = 'playlist' | 'queue' | 'timeline';
 export type LoggingMode = 'off' | 'normal' | 'debug';
+export type { DebugLoggingDepth } from '@/lib/perf/debugLoggingMode';
 /**
  * Wall-clock format for ETA / sleep-timer labels. `'auto'` follows the user's
  * system locale (existing behaviour); explicit `'24h'` / `'12h'` overrides it.
@@ -231,6 +233,8 @@ export interface AuthState {
   linuxWebkitInputForceRepaint: boolean;
   /** Runtime backend logging level. */
   loggingMode: LoggingMode;
+  /** Frontend diagnostic detail emitted while runtime logging is in Debug mode. */
+  debugLoggingDepth: DebugLoggingDepth;
   nowPlayingEnabled: boolean;
   lyricsServerFirst: boolean;
   enableNeteaselyrics: boolean;
@@ -451,6 +455,7 @@ export interface AuthState {
   setLinuxWaylandTextRenderProfile: (v: LinuxWaylandTextRenderProfile) => void;
   setLinuxWebkitInputForceRepaint: (v: boolean) => void;
   setLoggingMode: (v: LoggingMode) => void;
+  setDebugLoggingDepth: (v: DebugLoggingDepth) => void;
   setNowPlayingEnabled: (v: boolean) => void;
   setLyricsServerFirst: (v: boolean) => void;
   setEnableNeteaselyrics: (v: boolean) => void;


### PR DESCRIPTION
## Summary

- repair legacy empty Library scope state when adding another server, so multi-server browse and New Releases do not silently resolve to no selected servers
- apply the active-server fallback consistently to music-folder discovery and local New Releases reads
- add permanent redacted multi-server diagnostics with persisted basic / verbose depth, exposed in Settings and PsyLab only while Debug logging is active
- subscribe AppShell to detailed reachability transitions only while verbose diagnostics are enabled
- keep single-scope Artist browse responsive while a first-run identity rebuild completes in the background
- cover scope repair, fallback behavior, persisted debug depth, redaction, diagnostic gating, reachability subscription gating, and first-run Artist browse with regression tests

## User impact

Existing profiles that retained an empty `libraryBrowseServerIds` array can browse their configured servers again after adding another server. New Releases and music-folder discovery no longer collapse to an empty result in that state. Artist browse no longer waits for a full identity rebuild on the first launch after upgrading an existing large library.

Advanced diagnostics offer basic level 1 and verbose level 3 without exposing credentials or sensitive URL data. The full reachability snapshot is subscribed only while verbose diagnostics are active, so default AppShell renders do not pay for off-by-default logging.

## Verification

- `npm run lint`
- `npm run dep:check`
- `npm test` (491 files, 3403 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh` (15/15 files pass)
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Scope notes

- Mixed frontend + Rust library change; no Tauri command, event, or payload contract changes.
- Persisted debug depth is backward-compatible and sanitised during rehydrate; the unused level 2 maps to basic level 1.
- All shipped locales include the debug-depth copy.
