### PR TITLE
feat(themes): gate theme installs on the theme's minimum app version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The fullscreen player's volume control, previously only in **Prism** mode, is now also in the **Minimal** and **Immersive** styles — a mute toggle plus an always-visible level slider.
 
+### Theme store — respect a theme's minimum app version
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1344](https://github.com/Psychotoxical/psysonic/pull/1344)**
+
+* A store theme that needs a newer Psysonic now shows "requires a newer version" in place of the install button, and pending updates that need a newer app are held back, instead of the install failing with a generic error. The notice clears once the app itself is updated.
+
 ## Changed
 
 ### Library index — designed for several live servers at once

--- a/src/features/settings/components/ThemeStoreSection.test.tsx
+++ b/src/features/settings/components/ThemeStoreSection.test.tsx
@@ -11,6 +11,8 @@ vi.mock('@/lib/themes/themeRegistry', () => ({
   fetchRegistry: vi.fn(),
   fetchThemeCss: vi.fn(async () => 'css'),
   assetUrl: (p: string) => `https://raw.example/${p}`,
+  // Sentinel floor: a theme tagged with this minAppVersion reads as too new.
+  themeRequiresNewerApp: (th: { minAppVersion?: string }) => th.minAppVersion === 'TOO_NEW',
 }));
 
 import { fetchRegistry } from '@/lib/themes/themeRegistry';
@@ -284,5 +286,17 @@ describe('ThemeStoreSection — pagination & refresh', () => {
     await screen.findByText('Zulu');
     // Without the pin, newest-first would order Alpha (06-10) before Zulu (06-01).
     expect(rowNames(container)).toEqual(['Zulu', 'Alpha']);
+  });
+
+  it('replaces the install button with a hint when the theme needs a newer app', async () => {
+    fetchRegistryMock.mockResolvedValue({
+      registry: registryOf([mkTheme('future', 'Future', { minAppVersion: 'TOO_NEW' })]),
+      stale: false,
+    });
+    renderWithProviders(<ThemeStoreSection />);
+
+    await screen.findByText('Future');
+    expect(screen.queryByRole('button', { name: /install/i })).toBeNull();
+    expect(screen.getByText(/requires psysonic/i)).toBeInTheDocument();
   });
 });

--- a/src/features/settings/components/ThemeStoreSection.tsx
+++ b/src/features/settings/components/ThemeStoreSection.tsx
@@ -12,6 +12,7 @@ import { useInstalledThemesStore, type InstalledTheme } from '@/store/installedT
 import {
   assetUrl,
   fetchRegistry,
+  themeRequiresNewerApp,
   type RegistryTheme,
 } from '@/lib/themes/themeRegistry';
 import { installThemeFromRegistry } from '@/lib/themes/installThemeFromRegistry';
