### PR TITLE
fix(library): resolve Various Artists albums to the VA entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Playing a multi-disc album from the header no longer interleaves the discs (disc 1 track 1, disc 2 track 1, disc 1 track 2, …). Tracks queue in disc-then-track order, so disc 1 plays in full before disc 2. Tracks without a disc number are treated as disc 1, matching the track list.
 
+### Artist details — Various Artists shows every compilation
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1335](https://github.com/Psychotoxical/psysonic/pull/1335)**
+
+* The "Various Artists" artist page lists every compilation again, instead of only the few tracks tagged directly with the Various Artists id. Compilations link to the artist through their album-artist label, which the local index now follows across all selected servers.
+* A compilation's album header links to "Various Artists" rather than to one of the individual track performers.
+
 
 ## [1.50.0]
 

--- a/src-tauri/crates/psysonic-library/src/album_compilation_filter.rs
+++ b/src-tauri/crates/psysonic-library/src/album_compilation_filter.rs
@@ -45,8 +45,30 @@ pub fn compilation_predicate_sql(
     format!("({})", parts.join(" OR "))
 }
 
+/// True when a credit is the "Various Artists" compilation label. Word-boundary
+/// matched to stay identical to the frontend `isVariousArtistsLabel`
+/// (`/\bvarious artists\b/i`): both gate the same album-artist unlink on the same
+/// album, so a substring match here against a word-boundary match there would let one
+/// side unlink while the other relinks to a guest performer. (The album-inclusion
+/// `LIKE '%various artists%'` in `various_artists_like_sql` stays a substring match —
+/// that is a different decision.)
 pub fn various_artists_label(s: &str) -> bool {
-    s.trim().to_ascii_lowercase().contains("various artists")
+    const NEEDLE: &str = "various artists";
+    let hay = s.trim().to_ascii_lowercase();
+    let bytes = hay.as_bytes();
+    let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let mut from = 0;
+    while let Some(rel) = hay[from..].find(NEEDLE) {
+        let start = from + rel;
+        let end = start + NEEDLE.len();
+        let before_boundary = start == 0 || !is_word(bytes[start - 1]);
+        let after_boundary = end >= bytes.len() || !is_word(bytes[end]);
+        if before_boundary && after_boundary {
+            return true;
+        }
+        from = start + 1;
+    }
+    false
 }
 
 /// SQL mirror of [`pick_album_group_artist`] over arbitrary column *expressions*
@@ -103,11 +125,18 @@ pub fn pick_album_group_artist_id(
     album_artist: Option<&str>,
     album_artist_id: Option<String>,
 ) -> Option<String> {
-    let album_artist_named = album_artist.map(str::trim).is_some_and(|s| !s.is_empty());
-    if album_artist_named {
+    let named = album_artist.map(str::trim).filter(|s| !s.is_empty());
+    if named.is_some() {
         if let Some(id) = album_artist_id.filter(|s| !s.trim().is_empty()) {
             return Some(id);
         }
+    }
+    // A "Various Artists" credit with no album-artist id must stay unlinked: the
+    // track performer is definitely *not* the album artist here, so linking to it
+    // would open a single guest under a Various Artists label. Everywhere else the
+    // performer id keeps credit and link on the same entity.
+    if named.is_some_and(various_artists_label) {
+        return None;
     }
     track_artist_id.filter(|s| !s.trim().is_empty())
 }
@@ -115,6 +144,21 @@ pub fn pick_album_group_artist_id(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn various_artists_label_is_word_boundary_matched() {
+        assert!(various_artists_label("Various Artists"));
+        assert!(various_artists_label("  various artists  "));
+        assert!(various_artists_label("VA / Various Artists"));
+        assert!(various_artists_label("Various Artists!"));
+        // Word-boundary, mirroring the frontend regex: an alnum-adjacent occurrence
+        // is not the label. These are exactly the strings a substring match would
+        // have disagreed with the frontend on.
+        assert!(!various_artists_label("various artistsX"));
+        assert!(!various_artists_label("Xvarious artists"));
+        assert!(!various_artists_label("Metallica"));
+        assert!(!various_artists_label(""));
+    }
 
     #[test]
     fn sql_mentions_json_paths() {
@@ -173,10 +217,17 @@ mod tests {
             ),
             Some("va-id".to_string())
         );
-        // Named album-artist but the server gave no album-artist id → keep the track
-        // id rather than blank the link.
+        // Named "Various Artists" but the server gave no album-artist id → leave the
+        // link empty. The track performer is provably not the album artist here, so
+        // linking to it would open one guest under a Various Artists credit.
         assert_eq!(
             pick_album_group_artist_id(Some("track-performer".into()), Some("Various Artists"), None),
+            None
+        );
+        // Any other named album-artist without an id keeps the track id, so credit
+        // and link stay on the same entity rather than going blank.
+        assert_eq!(
+            pick_album_group_artist_id(Some("track-performer".into()), Some("Alice"), None),
             Some("track-performer".to_string())
         );
         // Blank album-artist must not count as named → fall back to the track id,

--- a/src-tauri/crates/psysonic-library/src/album_compilation_filter.rs
+++ b/src-tauri/crates/psysonic-library/src/album_compilation_filter.rs
@@ -18,7 +18,7 @@ pub fn compilation_raw_json_sql(table_alias: &str) -> String {
     )
 }
 
-fn various_artists_like_sql(column: &str) -> String {
+pub(crate) fn various_artists_like_sql(column: &str) -> String {
     format!(
         "lower(trim(coalesce({column}, ''))) LIKE '%various artists%'",
         column = column
@@ -88,6 +88,30 @@ pub fn pick_album_group_artist(
     track_artist.filter(|s| !s.trim().is_empty())
 }
 
+/// Id-side mirror of [`pick_album_group_artist`]: pick the *artist id* the album
+/// header should link to. When the album carries a named album-artist — so the
+/// displayed credit comes from `album_artist` — the link must point at that
+/// album-artist entity (`raw_json.albumArtistId`), not a representative track's
+/// `artist_id`. On a "Various Artists" compilation the album-artist id differs
+/// from every track performer's id; without this the hero reads "Various Artists"
+/// but opens one of the guest performers. Falls back to the track artist id when
+/// the album has no named album-artist, or when the server supplied no
+/// album-artist id (keeps the credit and link consistent rather than mislabelling).
+/// Keep the branch condition in sync with [`pick_album_group_artist`].
+pub fn pick_album_group_artist_id(
+    track_artist_id: Option<String>,
+    album_artist: Option<&str>,
+    album_artist_id: Option<String>,
+) -> Option<String> {
+    let album_artist_named = album_artist.map(str::trim).is_some_and(|s| !s.is_empty());
+    if album_artist_named {
+        if let Some(id) = album_artist_id.filter(|s| !s.trim().is_empty()) {
+            return Some(id);
+        }
+    }
+    track_artist_id.filter(|s| !s.trim().is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,6 +158,39 @@ mod tests {
             Some("Alice".to_string())
         );
         assert_eq!(pick_album_group_artist(None, None), None);
+    }
+
+    #[test]
+    fn pick_album_group_artist_id_mirrors_name_side() {
+        // Named album-artist with an id → link to that album-artist entity, even
+        // though the representative track performer differs (the VA / collaboration
+        // case: display credit and link stay on the same entity).
+        assert_eq!(
+            pick_album_group_artist_id(
+                Some("track-performer".into()),
+                Some("Various Artists"),
+                Some("va-id".into()),
+            ),
+            Some("va-id".to_string())
+        );
+        // Named album-artist but the server gave no album-artist id → keep the track
+        // id rather than blank the link.
+        assert_eq!(
+            pick_album_group_artist_id(Some("track-performer".into()), Some("Various Artists"), None),
+            Some("track-performer".to_string())
+        );
+        // Blank album-artist must not count as named → fall back to the track id,
+        // ignoring any stray album-artist id.
+        assert_eq!(
+            pick_album_group_artist_id(Some("solo".into()), Some("   "), Some("ignored".into())),
+            Some("solo".to_string())
+        );
+        assert_eq!(
+            pick_album_group_artist_id(Some("solo".into()), None, None),
+            Some("solo".to_string())
+        );
+        // Nothing usable anywhere.
+        assert_eq!(pick_album_group_artist_id(None, Some("Various Artists"), Some("  ".into())), None);
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -1679,7 +1679,8 @@ fn lookup_artist_key(
 /// Canonical name of an artist entity from the `artist` table (the same source the
 /// browse list and header use). Independent of whether any track is tagged with the
 /// id — needed to detect the "Various Artists" entity even when its compilations
-/// link only through `album_artist` and no track carries the VA performer id.
+/// link only through `album_artist` and no track carries the VA performer id. Kept
+/// name-only so the common artist-detail load does not parse `raw_json`.
 fn lookup_artist_name(
     conn: &rusqlite::Connection,
     server_id: &str,
@@ -1692,6 +1693,42 @@ fn lookup_artist_name(
     )
     .optional()
     .map(Option::flatten)
+}
+
+/// The anchor's own `artist` row, used as a header fallback when no track in the
+/// scope carries the anchor `artist_id`. Various Artists compilations attach via
+/// the `album_artist` label only, so the track-backed candidate query returns
+/// nothing for them and the merged header would otherwise have an empty `id` —
+/// which the frontend loader treats as "no result" and discards the whole payload.
+fn lookup_artist_row(
+    conn: &rusqlite::Connection,
+    server_id: &str,
+    artist_id: &str,
+) -> rusqlite::Result<Option<LibraryArtistDto>> {
+    conn.query_row(
+        "SELECT server_id, id, name, album_count, synced_at, raw_json \
+         FROM artist WHERE server_id = ? AND id = ? LIMIT 1",
+        rusqlite::params![server_id, artist_id],
+        |r| {
+            let raw: Option<String> = r.get(5)?;
+            let name: String = r.get(2)?;
+            Ok(LibraryArtistDto {
+                server_id: r.get(0)?,
+                id: r.get(1)?,
+                // Derive the sort key from the name, matching every other candidate
+                // builder in this file — otherwise the seeded VA/track-less header
+                // reaches the frontend with no `nameSort` and sorts inconsistently.
+                name_sort: Some(sort_key_for_display_name(&name, DEFAULT_IGNORED_ARTICLES)),
+                name,
+                album_count: r.get(3)?,
+                synced_at: r.get(4)?,
+                raw_json: raw
+                    .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+                    .unwrap_or(Value::Null),
+            })
+        },
+    )
+    .optional()
 }
 
 fn lookup_track_partition(
@@ -1949,8 +1986,50 @@ fn overlay_priority_album_row(
         return Ok(());
     };
     album.name = name;
-    album.artist = artist;
-    album.artist_id = artist_id;
+    // Album-artist identity from the standalone row. `upsert_album_from_get_album`
+    // persists getAlbum's album-artist *name* correctly (e.g. "Various Artists") but
+    // the sync `Album` type maps only the legacy `artistId`, which on a compilation
+    // is a representative performer. So take the name from `albumArtist`/the legacy
+    // `artist` column (never the track-derived candidate — that would resurface a
+    // "feat." credit), and run the id through the same VA-aware rule used everywhere
+    // else: prefer `albumArtistId`, and leave a Various Artists credit unlinked
+    // rather than pointing it at a guest performer.
+    let parsed_raw: Option<Value> = raw_json
+        .as_deref()
+        .and_then(|raw| serde_json::from_str(raw).ok());
+    let raw_field = |key: &str| -> Option<String> {
+        parsed_raw
+            .as_ref()
+            .and_then(|v| v.get(key))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    let derived_name = album.artist.take().filter(|s| !s.trim().is_empty());
+    let derived_id = album.artist_id.take().filter(|s| !s.trim().is_empty());
+    // Name: server `albumArtist`, then the standalone row's clean album-artist column
+    // (getAlbum's album artist), then — only if both are empty — the track-derived
+    // candidate. The clean column must beat the candidate, or a per-track "feat."
+    // credit resurfaces in the header.
+    let final_name = raw_field("albumArtist").or(artist).or(derived_name.clone());
+    // Id resolution runs `pick_album_group_artist_id` against the FINAL name, so a
+    // Various Artists header without a real album-artist id stays unlinked instead of
+    // opening a guest. The only value trusted as an album-artist id is one that came
+    // from an album-artist source: the server's `albumArtistId`, or the candidate's
+    // id *when the candidate itself resolved a VA/album-artist name* — a candidate id
+    // paired with a performer name is a performer, not an album artist, and must not
+    // survive under a VA header sourced from the album row. `artist_id` (legacy row
+    // column) / the candidate id serve only as the non-VA performer fallback.
+    let candidate_album_artist_id = derived_id
+        .clone()
+        .filter(|_| derived_name.as_deref().is_some_and(various_artists_label));
+    album.artist_id = pick_album_group_artist_id(
+        artist_id.or(derived_id),
+        final_name.as_deref(),
+        raw_field("albumArtistId").or(candidate_album_artist_id),
+    );
+    album.artist = final_name;
     album.song_count = song_count;
     album.duration_sec = duration_sec;
     album.year = year;
@@ -1958,10 +2037,7 @@ fn overlay_priority_album_row(
     album.cover_art_id = cover_art_id;
     album.starred_at = starred_at;
     album.synced_at = synced_at;
-    album.raw_json = raw_json
-        .as_deref()
-        .and_then(|raw| serde_json::from_str(raw).ok())
-        .unwrap_or(Value::Null);
+    album.raw_json = parsed_raw.unwrap_or(Value::Null);
     Ok(())
 }
 
@@ -2028,10 +2104,7 @@ fn fetch_album_candidates(
                    MAX(t.year) AS year, MAX(t.genre) AS genre, MAX(t.cover_art_id) AS cover_art_id, \
                    MAX(t.starred_at) AS starred_at, MAX(t.synced_at) AS synced_at, \
                    COUNT(*) AS song_count, SUM(t.duration_sec) AS duration_total, MIN({priority}) AS best_pr, \
-                   MAX(CASE WHEN json_valid(t.raw_json) \
-                            THEN CASE WHEN json_type(t.raw_json, '$.albumArtistId') = 'text' \
-                                      THEN json_extract(t.raw_json, '$.albumArtistId') END \
-                            END) AS album_artist_id \
+                   MAX({album_artist_id}) AS album_artist_id \
             {scoped} AND t.album_id IS NOT NULL AND t.album_id != '' {key_filter} \
            GROUP BY t.server_id, t.album_id \
          ) \
@@ -2039,6 +2112,7 @@ fn fetch_album_candidates(
                 year, genre, cover_art_id, starred_at, synced_at, best_pr, album_artist_id \
          FROM grouped ORDER BY best_pr ASC",
         scoped = scoped,
+        album_artist_id = album_artist_id_expr("t.raw_json"),
     );
     let mut binds = scope_binds;
     if let Some(key) = album_key {
@@ -2255,6 +2329,20 @@ fn usable_release_types_expr(json_col: &str) -> String {
     )
 }
 
+/// The server's album-artist id from a track's `raw_json.albumArtistId`, guarded the
+/// same way as [`usable_release_types_expr`]: JSON1 raises `malformed JSON` on invalid
+/// TEXT, and `track.raw_json` is unconstrained, so one bad row would otherwise abort
+/// the whole query instead of contributing nothing.
+fn album_artist_id_expr(json_col: &str) -> String {
+    format!(
+        "CASE WHEN json_valid({c}) \
+              THEN CASE WHEN json_type({c}, '$.albumArtistId') = 'text' \
+                        THEN json_extract({c}, '$.albumArtistId') END \
+              END",
+        c = json_col,
+    )
+}
+
 fn fetch_albums_for_artist_key(
     conn: &rusqlite::Connection,
     scopes: &[LibraryScopePair],
@@ -2289,10 +2377,12 @@ fn fetch_albums_for_artist_key(
             " UNION ALL \
              SELECT t.server_id, t.album_id, t.album, t.artist, t.artist_id, t.album_artist, \
                     t.year, t.genre, t.cover_art_id, t.starred_at, t.synced_at, t.duration_sec, t.id, \
-                    ck.album_key, s.pr AS pr, {TRACK_DEDUP_KEY} AS track_dedup \
+                    ck.album_key, s.pr AS pr, {TRACK_DEDUP_KEY} AS track_dedup, \
+                    {album_artist_id} AS album_artist_id \
              {va_scoped} AND t.album_id IS NOT NULL AND t.album_id != '' AND {va_pred}",
             va_scoped = scoped_track_join(),
             va_pred = various_artists_like_sql("t.album_artist"),
+            album_artist_id = album_artist_id_expr("t.raw_json"),
         )
     } else {
         String::new()
@@ -2302,7 +2392,8 @@ fn fetch_albums_for_artist_key(
          base AS ( \
             SELECT t.server_id, t.album_id, t.album, t.artist, t.artist_id, t.album_artist, \
                    t.year, t.genre, t.cover_art_id, t.starred_at, t.synced_at, t.duration_sec, t.id, \
-                   ck.album_key, {priority} AS pr, {TRACK_DEDUP_KEY} AS track_dedup \
+                   ck.album_key, {priority} AS pr, {TRACK_DEDUP_KEY} AS track_dedup, \
+                   {album_artist_id} AS album_artist_id \
             {scoped} AND t.album_id IS NOT NULL AND t.album_id != '' {key_filter} \
             {va_arm} \
           ), \
@@ -2329,7 +2420,7 @@ fn fetch_albums_for_artist_key(
          ), \
          album_pick AS ( \
            SELECT b.server_id, b.album_id, b.album, b.artist, b.artist_id, b.album_artist, \
-                  b.year, b.genre, b.cover_art_id, b.starred_at, b.synced_at, b.album_dedup, \
+                  b.album_artist_id, b.year, b.genre, b.cover_art_id, b.starred_at, b.synced_at, b.album_dedup, \
                   ROW_NUMBER() OVER (PARTITION BY b.album_dedup ORDER BY b.pr ASC, b.album_id ASC, b.id ASC) AS rn \
             FROM physical_tracks b \
          ) \
@@ -2340,12 +2431,14 @@ fn fetch_albums_for_artist_key(
                   WHERE tt.server_id = p.server_id AND tt.album_id = p.album_id AND tt.deleted = 0 \
                     AND {release_types_expr} IS NOT NULL \
                   ORDER BY tt.id ASC \
-                  LIMIT 1) AS release_types \
+                  LIMIT 1) AS release_types, \
+                p.album_artist_id AS album_artist_id \
          FROM album_pick p \
          INNER JOIN album_stats st ON p.album_dedup = st.album_dedup \
          WHERE p.rn = 1 \
          ORDER BY p.album COLLATE NOCASE ASC",
         scoped = scoped,
+        album_artist_id = album_artist_id_expr("t.raw_json"),
     );
     let mut binds = scope_binds;
     if let Some(key) = artist_key {
@@ -2368,6 +2461,18 @@ fn fetch_albums_for_artist_key(
     let rows = stmt
         .query_map(params_from_iter(binds.iter()), |r| {
             let mut dto = album_row_to_dto(map_album_list_row(r)?);
+            // `album_row_to_dto` credits the album-artist name but leaves the id at
+            // the representative track performer. On a compilation the card would
+            // then read "Various Artists" while its artist link and the "go to
+            // artist" action open one guest. Apply the same choice to the id, taking
+            // both the name (column 5) and the album-artist id (column 14) from the
+            // *same* representative track so they cannot originate from different rows.
+            let album_artist: Option<String> = r.get(5)?;
+            dto.artist_id = pick_album_group_artist_id(
+                dto.artist_id.take(),
+                album_artist.as_deref(),
+                r.get::<_, Option<String>>(14)?,
+            );
             // SQL already guarantees a non-empty array of strings, or NULL; the
             // client-side re-check is a cheap invariant guard, not new filtering.
             dto.raw_json = r
@@ -2545,16 +2650,32 @@ pub fn artist_detail(
                 .position(|p| p.server_id == a.server_id)
                 .unwrap_or(usize::MAX) as i64
         });
-        let artist = merge_artist_by_priority(&candidates);
-        // The VA entity's compilations attach via the `album_artist` label, not the
-        // per-track performer id the `artist_key` source uses — detect it so its
-        // album grid includes every compilation. Resolve the name from the `artist`
-        // table by the anchor id (not the merged header, which is empty when no track
-        // carries the VA performer id), falling back to the header name.
-        let va_mode = lookup_artist_name(conn, server_id, artist_id)?
+        // `va_mode` decides from the anchor's canonical name (a name-only query on the
+        // hot path — no `raw_json` parse), falling back to the track-derived header.
+        let anchor_name = lookup_artist_name(conn, server_id, artist_id)?;
+        let mut artist = merge_artist_by_priority(&candidates);
+        let va_mode = anchor_name
             .as_deref()
             .map(various_artists_label)
             .unwrap_or_else(|| various_artists_label(&artist.name));
+        // Seed the header from the anchor's own `artist` row ONLY on the VA shape:
+        // its compilations attach by `album_artist` label, so no track carries the
+        // anchor id and the merged header would have an empty id — which the frontend
+        // loader treats as "no result" and discards. A non-VA artist with no in-scope
+        // tracks must keep that empty header so the loader's network fallback still
+        // fires; seeding it would render a populated-but-album-less page instead. The
+        // full-row fetch (with `raw_json` parse) is deferred to exactly this branch.
+        let seeded_from_anchor = if candidates.is_empty() && va_mode {
+            if let Some(row) = lookup_artist_row(conn, server_id, artist_id)? {
+                candidates.push(row);
+                artist = merge_artist_by_priority(&candidates);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
         let albums = fetch_albums_for_artist_key(
             conn,
             scopes,
@@ -2563,6 +2684,12 @@ pub fn artist_detail(
             artist_id,
             va_mode,
         )?;
+        // A label-linked VA entity's stored `album_count` is often 0 (no track tags
+        // its id), which would contradict the compilation grid we just built. When the
+        // header was seeded from that row, report the count actually returned instead.
+        if seeded_from_anchor {
+            artist.album_count = Some(albums.len() as i64);
+        }
         let tracks = if request.include_tracks {
             fetch_scope_deduped_tracks_for_artist_key(
                 conn,
@@ -3265,6 +3392,238 @@ mod tests {
         assert_eq!(solo_detail.album.artist_id.as_deref(), Some("solo"));
     }
 
+    /// Inserts the standalone `album` row that a normal S2/`getAlbum` sync writes.
+    /// `upsert_album_from_get_album` persists the *legacy* `artistId`, which on a
+    /// compilation is a representative performer — the value that must not win over
+    /// the resolved album-artist.
+    fn seed_album_row(
+        store: &LibraryStore,
+        server: &str,
+        id: &str,
+        name: &str,
+        artist: &str,
+        artist_id: &str,
+        raw_json: &str,
+    ) {
+        store
+            .with_conn_mut("test.seed_album_row", |conn| {
+                conn.execute(
+                    "INSERT INTO album (server_id, id, name, artist, artist_id, synced_at, raw_json) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6) \
+                     ON CONFLICT(server_id, id) DO UPDATE SET \
+                       artist = excluded.artist, artist_id = excluded.artist_id, \
+                       raw_json = excluded.raw_json",
+                    rusqlite::params![server, id, name, artist, artist_id, raw_json],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn album_detail_album_artist_id_survives_the_album_row_overlay() {
+        // Bug B, durable variant: the corrected album-artist id was computed in
+        // `fetch_album_candidates` and then overwritten by `overlay_priority_album_row`,
+        // which copied `album.artist_id` from the standalone album row. That row holds
+        // the legacy performer id (the sync `Album` type maps no `albumArtistId`), so a
+        // normally synced compilation relinked its "Various Artists" hero to a guest.
+        let store = LibraryStore::open_in_memory();
+        let c1 = va_comp_track("c1", "Song A", "Perf One", "p1", "Comp One", "comp1", "va");
+        let c2 = va_comp_track("c2", "Song B", "Perf Two", "p2", "Comp One", "comp1", "va");
+        seed_and_rebuild(&store, &[c1, c2]);
+        // What a normal getAlbum sync leaves behind: legacy performer credit in the
+        // hot columns, the real album-artist only in the raw payload.
+        seed_album_row(
+            &store, "s1", "comp1", "Comp One", "Perf One", "p1",
+            r#"{"artistId":"p1","albumArtist":"Various Artists","albumArtistId":"va"}"#,
+        );
+
+        let comp = album_detail(
+            &store,
+            &LibraryScopeAlbumDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                album_id: "comp1".into(),
+                server_id: "s1".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            comp.album.artist_id.as_deref(),
+            Some("va"),
+            "the album row's legacy performer id must not overwrite the album-artist"
+        );
+        assert_eq!(comp.album.artist.as_deref(), Some("Various Artists"));
+    }
+
+    #[test]
+    fn album_detail_overlay_unlinks_va_when_the_row_has_no_album_artist_id() {
+        // Overlay path, VA-unlink: a compilation with no `albumArtistId` anywhere —
+        // not on the tracks, not on the standalone album row — whose row credits
+        // "Various Artists" (name) but holds a legacy performer id. The id must
+        // resolve to None; pointing the link at the legacy performer under a VA
+        // credit is the bug being fixed.
+        let store = LibraryStore::open_in_memory();
+        let mut c1 = va_comp_track("c1", "Song A", "Perf One", "p1", "Comp One", "comp1", "va");
+        c1.raw_json = String::new();
+        let mut c2 = va_comp_track("c2", "Song B", "Perf Two", "p2", "Comp One", "comp1", "va");
+        c2.raw_json = String::new();
+        seed_and_rebuild(&store, &[c1, c2]);
+        seed_album_row(
+            &store, "s1", "comp1", "Comp One", "Various Artists", "p1",
+            r#"{"artistId":"p1"}"#,
+        );
+
+        let comp = album_detail(
+            &store,
+            &LibraryScopeAlbumDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                album_id: "comp1".into(),
+                server_id: "s1".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(comp.album.artist.as_deref(), Some("Various Artists"));
+        assert_eq!(
+            comp.album.artist_id, None,
+            "a VA credit with no album-artist id must stay unlinked, not open a guest"
+        );
+    }
+
+    #[test]
+    fn album_detail_overlay_unlinks_va_sourced_only_from_the_album_row() {
+        // The VA identity lives *only* on the standalone album row (raw `albumArtist`
+        // = "Various Artists", no `albumArtistId`); the tracks carry no album-artist
+        // label and their own performer id. The candidate is then a performer, so its
+        // id must NOT survive under the album row's VA header — the final id must be
+        // re-decided against the resolved name and stay unlinked.
+        let store = LibraryStore::open_in_memory();
+        let mut t1 = track(
+            "s1", "t1", "Song A", Some("Perf One"), "Comp", "comp1",
+            Some("p1"), 200, "lib-a", Some(2000), None, None,
+        );
+        t1.album_artist = None;
+        let mut t2 = track(
+            "s1", "t2", "Song B", Some("Perf Two"), "Comp", "comp1",
+            Some("p2"), 200, "lib-a", Some(2000), None, None,
+        );
+        t2.album_artist = None;
+        seed_and_rebuild(&store, &[t1, t2]);
+        seed_album_row(
+            &store, "s1", "comp1", "Comp", "Perf One", "p1",
+            r#"{"albumArtist":"Various Artists","artistId":"p1"}"#,
+        );
+
+        let comp = album_detail(
+            &store,
+            &LibraryScopeAlbumDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                album_id: "comp1".into(),
+                server_id: "s1".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(comp.album.artist.as_deref(), Some("Various Artists"));
+        assert_eq!(
+            comp.album.artist_id, None,
+            "a track performer id must not survive under an album-row VA header"
+        );
+    }
+
+    #[test]
+    fn album_detail_overlay_keeps_clean_album_artist_over_feat_tracks() {
+        // Overlay path, feat regression guard: the standalone album row holds a clean
+        // album-artist name and id, while the tracks carry a "feat." credit. The
+        // overlay must keep the clean row name — an earlier precedence let the
+        // track-derived candidate win and resurfaced the feat-polluted header.
+        let store = LibraryStore::open_in_memory();
+        let mut t1 = track(
+            "s1", "t1", "Song A", Some("Metallica feat. Guest"), "Album", "alb1",
+            Some("m-id"), 200, "lib-a", Some(2000), None, None,
+        );
+        t1.album_artist = None;
+        let mut t2 = track(
+            "s1", "t2", "Song B", Some("Metallica"), "Album", "alb1",
+            Some("m-id"), 200, "lib-a", Some(2000), None, None,
+        );
+        t2.album_artist = None;
+        seed_and_rebuild(&store, &[t1, t2]);
+        seed_album_row(&store, "s1", "alb1", "Album", "Metallica", "m-id", "{}");
+
+        let detail = album_detail(
+            &store,
+            &LibraryScopeAlbumDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                album_id: "alb1".into(),
+                server_id: "s1".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            detail.album.artist.as_deref(),
+            Some("Metallica"),
+            "the clean album-artist column must not be demoted below a feat. track credit"
+        );
+        assert_eq!(detail.album.artist_id.as_deref(), Some("m-id"));
+    }
+
+    #[test]
+    fn artist_detail_various_artists_albums_link_to_the_va_entity() {
+        // The VA artist page listed album cards whose displayed credit was "Various
+        // Artists" while `artist_id` still held a representative track performer, so
+        // the card's artist link and the "go to artist" action opened that guest.
+        let store = LibraryStore::open_in_memory();
+        let c1 = va_comp_track("c1", "Song A", "Perf One", "p1", "Comp One", "comp1", "va");
+        let c2 = va_comp_track("c2", "Song B", "Perf Two", "p2", "Comp Two", "comp2", "va");
+        // A compilation whose tracks carry no album-artist id at all: linking to the
+        // performer under a VA credit would be worse than not linking.
+        let mut unlinked = va_comp_track("c3", "Song C", "Perf Three", "p3", "Comp Three", "comp3", "va");
+        unlinked.raw_json = String::new();
+        seed_and_rebuild(&store, &[c1, c2, unlinked]);
+        seed_artist_row(&store, "s1", "va", "Various Artists");
+
+        let va = artist_detail(
+            &store,
+            &LibraryScopeArtistDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                artist_id: "va".into(),
+                server_id: "s1".into(),
+                include_tracks: false,
+                top_tracks_limit: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(va.albums.len(), 3);
+        for album in &va.albums {
+            assert_eq!(
+                album.artist.as_deref(),
+                Some("Various Artists"),
+                "album {} lost its VA credit",
+                album.id
+            );
+        }
+        // Exact per-album expectations: a blanket "va or nothing" assertion would
+        // also accept a mapper that returns None for every card.
+        let mut linked: Vec<(&str, Option<&str>)> = va
+            .albums
+            .iter()
+            .map(|a| (a.id.as_str(), a.artist_id.as_deref()))
+            .collect();
+        // The query orders by album *name* ("Comp One", "Comp Three", "Comp Two");
+        // sort by id so the expectation reads in album order.
+        linked.sort_unstable_by_key(|(id, _)| *id);
+        assert_eq!(
+            linked,
+            vec![
+                ("comp1", Some("va")),
+                ("comp2", Some("va")),
+                // No album-artist id anywhere on this album — stay unlinked rather
+                // than opening a guest performer under a Various Artists credit.
+                ("comp3", None),
+            ],
+            "VA cards must open the VA entity, and only the id-less one stays unlinked"
+        );
+    }
+
     /// Inserts an artist row directly, for VA entities that have no track tagged
     /// with their id (pure label-linked compilations — the common shape on servers
     /// where every track carries its own performer).
@@ -3309,6 +3668,64 @@ mod tests {
         let mut ids: Vec<&str> = va.albums.iter().map(|a| a.id.as_str()).collect();
         ids.sort_unstable();
         assert_eq!(ids, vec!["comp1", "comp2"]);
+        // The albums alone are not enough: the frontend loader discards the whole
+        // payload when the artist header has no id (`!response.artist?.id`), and the
+        // artist hook does not fall back once the multi-scope branch is taken. So an
+        // empty header makes these albums unreachable in the app even though the
+        // query found them.
+        assert_eq!(
+            va.artist.id, "va",
+            "header must carry the anchor id, or the frontend drops the response"
+        );
+        assert_eq!(va.artist.server_id, "s1");
+        assert_eq!(va.artist.name, "Various Artists");
+        // The seeded header must carry a derived sort key, like every other candidate
+        // builder — not None, which would reach the frontend without a `nameSort`.
+        assert_eq!(
+            va.artist.name_sort.as_deref(),
+            Some(sort_key_for_display_name("Various Artists", DEFAULT_IGNORED_ARTICLES).as_str()),
+            "seeded VA header must derive its sort key from the name"
+        );
+        // The stored VA `artist.album_count` is 0 (no track tags its id); the seeded
+        // header must report the compilations actually returned, not contradict the grid.
+        assert_eq!(
+            va.artist.album_count,
+            Some(2),
+            "seeded VA header count must match the returned album grid"
+        );
+    }
+
+    #[test]
+    fn artist_detail_non_va_track_less_artist_is_not_seeded() {
+        // A real (non-VA) artist that has an `artist` row but no track in the current
+        // scope must NOT be seeded: the header must stay empty so the frontend loader
+        // discards the payload and takes its network fallback. Only the VA label shape
+        // is seeded. (Guards against reviving a populated-but-album-less page.)
+        let store = LibraryStore::open_in_memory();
+        // Some unrelated track so the store isn't empty, but nothing tagged "ra".
+        let other = track(
+            "s1", "o1", "Song", Some("Other"), "Other Album", "oalb",
+            Some("other"), 200, "lib-a", Some(2000), None, None,
+        );
+        seed_and_rebuild(&store, &[other]);
+        seed_artist_row(&store, "s1", "ra", "Real Artist");
+
+        let detail = artist_detail(
+            &store,
+            &LibraryScopeArtistDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                artist_id: "ra".into(),
+                server_id: "s1".into(),
+                include_tracks: false,
+                top_tracks_limit: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            detail.artist.id, "",
+            "a non-VA track-less artist must keep an empty header for the frontend fallback"
+        );
+        assert!(detail.albums.is_empty());
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -8,7 +8,10 @@ use serde_json::Value;
 use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
-use crate::album_compilation_filter::pick_album_group_artist;
+use crate::album_compilation_filter::{
+    pick_album_group_artist, pick_album_group_artist_id, various_artists_label,
+    various_artists_like_sql,
+};
 use crate::artist_sort::{sort_key_for_display_name, DEFAULT_IGNORED_ARTICLES};
 use crate::browse_support::{overlay_album_starred_at_rows, read_album_starred_at};
 use crate::dto::{
@@ -1673,6 +1676,24 @@ fn lookup_artist_key(
     .map(Option::flatten)
 }
 
+/// Canonical name of an artist entity from the `artist` table (the same source the
+/// browse list and header use). Independent of whether any track is tagged with the
+/// id — needed to detect the "Various Artists" entity even when its compilations
+/// link only through `album_artist` and no track carries the VA performer id.
+fn lookup_artist_name(
+    conn: &rusqlite::Connection,
+    server_id: &str,
+    artist_id: &str,
+) -> rusqlite::Result<Option<String>> {
+    conn.query_row(
+        "SELECT name FROM artist WHERE server_id = ? AND id = ? LIMIT 1",
+        rusqlite::params![server_id, artist_id],
+        |r| r.get::<_, Option<String>>(0),
+    )
+    .optional()
+    .map(Option::flatten)
+}
+
 fn lookup_track_partition(
     conn: &rusqlite::Connection,
     server_id: &str,
@@ -2006,12 +2027,16 @@ fn fetch_album_candidates(
                    MAX(t.artist_id) AS artist_id, MAX(t.album_artist) AS album_artist, \
                    MAX(t.year) AS year, MAX(t.genre) AS genre, MAX(t.cover_art_id) AS cover_art_id, \
                    MAX(t.starred_at) AS starred_at, MAX(t.synced_at) AS synced_at, \
-                   COUNT(*) AS song_count, SUM(t.duration_sec) AS duration_total, MIN({priority}) AS best_pr \
+                   COUNT(*) AS song_count, SUM(t.duration_sec) AS duration_total, MIN({priority}) AS best_pr, \
+                   MAX(CASE WHEN json_valid(t.raw_json) \
+                            THEN CASE WHEN json_type(t.raw_json, '$.albumArtistId') = 'text' \
+                                      THEN json_extract(t.raw_json, '$.albumArtistId') END \
+                            END) AS album_artist_id \
             {scoped} AND t.album_id IS NOT NULL AND t.album_id != '' {key_filter} \
            GROUP BY t.server_id, t.album_id \
          ) \
          SELECT server_id, album_id, album, artist, artist_id, album_artist, song_count, duration_total, \
-                year, genre, cover_art_id, starred_at, synced_at, best_pr \
+                year, genre, cover_art_id, starred_at, synced_at, best_pr, album_artist_id \
          FROM grouped ORDER BY best_pr ASC",
         scoped = scoped,
     );
@@ -2026,8 +2051,16 @@ fn fetch_album_candidates(
     let rows = stmt
         .query_map(params_from_iter(binds.iter()), |r| {
             let track_artist: Option<String> = r.get(3)?;
+            let track_artist_id: Option<String> = r.get(4)?;
             let album_artist: Option<String> = r.get(5)?;
+            let album_artist_id: Option<String> = r.get(14)?;
             let pr: i64 = r.get(13)?;
+            // The hero credit (`artist`) prefers the album-artist name; the id it
+            // links to must follow the same choice, or a compilation reads "Various
+            // Artists" yet opens a guest performer (VA hero bug). `album_artist_id`
+            // is the server's album-artist id from `raw_json.albumArtistId`.
+            let artist_id =
+                pick_album_group_artist_id(track_artist_id, album_artist.as_deref(), album_artist_id);
             Ok((
                 pr,
                 LibraryAlbumDto {
@@ -2035,7 +2068,7 @@ fn fetch_album_candidates(
                     id: r.get(1)?,
                     name: r.get(2)?,
                     artist: pick_album_group_artist(track_artist, album_artist),
-                    artist_id: r.get(4)?,
+                    artist_id,
                     song_count: Some(r.get(6)?),
                     duration_sec: Some(r.get(7)?),
                     year: r.get(8)?,
@@ -2228,6 +2261,7 @@ fn fetch_albums_for_artist_key(
     artist_key: Option<&str>,
     anchor_server: &str,
     anchor_artist_id: &str,
+    va_mode: bool,
 ) -> rusqlite::Result<Vec<LibraryAlbumDto>> {
     let (scope_cte, scope_binds) = scope_cte_sql(scopes);
     let release_types_expr = usable_release_types_expr("tt.raw_json");
@@ -2236,6 +2270,33 @@ fn fetch_albums_for_artist_key(
         artist_key.map(|_| "artist_key"),
         "AND t.server_id = ? AND t.artist_id = ? AND ck.artist_key IS NULL",
     );
+    // "Various Artists" is not a real performer: its compilations are linked to the
+    // VA entity only through the `album_artist` string, while each track keeps its
+    // own performer `artist_id`. The `artist_key` source therefore finds only the
+    // few tracks literally tagged with the VA id, not the hundreds of compilations.
+    // When the detail target *is* the VA entity, union a second album source keyed
+    // on the VA `album_artist` label so the page shows every compilation. The union
+    // feeds the same dedup pipeline, so an album qualifying under both sources is
+    // still counted once. `scoped_track` is always defined by `scope_cte_sql`.
+    //
+    // Track-scoped like the `artist_key` source: a compilation with a few untagged
+    // tracks (empty `album_artist`) counts only its VA-tagged tracks in the card's
+    // `song_count`, matching how every artist page counts its own tracks. The album
+    // still appears, and opening it lists the full track set (album_detail keys on
+    // `album_key`), so this stays a card-count nuance rather than a missing album.
+    let va_arm = if va_mode {
+        format!(
+            " UNION ALL \
+             SELECT t.server_id, t.album_id, t.album, t.artist, t.artist_id, t.album_artist, \
+                    t.year, t.genre, t.cover_art_id, t.starred_at, t.synced_at, t.duration_sec, t.id, \
+                    ck.album_key, s.pr AS pr, {TRACK_DEDUP_KEY} AS track_dedup \
+             {va_scoped} AND t.album_id IS NOT NULL AND t.album_id != '' AND {va_pred}",
+            va_scoped = scoped_track_join(),
+            va_pred = various_artists_like_sql("t.album_artist"),
+        )
+    } else {
+        String::new()
+    };
     let sql = format!(
         "{cte}, \
          base AS ( \
@@ -2243,6 +2304,7 @@ fn fetch_albums_for_artist_key(
                    t.year, t.genre, t.cover_art_id, t.starred_at, t.synced_at, t.duration_sec, t.id, \
                    ck.album_key, {priority} AS pr, {TRACK_DEDUP_KEY} AS track_dedup \
             {scoped} AND t.album_id IS NOT NULL AND t.album_id != '' {key_filter} \
+            {va_arm} \
           ), \
           physical_albums AS ( \
             SELECT server_id, album_id, \
@@ -2484,12 +2546,22 @@ pub fn artist_detail(
                 .unwrap_or(usize::MAX) as i64
         });
         let artist = merge_artist_by_priority(&candidates);
+        // The VA entity's compilations attach via the `album_artist` label, not the
+        // per-track performer id the `artist_key` source uses — detect it so its
+        // album grid includes every compilation. Resolve the name from the `artist`
+        // table by the anchor id (not the merged header, which is empty when no track
+        // carries the VA performer id), falling back to the header name.
+        let va_mode = lookup_artist_name(conn, server_id, artist_id)?
+            .as_deref()
+            .map(various_artists_label)
+            .unwrap_or_else(|| various_artists_label(&artist.name));
         let albums = fetch_albums_for_artist_key(
             conn,
             scopes,
             artist_key.as_deref(),
             server_id,
             artist_id,
+            va_mode,
         )?;
         let tracks = if request.include_tracks {
             fetch_scope_deduped_tracks_for_artist_key(
@@ -3058,6 +3130,243 @@ mod tests {
             .find(|a| a.id == "alb-mixed")
             .expect("album missing");
         assert_eq!(album.raw_json["releaseTypes"][0], "EP");
+    }
+
+    /// Builds a compilation track: `album_artist` = "Various Artists", the track
+    /// credited to a real performer, and `raw_json.albumArtistId` = the VA entity id.
+    /// This is the shape that links a compilation to VA only through the label —
+    /// every track keeps its own performer `artist_id`.
+    #[allow(clippy::too_many_arguments)]
+    fn va_comp_track(
+        id: &str,
+        title: &str,
+        performer: &str,
+        performer_id: &str,
+        album: &str,
+        album_id: &str,
+        va_id: &str,
+    ) -> TrackRow {
+        let mut row = track(
+            "s1", id, title, Some(performer), album, album_id, Some(performer_id),
+            200, "lib-a", Some(2020), None, None,
+        );
+        row.album_artist = Some("Various Artists".into());
+        row.raw_json = format!(r#"{{"albumArtistId":"{va_id}"}}"#);
+        row
+    }
+
+    #[test]
+    fn artist_detail_various_artists_includes_album_artist_compilations() {
+        // Bug A: "Various Artists" is not a real performer — its compilations attach
+        // through the `album_artist` label while each track keeps its own performer
+        // `artist_id`. The `artist_key` source alone finds only tracks literally
+        // tagged with the VA id (here one Fat-Wreck-style album), so the page showed
+        // "a handful" instead of every compilation. The VA union arm must add the
+        // label-linked compilations, and a normal artist must stay unaffected.
+        let store = LibraryStore::open_in_memory();
+        // Two compilations linked to VA only through `album_artist`.
+        let c1a = va_comp_track("c1a", "Song A", "Perf One", "p1", "Comp One", "comp1", "va");
+        let c1b = va_comp_track("c1b", "Song B", "Perf Two", "p2", "Comp One", "comp1", "va");
+        let c2a = va_comp_track("c2a", "Song C", "Perf Three", "p3", "Comp Two", "comp2", "va");
+        // A track literally tagged with the VA performer id but with an *empty*
+        // album_artist: creates the "Various Artists" artist row and exercises the
+        // `artist_key` arm, which the union must not drop.
+        let mut vatag = track(
+            "s1", "vatag", "Punk Track", Some("Various Artists"), "Punk Comp", "punk1",
+            Some("va"), 200, "lib-a", Some(2019), None, None,
+        );
+        vatag.album_artist = Some(String::new());
+        // A normal solo artist that must NOT absorb the compilations.
+        let solo = track(
+            "s1", "solo1", "Solo Song", Some("Solo Artist"), "Solo Album", "soloalb",
+            Some("solo"), 200, "lib-a", Some(2022), None, None,
+        );
+        seed_and_rebuild(&store, &[c1a, c1b, c2a, vatag, solo]);
+
+        let va = artist_detail(
+            &store,
+            &LibraryScopeArtistDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                artist_id: "va".into(),
+                server_id: "s1".into(),
+                include_tracks: false,
+                top_tracks_limit: None,
+            },
+        )
+        .unwrap();
+        let mut ids: Vec<&str> = va.albums.iter().map(|a| a.id.as_str()).collect();
+        ids.sort_unstable();
+        // Label-linked compilations (comp1, comp2) plus the id-tagged album (punk1).
+        assert_eq!(ids, vec!["comp1", "comp2", "punk1"]);
+
+        // A normal artist page must not gain compilations from the VA label match.
+        let solo_detail = artist_detail(
+            &store,
+            &LibraryScopeArtistDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                artist_id: "solo".into(),
+                server_id: "s1".into(),
+                include_tracks: false,
+                top_tracks_limit: None,
+            },
+        )
+        .unwrap();
+        let solo_ids: Vec<&str> = solo_detail.albums.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(solo_ids, vec!["soloalb"]);
+    }
+
+    #[test]
+    fn album_detail_various_artists_hero_links_to_album_artist() {
+        // Bug B: a compilation's hero shows the album-artist credit ("Various
+        // Artists") but linked to a representative track's performer id, because the
+        // DTO took `artist_id` from `MAX(t.artist_id)`. The id must follow the same
+        // choice as the displayed name — the album-artist entity (`albumArtistId`).
+        let store = LibraryStore::open_in_memory();
+        let c1a = va_comp_track("c1a", "Song A", "Perf One", "p1", "Comp One", "comp1", "va");
+        let c1b = va_comp_track("c1b", "Song B", "Perf Two", "p2", "Comp One", "comp1", "va");
+        // Ensure the VA row exists (album-artist entity being linked to).
+        let mut vatag = track(
+            "s1", "vatag", "Punk Track", Some("Various Artists"), "Punk Comp", "punk1",
+            Some("va"), 200, "lib-a", Some(2019), None, None,
+        );
+        vatag.album_artist = Some(String::new());
+        let solo = track(
+            "s1", "solo1", "Solo Song", Some("Solo Artist"), "Solo Album", "soloalb",
+            Some("solo"), 200, "lib-a", Some(2022), None, None,
+        );
+        seed_and_rebuild(&store, &[c1a, c1b, vatag, solo]);
+
+        let comp = album_detail(
+            &store,
+            &LibraryScopeAlbumDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                album_id: "comp1".into(),
+                server_id: "s1".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(comp.album.artist.as_deref(), Some("Various Artists"));
+        assert_eq!(
+            comp.album.artist_id.as_deref(),
+            Some("va"),
+            "compilation hero must link to the VA entity, not a track performer"
+        );
+
+        // A solo album (no album-artist id in raw_json) keeps the track artist id.
+        let solo_detail = album_detail(
+            &store,
+            &LibraryScopeAlbumDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                album_id: "soloalb".into(),
+                server_id: "s1".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(solo_detail.album.artist_id.as_deref(), Some("solo"));
+    }
+
+    /// Inserts an artist row directly, for VA entities that have no track tagged
+    /// with their id (pure label-linked compilations — the common shape on servers
+    /// where every track carries its own performer).
+    fn seed_artist_row(store: &LibraryStore, server: &str, id: &str, name: &str) {
+        store
+            .with_conn_mut("test.seed_artist_row", |conn| {
+                conn.execute(
+                    "INSERT INTO artist (server_id, id, name, synced_at) VALUES (?1, ?2, ?3, 1) \
+                     ON CONFLICT(server_id, id) DO UPDATE SET name = excluded.name",
+                    rusqlite::params![server, id, name],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn artist_detail_various_artists_pure_label_compilations() {
+        // Bug A, no-id-tagged variant: a VA entity whose compilations link *only*
+        // through `album_artist` and no track carries the VA performer id. The
+        // `artist_key` source is then empty, so `va_mode` must come from the artist
+        // row itself (not the track-derived header) and the label arm alone must
+        // surface every compilation via the non-keyed detail path.
+        let store = LibraryStore::open_in_memory();
+        let c1 = va_comp_track("c1", "Song A", "Perf One", "p1", "Comp One", "comp1", "va");
+        let c2 = va_comp_track("c2", "Song B", "Perf Two", "p2", "Comp Two", "comp2", "va");
+        seed_and_rebuild(&store, &[c1, c2]);
+        // The VA row exists on the server but no track is tagged with its id.
+        seed_artist_row(&store, "s1", "va", "Various Artists");
+
+        let va = artist_detail(
+            &store,
+            &LibraryScopeArtistDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                artist_id: "va".into(),
+                server_id: "s1".into(),
+                include_tracks: false,
+                top_tracks_limit: None,
+            },
+        )
+        .unwrap();
+        let mut ids: Vec<&str> = va.albums.iter().map(|a| a.id.as_str()).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec!["comp1", "comp2"]);
+    }
+
+    #[test]
+    fn artist_detail_various_artists_union_does_not_double_count() {
+        // A track that qualifies under *both* arms (tagged with the VA id AND
+        // labelled "Various Artists") must be counted once. The union is UNION ALL,
+        // so such a track appears twice in `base`; the dedup pipeline
+        // (`track_dedup`) must collapse it, or the card `song_count` doubles.
+        let store = LibraryStore::open_in_memory();
+        let mut both1 = va_comp_track("both1", "Song A", "Various Artists", "va", "Both", "both", "va");
+        // Tagged with the VA performer id *and* labelled VA.
+        both1.artist = Some("Various Artists".into());
+        let mut both2 = va_comp_track("both2", "Song B", "Various Artists", "va", "Both", "both", "va");
+        both2.artist = Some("Various Artists".into());
+        seed_and_rebuild(&store, &[both1, both2]);
+
+        let va = artist_detail(
+            &store,
+            &LibraryScopeArtistDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                artist_id: "va".into(),
+                server_id: "s1".into(),
+                include_tracks: false,
+                top_tracks_limit: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(va.albums.len(), 1);
+        assert_eq!(
+            va.albums[0].song_count,
+            Some(2),
+            "two distinct tracks must not be counted four times by the UNION ALL"
+        );
+    }
+
+    #[test]
+    fn album_detail_album_artist_id_tolerates_malformed_raw_json() {
+        // The album-artist id is read with JSON1 (`json_type`/`json_extract`), which
+        // raise `malformed JSON` on invalid text. One badly-stored track must not
+        // abort the whole album_detail query — the guard makes it contribute no id,
+        // and a later valid track still resolves the VA link. (Mirror of the #1329
+        // release-types malformed guard for the hero-id path.)
+        let store = LibraryStore::open_in_memory();
+        let mut bad = va_comp_track("aa-bad", "Broken", "Perf One", "p1", "Comp", "comp1", "va");
+        bad.raw_json = "{not valid json".into();
+        let good = va_comp_track("zz-good", "Fine", "Perf Two", "p2", "Comp", "comp1", "va");
+        seed_and_rebuild(&store, &[bad, good]);
+
+        let comp = album_detail(
+            &store,
+            &LibraryScopeAlbumDetailRequest {
+                scopes: vec![scope_pair("s1", "lib-a")],
+                album_id: "comp1".into(),
+                server_id: "s1".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(comp.album.artist_id.as_deref(), Some("va"));
     }
 
     #[test]

--- a/src/lib/library/advancedSearchLocal.test.ts
+++ b/src/lib/library/advancedSearchLocal.test.ts
@@ -506,4 +506,74 @@ describe('albumToAlbum', () => {
     });
     expect(album.created).toBe('2023-11-14T22:13:20.000Z');
   });
+
+  it('keeps the resolved album artist when raw_json carries the legacy performer', () => {
+    // The backend resolves a compilation's hot columns to the album-artist entity,
+    // while raw_json still holds the server's legacy `artist` / `artistId` — a
+    // representative performer. Letting those win would relink a Various Artists
+    // album to a single guest.
+    const album = albumToAlbum({
+      serverId: 's1',
+      id: 'comp1',
+      name: 'Comp One',
+      artist: 'Various Artists',
+      artistId: 'va',
+      songCount: 2,
+      durationSec: 400,
+      year: null,
+      genre: null,
+      coverArtId: null,
+      starredAt: null,
+      syncedAt: 0,
+      rawJson: { id: 'comp1', artist: 'Perf One', artistId: 'p1' },
+    });
+    expect(album.artistId).toBe('va');
+    expect(album.artist).toBe('Various Artists');
+  });
+
+  it('still fills an empty album artist from raw_json', () => {
+    const album = albumToAlbum({
+      serverId: 's1', id: 'al1', name: 'Album', artist: null, artistId: null,
+      songCount: 1, durationSec: 100, year: null, genre: null, coverArtId: null,
+      starredAt: null, syncedAt: 0, rawJson: { artist: 'Artist', artistId: 'ar1' },
+    });
+    expect(album.artistId).toBe('ar1');
+    expect(album.artist).toBe('Artist');
+  });
+
+  it('fills an empty artistId from raw_json for a non-VA album with a set name', () => {
+    // A resolved credit but an empty hot id, with the id living only in raw_json:
+    // this must still link (distinct from the VA-unlink case below).
+    const album = albumToAlbum({
+      serverId: 's1', id: 'al1', name: 'Album', artist: 'Solo Artist', artistId: null,
+      songCount: 1, durationSec: 100, year: null, genre: null, coverArtId: null,
+      starredAt: null, syncedAt: 0, rawJson: { artistId: 'solo' },
+    });
+    expect(album.artistId).toBe('solo');
+    expect(album.artist).toBe('Solo Artist');
+  });
+
+  it('does not relink a VA album whose credit lives only in raw_json', () => {
+    // Empty hot artist columns, with the "Various Artists" credit and a legacy
+    // performer id both in raw_json: fill the name from raw, but keep it unlinked.
+    const album = albumToAlbum({
+      serverId: 's1', id: 'comp1', name: 'Comp', artist: null, artistId: null,
+      songCount: 2, durationSec: 400, year: null, genre: null, coverArtId: null,
+      starredAt: null, syncedAt: 0, rawJson: { artist: 'Various Artists', artistId: 'p1' },
+    });
+    expect(album.artist).toBe('Various Artists');
+    expect(album.artistId ?? '').toBe('');
+  });
+
+  it('keeps a Various Artists album unlinked even when raw_json carries an id', () => {
+    // The backend intentionally left artistId blank for a VA compilation with no
+    // album-artist id; raw_json's legacy performer id must not re-link it.
+    const album = albumToAlbum({
+      serverId: 's1', id: 'comp1', name: 'Comp', artist: 'Various Artists', artistId: null,
+      songCount: 2, durationSec: 400, year: null, genre: null, coverArtId: null,
+      starredAt: null, syncedAt: 0, rawJson: { artistId: 'p1' },
+    });
+    expect(album.artistId ?? '').toBe('');
+    expect(album.artist).toBe('Various Artists');
+  });
 });

--- a/src/lib/library/advancedSearchLocal.ts
+++ b/src/lib/library/advancedSearchLocal.ts
@@ -32,7 +32,7 @@ import {
 } from './libraryReady';
 import { logLibrarySearch, timed } from './libraryDevLog';
 import { isLosslessSuffix } from './losslessFormats';
-import { albumIsCompilation } from './albumCompilation';
+import { albumIsCompilation, isVariousArtistsLabel } from './albumCompilation';
 import { OXIMEDIA_MOOD_SEARCH_ENABLED } from './trackEnrichment';
 import { trackToSong } from './trackDtoMapping';
 import { getLibraryBrowseScope, type LibraryBrowseScope } from './libraryBrowseScope';
@@ -167,11 +167,38 @@ function buildRequest(
   };
 }
 
-/** Merge `raw_json` without stale `starred` reviving a cleared hot column. */
+/**
+ * `raw_json` augments the DTO, but the album-artist identity is not an augmentation
+ * field — the backend resolves it into the hot `artist`/`artistId` columns for EVERY
+ * album (`overlay_priority_album_row` + `pick_album_group_artist_id` run for VA and
+ * non-VA alike), while `raw_json` still carries the server's legacy `artist`/`artistId`
+ * (a representative performer on a compilation). So the hot columns are authoritative
+ * for these two keys on all albums and must not be overwritten by the legacy pair;
+ * this deliberately differs from every other raw key, which stays pure augmentation.
+ * Trusting the hot columns here is exactly what keeps the frontend link in step with
+ * the backend resolution — narrowing it to VA only would re-introduce a front/back
+ * mismatch for non-VA albums.
+ *
+ * `artistId` has two empty-string cases that must be told apart: a Various Artists
+ * album the backend deliberately left unlinked (keep it blank, do not open a guest)
+ * versus a plain album whose id lives only in `raw_json` (fill it). So suppress the
+ * raw `artistId` only when the hot id is already set or the credit is a VA label.
+ */
 function mergeAlbumRawJson(base: SubsonicAlbum, raw: Partial<SubsonicAlbum>): SubsonicAlbum {
   const merged = { ...base } as SubsonicAlbum & Record<string, unknown>;
+  const artistNameSet = typeof base.artist === 'string' && base.artist.trim() !== '';
+  const artistIdSet = typeof base.artistId === 'string' && base.artistId.trim() !== '';
+  // Test the VA label against the *effective* credit — the hot column, or `raw_json`
+  // when the hot column is empty. Otherwise an album with a blank hot artist but a
+  // "Various Artists" credit only in raw_json would fill the name from raw and then
+  // let raw's legacy performer id link it, the exact mislink this guard prevents.
+  const rawArtist = typeof raw.artist === 'string' ? raw.artist : '';
+  const effectiveArtist = artistNameSet ? base.artist : rawArtist;
+  const isVariousArtists = isVariousArtistsLabel(effectiveArtist);
   for (const [key, value] of Object.entries(raw)) {
     if (key === 'starred') continue;
+    if (key === 'artist' && artistNameSet) continue;
+    if (key === 'artistId' && (artistIdSet || isVariousArtists)) continue;
     if (value != null && value !== '') merged[key] = value;
   }
   return merged;

--- a/src/lib/library/albumCompilation.ts
+++ b/src/lib/library/albumCompilation.ts
@@ -11,18 +11,20 @@ export const ALBUM_COMP_FILTER_MAX_SCAN_ALBUMS = 500;
 
 const VARIOUS_ARTISTS = /\bvarious artists\b/i;
 
+/** True when a credit is the "Various Artists" compilation label. */
+export function isVariousArtistsLabel(name: string | null | undefined): boolean {
+  return !!name && VARIOUS_ARTISTS.test(name);
+}
+
 /** OpenSubsonic / Navidrome: `compilation`, `isCompilation`, `releaseTypes`, or VA artist. */
 export function albumIsCompilation(a: SubsonicAlbum): boolean {
   if (a.isCompilation === true) return true;
   const loose = a as SubsonicAlbum & { compilation?: boolean; albumArtist?: string };
   if (loose.compilation === true) return true;
   if (a.releaseTypes?.some(t => /^compilation$/i.test(t.trim()))) return true;
-  const artist = (a.artist ?? '').trim();
-  const displayArtist = (a.displayArtist ?? '').trim();
-  const albumArtist = (loose.albumArtist ?? '').trim();
-  return VARIOUS_ARTISTS.test(artist)
-    || VARIOUS_ARTISTS.test(displayArtist)
-    || VARIOUS_ARTISTS.test(albumArtist);
+  return isVariousArtistsLabel(a.artist)
+    || isVariousArtistsLabel(a.displayArtist)
+    || isVariousArtistsLabel(loose.albumArtist);
 }
 
 /** Any track in a grouped album matches compilation signals (offline / local aggregate). */

--- a/src/lib/library/loadArtistDetailMultiScope.test.ts
+++ b/src/lib/library/loadArtistDetailMultiScope.test.ts
@@ -101,6 +101,24 @@ describe('tryLoadArtistDetailMultiScope', () => {
     await expect(tryLoadArtistDetailMultiScope([], 'srv-1', 'art-1')).resolves.toBeNull();
   });
 
+  it('maps a Various Artists payload whose albums are label-linked only', async () => {
+    // The VA entity has no track carrying its performer id, so the backend seeds the
+    // header from the artist row. If that header ever came back with an empty id, the
+    // loader would discard the whole payload and the artist hook would stop without a
+    // network fallback — the compilations would be unreachable in the app.
+    libraryScopeArtistDetailMock.mockResolvedValue({
+      artist: artistDto({ id: 'va', name: 'Various Artists' }),
+      albums: [albumDto({ id: 'comp1', name: 'Comp One', artistId: 'va' })],
+      tracks: [],
+    });
+
+    const result = await tryLoadArtistDetailMultiScope([], 'srv-1', 'va');
+
+    expect(result).not.toBeNull();
+    expect(result?.artist.id).toBe('va');
+    expect(result?.albums.map(a => a.id)).toEqual(['comp1']);
+  });
+
   it('returns null when the scope command throws', async () => {
     libraryScopeArtistDetailMock.mockRejectedValue(new Error('ipc fail'));
 


### PR DESCRIPTION
## Summary

- The "Various Artists" entity links its compilations through the `album_artist` label, not a per-track `artist_id`. The local artist page (a scoped, index-first query since the local-first switch) followed track `artist_id` and so found only the handful of tracks literally tagged with the VA id instead of every compilation.
- **Artist detail:** when the target is the VA entity (resolved from the artist row's canonical name, so it works even when no track carries the VA id), union its `album_artist`-linked compilations into the album grid. Non-VA artist pages are unaffected.
- **Album detail:** derive the hero artist id from the album-artist (`raw_json.albumArtistId`) so a compilation links to "Various Artists" instead of a representative track's performer, falling back to the track id when the album has no named album-artist. The JSON1 read is guarded against malformed `raw_json` so one bad row cannot abort the query.
- The album-artist identity is resolved into the hot columns for every album and kept authoritative through the album-row overlay and the frontend `raw_json` merge, so the resolved link is not overwritten by the server's legacy performer id. Backend and frontend use the same word-boundary VA-label predicate so they never disagree on the same unlink.

## Test plan

- `cargo test --workspace` — new regression tests for both bugs, the pure-label and no-double-count union paths, the malformed-json guard, the overlay VA-unlink and feat-name cases, the non-VA-not-seeded and album-count behaviour, and the word-boundary matcher; each proven to fail against the unfixed code.
- Frontend: `tsc`, `eslint`, `vitest` (mapper VA-unlink parity + loader payload) all clean.
- `cargo clippy --workspace` clean.
- Verified against a real multi-server index (label linkage, over-inclusion, and query shape).

## Deferred (own scope)

- Album-artist links on the general browse grids and the non-VA compilation-ish fallback are left as-is here — the same class on other surfaces, out of this fix's scope.
- VA-label detection is a word-boundary match kept identical on both sides, not an exact-string match; tightening the VA semantics is a separate cluster-policy decision.
