### PR TITLE
feat(player): add a volume slider to the Minimal and Immersive fullscreen modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **Settings → System → Logging** and **PsyLab → Logs** offer basic and verbose debug-depth levels while Debug logging is enabled. Verbose mode adds structured multi-server scope, reachability, music-folder and New Releases diagnostics, with credentials and sensitive URL data redacted.
 
+### Fullscreen player — volume slider in Minimal and Immersive modes
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1340](https://github.com/Psychotoxical/psysonic/pull/1340)**
+
+* The fullscreen player's volume control, previously only in **Prism** mode, is now also in the **Minimal** and **Immersive** styles — a mute toggle plus an always-visible level slider.
+
 ## Changed
 
 ### Library index — designed for several live servers at once

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -433,6 +433,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Fullscreen player style — selectable Minimal or Immersive view, with the artist backdrop, cover-derived accent, and rail/Apple lyrics (PR #1249)',
       'Word-by-word lyrics from the server via OpenSubsonic songLyrics v2, no third-party backend needed (PR #1265)',
       'Artist page — add the whole discography to the queue (PR #1321)',
+      'Fullscreen player — volume slider added to the Minimal and Immersive styles (PR #1340)',
     ],
   },
   {

--- a/src/features/fullscreenPlayer/components/FsVolume.test.tsx
+++ b/src/features/fullscreenPlayer/components/FsVolume.test.tsx
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { FsVolume } from './FsVolume';
+import { renderWithProviders } from '@/test/helpers/renderWithProviders';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { resetAllStores } from '@/test/helpers/storeReset';
+import { onInvoke } from '@/test/mocks/tauri';
+
+beforeEach(() => {
+  resetAllStores();
+  // `setVolume` pushes the level to the audio backend; stub the invoke so the
+  // store update runs instead of rejecting on an uninitialised bridge.
+  onInvoke('audio_set_volume', () => undefined);
+});
+
+describe('FsVolume', () => {
+  it('renders the mute toggle and a slider reflecting the current volume', () => {
+    usePlayerStore.setState({ volume: 0.6 });
+    const { getByLabelText } = renderWithProviders(<FsVolume />);
+    expect(getByLabelText('Mute')).toBeInTheDocument();
+    const slider = getByLabelText('Volume') as HTMLInputElement;
+    expect(slider.value).toBe('0.6');
+    // Screen readers announce a meaningful percentage, not a bare 0–1 number.
+    expect(slider).toHaveAttribute('aria-valuetext', '60%');
+  });
+
+  it('dragging the slider sets the volume', () => {
+    usePlayerStore.setState({ volume: 0.6 });
+    const { getByLabelText } = renderWithProviders(<FsVolume />);
+    fireEvent.change(getByLabelText('Volume'), { target: { value: '0.25' } });
+    expect(usePlayerStore.getState().volume).toBe(0.25);
+  });
+
+  it('mutes, then restores the previous level on unmute', () => {
+    usePlayerStore.setState({ volume: 0.8 });
+    const { getByLabelText } = renderWithProviders(<FsVolume />);
+    fireEvent.click(getByLabelText('Mute'));
+    expect(usePlayerStore.getState().volume).toBe(0);
+    fireEvent.click(getByLabelText('Unmute'));
+    expect(usePlayerStore.getState().volume).toBe(0.8);
+  });
+
+  it('adds a hover tooltip on the mute button only when asked', () => {
+    const { getByLabelText, rerender } = renderWithProviders(<FsVolume />);
+    expect(getByLabelText('Mute')).not.toHaveAttribute('data-tooltip');
+    rerender(<FsVolume showTooltip />);
+    expect(getByLabelText('Mute')).toHaveAttribute('data-tooltip', 'Mute');
+  });
+
+  it('passes each mode its own class names so the styling attaches', () => {
+    const { container, getByLabelText } = renderWithProviders(
+      <FsVolume className="fs-volume" buttonClassName="fs-btn" sliderClassName="fs-volume-slider" />,
+    );
+    expect(container.querySelector('.fs-volume')).not.toBeNull();
+    expect(getByLabelText('Mute')).toHaveClass('fs-btn');
+    expect(getByLabelText('Volume')).toHaveClass('fs-volume-slider');
+  });
+});

--- a/src/features/fullscreenPlayer/components/FsVolume.tsx
+++ b/src/features/fullscreenPlayer/components/FsVolume.tsx
@@ -1,0 +1,59 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Volume2, VolumeX } from 'lucide-react';
+import { useVolumeToggle } from '@/features/playback';
+
+type FsVolumeProps = {
+  /** Container class (per mode). Prism uses it to hover-reveal the slider; Minimal/Immersive render it always-visible. */
+  className?: string;
+  /** Mute-toggle button class (per fullscreen mode's button idiom). */
+  buttonClassName?: string;
+  /** Range-input class (per fullscreen mode's slider idiom). */
+  sliderClassName?: string;
+  /** Icon size, matched to the mode's other transport buttons. */
+  iconSize?: number;
+  /** Show a hover tooltip on the mute button (modes whose transport buttons use `data-tooltip`). */
+  showTooltip?: boolean;
+};
+
+/**
+ * Shared fullscreen-player volume control — the mute toggle + level slider used
+ * by every fullscreen style (Minimal, Immersive, Prism). One `useVolumeToggle`
+ * call site and one a11y pattern; each mode passes its own class names so the
+ * control keeps that mode's visual language (Prism's `fsp2-*`, Minimal's
+ * `fsp-*`, Immersive's `fs-*`).
+ */
+export const FsVolume = memo(function FsVolume({
+  className,
+  buttonClassName,
+  sliderClassName,
+  iconSize = 18,
+  showTooltip = false,
+}: FsVolumeProps) {
+  const { t } = useTranslation();
+  const { volume, setVolume, muted, toggleMute } = useVolumeToggle();
+  const label = muted ? t('player.unmute') : t('player.mute');
+  return (
+    <div className={className}>
+      <button
+        className={buttonClassName}
+        aria-label={label}
+        data-tooltip={showTooltip ? label : undefined}
+        onClick={toggleMute}
+      >
+        {muted ? <VolumeX size={iconSize} /> : <Volume2 size={iconSize} />}
+      </button>
+      <input
+        className={sliderClassName}
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={volume}
+        onChange={e => setVolume(parseFloat(e.target.value))}
+        aria-label={t('player.volume')}
+        aria-valuetext={`${Math.round(volume * 100)}%`}
+      />
+    </div>
+  );
+});

