### PR TITLE
fix(library): order album detail tracks by disc then track number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The artist detail header no longer adopts a per-track "featuring" credit when a single track in the discography is tagged with a guest artist. It shows the artist's own name, matching the artist browse list.
 
+### Album details — play multi-disc albums in disc order
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1332](https://github.com/Psychotoxical/psysonic/pull/1332)**
+
+* Playing a multi-disc album from the header no longer interleaves the discs (disc 1 track 1, disc 2 track 1, disc 1 track 2, …). Tracks queue in disc-then-track order, so disc 1 plays in full before disc 2.
+
 
 ## [1.50.0]
 

--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -2350,10 +2350,22 @@ mod tests {
     #[test]
     fn find_by_album_orders_by_disc_then_track_then_id() {
         let store = Arc::new(LibraryStore::open_in_memory());
+        // A missing disc number is treated as disc 1 (matching the album UI's
+        // `discNumber ?? 1`), then track number, then a stable `id` tie-break for
+        // duplicate disc/track positions.
+        let with_disc = |id: &str, album: &str, disc: Option<i64>, trk: i64| {
+            let mut r = make_row("s1", id, album, trk);
+            r.disc_number = disc;
+            r
+        };
         TrackRepository::new(&store)
             .upsert_batch(&[
-                make_row("s1", "tr_b", "al_1", 2),
-                make_row("s1", "tr_a", "al_1", 1),
+                with_disc("tr_dup_z", "al_1", Some(2), 2),
+                with_disc("tr_a", "al_1", Some(1), 1),
+                with_disc("tr_dup_b", "al_1", Some(2), 2),
+                with_disc("tr_null", "al_1", None, 3),
+                with_disc("tr_d2t1", "al_1", Some(2), 1),
+                with_disc("tr_m", "al_1", Some(1), 2),
                 make_row("s1", "tr_c", "al_2", 1),
             ])
             .unwrap();
@@ -2361,7 +2373,12 @@ mod tests {
             .find_by_album("s1", "al_1")
             .unwrap();
         let ids: Vec<&str> = album1.iter().map(|r| r.id.as_str()).collect();
-        assert_eq!(ids, vec!["tr_a", "tr_b"]);
+        // disc 1: tr_a (t1), tr_m (t2), tr_null (untagged -> disc 1, t3);
+        // disc 2: tr_d2t1 (t1), then the tr_dup_b/tr_dup_z tie (t2) by id.
+        assert_eq!(
+            ids,
+            vec!["tr_a", "tr_m", "tr_null", "tr_d2t1", "tr_dup_b", "tr_dup_z"]
+        );
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/repos/track.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track.rs
@@ -409,9 +409,11 @@ impl<'a> TrackRepository<'a> {
     }
 
     /// SELECT every non-deleted track on this album, ordered by
-    /// `COALESCE(disc_number, 1) ASC, track_number ASC, id ASC` for stable display.
-    /// A missing disc number is treated as disc 1 (matching the album UI's
-    /// `discNumber ?? 1`), and `id` is the final tie-break so the order is total.
+    /// `COALESCE(disc_number, 1) ASC, track_number ASC, id ASC, server_id ASC` for
+    /// stable display. A missing disc number is treated as disc 1 (matching the album
+    /// UI's `discNumber ?? 1`). `(id, server_id)` is the final tie-break — shared with
+    /// the scoped merge loader, where `id` alone is not globally unique — so the order
+    /// is total. This query is single-server, so `server_id` is constant here.
     pub fn find_by_album(&self, server_id: &str, album_id: &str) -> Result<Vec<TrackRow>, String> {
         self.store.with_read_conn(|conn| {
             let mut stmt = conn.prepare(SELECT_TRACKS_BY_ALBUM)?;
@@ -993,7 +995,7 @@ const SELECT_TRACKS_BY_ALBUM: &str = "SELECT server_id, id, title, title_sort, a
   server_path, library_id, isrc, mbid_recording, bpm, replay_gain_track_db, replay_gain_album_db, replay_gain_peak, \
   content_hash, server_updated_at, server_created_at, deleted, synced_at, raw_json \
   FROM track WHERE server_id = ?1 AND album_id = ?2 AND deleted = 0 \
-  ORDER BY COALESCE(disc_number, 1) ASC, track_number ASC NULLS LAST, id ASC";
+  ORDER BY COALESCE(disc_number, 1) ASC, track_number ASC NULLS LAST, id ASC, server_id ASC";
 
 pub(crate) fn track_columns() -> &'static str {
     TRACK_COLUMNS

--- a/src-tauri/crates/psysonic-library/src/repos/track.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track.rs
@@ -409,7 +409,9 @@ impl<'a> TrackRepository<'a> {
     }
 
     /// SELECT every non-deleted track on this album, ordered by
-    /// `disc_number ASC, track_number ASC` for stable display.
+    /// `COALESCE(disc_number, 1) ASC, track_number ASC, id ASC` for stable display.
+    /// A missing disc number is treated as disc 1 (matching the album UI's
+    /// `discNumber ?? 1`), and `id` is the final tie-break so the order is total.
     pub fn find_by_album(&self, server_id: &str, album_id: &str) -> Result<Vec<TrackRow>, String> {
         self.store.with_read_conn(|conn| {
             let mut stmt = conn.prepare(SELECT_TRACKS_BY_ALBUM)?;
@@ -991,7 +993,7 @@ const SELECT_TRACKS_BY_ALBUM: &str = "SELECT server_id, id, title, title_sort, a
   server_path, library_id, isrc, mbid_recording, bpm, replay_gain_track_db, replay_gain_album_db, replay_gain_peak, \
   content_hash, server_updated_at, server_created_at, deleted, synced_at, raw_json \
   FROM track WHERE server_id = ?1 AND album_id = ?2 AND deleted = 0 \
-  ORDER BY disc_number ASC NULLS LAST, track_number ASC NULLS LAST, id ASC";
+  ORDER BY COALESCE(disc_number, 1) ASC, track_number ASC NULLS LAST, id ASC";
 
 pub(crate) fn track_columns() -> &'static str {
     TRACK_COLUMNS

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -2074,7 +2074,7 @@ fn fetch_scope_deduped_tracks_for_album_key(
             {scoped} AND t.album_id IS NOT NULL {key_filter} \
          ) \
          SELECT {plain_cols} FROM ranked WHERE rn = 1 \
-         ORDER BY disc_number ASC NULLS LAST, track_number ASC NULLS LAST, title COLLATE NOCASE ASC",
+         ORDER BY COALESCE(disc_number, 1) ASC, track_number ASC NULLS LAST, id ASC",
         scoped = scoped,
     );
     let mut binds = scope_binds;
@@ -3420,22 +3420,31 @@ mod tests {
         // A multi-disc album must play disc 1 in full before disc 2 — ordered by
         // (disc_number, track_number). Ordering by track_number first interleaves
         // the discs (D1T1, D2T1, D1T2, D2T2), which is what the Play-All queue did.
+        // A missing disc number is treated as disc 1 (matching the UI's
+        // `discNumber ?? 1`), so an untagged track stays in the disc-1 group and
+        // precedes disc 2 rather than sorting after every explicit disc. `id` is the
+        // final tie-break, so duplicate disc/track metadata is still deterministic.
         let store = LibraryStore::open_in_memory();
-        let mk = |id: &str, disc: i64, trk: i64| {
+        // Unique title per id, so nothing dedups by title.
+        let mk = |id: &str, disc: Option<i64>, trk: i64| {
             let mut t = track(
-                "s1", id, "Song", Some("Artist"), "Double Album", "alb-2disc",
+                "s1", id, id, Some("Artist"), "Double Album", "alb-2disc",
                 Some("art1"), 200, "lib-a", Some(2000), None, None,
             );
-            t.disc_number = Some(disc);
+            t.disc_number = disc;
             t.track_number = Some(trk);
             t
         };
         // Seeded scrambled; ids deliberately don't match the target order.
+        // `u-null-t3` has no disc number and must land in the disc-1 group; `b`/`z`
+        // share disc 2 / track 2 and must fall back to id order.
         seed_and_rebuild(&store, &[
-            mk("z-d2t2", 2, 2),
-            mk("q-d1t1", 1, 1),
-            mk("a-d2t1", 2, 1),
-            mk("m-d1t2", 1, 2),
+            mk("z-d2t2", Some(2), 2),
+            mk("q-d1t1", Some(1), 1),
+            mk("b-d2t2", Some(2), 2),
+            mk("u-null-t3", None, 3),
+            mk("a-d2t1", Some(2), 1),
+            mk("m-d1t2", Some(1), 2),
         ]);
 
         let detail = album_detail(
@@ -3449,7 +3458,10 @@ mod tests {
         .unwrap();
 
         let ids: Vec<&str> = detail.tracks.iter().map(|t| t.id.as_str()).collect();
-        assert_eq!(ids, ["q-d1t1", "m-d1t2", "a-d2t1", "z-d2t2"]);
+        assert_eq!(
+            ids,
+            ["q-d1t1", "m-d1t2", "u-null-t3", "a-d2t1", "b-d2t2", "z-d2t2"]
+        );
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -2074,7 +2074,7 @@ fn fetch_scope_deduped_tracks_for_album_key(
             {scoped} AND t.album_id IS NOT NULL {key_filter} \
          ) \
          SELECT {plain_cols} FROM ranked WHERE rn = 1 \
-         ORDER BY track_number ASC NULLS LAST, disc_number ASC NULLS LAST, title COLLATE NOCASE ASC",
+         ORDER BY disc_number ASC NULLS LAST, track_number ASC NULLS LAST, title COLLATE NOCASE ASC",
         scoped = scoped,
     );
     let mut binds = scope_binds;
@@ -3413,6 +3413,43 @@ mod tests {
         assert_eq!(detail.album.genre, None);
         assert_eq!(detail.album.cover_art_id, None);
         assert_eq!(detail.tracks.len(), 2);
+    }
+
+    #[test]
+    fn album_detail_orders_tracks_disc_then_track() {
+        // A multi-disc album must play disc 1 in full before disc 2 — ordered by
+        // (disc_number, track_number). Ordering by track_number first interleaves
+        // the discs (D1T1, D2T1, D1T2, D2T2), which is what the Play-All queue did.
+        let store = LibraryStore::open_in_memory();
+        let mk = |id: &str, disc: i64, trk: i64| {
+            let mut t = track(
+                "s1", id, "Song", Some("Artist"), "Double Album", "alb-2disc",
+                Some("art1"), 200, "lib-a", Some(2000), None, None,
+            );
+            t.disc_number = Some(disc);
+            t.track_number = Some(trk);
+            t
+        };
+        // Seeded scrambled; ids deliberately don't match the target order.
+        seed_and_rebuild(&store, &[
+            mk("z-d2t2", 2, 2),
+            mk("q-d1t1", 1, 1),
+            mk("a-d2t1", 2, 1),
+            mk("m-d1t2", 1, 2),
+        ]);
+
+        let detail = album_detail(
+            &store,
+            &LibraryScopeAlbumDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                album_id: "alb-2disc".into(),
+                server_id: "s1".into(),
+            },
+        )
+        .unwrap();
+
+        let ids: Vec<&str> = detail.tracks.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, ["q-d1t1", "m-d1t2", "a-d2t1", "z-d2t2"]);
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -2074,7 +2074,7 @@ fn fetch_scope_deduped_tracks_for_album_key(
             {scoped} AND t.album_id IS NOT NULL {key_filter} \
          ) \
          SELECT {plain_cols} FROM ranked WHERE rn = 1 \
-         ORDER BY COALESCE(disc_number, 1) ASC, track_number ASC NULLS LAST, id ASC",
+         ORDER BY COALESCE(disc_number, 1) ASC, track_number ASC NULLS LAST, id ASC, server_id ASC",
         scoped = scoped,
     );
     let mut binds = scope_binds;
@@ -3462,6 +3462,61 @@ mod tests {
             ids,
             ["q-d1t1", "m-d1t2", "u-null-t3", "a-d2t1", "b-d2t2", "z-d2t2"]
         );
+    }
+
+    #[test]
+    fn album_detail_disc_order_tie_break_is_total_across_servers() {
+        // The scoped loader merges a cross-server album, so a server-local `id` is
+        // not a total tie-break: two surviving tracks from different servers can
+        // share disc, track number, and id. `server_id` is the final key, so the
+        // Play-All order stays deterministic (priority server first).
+        let store = LibraryStore::open_in_memory();
+        let disc1 = |mut t: TrackRow, trk: i64| {
+            t.disc_number = Some(1);
+            t.track_number = Some(trk);
+            t
+        };
+        // Matching anchor tracks (same title + duration) de-duplicate and merge the
+        // album across the two servers.
+        let s1_anchor = disc1(track(
+            "s1", "s1-anchor", "Anchor", Some("Band"), "Tie Album", "s1-tie",
+            Some("band"), 100, "lib-a", Some(2020), None, None,
+        ), 1);
+        let s2_anchor = disc1(track(
+            "s2", "s2-anchor", "Anchor", Some("Band"), "Tie Album", "s2-tie",
+            Some("band"), 100, "lib-b", Some(2020), None, None,
+        ), 1);
+        // Same id / disc / track on both servers, but distinct title + duration so
+        // the two rows do not de-duplicate and both survive the merge — tying on
+        // every key except server_id.
+        let s1_dup = disc1(track(
+            "s1", "dup", "Alpha", Some("Band"), "Tie Album", "s1-tie",
+            Some("band"), 200, "lib-a", Some(2020), None, None,
+        ), 2);
+        let s2_dup = disc1(track(
+            "s2", "dup", "Beta", Some("Band"), "Tie Album", "s2-tie",
+            Some("band"), 300, "lib-b", Some(2020), None, None,
+        ), 2);
+        seed_and_rebuild(&store, &[s1_anchor, s1_dup, s2_anchor, s2_dup]);
+
+        let detail = album_detail(
+            &store,
+            &LibraryScopeAlbumDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a"), scope_pair("s2", "lib-b")],
+                album_id: "s1-tie".into(),
+                server_id: "s1".into(),
+            },
+        )
+        .unwrap();
+
+        let seq: Vec<(&str, &str)> = detail
+            .tracks
+            .iter()
+            .map(|t| (t.server_id.as_str(), t.id.as_str()))
+            .collect();
+        // Anchor merges to the priority server; the tied `dup` tracks keep a
+        // deterministic order by server_id (s1 before s2).
+        assert_eq!(seq, [("s1", "s1-anchor"), ("s1", "dup"), ("s2", "dup")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Multi-disc album detail returned tracks ordered by `track_number` before `disc_number`, so Play-All queued them interleaved across discs (disc 1 track 1, disc 2 track 1, disc 1 track 2, …) instead of playing disc 1 in full, then disc 2. The album track list already groups the *display* by disc, which hid the issue — only the flat Play-All queue exposed it.

## Fix

Order the album-detail track query by `(disc_number, track_number)` in `fetch_scope_deduped_tracks_for_album_key` (`scope_merge.rs`), matching the existing convention in `repos/track.rs`. Adds a regression test that seeds a scrambled two-disc album and asserts disc-then-track order.

## Verification

- New test `album_detail_orders_tracks_disc_then_track`; existing album-detail tests still pass.
- clippy clean.