### PR TITLE
Show the real decoded stream format in now-playing, not stored metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Playing a multi-disc album from the header no longer interleaves the discs (disc 1 track 1, disc 2 track 1, disc 1 track 2, …). Tracks queue in disc-then-track order, so disc 1 plays in full before disc 2. Tracks without a disc number are treated as disc 1, matching the track list.
 
+### Now playing — show the real streamed format when the server transcodes
+
+**By [@Manwe-777](https://github.com/Manwe-777), PR [#1338](https://github.com/Psychotoxical/psysonic/pull/1338)**
+
+* The quality badge (queue, now-playing hero, mobile player, immersive fullscreen) was built from the track's stored library metadata, so a server-side transcode still read the original file — e.g. "FLAC · 3149 kbps · 24-bit" while actually receiving Opus. It now shows the format the audio engine actually decoded, with the original file's format in a tooltip, and falls back to the stored metadata when no transcode is happening. When the transmitted bitrate is unknown, none is shown instead of a wrong one.
+
 
 ## [1.50.0]
 

--- a/src-tauri/crates/psysonic-audio/src/commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/commands.rs
@@ -347,6 +347,7 @@ pub async fn audio_play(
     let duration_secs = built.duration_secs;
     let output_rate = built.output_rate;
     let output_channels = built.output_channels;
+    let resolved_format = built.resolved_format;
 
     // Store the actual output rate/channels for position calculation.
     state.current_sample_rate.store(output_rate, Ordering::Relaxed);
@@ -354,6 +355,21 @@ pub async fn audio_play(
 
     if state.generation.load(Ordering::SeqCst) != gen {
         return Ok(());
+    }
+
+    // Surface the real decoded format so now-playing badges reflect what the
+    // server is actually transmitting — it may differ from the library's
+    // stored metadata when the server transcodes. Emitted before the
+    // play/deferred-start branching so it fires on both paths; the frontend
+    // stamps it onto the current track and drops stale/mismatched events.
+    if let Some(fmt) = resolved_format.as_ref() {
+        let ev = crate::decode::AudioFormatEvent::from_info(fmt, crate::decode::AudioFormatIdentity {
+            track_id: logical_trim.clone(),
+            server_id: analysis_server_id.map(str::to_string),
+            generation: Some(gen),
+            stream_cap_kbps: crate::play_input::url_stream_cap_kbps(&url),
+        });
+        app.emit("audio:format", ev).ok();
     }
 
     let current_stream_rate = state.stream_sample_rate.load(Ordering::Relaxed);
@@ -845,6 +861,7 @@ pub async fn audio_chain_preload(
         analysis_track_id: logical_trim,
         server_id: analysis_server_id.map(str::to_string),
         raw_bytes,
+        resolved_format: built.resolved_format,
         duration_secs,
         replay_gain_linear: gain_linear,
         base_volume: volume.clamp(0.0, 1.0),

--- a/src-tauri/crates/psysonic-audio/src/decode.rs
+++ b/src-tauri/crates/psysonic-audio/src/decode.rs
@@ -102,6 +102,93 @@ impl MediaSource for ProbeSeekGate {
 // Implements Iterator<Item = i16> + Source — identical interface to
 // rodio::Decoder, so the rest of the source chain is unchanged.
 
+/// Resolved audio format of a decoded stream — the real codec/rate/depth the
+/// engine is playing, which can differ from the server's stored file metadata
+/// when the server transcodes on the fly.
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedCodecInfo {
+    /// Symphonia codec short name, e.g. `mp3`, `flac`, `aac`, `pcm_s16le`.
+    pub(crate) codec_name: &'static str,
+    pub(crate) sample_rate: Option<u32>,
+    pub(crate) bits_per_sample: Option<u32>,
+    pub(crate) channels: Option<u16>,
+    pub(crate) lossless: bool,
+}
+
+/// Extract the human/UI-facing format from symphonia codec parameters.
+pub(crate) fn resolve_codec_info(params: &AudioCodecParameters) -> ResolvedCodecInfo {
+    // Resolve the codec name from the SAME registry the engine decodes with
+    // (`psysonic_codec_registry`), not `symphonia::default::get_codecs()`. The
+    // app registry adds decoders the stock one lacks (e.g. the libopus adapter);
+    // using the stock registry would render those as "?" even though playback
+    // works — which is exactly what a server Opus transcode would show.
+    let codec_name = psysonic_codec_registry()
+        .get_audio_decoder(params.codec)
+        .map(|d| d.codec.info.short_name)
+        .unwrap_or("?");
+    let lossless = codec_name.starts_with("pcm")
+        || matches!(
+            codec_name,
+            "flac" | "alac" | "wavpack" | "monkeys-audio" | "tta" | "shorten"
+        );
+    ResolvedCodecInfo {
+        codec_name,
+        sample_rate: params.sample_rate,
+        bits_per_sample: params.bits_per_sample.or(params.bits_per_coded_sample),
+        channels: params.channels.as_ref().map(|c| c.count() as u16),
+        lossless,
+    }
+}
+
+/// `audio:format` event payload — the actually-decoded stream format, sent to
+/// the frontend so now-playing badges can show real transmitted quality.
+/// Hand-serialized (not tauri-specta) to match the `audio:*` event convention.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AudioFormatEvent {
+    /// Track this format was resolved for — lets the frontend drop the event if
+    /// the user has since skipped. `None` on legacy/identity-less emits.
+    pub(crate) track_id: Option<String>,
+    /// Playback server index key — disambiguates duplicate ids across servers.
+    pub(crate) server_id: Option<String>,
+    /// Playback generation the stream belongs to (stale-event rejection).
+    pub(crate) generation: Option<u64>,
+    /// `maxBitRate` cap (kbps) the stream URL was opened with — latched per
+    /// stream, so a mid-playback settings change never relabels the current one.
+    pub(crate) stream_cap_kbps: Option<u32>,
+    pub(crate) codec: String,
+    pub(crate) sample_rate: Option<u32>,
+    pub(crate) bits_per_sample: Option<u32>,
+    pub(crate) channels: Option<u16>,
+    pub(crate) lossless: bool,
+}
+
+/// Identity a resolved-format event is stamped with (who/which stream).
+#[derive(Clone, Default)]
+pub(crate) struct AudioFormatIdentity {
+    pub(crate) track_id: Option<String>,
+    pub(crate) server_id: Option<String>,
+    pub(crate) generation: Option<u64>,
+    pub(crate) stream_cap_kbps: Option<u32>,
+}
+
+impl AudioFormatEvent {
+    pub(crate) fn from_info(info: &ResolvedCodecInfo, id: AudioFormatIdentity) -> Self {
+        Self {
+            track_id: id.track_id,
+            server_id: id.server_id,
+            generation: id.generation,
+            stream_cap_kbps: id.stream_cap_kbps,
+            codec: info.codec_name.to_string(),
+            // Bit depth is only meaningful for lossless output.
+            bits_per_sample: if info.lossless { info.bits_per_sample } else { None },
+            sample_rate: info.sample_rate,
+            channels: info.channels,
+            lossless: info.lossless,
+        }
+    }
+}
+
 /// Debug logging: codec parameters in human-readable form to verify whether
 /// playback is genuinely lossless.
 pub(crate) fn log_codec_resolution(
@@ -109,26 +196,18 @@ pub(crate) fn log_codec_resolution(
     params: &AudioCodecParameters,
     container_hint: Option<&str>,
 ) {
-    let codec_name = symphonia::default::get_codecs()
-        .get_audio_decoder(params.codec)
-        .map(|d| d.codec.info.short_name)
-        .unwrap_or("?");
-    let rate = params.sample_rate.map(|r| format!("{} Hz", r)).unwrap_or_else(|| "? Hz".into());
-    let bits = params.bits_per_sample
-        .or(params.bits_per_coded_sample)
+    let info = resolve_codec_info(params);
+    let rate = info.sample_rate.map(|r| format!("{} Hz", r)).unwrap_or_else(|| "? Hz".into());
+    let bits = info.bits_per_sample
         .map(|b| format!("{}-bit", b))
         .unwrap_or_else(|| "?-bit".into());
-    let ch = params.channels.as_ref()
-        .map(|c| format!("{}ch", c.count()))
+    let ch = info.channels
+        .map(|c| format!("{}ch", c))
         .unwrap_or_else(|| "?ch".into());
-    let lossless = codec_name.starts_with("pcm")
-        || matches!(
-            codec_name,
-            "flac" | "alac" | "wavpack" | "monkeys-audio" | "tta" | "shorten"
-        );
-    let kind = if lossless { "LOSSLESS" } else { "lossy" };
+    let kind = if info.lossless { "LOSSLESS" } else { "lossy" };
     crate::app_deprintln!(
-        "[stream] {tag}: codec={codec_name} ({kind}) {bits} {rate} {ch} container={}",
+        "[stream] {tag}: codec={} ({kind}) {bits} {rate} {ch} container={}",
+        info.codec_name,
         container_hint.unwrap_or("?")
     );
 }
@@ -154,6 +233,8 @@ pub(crate) struct SizedDecoder {
     /// Interleaved f32 samples of the currently decoded packet.
     buffer: Vec<f32>,
     spec: AudioSpec,
+    /// Real decoded format (codec/rate/depth) for the now-playing UI badge.
+    codec_info: ResolvedCodecInfo,
     /// Counts consecutive DecodeErrors in the hot-path. Reset to 0 on every
     /// successfully decoded frame. Used to detect fully undecodable streams.
     consecutive_decode_errors: usize,
@@ -253,6 +334,7 @@ impl SizedDecoder {
             .clone();
 
         log_codec_resolution("bytes", &audio_params, format_hint);
+        let codec_info = resolve_codec_info(&audio_params);
 
         // Gapless trimming is performed by `build_source` (iTunSMPB), so disable
         // the decoder's built-in trimming to avoid double-trimming.
@@ -314,6 +396,7 @@ impl SizedDecoder {
             total_duration,
             buffer,
             spec,
+            codec_info,
             consecutive_decode_errors: 0,
         })
     }
@@ -428,6 +511,7 @@ impl SizedDecoder {
             .ok_or_else(|| format!("{source_tag}: track has no audio codec parameters"))?
             .clone();
         log_codec_resolution(source_tag, &audio_params, format_hint);
+        let codec_info = resolve_codec_info(&audio_params);
         // Live streams have no known total frame count → total_duration = None.
         let total_duration = None;
         let mut decoder = try_make_radio_decoder(&audio_params, &AudioDecoderOptions::default().gapless(false))
@@ -455,7 +539,7 @@ impl SizedDecoder {
         };
         let spec = decoded.spec().clone();
         let buffer = Self::make_buffer(&decoded);
-        Ok(SizedDecoder { decoder, current_frame_offset: 0, format, total_duration, buffer, spec, consecutive_decode_errors: 0 })
+        Ok(SizedDecoder { decoder, current_frame_offset: 0, format, total_duration, buffer, spec, codec_info, consecutive_decode_errors: 0 })
     }
 
     #[inline]
@@ -463,6 +547,12 @@ impl SizedDecoder {
         let mut buffer = Vec::new();
         decoded.copy_to_vec_interleaved(&mut buffer);
         buffer
+    }
+
+    /// Real decoded format (codec/rate/depth) for the now-playing UI badge.
+    #[inline]
+    pub(crate) fn codec_info(&self) -> &ResolvedCodecInfo {
+        &self.codec_info
     }
 
     /// Refine position after a coarse seek — decode packets until we reach the
@@ -711,6 +801,9 @@ pub(crate) struct BuiltSource {
     pub(crate) duration_secs: f64,
     pub(crate) output_rate: u32,
     pub(crate) output_channels: u16,
+    /// Real decoded stream format for the `audio:format` event. None only if the
+    /// source could not report codec params.
+    pub(crate) resolved_format: Option<ResolvedCodecInfo>,
     /// Trigger for the sample-level crossfade fade-out.
     pub(crate) fadeout_trigger: Arc<AtomicBool>,
     /// Total samples for the fade-out (set before triggering).
@@ -748,6 +841,7 @@ pub(crate) fn build_source(
     let decoder = SizedDecoder::new(data, format_hint, hi_res)?;
     let sample_rate = decoder.sample_rate();
     let channels = decoder.channels();
+    let resolved_format = Some(decoder.codec_info().clone());
 
     // Determine effective duration.
     // Prefer hint from Subsonic API (reliable) over decoder (unreliable for VBR MP3).
@@ -820,6 +914,7 @@ pub(crate) fn build_source(
         duration_secs: crate::playback_rate::effective_duration_secs(effective_dur, &playback_rate),
         output_rate,
         output_channels: channels.get(),
+        resolved_format,
         fadeout_trigger,
         fadeout_samples,
     })
@@ -844,6 +939,7 @@ pub(crate) fn build_streaming_source(
 ) -> Result<BuiltSource, String> {
     let sample_rate = decoder.sample_rate();
     let channels = decoder.channels();
+    let resolved_format = Some(decoder.codec_info().clone());
 
     // For streaming starts prefer server-provided duration when available.
     let effective_dur = if duration_hint > 1.0 {
@@ -892,6 +988,7 @@ pub(crate) fn build_streaming_source(
         duration_secs: crate::playback_rate::effective_duration_secs(effective_dur, &playback_rate),
         output_rate,
         output_channels: channels.get(),
+        resolved_format,
         fadeout_trigger,
         fadeout_samples,
     })
@@ -1126,6 +1223,73 @@ mod tests {
     fn log_codec_resolution_handles_unknown_codec_gracefully() {
         let params = AudioCodecParameters::new();
         log_codec_resolution("unknown", &params, None);
+    }
+
+    // ── resolve_codec_info / AudioFormatEvent ────────────────────────────────
+
+    #[test]
+    fn resolve_codec_info_reports_pcm_as_lossless() {
+        let mut params = AudioCodecParameters::new();
+        params.codec = symphonia::core::codecs::audio::well_known::CODEC_ID_PCM_S16LE;
+        params.sample_rate = Some(44_100);
+        params.bits_per_sample = Some(16);
+        params.channels = Some(symphonia::core::audio::Channels::Discrete(1));
+        let info = resolve_codec_info(&params);
+        assert!(info.codec_name.starts_with("pcm"));
+        assert!(info.lossless);
+        assert_eq!(info.sample_rate, Some(44_100));
+        assert_eq!(info.bits_per_sample, Some(16));
+        assert_eq!(info.channels, Some(1));
+    }
+
+    #[test]
+    fn resolve_codec_info_reports_mp3_as_lossy() {
+        let mut params = AudioCodecParameters::new();
+        params.codec = symphonia::core::codecs::audio::well_known::CODEC_ID_MP3;
+        params.sample_rate = Some(44_100);
+        let info = resolve_codec_info(&params);
+        assert_eq!(info.codec_name, "mp3");
+        assert!(!info.lossless);
+    }
+
+    #[test]
+    fn audio_format_event_drops_bit_depth_for_lossy() {
+        let lossy = ResolvedCodecInfo {
+            codec_name: "mp3",
+            sample_rate: Some(44_100),
+            bits_per_sample: Some(16),
+            channels: Some(2),
+            lossless: false,
+        };
+        let ev = AudioFormatEvent::from_info(&lossy, AudioFormatIdentity {
+            track_id: Some("t1".into()),
+            server_id: Some("srv".into()),
+            generation: Some(7),
+            stream_cap_kbps: Some(128),
+        });
+        assert_eq!(ev.bits_per_sample, None);
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["codec"], "mp3");
+        assert_eq!(json["sampleRate"], 44_100);
+        assert_eq!(json["lossless"], false);
+        assert!(json["bitsPerSample"].is_null());
+        assert_eq!(json["trackId"], "t1");
+        assert_eq!(json["serverId"], "srv");
+        assert_eq!(json["generation"], 7);
+        assert_eq!(json["streamCapKbps"], 128);
+    }
+
+    #[test]
+    fn audio_format_event_keeps_bit_depth_for_lossless() {
+        let lossless = ResolvedCodecInfo {
+            codec_name: "flac",
+            sample_rate: Some(96_000),
+            bits_per_sample: Some(24),
+            channels: Some(2),
+            lossless: true,
+        };
+        let ev = AudioFormatEvent::from_info(&lossless, AudioFormatIdentity::default());
+        assert_eq!(ev.bits_per_sample, Some(24));
     }
 }
 

--- a/src-tauri/crates/psysonic-audio/src/device_resume.rs
+++ b/src-tauri/crates/psysonic-audio/src/device_resume.rs
@@ -254,6 +254,16 @@ pub(crate) async fn try_resume_after_device_change(
 
     // Inform the frontend of the new duration (keeps seekbar range correct).
     app.emit("audio:playing", ps.built.duration_secs).ok();
+    // Re-assert the real decoded format after the device swap (same track).
+    if let Some(fmt) = ps.built.resolved_format.as_ref() {
+        let ev = crate::decode::AudioFormatEvent::from_info(fmt, crate::decode::AudioFormatIdentity {
+            track_id: engine.current_analysis_track_id.lock().unwrap().clone(),
+            server_id: engine.current_playback_server_id.lock().unwrap().clone(),
+            generation: Some(gen),
+            stream_cap_kbps: crate::play_input::url_stream_cap_kbps(url),
+        });
+        app.emit("audio:format", ev).ok();
+    }
 
     let analysis_app = app.clone();
     spawn_progress_task(

--- a/src-tauri/crates/psysonic-audio/src/play_input.rs
+++ b/src-tauri/crates/psysonic-audio/src/play_input.rs
@@ -449,3 +449,34 @@ pub(crate) fn url_format_hint(url: &str) -> Option<String> {
         })
         .map(|s| s.to_lowercase())
 }
+
+/// The `maxBitRate` cap (kbps) a `stream.view` URL was opened with, if any.
+/// This latches the requested quality to the stream itself: today's frontend
+/// never sends the param, so it resolves to `None`; a future client-side cap
+/// feature (or a proxy) shows up here without further changes.
+pub(crate) fn url_stream_cap_kbps(url: &str) -> Option<u32> {
+    let query = url.split_once('?')?.1;
+    query.split('&').find_map(|kv| {
+        let (k, v) = kv.split_once('=')?;
+        if k != "maxBitRate" { return None; }
+        v.parse::<u32>().ok().filter(|&n| n > 0)
+    })
+}
+
+#[cfg(test)]
+mod url_param_tests {
+    use super::url_stream_cap_kbps;
+
+    #[test]
+    fn parses_max_bit_rate_from_stream_url() {
+        let url = "https://s.example/rest/stream.view?id=t1&u=a&maxBitRate=128&f=json";
+        assert_eq!(url_stream_cap_kbps(url), Some(128));
+    }
+
+    #[test]
+    fn absent_or_zero_cap_is_none() {
+        assert_eq!(url_stream_cap_kbps("https://s.example/rest/stream.view?id=t1&u=a"), None);
+        assert_eq!(url_stream_cap_kbps("https://s.example/rest/stream.view?id=t1&maxBitRate=0"), None);
+        assert_eq!(url_stream_cap_kbps("psysonic-local:///library/t1.flac"), None);
+    }
+}

--- a/src-tauri/crates/psysonic-audio/src/progress_task.rs
+++ b/src-tauri/crates/psysonic-audio/src/progress_task.rs
@@ -26,6 +26,9 @@ pub trait ProgressEmitter: Send + Sync + 'static {
     fn emit_progress(&self, payload: ProgressPayload);
     fn emit_track_switched(&self, duration_secs: f64);
     fn emit_ended(&self);
+    /// Resolved format of a gapless successor. Default no-op keeps test mocks
+    /// unaffected; only the live `AppHandle` forwards it to the frontend.
+    fn emit_format(&self, _ev: crate::decode::AudioFormatEvent) {}
 }
 
 impl<R: Runtime> ProgressEmitter for AppHandle<R> {
@@ -34,6 +37,9 @@ impl<R: Runtime> ProgressEmitter for AppHandle<R> {
     }
     fn emit_track_switched(&self, duration_secs: f64) {
         let _ = Emitter::emit(self, "audio:track_switched", duration_secs);
+    }
+    fn emit_format(&self, ev: crate::decode::AudioFormatEvent) {
+        let _ = Emitter::emit(self, "audio:format", ev);
     }
     fn emit_ended(&self) {
         let _ = Emitter::emit(self, "audio:ended", ());
@@ -181,6 +187,20 @@ pub(crate) fn spawn_progress_task<E: ProgressEmitter>(
                     // Emit the new track_switched event — this is immediate,
                     // not delayed by 500 ms like the old audio:playing was.
                     emitter.emit_track_switched(info.duration_secs);
+                    // Surface the successor's real decoded format too — a gapless
+                    // advance never re-runs the play command, so without this the
+                    // badge would keep showing the previous track's format.
+                    if let Some(fmt) = info.resolved_format.as_ref() {
+                        emitter.emit_format(crate::decode::AudioFormatEvent::from_info(
+                            fmt,
+                            crate::decode::AudioFormatIdentity {
+                                track_id: info.analysis_track_id.clone(),
+                                server_id: info.server_id.clone(),
+                                generation: Some(gen_counter.load(Ordering::SeqCst)),
+                                stream_cap_kbps: crate::play_input::url_stream_cap_kbps(&info.url),
+                            },
+                        ));
+                    }
                     near_end_ticks = 0;
                     continue;
                 }
@@ -299,6 +319,7 @@ mod tests {
     struct MockEmitter {
         progress: Mutex<Vec<ProgressPayload>>,
         track_switched: Mutex<Vec<f64>>,
+        formats: Mutex<Vec<crate::decode::AudioFormatEvent>>,
         ended: std::sync::atomic::AtomicUsize,
     }
 
@@ -330,6 +351,9 @@ mod tests {
         }
         fn emit_ended(&self) {
             self.ended.fetch_add(1, Ordering::SeqCst);
+        }
+        fn emit_format(&self, ev: crate::decode::AudioFormatEvent) {
+            self.formats.lock().unwrap().push(ev);
         }
     }
 
@@ -533,9 +557,16 @@ mod tests {
         let chained_samples = Arc::new(AtomicU64::new(0));
         *h.chained.lock().unwrap() = Some(ChainedInfo {
             url: chain_url.clone(),
-            analysis_track_id: None,
-            server_id: None,
+            analysis_track_id: Some("next-track".into()),
+            server_id: Some("srv-1".into()),
             raw_bytes: Arc::new(Vec::new()),
+            resolved_format: Some(crate::decode::ResolvedCodecInfo {
+                codec_name: "flac",
+                sample_rate: Some(44_100),
+                bits_per_sample: Some(16),
+                channels: Some(2),
+                lossless: true,
+            }),
             duration_secs: 200.0,
             replay_gain_linear: 1.0,
             base_volume: 1.0,
@@ -570,6 +601,17 @@ mod tests {
             h.gapless_switch_at.load(Ordering::SeqCst) > 0,
             "gapless_switch_at timestamp recorded for ghost-command guard"
         );
+
+        // The successor's resolved format must be emitted at the transition —
+        // a gapless advance never re-runs audio_play, so without this the
+        // frontend badge would keep the previous track's format.
+        {
+            let formats = emitter.formats.lock().unwrap();
+            assert_eq!(formats.len(), 1, "audio:format must fire for the gapless successor");
+            assert_eq!(formats[0].codec, "flac");
+            assert_eq!(formats[0].track_id.as_deref(), Some("next-track"));
+            assert_eq!(formats[0].server_id.as_deref(), Some("srv-1"));
+        }
 
         // Stop the task.
         h.gen_counter.store(99, Ordering::SeqCst);

--- a/src-tauri/crates/psysonic-audio/src/state.rs
+++ b/src-tauri/crates/psysonic-audio/src/state.rs
@@ -25,6 +25,9 @@ pub(crate) struct ChainedInfo {
     /// Raw file bytes (shared with the chained decoder). Lets manual skip reuse
     /// them instead of re-downloading after dropping the Sink queue.
     pub(crate) raw_bytes: Arc<Vec<u8>>,
+    /// Real decoded format of the chained successor, for the `audio:format`
+    /// event emitted at the gapless transition.
+    pub(crate) resolved_format: Option<crate::decode::ResolvedCodecInfo>,
     pub(crate) duration_secs: f64,
     pub(crate) replay_gain_linear: f32,
     pub(crate) base_volume: f32,

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -493,6 +493,13 @@ const CONTRIBUTOR_ENTRIES = [
       'Accessibility: modal dialogs announce their title to screen readers (aria-labelledby) (PR #1301)',
     ],
   },
+  {
+    github: 'Manwe-777',
+    since: '1.51.0',
+    contributions: [
+      'Now-playing badge shows the real decoded stream format on server transcode (PR #1338)',
+    ],
+  },
 ] as const;
 
 // PR number of a contributor's first listed contribution, used as the

--- a/src/features/fullscreenPlayer/components/FullscreenPlayerImmersive.tsx
+++ b/src/features/fullscreenPlayer/components/FullscreenPlayerImmersive.tsx
@@ -10,6 +10,7 @@ import { useCachedUrl } from '@/ui/CachedImage';
 import { getCachedBlob } from '@/cover/imageCache';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/store/authStore';
+import { effectiveAudioFormat } from '@/lib/media/streamFormat';
 import { useFsArtistBackdrop } from '@/features/fullscreenPlayer/hooks/useFsArtistBackdrop';
 import { FsLyricsApple } from './FsLyricsApple';
 import { FsLyricsRail } from './FsLyricsRail';
@@ -30,6 +31,7 @@ interface FullscreenPlayerProps {
 export default function FullscreenPlayer({ onClose }: FullscreenPlayerProps) {
   const { t } = useTranslation();
   const currentTrack       = usePlayerStore(s => s.currentTrack);
+  const resolvedStreamFormat = usePlayerStore(s => s.resolvedStreamFormat);
   const repeatMode         = usePlayerStore(s => s.repeatMode);
   const next               = usePlayerStore(s => s.next);
   const previous           = usePlayerStore(s => s.previous);
@@ -109,12 +111,17 @@ export default function FullscreenPlayer({ onClose }: FullscreenPlayerProps) {
   // Idle-fade system — hides controls after 3 s of inactivity; Esc closes.
   const { isIdle, handleMouseMove } = useFsIdleFade(onClose);
 
-  const metaParts = useMemo(() => [
-    currentTrack?.album,
-    currentTrack?.year?.toString(),
-    currentTrack?.suffix?.toUpperCase(),
-    currentTrack?.bitRate ? `${currentTrack.bitRate} kbps` : '',
-  ].filter(Boolean), [currentTrack]);
+  const metaParts = useMemo(() => {
+    const fmt = currentTrack
+      ? effectiveAudioFormat(currentTrack, resolvedStreamFormat)
+      : null;
+    return [
+      currentTrack?.album,
+      currentTrack?.year?.toString(),
+      fmt?.formatLabel,
+      fmt?.bitRate ? `${fmt.bitRateIsCap ? '≤' : ''}${fmt.bitRate} kbps` : '',
+    ].filter(Boolean);
+  }, [currentTrack, resolvedStreamFormat]);
 
   return (
     <div

--- a/src/features/nowPlaying/components/Hero.tsx
+++ b/src/features/nowPlaying/components/Hero.tsx
@@ -9,6 +9,8 @@ import { OpenArtistRefInline } from '@/ui/OpenArtistRefInline';
 import { formatTrackTime } from '@/lib/format/formatDuration';
 import { renderPresetIcon, useEnrichmentPrimaryIcon, useEnrichmentPrimaryLabel } from '@/music-network/ui';
 import { buildArtistDetailPath } from '@/lib/navigation/detailServerScope';
+import { effectiveAudioFormat, effectiveAudioFormatParts } from '@/lib/media/streamFormat';
+import { usePlayerStore } from '@/features/playback';
 
 interface HeroProps {
   track: { title: string; artist: string; album: string; year?: number;
@@ -53,7 +55,14 @@ const Hero = memo(function Hero({ track, artistRefs, genre, playCount, userRatin
   const networkLabel = useEnrichmentPrimaryLabel() ?? '';
   const networkIcon = useEnrichmentPrimaryIcon();
   const rating = userRatingOverride ?? track.userRating;
-  const hiRes  = (track.bitDepth ?? 0) > 16 || (track.samplingRate ?? 0) > 48000;
+  const resolvedStreamFormat = usePlayerStore(s => s.resolvedStreamFormat);
+  const fmt = effectiveAudioFormat(track, resolvedStreamFormat);
+  const transcodedTooltip = fmt.transcoded
+    ? t('queue.streamTranscoded', {
+      original: effectiveAudioFormatParts(effectiveAudioFormat(track, null)).join(' · '),
+    })
+    : undefined;
+  const hiRes  = (fmt.bitDepth ?? 0) > 16 || (fmt.sampleRate ?? 0) > 48000;
   const releaseAge = track.year ? new Date().getFullYear() - track.year : 0;
 
   return (
@@ -112,10 +121,15 @@ const Hero = memo(function Hero({ track, artistRefs, genre, playCount, userRatin
 
         <div className="np-dash-hero-badges">
           {genre && <span className="np-badge">{genre}</span>}
-          {track.suffix && <span className="np-badge">{track.suffix.toUpperCase()}</span>}
-          {(track.bitRate ?? 0) > 0 && <span className="np-badge">{track.bitRate} kbps</span>}
-          {(track.samplingRate ?? 0) > 0 && <span className="np-badge">{((track.samplingRate ?? 0) / 1000).toFixed(1)} kHz</span>}
-          {(track.bitDepth ?? 0) > 0 && <span className="np-badge">{track.bitDepth}-bit</span>}
+          {fmt.formatLabel && (
+            <span
+              className={`np-badge${fmt.transcoded ? ' np-badge-transcoded' : ''}`}
+              data-tooltip={transcodedTooltip}
+            >{fmt.formatLabel}</span>
+          )}
+          {(fmt.bitRate ?? 0) > 0 && <span className="np-badge">{fmt.bitRateIsCap ? '≤' : ''}{fmt.bitRate} kbps</span>}
+          {(fmt.sampleRate ?? 0) > 0 && <span className="np-badge">{((fmt.sampleRate ?? 0) / 1000).toFixed(1)} kHz</span>}
+          {(fmt.bitDepth ?? 0) > 0 && <span className="np-badge">{fmt.bitDepth}-bit</span>}
           {hiRes && <span className="np-badge np-badge-hires">Hi-Res</span>}
           {track.duration > 0 && <span className="np-badge">{formatTrackTime(track.duration)}</span>}
         </div>

--- a/src/features/nowPlaying/components/MobilePlayerView.tsx
+++ b/src/features/nowPlaying/components/MobilePlayerView.tsx
@@ -2,6 +2,7 @@ import { queueSongStar } from '@/features/playback/store/pendingStarSync';
 import { usePlaybackCoverArt } from '@/cover/usePlaybackCoverArt';
 import { usePlaybackTrackCoverRef } from '@/cover/useLibraryCoverRef';
 import type { Track } from '@/lib/media/trackTypes';
+import { effectiveAudioFormat } from '@/lib/media/streamFormat';
 import { getPlaybackProgressSnapshot, subscribePlaybackProgress } from '@/features/playback/store/playbackProgress';
 import React, { useState, useCallback, useRef, useEffect, useSyncExternalStore, CSSProperties } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -220,6 +221,7 @@ export default function MobilePlayerView() {
   }, []);
 
   const currentTrack = usePlayerStore(s => s.currentTrack);
+  const resolvedStreamFormat = usePlayerStore(s => s.resolvedStreamFormat);
   const isPlaying    = usePlayerStore(s => s.isPlaying);
   const playbackProgress = useSyncExternalStore(
     onStoreChange => subscribePlaybackProgress(() => onStoreChange()),
@@ -413,11 +415,12 @@ export default function MobilePlayerView() {
             )}
           </div>
           {(() => {
+            const fmt = effectiveAudioFormat(currentTrack, resolvedStreamFormat);
             const parts = [
               currentTrack.year,
               currentTrack.genre,
-              currentTrack.suffix?.toUpperCase(),
-              currentTrack.bitRate ? `${currentTrack.bitRate} kbps` : null,
+              fmt.formatLabel,
+              fmt.bitRate ? `${fmt.bitRateIsCap ? '≤' : ''}${fmt.bitRate} kbps` : null,
             ].filter(Boolean);
             return parts.length > 0
               ? <div className="mp-track-info truncate">{parts.join(' • ')}</div>

--- a/src/features/playback/store/audioEventHandlers.ts
+++ b/src/features/playback/store/audioEventHandlers.ts
@@ -32,6 +32,7 @@ import {
 import { noteEngineProgressForGapless } from '@/features/playback/store/gaplessProgressTracking';
 import { showToast } from '@/lib/dom/toast';
 import { useAuthStore } from '@/store/authStore';
+import { indexKeyBelongsToServer } from '@/store/localPlaybackResolve';
 import { getPlayGeneration, setIsAudioPaused } from '@/features/playback/store/engineState';
 import {
   clearPreloadingIds,
@@ -137,6 +138,65 @@ export function handleAudioPlaying(duration: number): void {
     // the `playing` state for servers with the playbackReport extension.
     playbackReportPlaying();
   }
+}
+
+/** Rust-side `audio:format` event payload — the actually-decoded stream format. */
+export type AudioFormatPayload = {
+  /** Track the engine resolved this format for. Absent on legacy events. */
+  trackId?: string | null;
+  /** Playback server index key — disambiguates duplicate track ids across servers. */
+  serverId?: string | null;
+  /** Playback generation of the stream (stale-event rejection). */
+  generation?: number | null;
+  /** `maxBitRate` the stream URL was opened with — latched per stream by Rust. */
+  streamCapKbps?: number | null;
+  codec: string;
+  sampleRate?: number | null;
+  bitsPerSample?: number | null;
+  channels?: number | null;
+  lossless: boolean;
+};
+
+/**
+ * The engine resolved the real codec/format of the live stream. Stamp it onto
+ * the current track so now-playing badges can show what the server is actually
+ * transmitting (a server-side transcode differs from the library's stored
+ * metadata). Identity-guarded: events for a since-skipped track, a duplicate
+ * id on another server, or an older playback generation are dropped.
+ */
+export function handleAudioFormat(payload: AudioFormatPayload): void {
+  const cur = usePlayerStore.getState().currentTrack;
+  if (!cur || !payload?.codec) return;
+  if (payload.trackId != null && payload.trackId !== cur.id) return;
+  // Rust sends the playback index key; the track carries a server profile id.
+  // `indexKeyBelongsToServer` maps between the two so a duplicate id on another
+  // server is rejected without false-rejecting the normal case.
+  if (payload.serverId != null && cur.serverId != null
+    && !indexKeyBelongsToServer(payload.serverId, cur.serverId)) return;
+  // Generation guard: a late event from a superseded playback of the SAME
+  // track (replay/restart) must not overwrite the current stream's format.
+  const prev = usePlayerStore.getState().resolvedStreamFormat;
+  if (
+    payload.generation != null
+    && prev?.generation != null
+    && prev.trackId === cur.id
+    && payload.generation < prev.generation
+  ) return;
+  usePlayerStore.setState({
+    resolvedStreamFormat: {
+      trackId: cur.id,
+      generation: payload.generation ?? undefined,
+      codec: payload.codec,
+      sampleRate: payload.sampleRate ?? undefined,
+      bitsPerSample: payload.bitsPerSample ?? undefined,
+      channels: payload.channels ?? undefined,
+      lossless: !!payload.lossless,
+      // The cap the stream was opened with, latched by Rust from the URL. No
+      // client-side cap feature exists yet, so this is normally absent/null —
+      // an explicit null is a real "no cap", never re-labelled.
+      streamCapKbps: payload.streamCapKbps ?? 0,
+    },
+  });
 }
 
 export function handleAudioProgress(

--- a/src/features/playback/store/audioFormatEvent.test.ts
+++ b/src/features/playback/store/audioFormatEvent.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Identity guarantees for the `audio:format` event.
+ *
+ * The engine resolves a stream's real format asynchronously; by the time the
+ * event reaches the frontend the user may have skipped, a different server
+ * may be serving a track that shares the same Subsonic id, or a superseded
+ * playback of the same track may deliver late. The resolved format must
+ * attach to the stream it was resolved for — never to whatever happens to be
+ * current when the event lands.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { handleAudioFormat } from '@/features/playback/store/audioEventHandlers';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { resetPlayerStore, resetAuthStore } from '@/test/helpers/storeReset';
+import type { Track } from '@/lib/media/trackTypes';
+
+function track(id: string, serverId: string): Track {
+  return {
+    id, title: 't', artist: 'a', album: 'al', albumId: 'alid',
+    duration: 100, suffix: 'flac', serverId,
+  };
+}
+
+beforeEach(() => {
+  resetPlayerStore();
+  resetAuthStore();
+});
+
+describe('audio:format event identity', () => {
+  it('attaches the format when it matches the current track', () => {
+    usePlayerStore.setState({ currentTrack: track('a', 's1') });
+    handleAudioFormat({ trackId: 'a', serverId: 's1', codec: 'opus', lossless: false });
+    expect(usePlayerStore.getState().resolvedStreamFormat?.trackId).toBe('a');
+    expect(usePlayerStore.getState().resolvedStreamFormat?.codec).toBe('opus');
+  });
+
+  it('does NOT attach a format resolved for a since-skipped track', () => {
+    // Event was resolved for track "a", but the user skipped to "b" first.
+    usePlayerStore.setState({ currentTrack: track('b', 's1') });
+    handleAudioFormat({ trackId: 'a', serverId: 's1', codec: 'opus', lossless: false });
+    expect(usePlayerStore.getState().resolvedStreamFormat).toBeNull();
+  });
+
+  it('does NOT attach across servers that share a track id', () => {
+    // Same Subsonic id "x", but the current track belongs to a different server.
+    usePlayerStore.setState({ currentTrack: track('x', 's2') });
+    handleAudioFormat({ trackId: 'x', serverId: 's1', codec: 'opus', lossless: false });
+    expect(usePlayerStore.getState().resolvedStreamFormat).toBeNull();
+  });
+
+  it('rejects an older-generation event for the same track (out-of-order delivery)', () => {
+    // Same track id + server (replay/repeat): a late event from the PREVIOUS
+    // playback generation must not overwrite the current stream's format.
+    usePlayerStore.setState({ currentTrack: track('a', 's1') });
+    handleAudioFormat({
+      trackId: 'a', serverId: 's1', generation: 7, streamCapKbps: null, codec: 'flac', lossless: true,
+    });
+    handleAudioFormat({
+      trackId: 'a', serverId: 's1', generation: 5, streamCapKbps: 128, codec: 'opus', lossless: false,
+    });
+    const fmt = usePlayerStore.getState().resolvedStreamFormat;
+    expect(fmt?.codec).toBe('flac');
+  });
+
+  it('treats an absent or explicit-null cap as a real "no cap"', () => {
+    usePlayerStore.setState({ currentTrack: track('a', 's1') });
+    handleAudioFormat({
+      trackId: 'a', serverId: 's1', streamCapKbps: null, codec: 'flac', lossless: true,
+    });
+    expect(usePlayerStore.getState().resolvedStreamFormat?.streamCapKbps).toBe(0);
+  });
+});

--- a/src/features/playback/store/audioListenerSetup/audioEngineListeners.ts
+++ b/src/features/playback/store/audioListenerSetup/audioEngineListeners.ts
@@ -8,9 +8,11 @@ import {
 import {
   handleAudioEnded,
   handleAudioError,
+  handleAudioFormat,
   handleAudioPlaying,
   handleAudioProgress,
   handleAudioTrackSwitched,
+  type AudioFormatPayload,
   type NormalizationStatePayload,
 } from '@/features/playback/store/audioEventHandlers';
 import {
@@ -57,6 +59,7 @@ export function setupAudioEngineListeners(): () => void {
 
   const pending = [
     listen<number>('audio:playing', ({ payload }) => handleAudioPlaying(payload)),
+    listen<AudioFormatPayload>('audio:format', ({ payload }) => handleAudioFormat(payload)),
     listen<{ current_time: number; duration: number; buffering?: boolean }>('audio:progress', ({ payload }) => {
       if (import.meta.env.DEV) {
         _devEventCount++;

--- a/src/features/playback/store/playTrackAction.ts
+++ b/src/features/playback/store/playTrackAction.ts
@@ -443,6 +443,9 @@ export function runPlayTrack(
       resetGaplessProgressTracking();
       set({
         currentTrack: trackForPlay,
+        // New playback generation: the previous stream's resolved format no
+        // longer applies (same-id replays would otherwise show stale data).
+        resolvedStreamFormat: null,
         waveformBins: null,
         ...deriveNormalizationSnapshot(trackForPlay, playNormWindow, normIdx),
         progress: initialProgress,
@@ -471,6 +474,7 @@ export function runPlayTrack(
       set({
         currentTrack: trackForPlay,
         currentRadio: null,
+        resolvedStreamFormat: null,
         waveformBins: null,
         ...deriveNormalizationSnapshot(trackForPlay, playNormWindow, normIdx),
         // Only a replace rewrites the queue; navigation keeps the canonical refs.

--- a/src/features/playback/store/playerStore.ts
+++ b/src/features/playback/store/playerStore.ts
@@ -43,6 +43,7 @@ export const usePlayerStore = create<PlayerState>()(
 
       return {
       currentTrack: null,
+      resolvedStreamFormat: null,
       waveformBins: null,
       normalizationNowDb: null,
       normalizationTargetLufs: null,

--- a/src/features/playback/store/playerStoreTypes.ts
+++ b/src/features/playback/store/playerStoreTypes.ts
@@ -1,9 +1,17 @@
 import type { InternetRadioStation } from '@/lib/api/subsonicTypes';
 import type { PlaybackSourceKind } from '@/features/playback/utils/playback/resolvePlaybackUrl';
 import type { Track, QueueItemRef } from '@/lib/media/trackTypes';
+import type { ResolvedStreamFormat } from '@/lib/media/streamFormat';
 
 export interface PlayerState {
   currentTrack: Track | null;
+  /**
+   * Format the Rust engine actually decoded for the live stream (`audio:format`
+   * event), stamped with the track it belongs to. Lets the now-playing badges
+   * show the real transmitted format when the server transcodes, instead of the
+   * stored library metadata. Not persisted; runtime-only.
+   */
+  resolvedStreamFormat: ResolvedStreamFormat | null;
   waveformBins: number[] | null;
   normalizationNowDb: number | null;
   normalizationTargetLufs: number | null;

--- a/src/features/queue/components/QueueCurrentTrack.tsx
+++ b/src/features/queue/components/QueueCurrentTrack.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ChevronDown, FolderOpen, HardDrive, Music, Waves } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import type { Track } from '@/lib/media/trackTypes';
+import { effectiveAudioFormat, effectiveAudioFormatParts } from '@/lib/media/streamFormat';
 import type { LoudnessLufsPreset, NormalizationEngine } from '@/store/authStoreTypes';
 import type { PlaybackSourceKind } from '@/features/playback/utils/playback/resolvePlaybackUrl';
 import {
@@ -55,6 +56,7 @@ export function QueueCurrentTrack({
   lufsTgtBtnRef, lufsTgtMenuRef, lufsTgtPopStyle, t,
 }: Props) {
   const showBufferingOverlay = usePlayerStore(s => s.isPlaybackBuffering);
+  const resolvedStreamFormat = usePlayerStore(s => s.resolvedStreamFormat);
   const coverRef = usePlaybackTrackCoverRef(currentTrack);
   const directCoverUrl = currentTrack?.directCoverArtUrl;
   const artistRefs = resolveTrackArtistRefs(currentTrack);
@@ -64,19 +66,16 @@ export function QueueCurrentTrack({
   return (
     <div className="queue-current-track">
       {(() => {
+        const fmt = effectiveAudioFormat(currentTrack, resolvedStreamFormat);
         const baseParts = [
-          currentTrack.suffix?.toUpperCase(),
-          currentTrack.bitRate ? `${currentTrack.bitRate} kbps` : undefined,
-          (() => {
-            const bd = currentTrack.bitDepth;
-            const sr = currentTrack.samplingRate ? `${currentTrack.samplingRate / 1000} kHz` : '';
-            if (bd && sr) return `${bd}/${sr}`;
-            if (bd) return `${bd}-bit`;
-            if (sr) return sr;
-            return undefined;
-          })(),
+          ...effectiveAudioFormatParts(fmt),
           bpmTech ?? undefined,
         ].filter(Boolean) as string[];
+        const transcodedTooltip = fmt.transcoded
+          ? t('queue.streamTranscoded', {
+            original: effectiveAudioFormatParts(effectiveAudioFormat(currentTrack, null)).join(' · '),
+          })
+          : undefined;
         const rgParts = formatQueueReplayGainParts(currentTrack, t);
         const baseLine = baseParts.join(' · ');
         const rgLine = rgParts.join(' · ');
@@ -124,7 +123,14 @@ export function QueueCurrentTrack({
                     {playbackSource === 'stream' && <Waves size={11} strokeWidth={2.25} />}
                   </span>
                 )}
-                {baseLine && <span className="queue-current-tech-main">{baseLine}</span>}
+                {baseLine && (
+                  <span
+                    className={`queue-current-tech-main${fmt.transcoded ? ' queue-current-tech-main--transcoded' : ''}`}
+                    data-tooltip={transcodedTooltip}
+                  >
+                    {baseLine}
+                  </span>
+                )}
                 {!isLoudnessActive && rgLine && (
                   <button
                     type="button"

--- a/src/lib/media/streamFormat.test.ts
+++ b/src/lib/media/streamFormat.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+  effectiveAudioFormat,
+  effectiveAudioFormatParts,
+  isStreamTranscoded,
+  type ResolvedStreamFormat,
+} from '@/lib/media/streamFormat';
+
+function resolved(partial: Partial<ResolvedStreamFormat> & { codec: string }): ResolvedStreamFormat {
+  return { trackId: 't1', lossless: false, ...partial };
+}
+
+describe('isStreamTranscoded', () => {
+  it('is false when the decoded codec matches the file suffix', () => {
+    expect(isStreamTranscoded('flac', 'flac')).toBe(false);
+    expect(isStreamTranscoded('mp3', 'mp3')).toBe(false);
+  });
+
+  it('is true when the server transcoded to a different codec', () => {
+    expect(isStreamTranscoded('flac', 'mp3')).toBe(true);
+    expect(isStreamTranscoded('flac', 'aac')).toBe(true);
+  });
+
+  it('treats multi-codec containers leniently (no false positive)', () => {
+    // m4a can hold AAC or ALAC; ogg can hold Vorbis or Opus.
+    expect(isStreamTranscoded('m4a', 'aac')).toBe(false);
+    expect(isStreamTranscoded('m4a', 'alac')).toBe(false);
+    expect(isStreamTranscoded('ogg', 'vorbis')).toBe(false);
+    expect(isStreamTranscoded('ogg', 'opus')).toBe(false);
+  });
+
+  it('normalizes pcm_* decoder names against wav', () => {
+    expect(isStreamTranscoded('wav', 'pcm_s16le')).toBe(false);
+    expect(isStreamTranscoded('wav', 'pcm_f32le')).toBe(false);
+  });
+
+  it('is conservative for unknown suffix / missing codec', () => {
+    expect(isStreamTranscoded('xyz', 'mp3')).toBe(false);
+    expect(isStreamTranscoded(undefined, 'mp3')).toBe(false);
+    expect(isStreamTranscoded('flac', '')).toBe(false);
+  });
+});
+
+describe('effectiveAudioFormat', () => {
+  const track = { id: 't1', suffix: 'flac', bitRate: 3149, samplingRate: 96000, bitDepth: 24 };
+
+  it('returns stored metadata when no resolved format is present', () => {
+    const fmt = effectiveAudioFormat(track, null);
+    expect(fmt).toMatchObject({
+      formatLabel: 'FLAC', bitRate: 3149, sampleRate: 96000, bitDepth: 24, transcoded: false,
+    });
+  });
+
+  it('ignores a resolved format stamped for a different track', () => {
+    const fmt = effectiveAudioFormat(track, resolved({ trackId: 'other', codec: 'mp3' }));
+    expect(fmt.formatLabel).toBe('FLAC');
+    expect(fmt.transcoded).toBe(false);
+  });
+
+  it('shows the real codec and drops stale bitrate/depth on a server transcode', () => {
+    const fmt = effectiveAudioFormat(
+      track,
+      resolved({ codec: 'mp3', sampleRate: 44100, lossless: false }),
+    );
+    expect(fmt.transcoded).toBe(true);
+    expect(fmt.formatLabel).toBe('MP3');
+    expect(fmt.bitRate).toBeUndefined();      // exact transmitted bitrate unknown, no cap set
+    expect(fmt.bitDepth).toBeUndefined();     // no bit depth for lossy output
+    expect(fmt.sampleRate).toBe(44100);
+  });
+
+  it('shows the requested cap as an upper bound when the user set one', () => {
+    const fmt = effectiveAudioFormat(
+      track,
+      resolved({ codec: 'mp3', sampleRate: 44100, streamCapKbps: 320 }),
+    );
+    expect(fmt.bitRate).toBe(320);
+    expect(fmt.bitRateIsCap).toBe(true);
+    expect(effectiveAudioFormatParts(fmt)).toContain('≤320 kbps');
+  });
+
+  it('keeps lossless bit depth when transcoding to another lossless codec', () => {
+    const fmt = effectiveAudioFormat(
+      { id: 't1', suffix: 'flac', bitRate: 3149, samplingRate: 96000, bitDepth: 24 },
+      resolved({ codec: 'alac', sampleRate: 96000, bitsPerSample: 24, lossless: true }),
+    );
+    expect(fmt.transcoded).toBe(true);
+    expect(fmt.formatLabel).toBe('ALAC');
+    expect(fmt.bitDepth).toBe(24);
+  });
+
+  it('detects a same-codec transcode when a cap below the stored bitrate is set (#6)', () => {
+    // Navidrome capping mp3@320 → mp3@128: codec is unchanged, so codec
+    // comparison alone misses it. A cap below the stored bitrate reveals it.
+    const mp3 = { id: 't1', suffix: 'mp3', bitRate: 320, samplingRate: 44100, bitDepth: undefined };
+    const fmt = effectiveAudioFormat(mp3, resolved({ codec: 'mp3', sampleRate: 44100, streamCapKbps: 128 }));
+    expect(fmt.transcoded).toBe(true);
+    expect(fmt.formatLabel).toBe('MP3');
+    expect(fmt.bitRate).toBe(128);
+    expect(fmt.bitRateIsCap).toBe(true);
+  });
+
+  it('does NOT flag a transcode when the cap is above the stored bitrate', () => {
+    // Stored 96 kbps, cap 128 → server streams the original untouched.
+    const mp3 = { id: 't1', suffix: 'mp3', bitRate: 96, samplingRate: 44100, bitDepth: undefined };
+    const fmt = effectiveAudioFormat(mp3, resolved({ codec: 'mp3', sampleRate: 44100, streamCapKbps: 128 }));
+    expect(fmt.transcoded).toBe(false);
+    expect(fmt.bitRate).toBe(96);
+  });
+
+  it('prefers the decoded sample rate when the codec is unchanged', () => {
+    const fmt = effectiveAudioFormat(
+      { id: 't1', suffix: 'flac', bitRate: 900, samplingRate: 44100, bitDepth: 16 },
+      resolved({ codec: 'flac', sampleRate: 48000, bitsPerSample: 24, lossless: true }),
+    );
+    expect(fmt.transcoded).toBe(false);
+    expect(fmt.sampleRate).toBe(48000);
+    expect(fmt.bitDepth).toBe(24);
+    expect(fmt.bitRate).toBe(900);            // stored bitrate kept (no transcode)
+  });
+});
+
+describe('effectiveAudioFormatParts', () => {
+  it('joins into the "FLAC · 3149 kbps · 24/96 kHz" shape', () => {
+    const parts = effectiveAudioFormatParts(
+      effectiveAudioFormat(
+        { id: 't1', suffix: 'flac', bitRate: 3149, samplingRate: 96000, bitDepth: 24 },
+        null,
+      ),
+    );
+    expect(parts).toEqual(['FLAC', '3149 kbps', '24/96 kHz']);
+  });
+});

--- a/src/lib/media/streamFormat.ts
+++ b/src/lib/media/streamFormat.ts
@@ -1,0 +1,169 @@
+import type { Track } from '@/lib/media/trackTypes';
+
+/**
+ * The format the Rust audio engine actually decoded for the live stream,
+ * delivered by the `audio:format` event. This reflects what the server is
+ * *transmitting right now* — which can differ from the track's stored library
+ * metadata when the server transcodes on the fly (e.g. Navidrome forced
+ * transcoding, or a client-requested `maxBitRate` cap).
+ *
+ * `trackId` stamps the currently-playing track at the moment the event
+ * arrived, so a stale format from a previous track is never shown against a
+ * new one (see `handleAudioFormat`).
+ */
+export interface ResolvedStreamFormat {
+  trackId: string;
+  /** Decoder codec short name, e.g. `mp3`, `flac`, `aac`, `opus`, `pcm_s16le`. */
+  codec: string;
+  /** Decoded sample rate in Hz. */
+  sampleRate?: number;
+  /** Bit depth — only meaningful (and only sent) for lossless codecs. */
+  bitsPerSample?: number;
+  channels?: number;
+  lossless: boolean;
+  /**
+   * Streaming bitrate cap (kbps) in effect when this stream was opened; 0 =
+   * Original. Captured at resolve time so the badge shows the cap the current
+   * stream actually used, not a setting the user changed mid-playback.
+   */
+  streamCapKbps?: number;
+  /**
+   * Playback generation the format belongs to — used to reject out-of-order
+   * events from a superseded stream of the same track (replay, rapid restart).
+   */
+  generation?: number;
+}
+
+/**
+ * Canonical codec family for a symphonia codec short-name. Collapses the
+ * decoder's specific name (`pcm_s16le`, `pcm_f32le`, …) onto the family we can
+ * compare against a file suffix.
+ */
+function codecFamily(codec: string): string {
+  const c = codec.trim().toLowerCase();
+  if (c.startsWith('pcm')) return 'pcm';
+  return c;
+}
+
+/**
+ * Codec families each file suffix can legitimately contain *without* a
+ * transcode. Containers that carry more than one codec (`m4a` → AAC or ALAC,
+ * `ogg` → Vorbis or Opus) list every acceptable family so an original file is
+ * never mislabelled as transcoded.
+ */
+const SUFFIX_CODECS: Record<string, readonly string[]> = {
+  mp3: ['mp3'],
+  flac: ['flac'],
+  m4a: ['aac', 'alac'],
+  m4b: ['aac', 'alac'],
+  mp4: ['aac', 'alac'],
+  aac: ['aac'],
+  ogg: ['vorbis', 'opus'],
+  oga: ['vorbis', 'opus'],
+  opus: ['opus'],
+  wav: ['pcm'],
+  wave: ['pcm'],
+  aiff: ['pcm'],
+  aif: ['pcm'],
+  wv: ['wavpack'],
+  wavpack: ['wavpack'],
+  ape: ['monkeys-audio'],
+  tta: ['tta'],
+  wma: ['wma'],
+};
+
+/**
+ * Whether the live-decoded codec differs from what the track's suffix implies —
+ * i.e. the server transcoded the stream. Conservative: an unknown suffix, a
+ * missing codec, or a suffix whose codec set includes the decoded family is
+ * treated as NOT transcoded, so we never show a spurious badge.
+ */
+export function isStreamTranscoded(suffix: string | undefined, codec: string): boolean {
+  if (!suffix || !codec) return false;
+  const accepted = SUFFIX_CODECS[suffix.trim().toLowerCase()];
+  if (!accepted) return false;
+  return !accepted.includes(codecFamily(codec));
+}
+
+/** Effective audio-format fields for the now-playing badges. */
+export interface EffectiveAudioFormat {
+  /** Uppercased format label — decoded codec when transcoded, else file suffix. */
+  formatLabel?: string;
+  /** kbps to display, or undefined when unknown (server-forced transcode, no cap). */
+  bitRate?: number;
+  /** `true` when {@link bitRate} is an upper bound (a client-requested cap), not exact. */
+  bitRateIsCap: boolean;
+  sampleRate?: number;
+  bitDepth?: number;
+  /** The stream is being transcoded by the server relative to the stored file. */
+  transcoded: boolean;
+}
+
+/**
+ * Merge the track's stored metadata with the live-resolved stream format into
+ * the fields the badges should display.
+ *
+ * - No resolved format, or not the current track, or no transcode detected →
+ *   the stored metadata is accurate; return it unchanged.
+ * - Transcode detected → show the decoded codec/sample-rate. Bit depth is only
+ *   kept for lossless output. The exact transmitted bitrate is not knowable, so
+ *   show the requested cap (`streamCapKbps`) when the user set one, else omit.
+ */
+export function effectiveAudioFormat(
+  track: Pick<Track, 'id' | 'suffix' | 'bitRate' | 'samplingRate' | 'bitDepth'>,
+  resolved: ResolvedStreamFormat | null | undefined,
+): EffectiveAudioFormat {
+  // The cap the stream was opened at travels on the resolved format, so the
+  // badge reflects the actual stream — not a setting changed mid-playback.
+  const streamCapKbps = resolved?.streamCapKbps ?? 0;
+  const base: EffectiveAudioFormat = {
+    formatLabel: track.suffix ? track.suffix.toUpperCase() : undefined,
+    bitRate: track.bitRate && track.bitRate > 0 ? track.bitRate : undefined,
+    bitRateIsCap: false,
+    sampleRate: track.samplingRate,
+    bitDepth: track.bitDepth,
+    transcoded: false,
+  };
+
+  if (!resolved || resolved.trackId !== track.id) return base;
+
+  // A transcode is happening if the decoded codec differs from the file, OR a
+  // cap below the stored bitrate is in effect — the latter catches same-codec
+  // reductions (e.g. mp3@320 → mp3@128) that a codec comparison alone misses.
+  const codecTranscoded = isStreamTranscoded(track.suffix, resolved.codec);
+  const capTranscoded = streamCapKbps > 0 && (track.bitRate == null || track.bitRate > streamCapKbps);
+  if (!codecTranscoded && !capTranscoded) {
+    // Not transcoded: the live decode confirms the stored metadata. Prefer the
+    // decoded sample rate / bit depth when the server reported them.
+    return {
+      ...base,
+      sampleRate: resolved.sampleRate ?? base.sampleRate,
+      bitDepth: resolved.lossless ? (resolved.bitsPerSample ?? base.bitDepth) : base.bitDepth,
+    };
+  }
+
+  const cap = streamCapKbps > 0 ? streamCapKbps : undefined;
+  return {
+    formatLabel: resolved.codec.toUpperCase(),
+    bitRate: cap,
+    bitRateIsCap: cap != null,
+    sampleRate: resolved.sampleRate ?? track.samplingRate,
+    bitDepth: resolved.lossless ? resolved.bitsPerSample : undefined,
+    transcoded: true,
+  };
+}
+
+/** Human-readable "SUFFIX · 320 kbps · 24-bit" parts for a joined badge line. */
+export function effectiveAudioFormatParts(fmt: EffectiveAudioFormat): string[] {
+  const parts: string[] = [];
+  if (fmt.formatLabel) parts.push(fmt.formatLabel);
+  if (fmt.bitRate) parts.push(`${fmt.bitRateIsCap ? '≤' : ''}${fmt.bitRate} kbps`);
+  if (fmt.bitDepth && fmt.sampleRate) {
+    parts.push(`${fmt.bitDepth}/${fmt.sampleRate / 1000} kHz`);
+  } else if (fmt.bitDepth) {
+    parts.push(`${fmt.bitDepth}-bit`);
+  } else if (fmt.sampleRate) {
+    parts.push(`${fmt.sampleRate / 1000} kHz`);
+  }
+  return parts;
+}

--- a/src/locales/bg/queue.ts
+++ b/src/locales/bg/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Възпроизвеждане от офлайн библиотека',
   sourceHot: 'Възпроизвеждане от кеша',
   sourceStream: 'Възпроизвеждане от мрежов поток',
+  streamTranscoded: 'Транскодирано от сървъра — оригинален файл: {{original}}',
   clearCachedLoudnessWaveform: 'Изчисти кешираната сила на звука и вълновата форма, след което анализирай отново тази песен',
   recalculatingLoudnessWaveform: 'Преизчисляване на силата на звука и вълновата форма за тази песен…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/de/queue.ts
+++ b/src/locales/de/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Wiedergabe aus der Offline-Bibliothek',
   sourceHot: 'Wiedergabe aus dem Cache',
   sourceStream: 'Wiedergabe aus dem Netzwerkstream',
+  streamTranscoded: 'Vom Server transkodiert — Originaldatei: {{original}}',
   clearCachedLoudnessWaveform: 'Clear cached loudness and waveform, then re-analyze this track',
   recalculatingLoudnessWaveform: 'Recalculating loudness and waveform for this track…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/en/queue.ts
+++ b/src/locales/en/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Playing from offline library',
   sourceHot: 'Playing from cache',
   sourceStream: 'Playing from network stream',
+  streamTranscoded: 'Transcoded by the server — original file: {{original}}',
   clearCachedLoudnessWaveform: 'Clear cached loudness and waveform, then re-analyze this track',
   recalculatingLoudnessWaveform: 'Recalculating loudness and waveform for this track…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/es/queue.ts
+++ b/src/locales/es/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Reproducción desde la biblioteca sin conexión',
   sourceHot: 'Reproducción desde la caché',
   sourceStream: 'Reproducción desde la transmisión en red',
+  streamTranscoded: 'Transcodificado por el servidor — archivo original: {{original}}',
   clearCachedLoudnessWaveform: 'Clear cached loudness and waveform, then re-analyze this track',
   recalculatingLoudnessWaveform: 'Recalculating loudness and waveform for this track…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/fr/queue.ts
+++ b/src/locales/fr/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Lecture depuis la bibliothèque hors ligne',
   sourceHot: 'Lecture depuis le cache',
   sourceStream: 'Lecture depuis le flux réseau',
+  streamTranscoded: 'Transcodé par le serveur — fichier d’origine : {{original}}',
   clearCachedLoudnessWaveform: 'Clear cached loudness and waveform, then re-analyze this track',
   recalculatingLoudnessWaveform: 'Recalculating loudness and waveform for this track…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/hu/queue.ts
+++ b/src/locales/hu/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Lejátszás az offline könyvtárból',
   sourceHot: 'Lejátszás a gyorsítótárból',
   sourceStream: 'Lejátszás hálózati streamből',
+  streamTranscoded: 'A szerver transzkódolta — eredeti fájl: {{original}}',
   clearCachedLoudnessWaveform: 'Gyorsítótárazott hangerő és hullámforma törlése, majd a szám újraelemzése',
   recalculatingLoudnessWaveform: 'A szám hangerejének és hullámformájának újraszámítása…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/it/queue.ts
+++ b/src/locales/it/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Riproduzione dalla libreria offline',
   sourceHot: 'Riproduzione dalla cache',
   sourceStream: 'Riproduzione dalla rete',
+  streamTranscoded: 'Transcodificato dal server — file originale: {{original}}',
   clearCachedLoudnessWaveform: 'Cancella la memoria cache del volume e della forma d\'onda, ri-analizza questo brano',
   recalculatingLoudnessWaveform: 'Ricalcolo del volume e della forma d\'onda per questo brano…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/ja/queue.ts
+++ b/src/locales/ja/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'オフラインライブラリから再生中',
   sourceHot: 'キャッシュから再生中',
   sourceStream: 'ネットワークストリームから再生中',
+  streamTranscoded: 'サーバーで変換済み — 元ファイル: {{original}}',
   clearCachedLoudnessWaveform: 'キャッシュ済みのラウドネスと波形をクリアし、このトラックを再解析',
   recalculatingLoudnessWaveform: 'このトラックのラウドネスと波形を再計算中…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/nb/queue.ts
+++ b/src/locales/nb/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Spiller fra offlinebibliotek',
   sourceHot: 'Spiller fra cache',
   sourceStream: 'Spiller fra nettverksstrøm',
+  streamTranscoded: 'Transkodet av serveren — originalfil: {{original}}',
   clearCachedLoudnessWaveform: 'Clear cached loudness and waveform, then re-analyze this track',
   recalculatingLoudnessWaveform: 'Recalculating loudness and waveform for this track…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/nl/queue.ts
+++ b/src/locales/nl/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Afspelen vanuit offlinebibliotheek',
   sourceHot: 'Afspelen vanuit cache',
   sourceStream: 'Afspelen vanuit netwerkstream',
+  streamTranscoded: 'Getranscodeerd door de server — origineel bestand: {{original}}',
   clearCachedLoudnessWaveform: 'Clear cached loudness and waveform, then re-analyze this track',
   recalculatingLoudnessWaveform: 'Recalculating loudness and waveform for this track…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/pl/queue.ts
+++ b/src/locales/pl/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Odtwarzanie z biblioteki offline',
   sourceHot: 'Odtwarzanie z pamięci podręcznej',
   sourceStream: 'Odtwarzanie z strumienia sieciowego',
+  streamTranscoded: 'Transkodowane przez serwer — oryginalny plik: {{original}}',
   clearCachedLoudnessWaveform: 'Wyczyść pamięć podręczną głośności i fali, a następnie ponownie przeanalizuj ten utwór',
   recalculatingLoudnessWaveform: 'Ponowne obliczanie głośności i fali dla tego utworu…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/ro/queue.ts
+++ b/src/locales/ro/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Se redă din librăria offline',
   sourceHot: 'Se redă din cache',
   sourceStream: 'Se redă din stream-ul de rețea',
+  streamTranscoded: 'Transcodat de server — fișier original: {{original}}',
   clearCachedLoudnessWaveform: 'Golește zgomotul si formele de undă din cache, apoi reanalizează piesa',
   recalculatingLoudnessWaveform: 'Se recalculează zgomotul și formele de undă pentru această piesă…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/ru/queue.ts
+++ b/src/locales/ru/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: 'Играет из офлайн-библиотеки',
   sourceHot: 'Играет из кэша',
   sourceStream: 'Играет из сетевого потока',
+  streamTranscoded: 'Транскодировано сервером — исходный файл: {{original}}',
   clearCachedLoudnessWaveform: 'Сбросить кэш громкости (LUFS) и формы волны и заново проанализировать трек',
   recalculatingLoudnessWaveform: 'Пересчёт громкости и формы волны для этого трека…',
   bpm: '{{bpm}} BPM',

--- a/src/locales/zh/queue.ts
+++ b/src/locales/zh/queue.ts
@@ -50,6 +50,7 @@ export const queue = {
   sourceOffline: '正在从离线库播放',
   sourceHot: '正在从缓存播放',
   sourceStream: '正在从网络流播放',
+  streamTranscoded: '已由服务器转码——原始文件:{{original}}',
   clearCachedLoudnessWaveform: 'Clear cached loudness and waveform, then re-analyze this track',
   recalculatingLoudnessWaveform: 'Recalculating loudness and waveform for this track…',
   bpm: '{{bpm}} BPM',

--- a/src/styles/layout/queue-panel.css
+++ b/src/styles/layout/queue-panel.css
@@ -395,6 +395,14 @@
   text-overflow: ellipsis;
 }
 
+/* Server is transcoding the live stream: the format shown is the real
+   transmitted codec, not the stored file. Accent it and hint via cursor that a
+   tooltip reveals the original. */
+.queue-current-tech-main--transcoded {
+  color: var(--accent, #8b5cf6);
+  cursor: help;
+}
+
 /* Two-line layout: base info + RG badge on top, optional ReplayGain
    values underneath when the badge is expanded. The stack wraps both
    rows so the source icon stays vertically centered next to the whole


### PR DESCRIPTION
## What this solves

The now-playing quality badge is built from the track's **stored library metadata**, so when the server transcodes the stream (e.g. Navidrome forced transcoding), the player still shows the original file — `FLAC · 3149 kbps · 24-bit` while actually receiving Opus.

The audio engine already resolves the true codec at decode time but only wrote it to the debug log. This PR surfaces it to the UI via a new additive `audio:format` event: badges on the queue panel, now-playing hero, mobile player, and immersive fullscreen show the **actually decoded** format when a transcode is happening (with the original file's format in a tooltip), and fall back to stored metadata otherwise. When the transmitted bitrate is unknown, none is shown rather than a wrong one.

## Scope

This is the read-only decoded-format reporting split out of #1334, per the review discussion there — it is useful on its own and ships independently of any streaming-quality controls. The event contract already carries the identity fields agreed in that review (track id, playback server, generation, latched `maxBitRate` from the stream URL — always absent today since nothing sends the param), so #1334 rebases onto this cleanly.

- Codec names resolve via the engine's own codec registry (includes the libopus adapter) — Opus streams read `OPUS`, not `?`.
- The frontend drops events for a since-skipped track, a duplicate Subsonic id on another server, or an older playback generation; a new playback clears the previous format.
- Gapless successors emit their resolved format at the transition (a chained advance never re-runs the play command).
- Transcode detection is container-aware (`m4a`→aac/alac, `ogg`→vorbis/opus) to avoid false positives on originals.

## Verification

- Regression tests: stale-event rejection (rapid skips, cross-server duplicate ids, out-of-order generations), explicit-null cap handling, gapless format emit (mock emitter), codec-registry resolution, format/transcode-detection helper cases.
- Full frontend and Rust suites pass locally; verified live against Navidrome with forced transcoding (badge reads the transcoded stream; original shown in tooltip).

<img width="336" height="198" alt="Screenshot 2026-07-23 at 4 20 29 PM" src="https://github.com/user-attachments/assets/3ac7ad41-5fe0-4f71-9d92-29c914434396" />

## Notes

- **Tauri boundary:** one additive event (`audio:format`). No commands changed or renamed; no bindings regeneration (events are hand-typed).
- **i18n:** the badge tooltip key is included for all shipped locales.
- **Server compatibility:** display-only; works with whatever the server transmits, no server support required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Merge order & rebase plan (this PR vs #1334)

This PR is a strict subset of #1334, extracted so the display-only fix can ship first. Intended sequence:

1. **Merge this PR (#1338) first.** It is self-contained: display-only, no persisted settings, no migrations, no on-disk changes, one additive Tauri event. Safe for any patch release.
2. **Then #1334 gets rebased onto `main`.** The shared code (event contract, badge surfaces, gapless emit, format helper, locale keys) is byte-identical here, so those hunks dissolve in the rebase and #1334 reduces to the streaming-quality feature itself: per-address bitrate/format controls, the trusted-original fingerprint probe, quality-aware cache identity, and the second-review fixes that only make sense alongside the cap feature. I'll do that rebase promptly after this merges and push with `--force-with-lease` — if anyone has local work on the #1334 branch at that moment, flag it there first so nothing gets stranded.
3. **Reviewing order note:** any review feedback on the shared code is best raised here (it lands in both), while cap/probe/settings feedback belongs on #1334.

Release/changelog: the 1.51.0 changelog entry currently sits in #1334 and describes the combined feature set. If this PR ships in a release before #1334, say the word and I'll add a standalone changelog line here (decoded-format display only) and trim the #1334 entry accordingly.

If the order ends up inverted for any reason (#1334 first), this PR becomes redundant and should simply be closed — everything in it is contained there.