--- a/src/features/fullscreenPlayer/components/FullscreenPlayerImmersive.tsx
+++ b/src/features/fullscreenPlayer/components/FullscreenPlayerImmersive.tsx
@@ -20,6 +20,7 @@ import { FsSeekbar } from './FsSeekbar';
 import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
 import { FsLyricsMenu } from './FsLyricsMenu';
 import { FsPlayBtn } from './FsPlayBtn';
+import { FsVolume } from './FsVolume';
 import { useFsDynamicAccent } from '@/features/fullscreenPlayer/hooks/useFsDynamicAccent';
 import { useFsIdleFade } from '@/features/fullscreenPlayer/hooks/useFsIdleFade';
 import { useQueueTrackAt } from '@/features/queue';
@@ -242,6 +243,13 @@ export default function FullscreenPlayer({ onClose }: FullscreenPlayerProps) {
               <MicVocal size={14} />
             </button>
           </div>
+          <FsVolume
+            className="fs-volume"
+            buttonClassName="fs-btn fs-btn-sm"
+            sliderClassName="fs-volume-slider"
+            iconSize={14}
+            showTooltip
+          />
         </div>
 
       </div>

--- a/src/features/fullscreenPlayer/components/FullscreenPlayerPrism.tsx
+++ b/src/features/fullscreenPlayer/components/FullscreenPlayerPrism.tsx
@@ -2,9 +2,10 @@ import React, { memo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   SkipBack, SkipForward, Play, Pause, Repeat, Repeat1,
-  Volume2, VolumeX, ListMusic, MessageSquare, Shrink,
+  ListMusic, MessageSquare, Shrink,
 } from 'lucide-react';
-import { usePlayerStore, useVolumeToggle, type PlaybackProgressSnapshot } from '@/features/playback';
+import { usePlayerStore, type PlaybackProgressSnapshot } from '@/features/playback';
+import { FsVolume } from './FsVolume';
 import { useAlbumCoverRef } from '@/cover/useLibraryCoverRef';
 import { usePlaybackCoverArt } from '@/cover/usePlaybackCoverArt';
 import { useFsArtistBackdrop } from '@/features/fullscreenPlayer/hooks/useFsArtistBackdrop';
@@ -37,30 +38,6 @@ const PrismProgress = memo(function PrismProgress() {
         type="range" min={0} max={1} step={0.001} defaultValue={0}
         aria-label="Seek"
         {...seekHandlers}
-      />
-    </div>
-  );
-});
-
-/** Compact volume — icon toggles mute, hover reveals the slider. */
-const PrismVolume = memo(function PrismVolume() {
-  const { t } = useTranslation();
-  const { volume, setVolume, muted, toggleMute } = useVolumeToggle();
-  return (
-    <div className="fsp2-volume">
-      <button
-        className="fsp2-btn"
-        aria-label={muted ? t('player.unmute') : t('player.mute')}
-        onClick={toggleMute}
-      >
-        {muted ? <VolumeX size={18} /> : <Volume2 size={18} />}
-      </button>
-      <input
-        className="fsp2-volume-slider"
-        type="range" min={0} max={1} step={0.01}
-        value={volume}
-        onChange={e => setVolume(parseFloat(e.target.value))}
-        aria-label={t('player.volume')}
       />
     </div>
   );
@@ -144,7 +121,11 @@ export default function FullscreenPlayerPrism({ onClose }: { onClose: () => void
 
         {/* Utilities */}
         <div className="fsp2-bar-right">
-          <PrismVolume />
+          <FsVolume
+            className="fsp2-volume"
+            buttonClassName="fsp2-btn"
+            sliderClassName="fsp2-volume-slider"
+          />
           <button
             className={`fsp2-btn${queueOpen ? ' fsp2-btn-active' : ''}`}
             onClick={() => setQueueOpen(o => !o)}

--- a/src/features/fullscreenPlayer/components/FullscreenPlayerStatic.tsx
+++ b/src/features/fullscreenPlayer/components/FullscreenPlayerStatic.tsx
@@ -18,6 +18,7 @@ import { FsLyricsApple } from '@/features/fullscreenPlayer/components/FsLyricsAp
 import { FsPlayBtn } from '@/features/fullscreenPlayer/components/FsPlayBtn';
 import { FsClock } from '@/features/fullscreenPlayer/components/FsClock';
 import { FsTimeReadout } from '@/features/fullscreenPlayer/components/FsTimeReadout';
+import { FsVolume } from '@/features/fullscreenPlayer/components/FsVolume';
 import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
 
 interface Props {
@@ -227,6 +228,13 @@ export default function FullscreenPlayerStatic({ onClose }: Props) {
           <FsTimeReadout duration={duration} />
 
           <div className="fsp-actions">
+            <FsVolume
+              className="fsp-volume"
+              buttonClassName="fsp-btn fsp-btn-sm"
+              sliderClassName="fsp-volume-slider"
+              iconSize={20}
+              showTooltip
+            />
             <button className="fsp-btn fsp-btn-sm" onClick={() => setQueueOpen(true)} aria-label={t('queue.title')} data-tooltip={t('queue.title')}>
               <ListMusic size={20} />
             </button>

--- a/src/styles/components/fullscreen-player-immersive.css
+++ b/src/styles/components/fullscreen-player-immersive.css
@@ -315,6 +315,19 @@
   height: 28px;
 }
 
+/* Volume — mute toggle + an always-visible level slider (issue #1327). Shown at a
+   glance like every other control in this permanent toolbar. */
+.fs-volume {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.fs-volume-slider {
+  width: 72px;
+  accent-color: var(--dynamic-fs-accent, var(--accent));
+  cursor: pointer;
+}
+
 .fs-btn-play {
   width: 52px;
   height: 52px;

--- a/src/styles/components/fullscreen-player-static.css
+++ b/src/styles/components/fullscreen-player-static.css
@@ -329,6 +329,19 @@
   height: 46px;
 }
 
+/* Volume — mute toggle + an always-visible level slider (issue #1327). Shown at a
+   glance like every other control in this permanent toolbar. */
+.fsp-volume {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.fsp-volume-slider {
+  width: 96px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
 /* Reused FsPlayBtn (renders .fs-btn.fs-btn-play) — scope its look to this player. */
 .fsp .playback-transport-play-wrap {
   position: relative;


### PR DESCRIPTION
## Summary

Closes #1327. The fullscreen player only had a volume control in **Prism** mode — this adds one to **Minimal** and **Immersive** too.

- Prism's inline volume control is extracted into a shared **`FsVolume`** component: one `useVolumeToggle` call site and one accessibility pattern, with per-mode class names so each style keeps its own look (Prism `fsp2-*`, Minimal `fsp-*`, Immersive `fs-*`). Prism is unchanged visually.
- In the two permanent toolbars the slider is **always visible** (not hover-revealed like Prism) so the level shows at a glance and stays reachable by touch, and the mute button gets a `data-tooltip` like its sibling transport buttons.
- The slider announces its level as a **percentage** (`aria-valuetext`) instead of a bare 0–1 number; `0%` doubles as the muted signal.

## Test plan

- New `FsVolume.test.tsx` — slider reflects the store volume, dragging sets it, mute→unmute restores the previous level, the tooltip is opt-in, and the percentage value text is exposed.
- `tsc --noEmit`, `eslint`, `dependency-cruiser`, and `vitest run` (fullscreen-player suite, 18 tests) all clean.