@@ -329,7 +330,11 @@ export function ThemeStoreSection() {
           {pageItems.map((th, idx) => {
             const inst = installedMap.get(th.id);
             const isInstalled = !!inst;
-            const updateAvailable = isInstalled && isNewer(th.version, inst!.version);
+            // A theme built for a newer app can't be installed or updated here;
+            // the store shows a "requires a newer version" hint in place of the
+            // button rather than letting the install fail.
+            const requiresNewerApp = themeRequiresNewerApp(th);
+            const updateAvailable = isInstalled && isNewer(th.version, inst!.version) && !requiresNewerApp;
             const isActive = activeTheme === th.id;
             const busy = busyId === th.id;
             const changelogEntries = th.changelog ? sortedChangelog(th.changelog) : [];
@@ -435,7 +440,12 @@ export function ThemeStoreSection() {
                     </div>
                   )}
                   <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 12 }}>
-                    {!isInstalled && (
+                    {!isInstalled && requiresNewerApp && (
+                      <span role="status" style={{ fontSize: 12, color: 'var(--text-muted)', alignSelf: 'center' }}>
+                        {t('settings.themeStoreRequiresNewerApp', { version: th.minAppVersion })}
+                      </span>
+                    )}
+                    {!isInstalled && !requiresNewerApp && (
                       <button
                         className="btn btn-primary"
                         style={{ fontSize: 12, padding: '4px 12px', display: 'inline-flex', alignItems: 'center', gap: 5 }}

--- a/src/features/settings/hooks/useThemeUpdates.test.ts
+++ b/src/features/settings/hooks/useThemeUpdates.test.ts
@@ -4,6 +4,9 @@ import { renderHook, waitFor } from '@testing-library/react';
 vi.mock('@/lib/themes/themeRegistry', () => ({
   fetchRegistry: vi.fn(),
   getCachedRegistry: vi.fn(() => null),
+  // Sentinel floor so the filter wiring can be exercised without the real
+  // app-version comparison: any theme tagged with this minAppVersion is "too new".
+  themeRequiresNewerApp: (th: { minAppVersion?: string }) => th.minAppVersion === 'TOO_NEW',
 }));
 
 import { fetchRegistry, type Registry } from '@/lib/themes/themeRegistry';
@@ -16,8 +19,10 @@ function inst(id: string, version: string): InstalledTheme {
   return { id, name: id, author: 'x', version, description: '', mode: 'dark', css: '', installedAt: 0 };
 }
 
-function registry(themes: { id: string; version: string }[]): Registry {
-  return { themes: themes.map(t => ({ id: t.id, name: t.id, version: t.version })) } as unknown as Registry;
+function registry(themes: { id: string; version: string; minAppVersion?: string }[]): Registry {
+  return {
+    themes: themes.map(t => ({ id: t.id, name: t.id, version: t.version, minAppVersion: t.minAppVersion })),
+  } as unknown as Registry;
 }
 
 beforeEach(() => {
@@ -55,6 +60,18 @@ describe('useThemeUpdates', () => {
   it('ignores registry themes the user has not installed', async () => {
     useInstalledThemesStore.setState({ themes: [inst('a', '1.0.0')] });
     fetchRegistryMock.mockResolvedValue({ registry: registry([{ id: 'z', version: '9.0.0' }]), stale: false });
+
+    const { result } = renderHook(() => useThemeUpdates());
+    await waitFor(() => expect(fetchRegistryMock).toHaveBeenCalled());
+    expect(result.current).toEqual([]);
+  });
+
+  it('does not offer an update the current app is too old to install', async () => {
+    useInstalledThemesStore.setState({ themes: [inst('a', '1.0.0')] });
+    fetchRegistryMock.mockResolvedValue({
+      registry: registry([{ id: 'a', version: '2.0.0', minAppVersion: 'TOO_NEW' }]),
+      stale: false,
+    });
 
     const { result } = renderHook(() => useThemeUpdates());
     await waitFor(() => expect(fetchRegistryMock).toHaveBeenCalled());

--- a/src/features/settings/hooks/useThemeUpdates.ts
+++ b/src/features/settings/hooks/useThemeUpdates.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { isNewer } from '@/lib/util/appUpdaterHelpers';
-import { fetchRegistry, getCachedRegistry, type Registry, type RegistryTheme } from '@/lib/themes/themeRegistry';
+import { fetchRegistry, getCachedRegistry, themeRequiresNewerApp, type Registry, type RegistryTheme } from '@/lib/themes/themeRegistry';
 import { useInstalledThemesStore } from '@/store/installedThemesStore';
 
 // Refresh the registry from source once per app launch (not just from the
@@ -39,7 +39,10 @@ export function useThemeUpdates(): RegistryTheme[] {
     );
     return registry.themes.filter(rt => {
       const current = installedVersionById.get(rt.id);
-      return current != null && isNewer(rt.version, current);
+      // Don't offer an update this build cannot install — it would fail at the
+      // install choke point and the notice would never clear. It reappears once
+      // the app itself is updated past the theme's floor.
+      return current != null && isNewer(rt.version, current) && !themeRequiresNewerApp(rt);
     });
   }, [registry, installed]);
 }

--- a/src/lib/themes/installThemeFromRegistry.test.ts
+++ b/src/lib/themes/installThemeFromRegistry.test.ts
@@ -1,15 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/lib/themes/themeRegistry', () => ({ fetchThemeCss: vi.fn() }));
+vi.mock('@/lib/themes/themeRegistry', () => ({
+  fetchThemeCss: vi.fn(),
+  themeRequiresNewerApp: vi.fn(),
+}));
 vi.mock('@/lib/themes/themeInjection', () => ({ validateThemeCss: vi.fn() }));
 
-import { fetchThemeCss, type RegistryTheme } from '@/lib/themes/themeRegistry';
+import { fetchThemeCss, themeRequiresNewerApp, type RegistryTheme } from '@/lib/themes/themeRegistry';
 import { validateThemeCss } from '@/lib/themes/themeInjection';
 import { useInstalledThemesStore } from '@/store/installedThemesStore';
 import { installThemeFromRegistry } from '@/lib/themes/installThemeFromRegistry';
 
 const fetchCss = vi.mocked(fetchThemeCss);
 const validate = vi.mocked(validateThemeCss);
+const requiresNewerApp = vi.mocked(themeRequiresNewerApp);
 
 const TH = {
   id: 'theme-a',
@@ -26,6 +30,8 @@ beforeEach(() => {
   useInstalledThemesStore.setState({ themes: [] });
   fetchCss.mockReset();
   validate.mockReset();
+  requiresNewerApp.mockReset();
+  requiresNewerApp.mockReturnValue(false);
 });
 
 describe('installThemeFromRegistry', () => {
@@ -52,6 +58,14 @@ describe('installThemeFromRegistry', () => {
     fetchCss.mockRejectedValue(new Error('network'));
 
     await expect(installThemeFromRegistry(TH)).resolves.toBe('error');
+    expect(useInstalledThemesStore.getState().isInstalled('theme-a')).toBe(false);
+  });
+
+  it('refuses a theme that needs a newer app, before any fetch', async () => {
+    requiresNewerApp.mockReturnValue(true);
+
+    await expect(installThemeFromRegistry(TH)).resolves.toBe('app-too-old');
+    expect(fetchCss).not.toHaveBeenCalled();
     expect(useInstalledThemesStore.getState().isInstalled('theme-a')).toBe(false);
   });
 });

--- a/src/lib/themes/installThemeFromRegistry.ts
+++ b/src/lib/themes/installThemeFromRegistry.ts
@@ -1,8 +1,8 @@
-import { fetchThemeCss, type RegistryTheme } from '@/lib/themes/themeRegistry';
+import { fetchThemeCss, themeRequiresNewerApp, type RegistryTheme } from '@/lib/themes/themeRegistry';
 import { validateThemeCss } from '@/lib/themes/themeInjection';
 import { useInstalledThemesStore } from '@/store/installedThemesStore';
 
-export type InstallResult = 'ok' | 'invalid' | 'error';
+export type InstallResult = 'ok' | 'invalid' | 'error' | 'app-too-old';
 
 /**
  * Fetch a registry theme's CSS, validate it against the in-app safety floor,
@@ -10,10 +10,16 @@ export type InstallResult = 'ok' | 'invalid' | 'error';
  * Shared by the Theme Store list and the "your themes" update chip so both go
  * through the same fetch → validate → install path.
  *
- * Never throws: returns `'invalid'` when the CSS fails the floor and `'error'`
- * on a network/fetch failure, so callers can surface it without a try/catch.
+ * Never throws: returns `'app-too-old'` when the theme needs a newer app,
+ * `'invalid'` when the CSS fails the floor and `'error'` on a network/fetch
+ * failure, so callers can surface it without a try/catch.
  */
 export async function installThemeFromRegistry(th: RegistryTheme): Promise<InstallResult> {
+  // Refuse before any fetch: a theme built for a newer app may rely on a
+  // capability this build lacks, so installing it would render broken. This is
+  // the single choke point every install/update path goes through, so the guard
+  // holds even where a caller forgets to check.
+  if (themeRequiresNewerApp(th)) return 'app-too-old';
   try {
     const css = await fetchThemeCss(th.css);
     // Don't persist CSS that won't inject — it would show as installed/active

--- a/src/lib/themes/themeRegistry.test.ts
+++ b/src/lib/themes/themeRegistry.test.ts
@@ -3,7 +3,7 @@
  * stale-on-error fallback, and malformed-cache tolerance.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchRegistry, getCachedRegistry, revalidateRegistry } from '@/lib/themes/themeRegistry';
+import { fetchRegistry, getCachedRegistry, revalidateRegistry, themeRequiresNewerApp } from '@/lib/themes/themeRegistry';
 
 const CACHE_KEY = 'psysonic_theme_registry_cache';
 const NOW = 1_000_000_000;
@@ -145,5 +145,24 @@ describe('revalidateRegistry', () => {
     const seen: string[] = [];
     await expect(revalidateRegistry(r => seen.push(r.generatedAt))).resolves.toBeUndefined();
     expect(seen).toEqual([]);
+  });
+});
+
+describe('themeRequiresNewerApp', () => {
+  it('is false when the theme declares no floor', () => {
+    expect(themeRequiresNewerApp({}, '1.51.0')).toBe(false);
+    expect(themeRequiresNewerApp({ minAppVersion: undefined }, '1.51.0')).toBe(false);
+  });
+
+  it('is true only when the floor is above the running app', () => {
+    expect(themeRequiresNewerApp({ minAppVersion: '1.52.0' }, '1.51.0')).toBe(true);
+    expect(themeRequiresNewerApp({ minAppVersion: '1.51.0' }, '1.51.0')).toBe(false);
+    expect(themeRequiresNewerApp({ minAppVersion: '1.50.0' }, '1.51.0')).toBe(false);
+  });
+
+  it('ignores a pre-release suffix on the running build', () => {
+    // A dev/rc build of the same numeric version still satisfies the floor.
+    expect(themeRequiresNewerApp({ minAppVersion: '1.51.0' }, '1.51.0-dev')).toBe(false);
+    expect(themeRequiresNewerApp({ minAppVersion: '1.52.0' }, '1.51.0-dev')).toBe(true);
   });
 });

--- a/src/lib/themes/themeRegistry.ts
+++ b/src/lib/themes/themeRegistry.ts
@@ -6,6 +6,9 @@
  * offline against the last-seen catalogue.
  */
 
+import { APP_VERSION } from '@/generated/appVersion';
+import { isNewer } from '@/lib/util/appUpdaterHelpers';
+
 const RAW_BASE = 'https://raw.githubusercontent.com/Psysonic/psysonic-themes/main';
 const REGISTRY_URL = `${RAW_BASE}/registry.json`;
 const CACHE_KEY = 'psysonic_theme_registry_cache';
@@ -36,6 +39,14 @@ export interface RegistryTheme {
    * absent for themes that don't ship one.
    */
   changelog?: Record<string, string[]>;
+  /**
+   * Optional minimum app version the theme needs (`X.Y.Z`). Author-provided in
+   * the manifest and carried through the generated registry. Themes that rely on
+   * a capability a given app build lacks (e.g. local theme assets) set it so the
+   * store can show "requires a newer version" instead of a confusing failed
+   * install. Absent for themes with no floor.
+   */
+  minAppVersion?: string;
 }
 
 export interface Registry {
@@ -151,4 +162,17 @@ export async function fetchThemeCss(relPath: string): Promise<string> {
   const res = await fetch(assetUrl(relPath), { cache: 'no-cache' });
   if (!res.ok) throw new Error(`theme css fetch failed: ${res.status}`);
   return res.text();
+}
+
+/**
+ * True when a theme declares a minimum app version newer than this build, i.e.
+ * the running app is too old to install it correctly. Uses the same numeric
+ * `isNewer` comparison as theme updates, so a pre-release suffix on either side
+ * (`1.51.0-dev`) is ignored. A theme with no floor always returns `false`.
+ */
+export function themeRequiresNewerApp(
+  theme: Pick<RegistryTheme, 'minAppVersion'>,
+  appVersion: string = APP_VERSION,
+): boolean {
+  return !!theme.minAppVersion && isNewer(theme.minAppVersion, appVersion);
 }

--- a/src/locales/bg/settings.ts
+++ b/src/locales/bg/settings.ts
@@ -483,6 +483,7 @@ export const settings = {
   themeStoreUpdating: 'Обновяване…',
   themeStoreUninstall: 'Деинсталирай',
   themeStoreInstallFailed: 'Инсталирането се провали',
+  themeStoreRequiresNewerApp: 'Изисква Psysonic {{version}}+',
   themeStorePagePrev: 'Предишна страница',
   themeStorePageNext: 'Следваща страница',
   themeStorePageStatus: 'Страница {{page}} от {{total}}',

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -439,6 +439,7 @@ export const settings = {
   themeStoreUpdating: 'Aktualisiere…',
   themeStoreUninstall: 'Deinstallieren',
   themeStoreInstallFailed: 'Installation fehlgeschlagen',
+  themeStoreRequiresNewerApp: 'Benötigt Psysonic {{version}}+',
   themeStorePagePrev: 'Vorherige Seite',
   themeStorePageNext: 'Nächste Seite',
   themeStorePageStatus: 'Seite {{page}} von {{total}}',

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -483,6 +483,7 @@ export const settings = {
   themeStoreUpdating: 'Updating…',
   themeStoreUninstall: 'Uninstall',
   themeStoreInstallFailed: 'Install failed',
+  themeStoreRequiresNewerApp: 'Requires Psysonic {{version}}+',
   themeStorePagePrev: 'Previous page',
   themeStorePageNext: 'Next page',
   themeStorePageStatus: 'Page {{page}} of {{total}}',

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -437,6 +437,7 @@ export const settings = {
   themeStoreUpdating: 'Actualizando…',
   themeStoreUninstall: 'Desinstalar',
   themeStoreInstallFailed: 'Error al instalar',
+  themeStoreRequiresNewerApp: 'Requiere Psysonic {{version}}+',
   themeStorePagePrev: 'Página anterior',
   themeStorePageNext: 'Página siguiente',
   themeStorePageStatus: 'Página {{page}} de {{total}}',

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -425,6 +425,7 @@ export const settings = {
   themeStoreUpdating: 'Mise à jour…',
   themeStoreUninstall: 'Désinstaller',
   themeStoreInstallFailed: "Échec de l'installation",
+  themeStoreRequiresNewerApp: 'Nécessite Psysonic {{version}}+',
   themeStorePagePrev: 'Page précédente',
   themeStorePageNext: 'Page suivante',
   themeStorePageStatus: 'Page {{page}} sur {{total}}',

--- a/src/locales/hu/settings.ts
+++ b/src/locales/hu/settings.ts
@@ -483,6 +483,7 @@ export const settings = {
   themeStoreUpdating: 'Frissítés…',
   themeStoreUninstall: 'Eltávolítás',
   themeStoreInstallFailed: 'A telepítés sikertelen',
+  themeStoreRequiresNewerApp: 'Psysonic {{version}}+ szükséges',
   themeStorePagePrev: 'Előző oldal',
   themeStorePageNext: 'Következő oldal',
   themeStorePageStatus: '{{page}}. oldal a(z) {{total}}-ból',

--- a/src/locales/it/settings.ts
+++ b/src/locales/it/settings.ts
@@ -483,6 +483,7 @@ export const settings = {
   themeStoreUpdating: 'Aggiornamento in corso…',
   themeStoreUninstall: 'Disinstalla',
   themeStoreInstallFailed: 'Installazione non riuscita',
+  themeStoreRequiresNewerApp: 'Richiede Psysonic {{version}}+',
   themeStorePagePrev: 'Pagina precedente',
   themeStorePageNext: 'Pagina successiva',
   themeStorePageStatus: 'Pagina {{page}} di {{total}}',

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -477,6 +477,7 @@ export const settings = {
   themeStoreUpdating: '更新中…',
   themeStoreUninstall: 'アンインストール',
   themeStoreInstallFailed: 'インストールに失敗しました',
+  themeStoreRequiresNewerApp: 'Psysonic {{version}} 以降が必要です',
   themeStorePagePrev: '前のページ',
   themeStorePageNext: '次のページ',
   themeStorePageStatus: '{{page}} / {{total}} ページ',

--- a/src/locales/nb/settings.ts
+++ b/src/locales/nb/settings.ts
@@ -428,6 +428,7 @@ export const settings = {
   themeStoreUpdating: 'Oppdaterer…',
   themeStoreUninstall: 'Avinstaller',
   themeStoreInstallFailed: 'Installasjonen mislyktes',
+  themeStoreRequiresNewerApp: 'Krever Psysonic {{version}}+',
   themeStorePagePrev: 'Forrige side',
   themeStorePageNext: 'Neste side',
   themeStorePageStatus: 'Side {{page}} av {{total}}',

--- a/src/locales/nl/settings.ts
+++ b/src/locales/nl/settings.ts
@@ -425,6 +425,7 @@ export const settings = {
   themeStoreUpdating: 'Bijwerken…',
   themeStoreUninstall: 'Verwijderen',
   themeStoreInstallFailed: 'Installatie mislukt',
+  themeStoreRequiresNewerApp: 'Vereist Psysonic {{version}}+',
   themeStorePagePrev: 'Vorige pagina',
   themeStorePageNext: 'Volgende pagina',
   themeStorePageStatus: 'Pagina {{page}} van {{total}}',

--- a/src/locales/pl/settings.ts
+++ b/src/locales/pl/settings.ts
@@ -483,6 +483,7 @@ export const settings = {
   themeStoreUpdating: 'Aktualizowanie…',
   themeStoreUninstall: 'Odinstaluj',
   themeStoreInstallFailed: 'Instalacja nie powiodła się',
+  themeStoreRequiresNewerApp: 'Wymaga Psysonic {{version}}+',
   themeStorePagePrev: 'Poprzednia strona',
   themeStorePageNext: 'Następna strona',
   themeStorePageStatus: 'Strona {{page}} o {{total}}',

--- a/src/locales/ro/settings.ts
+++ b/src/locales/ro/settings.ts
@@ -441,6 +441,7 @@ export const settings = {
   themeStoreUpdating: 'Se actualizează…',
   themeStoreUninstall: 'Dezinstalează',
   themeStoreInstallFailed: 'Instalarea a eșuat',
+  themeStoreRequiresNewerApp: 'Necesită Psysonic {{version}}+',
   themeStorePagePrev: 'Pagina anterioară',
   themeStorePageNext: 'Pagina următoare',
   themeStorePageStatus: 'Pagina {{page}} din {{total}}',

--- a/src/locales/ru/settings.ts
+++ b/src/locales/ru/settings.ts
@@ -493,6 +493,7 @@ export const settings = {
   themeStoreUpdating: 'Обновление…',
   themeStoreUninstall: 'Удалить',
   themeStoreInstallFailed: 'Ошибка установки',
+  themeStoreRequiresNewerApp: 'Требуется Psysonic {{version}}+',
   themeStorePagePrev: 'Предыдущая страница',
   themeStorePageNext: 'Следующая страница',
   themeStorePageStatus: 'Страница {{page}} из {{total}}',

--- a/src/locales/zh/settings.ts
+++ b/src/locales/zh/settings.ts
@@ -424,6 +424,7 @@ export const settings = {
   themeStoreUpdating: '正在更新…',
   themeStoreUninstall: '卸载',
   themeStoreInstallFailed: '安装失败',
+  themeStoreRequiresNewerApp: '需要 Psysonic {{version}} 或更高版本',
   themeStorePagePrev: '上一页',
   themeStorePageNext: '下一页',
   themeStorePageStatus: '第 {{page}} 页，共 {{total}} 页',


### PR DESCRIPTION
A theme can declare `minAppVersion` in its manifest and the generated registry already carries it, but the app never used it — a theme built for a newer build would fetch, fail the safety floor and report a bare "install failed".

- `themeRequiresNewerApp` compares the declared floor against the running build with the same numeric `isNewer` rule theme updates use (pre-release suffix ignored).
- `installThemeFromRegistry` refuses `app-too-old` before any fetch — the single choke point both the store and the update chip go through.
- The update hook no longer offers an update the app can't install; it reappears once the app itself is updated.
- The store card shows "requires a newer version" in place of the install button, in all 14 locales.

Groundwork for local theme assets. No repo change needed — the registry build already passes `minAppVersion` through.

Test plan
- New tests: `themeRequiresNewerApp`, the install guard refusing before fetch, `useThemeUpdates` filtering an uninstallable update, and the store card hint. Guard verified red when removed.
- `npx tsc --noEmit`, `npm run lint`, `npm run dep:check` clean; full `npx vitest run` green (3462 / 495).