### PR TITLE
feat(themes): support local asset files in installed themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * A store theme that needs a newer Psysonic now shows "requires a newer version" in place of the install button, and pending updates that need a newer app are held back, instead of the install failing with a generic error. The notice clears once the app itself is updated.
 
+### Themes — bundle local images and fonts
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1345](https://github.com/Psychotoxical/psysonic/pull/1345)**
+
+* Themes can ship their own images and fonts in an `assets/` folder and reference them with a relative `url("assets/…")`, instead of embedding everything as inline data. Assets are written to disk on install and served locally — themes still never reach the network. Works for both Theme Store installs and imported `.zip` themes; uninstalling a theme removes its files.
+
 ## Changed
 
 ### Library index — designed for several live servers at once

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -22,6 +22,8 @@
     "fs:allow-write-file",
     "fs:allow-read-file",
     "fs:allow-mkdir",
+    "fs:allow-remove",
+    "fs:allow-read-dir",
     "fs:allow-app-write-recursive",
     "fs:scope-download-recursive",
     "fs:scope-home-recursive",

--- a/src-tauri/src/theme_import.rs
+++ b/src-tauri/src/theme_import.rs
@@ -1,30 +1,50 @@
 //! Local theme-package import.
 //!
-//! Reads a user-picked `.zip` and returns its `manifest.json` + `theme.css`
-//! to the frontend, which runs the full theme-store contract validation
-//! (`src/utils/themes/validateThemePackage.ts`) before installing.
+//! Reads a user-picked `.zip` and returns its `manifest.json`, `theme.css` and
+//! any `assets/` files to the frontend, which runs the full theme-store contract
+//! validation (`src/lib/themes/validateThemePackage.ts` + `themeAssets.ts`)
+//! before installing.
 //!
-//! Only those two entries are pulled out — the thumbnail is not needed (the UI
-//! derives a swatch from the CSS). Parsing the untrusted archive happens here
-//! in Rust, outside the webview, and every read is size-capped so a malformed
-//! or hostile archive (lying header, zip-bomb, path traversal) cannot exhaust
-//! memory or escape the archive.
+//! The thumbnail is not returned (the UI derives a swatch from the CSS). Parsing
+//! the untrusted archive happens here in Rust, outside the webview, and every
+//! read is size-capped so a malformed or hostile archive (lying header, zip-bomb,
+//! path traversal) cannot exhaust memory or escape the archive. Asset extraction
+//! additionally enforces the contract's extension whitelist and budgets; the
+//! frontend re-validates (path containment, SVG content) before writing to disk.
 
 use std::io::Read;
 
 use serde::Serialize;
 
-/// On-disk archive cap. A real token-only theme zip is a few KB.
-const MAX_ARCHIVE_BYTES: u64 = 4 * 1024 * 1024;
+/// On-disk archive cap. Small — a theme with a couple of assets is well under this.
+const MAX_ARCHIVE_BYTES: u64 = 8 * 1024 * 1024;
 /// Per-entry uncompressed caps — mirror the frontend/CI limits
-/// (`validateThemeCss` caps CSS at 64 KB; the manifest is tiny).
+/// (`validateThemeCss` caps CSS at 256 KB; the manifest is tiny).
 const MAX_MANIFEST_BYTES: usize = 64 * 1024;
 const MAX_CSS_BYTES: usize = 256 * 1024;
+/// Asset budgets — mirror `themeAssets.ts` `ASSET_CAPS`.
+const MAX_ASSET_FILE_BYTES: u64 = 1024 * 1024; // 1 MB
+const MAX_ASSETS_TOTAL_BYTES: u64 = 4 * 1024 * 1024; // 4 MB
+const MAX_ASSET_FILES: usize = 32;
+/// Allowed asset extensions — mirror `themeAssets.ts` `ASSET_EXTS`.
+const ASSET_EXTS: &[&str] = &[
+    "webp", "png", "jpg", "jpeg", "gif", "avif", "svg", "woff2", "woff",
+];
+
+#[derive(Serialize, specta::Type, Debug)]
+pub struct ImportedThemeAsset {
+    /// Theme-relative path, forward-slashed, e.g. `assets/logo.svg`.
+    pub rel: String,
+    /// Raw bytes. Assets are small (whitelisted images/fonts, ≤ 1 MB each), so a
+    /// plain byte array over IPC is fine.
+    pub bytes: Vec<u8>,
+}
 
 #[derive(Serialize, specta::Type)]
 pub struct ImportedThemeFiles {
     pub manifest: String,
     pub css: String,
+    pub assets: Vec<ImportedThemeAsset>,
 }
 
 #[tauri::command]
@@ -49,8 +69,83 @@ pub fn import_theme_zip(path: String) -> Result<ImportedThemeFiles, String> {
         .ok_or_else(|| "manifest.json was not found in the archive".to_string())?;
     let css = read_capped_entry(&mut archive, "theme.css", MAX_CSS_BYTES)?
         .ok_or_else(|| "theme.css was not found in the archive".to_string())?;
+    let assets = read_asset_entries(&mut archive)?;
 
-    Ok(ImportedThemeFiles { manifest, css })
+    Ok(ImportedThemeFiles {
+        manifest,
+        css,
+        assets,
+    })
+}
+
+/// Read every file entry under `assets/` (at the archive root or under a single
+/// wrapping folder). Rejects traversal, enforces the extension whitelist and the
+/// per-file / total / count budgets. Bytes are read bounded so a lying header
+/// cannot allocate past the cap.
+fn read_asset_entries<R: Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+) -> Result<Vec<ImportedThemeAsset>, String> {
+    let mut assets = Vec::new();
+    let mut total: u64 = 0;
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| format!("corrupt archive entry: {e}"))?;
+        if entry.is_dir() {
+            continue;
+        }
+        // `enclosed_name()` is `None` for absolute paths or `..` traversal.
+        let path = match entry.enclosed_name() {
+            Some(p) => p,
+            None => return Err("archive contains an unsafe path".to_string()),
+        };
+        // Normalize to the theme-relative `assets/…` form, tolerating a single
+        // wrapping folder (`<name>/assets/…`).
+        let rel = {
+            let comps: Vec<String> = path
+                .components()
+                .filter_map(|c| c.as_os_str().to_str().map(|s| s.to_string()))
+                .collect();
+            match comps.iter().position(|c| c == "assets") {
+                Some(idx) if idx + 1 < comps.len() => comps[idx..].join("/"),
+                _ => continue, // not under assets/
+            }
+        };
+        let ext = rel.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+        if !ASSET_EXTS.contains(&ext.as_str()) {
+            return Err(format!("asset \"{rel}\" has a disallowed type"));
+        }
+        if entry.size() > MAX_ASSET_FILE_BYTES {
+            return Err(format!(
+                "asset \"{rel}\" is too large (> {} KB)",
+                MAX_ASSET_FILE_BYTES / 1024
+            ));
+        }
+        if assets.len() >= MAX_ASSET_FILES {
+            return Err(format!("archive has more than {MAX_ASSET_FILES} asset files"));
+        }
+        let mut buf = Vec::new();
+        entry
+            .by_ref()
+            .take(MAX_ASSET_FILE_BYTES + 1)
+            .read_to_end(&mut buf)
+            .map_err(|e| format!("cannot read {rel}: {e}"))?;
+        if buf.len() as u64 > MAX_ASSET_FILE_BYTES {
+            return Err(format!(
+                "asset \"{rel}\" is too large (> {} KB)",
+                MAX_ASSET_FILE_BYTES / 1024
+            ));
+        }
+        total += buf.len() as u64;
+        if total > MAX_ASSETS_TOTAL_BYTES {
+            return Err(format!(
+                "assets exceed the total cap (> {} KB)",
+                MAX_ASSETS_TOTAL_BYTES / 1024
+            ));
+        }
+        assets.push(ImportedThemeAsset { rel, bytes: buf });
+    }
+    Ok(assets)
 }
 
 /// Find the first non-directory entry whose file name equals `wanted` (at the
@@ -97,4 +192,73 @@ fn read_capped_entry<R: Read + std::io::Seek>(
             .map_err(|_| format!("{wanted} is not valid UTF-8"));
     }
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+    use zip::write::SimpleFileOptions;
+
+    /// Build an in-memory zip from `(name, bytes)` entries.
+    fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = SimpleFileOptions::default();
+            for (name, bytes) in entries {
+                w.start_file(*name, opts).unwrap();
+                w.write_all(bytes).unwrap();
+            }
+            w.finish().unwrap();
+        }
+        buf
+    }
+
+    fn assets_of(entries: &[(&str, &[u8])]) -> Result<Vec<ImportedThemeAsset>, String> {
+        let buf = make_zip(entries);
+        let mut archive = zip::ZipArchive::new(Cursor::new(buf)).unwrap();
+        read_asset_entries(&mut archive)
+    }
+
+    #[test]
+    fn extracts_assets_and_ignores_other_files() {
+        let got = assets_of(&[
+            ("manifest.json", b"{}"),
+            ("theme.css", b"body{}"),
+            ("assets/logo.svg", b"<svg/>"),
+            ("assets/fonts/x.woff2", b"font"),
+        ])
+        .unwrap();
+        let rels: Vec<_> = got.iter().map(|a| a.rel.as_str()).collect();
+        assert!(rels.contains(&"assets/logo.svg"));
+        assert!(rels.contains(&"assets/fonts/x.woff2"));
+        assert_eq!(got.len(), 2);
+    }
+
+    #[test]
+    fn tolerates_a_single_wrapping_folder() {
+        let got = assets_of(&[("bloodmoon/assets/logo.svg", b"<svg/>")]).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].rel, "assets/logo.svg");
+    }
+
+    #[test]
+    fn rejects_a_disallowed_extension() {
+        let err = assets_of(&[("assets/evil.exe", b"MZ")]).unwrap_err();
+        assert!(err.contains("disallowed type"), "{err}");
+    }
+
+    #[test]
+    fn rejects_a_file_over_the_per_file_cap() {
+        let big = vec![0u8; (MAX_ASSET_FILE_BYTES + 1) as usize];
+        let err = assets_of(&[("assets/big.png", &big)]).unwrap_err();
+        assert!(err.contains("too large"), "{err}");
+    }
+
+    #[test]
+    fn a_theme_without_assets_yields_an_empty_list() {
+        let got = assets_of(&[("manifest.json", b"{}"), ("theme.css", b"body{}")]).unwrap();
+        assert!(got.is_empty());
+    }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { useLyricsStore } from './store/lyricsStore';
 import { useThemeStore } from './store/themeStore';
 import { useInstalledThemesStore } from './store/installedThemesStore';
 import { gateInjectedThemes, syncInjectedThemes } from '@/lib/themes/themeInjection';
+import { reconcileThemeAssetsOnStartup } from '@/app/themeAssetStartup';
 import { useThemeScheduler } from '@/app/hooks/useThemeScheduler';
 import { useFontStore } from './store/fontStore';
 import { getWindowKind } from './app/windowKind';
@@ -38,6 +39,15 @@ export default function App() {
     // applied.
     gateInjectedThemes([theme, themeDay, themeNight, effectiveTheme]);
   }, [installedThemes, theme, themeDay, themeNight, effectiveTheme]);
+
+  // Once, in the main window: repair a moved profile's asset paths and sweep
+  // orphaned theme directories. Async and best-effort, so it runs after the
+  // first paint (the synchronous startup injection already used the stored
+  // base). Main-window only, to avoid two webviews sweeping at once.
+  useEffect(() => {
+    if (getWindowKind() !== 'main') return;
+    void reconcileThemeAssetsOnStartup();
+  }, []);
 
   // Dev only: `--theme-watch <theme.css | dir>` (debug builds) pushes local
   // theme CSS (+ sibling manifest.json metadata) in on every save. Each

--- a/src/app/themeAssetStartup.ts
+++ b/src/app/themeAssetStartup.ts
@@ -1,0 +1,36 @@
+import { isTauri } from '@tauri-apps/api/core';
+import { useInstalledThemesStore } from '@/store/installedThemesStore';
+import { themeAssetBaseDir, sweepOrphanThemeDirs } from '@/lib/themes/themeAssetStorage';
+
+/**
+ * Startup reconciliation for on-disk theme assets. Runs once, in the main
+ * window only, after mount:
+ *
+ *  1. **Self-heal** a stored `assetBase` that no longer matches the current app
+ *     data directory — the profile was moved, copied to another machine, or a
+ *     portable install changed paths. Re-storing the corrected base re-injects
+ *     the theme with working `asset:` URLs. Without this, a moved profile would
+ *     render every asset-using theme with broken images until re-install.
+ *  2. **Sweep orphan directories** left by a crash mid-install or by an older
+ *     client that removed a theme without cleaning up its files.
+ *
+ * Lives in the app layer (not `lib/`) because it reads the installed-themes
+ * store to reconcile it. Best-effort: any failure is swallowed, since none of
+ * this is load-bearing for the app to run.
+ */
+export async function reconcileThemeAssetsOnStartup(): Promise<void> {
+  if (!isTauri()) return;
+  const store = useInstalledThemesStore.getState();
+  try {
+    for (const t of store.themes) {
+      if (!t.assetBase) continue;
+      const expected = await themeAssetBaseDir(t.id);
+      if (t.assetBase !== expected) {
+        store.install({ ...t, assetBase: expected });
+      }
+    }
+    await sweepOrphanThemeDirs(new Set(store.themes.map((t) => t.id)));
+  } catch {
+    // best-effort — a stale base or orphan directory is not fatal
+  }
+}

--- a/src/features/settings/components/ThemeImportSection.tsx
+++ b/src/features/settings/components/ThemeImportSection.tsx
@@ -5,13 +5,25 @@ import { commands } from '@/generated/bindings';
 import { open } from '@tauri-apps/plugin-dialog';
 import { useInstalledThemesStore } from '@/store/installedThemesStore';
 import { validateThemePackage, type ValidatedTheme } from '@/lib/themes/validateThemePackage';
+import { parseAssetRefs } from '@/lib/themes/themeAssets';
+import { installLocalAssets, type LocalAssetInput } from '@/lib/themes/themeAssetInstall';
+import { removeThemeAssets } from '@/lib/themes/themeAssetStorage';
 import { showToast } from '@/lib/dom/toast';
 import ConfirmModal from '@/ui/ConfirmModal';
 
+interface PendingImport {
+  theme: ValidatedTheme;
+  /** `assets/…` paths the CSS references, to be written on confirm. */
+  refs: string[];
+  /** Asset bytes extracted from the zip by Rust. */
+  assets: LocalAssetInput[];
+}
+
 /**
- * Import a community theme from a local `.zip` (manifest.json + theme.css).
- * Rust extracts the two entries (size-capped, outside the webview); the full
- * store contract validation then runs before the theme is persisted. Anything
+ * Import a community theme from a local `.zip` (manifest.json + theme.css, plus
+ * any `assets/` files). Rust extracts the entries (size-capped, outside the
+ * webview); the full store contract validation runs before the theme is
+ * persisted, and referenced assets are written to disk on confirm. Anything
  * off-contract is rejected with the exact reasons listed.
  */
 export function ThemeImportSection() {
@@ -20,7 +32,7 @@ export function ThemeImportSection() {
   const [importErrors, setImportErrors] = useState<string[] | null>(null);
   const [importing, setImporting] = useState(false);
   // A validated-but-not-yet-installed theme, awaiting the user's confirmation.
-  const [pending, setPending] = useState<ValidatedTheme | null>(null);
+  const [pending, setPending] = useState<PendingImport | null>(null);
 
   const handleImport = async () => {
     setImportErrors(null);
@@ -48,7 +60,12 @@ export function ThemeImportSection() {
         return;
       }
       // Validated — confirm with the user (name + author) before persisting.
-      setPending(result.theme);
+      // Assets are written on confirm, so carry the zip's bytes through.
+      setPending({
+        theme: result.theme,
+        refs: parseAssetRefs(result.theme.css),
+        assets: files.assets.map(a => ({ rel: a.rel, bytes: new Uint8Array(a.bytes) })),
+      });
     } catch (e) {
       setImportErrors([String(e)]);
     } finally {
@@ -56,10 +73,35 @@ export function ThemeImportSection() {
     }
   };
 
-  const confirmInstall = () => {
+  const confirmInstall = async () => {
     if (!pending) return;
-    install({ ...pending, installedAt: Date.now() });
-    showToast(t('settings.themeImportSuccess', { name: pending.name }), 4000, 'success');
+    const { theme, refs, assets } = pending;
+    let assetBase: string | undefined;
+    let assetRels: string[] | undefined;
+    if (refs.length > 0) {
+      const written = await installLocalAssets(theme.id, refs, assets);
+      if (!written.ok) {
+        await removeThemeAssets(theme.id);
+        setPending(null);
+        setImportErrors([
+          written.reason === 'invalid'
+            ? t('settings.themeImportAssetInvalid')
+            : t('settings.themeImportAssetError'),
+        ]);
+        return;
+      }
+      assetBase = written.assetBase;
+      assetRels = written.rels;
+    } else {
+      // No assets referenced — clear any directory a prior asset theme left.
+      await removeThemeAssets(theme.id);
+    }
+    install({
+      ...theme,
+      installedAt: Date.now(),
+      ...(assetBase ? { assetBase, assets: assetRels } : {}),
+    });
+    showToast(t('settings.themeImportSuccess', { name: theme.name }), 4000, 'success');
     setPending(null);
   };
 
@@ -134,10 +176,10 @@ export function ThemeImportSection() {
       <ConfirmModal
         open={pending !== null}
         title={t('settings.themeImportConfirmTitle')}
-        message={pending ? `${t('settings.themeImportConfirmBody', { name: pending.name, author: pending.author })} ${t('settings.themeImportConfirmRisk')}` : ''}
+        message={pending ? `${t('settings.themeImportConfirmBody', { name: pending.theme.name, author: pending.theme.author })} ${t('settings.themeImportConfirmRisk')}` : ''}
         confirmLabel={t('settings.themeStoreInstall')}
         cancelLabel={t('common.cancel')}
-        onConfirm={confirmInstall}
+        onConfirm={() => void confirmInstall()}
         onCancel={() => setPending(null)}
       />
     </div>

--- a/src/generated/bindings.ts
+++ b/src/generated/bindings.ts
@@ -1026,9 +1026,20 @@ export type IcyMetadata = {
 	icy_description: string | null,
 };
 
+export type ImportedThemeAsset = {
+	/**  Theme-relative path, forward-slashed, e.g. `assets/logo.svg`. */
+	rel: string,
+	/**
+	 *  Raw bytes. Assets are small (whitelisted images/fonts, ≤ 1 MB each), so a
+	 *  plain byte array over IPC is fine.
+	 */
+	bytes: number[],
+};
+
 export type ImportedThemeFiles = {
 	manifest: string,
 	css: string,
+	assets: ImportedThemeAsset[],
 };
 
 export type LegacyOfflineMigrationResult = {

--- a/src/lib/themes/installThemeFromRegistry.test.ts
+++ b/src/lib/themes/installThemeFromRegistry.test.ts
@@ -5,15 +5,21 @@ vi.mock('@/lib/themes/themeRegistry', () => ({
   themeRequiresNewerApp: vi.fn(),
 }));
 vi.mock('@/lib/themes/themeInjection', () => ({ validateThemeCss: vi.fn() }));
+vi.mock('@/lib/themes/themeAssetInstall', () => ({ installRegistryAssets: vi.fn() }));
+vi.mock('@/lib/themes/themeAssetStorage', () => ({ removeThemeAssets: vi.fn().mockResolvedValue(undefined) }));
 
 import { fetchThemeCss, themeRequiresNewerApp, type RegistryTheme } from '@/lib/themes/themeRegistry';
 import { validateThemeCss } from '@/lib/themes/themeInjection';
+import { installRegistryAssets } from '@/lib/themes/themeAssetInstall';
+import { removeThemeAssets } from '@/lib/themes/themeAssetStorage';
 import { useInstalledThemesStore } from '@/store/installedThemesStore';
 import { installThemeFromRegistry } from '@/lib/themes/installThemeFromRegistry';
 
 const fetchCss = vi.mocked(fetchThemeCss);
 const validate = vi.mocked(validateThemeCss);
 const requiresNewerApp = vi.mocked(themeRequiresNewerApp);
+const installAssets = vi.mocked(installRegistryAssets);
+const removeAssets = vi.mocked(removeThemeAssets);
 
 const TH = {
   id: 'theme-a',
@@ -32,6 +38,9 @@ beforeEach(() => {
   validate.mockReset();
   requiresNewerApp.mockReset();
   requiresNewerApp.mockReturnValue(false);
+  installAssets.mockReset();
+  removeAssets.mockReset();
+  removeAssets.mockResolvedValue(undefined);
 });
 
 describe('installThemeFromRegistry', () => {
@@ -67,5 +76,39 @@ describe('installThemeFromRegistry', () => {
     await expect(installThemeFromRegistry(TH)).resolves.toBe('app-too-old');
     expect(fetchCss).not.toHaveBeenCalled();
     expect(useInstalledThemesStore.getState().isInstalled('theme-a')).toBe(false);
+  });
+
+  it('writes assets and persists the asset base for a theme that ships them', async () => {
+    fetchCss.mockResolvedValue('/* css */');
+    validate.mockReturnValue('/* css */');
+    installAssets.mockResolvedValue({ ok: true, assetBase: '/data/themes/theme-a', rels: ['assets/logo.svg'] });
+    const withAssets = { ...TH, assets: [{ path: 'themes/theme-a/assets/logo.svg', bytes: 10 }] } as RegistryTheme;
+
+    await expect(installThemeFromRegistry(withAssets)).resolves.toBe('ok');
+    const installed = useInstalledThemesStore.getState().getInstalled('theme-a');
+    expect(installed?.assetBase).toBe('/data/themes/theme-a');
+    expect(installed?.assets).toEqual(['assets/logo.svg']);
+  });
+
+  it('aborts and cleans up when an asset fails the contract', async () => {
+    fetchCss.mockResolvedValue('/* css */');
+    validate.mockReturnValue('/* css */');
+    installAssets.mockResolvedValue({ ok: false, reason: 'invalid' });
+    const withAssets = { ...TH, assets: [{ path: 'themes/theme-a/assets/evil.exe', bytes: 10 }] } as RegistryTheme;
+
+    await expect(installThemeFromRegistry(withAssets)).resolves.toBe('invalid');
+    expect(removeAssets).toHaveBeenCalledWith('theme-a');
+    expect(useInstalledThemesStore.getState().isInstalled('theme-a')).toBe(false);
+  });
+
+  it('clears a prior asset directory when an update drops its assets', async () => {
+    fetchCss.mockResolvedValue('/* css */');
+    validate.mockReturnValue('/* css */');
+
+    await expect(installThemeFromRegistry(TH)).resolves.toBe('ok');
+    expect(removeAssets).toHaveBeenCalledWith('theme-a');
+    expect(installAssets).not.toHaveBeenCalled();
+    const installed = useInstalledThemesStore.getState().getInstalled('theme-a');
+    expect(installed?.assetBase).toBeUndefined();
   });
 });

--- a/src/lib/themes/installThemeFromRegistry.ts
+++ b/src/lib/themes/installThemeFromRegistry.ts
@@ -1,18 +1,21 @@
 import { fetchThemeCss, themeRequiresNewerApp, type RegistryTheme } from '@/lib/themes/themeRegistry';
 import { validateThemeCss } from '@/lib/themes/themeInjection';
+import { installRegistryAssets } from '@/lib/themes/themeAssetInstall';
+import { removeThemeAssets } from '@/lib/themes/themeAssetStorage';
 import { useInstalledThemesStore } from '@/store/installedThemesStore';
 
 export type InstallResult = 'ok' | 'invalid' | 'error' | 'app-too-old';
 
 /**
  * Fetch a registry theme's CSS, validate it against the in-app safety floor,
- * and persist it (install or in-place update — the store replaces by id).
- * Shared by the Theme Store list and the "your themes" update chip so both go
- * through the same fetch → validate → install path.
+ * write any local assets to disk, and persist it (install or in-place update —
+ * the store replaces by id). Shared by the Theme Store list and the "your
+ * themes" update chip so both go through the same fetch → validate → install
+ * path.
  *
  * Never throws: returns `'app-too-old'` when the theme needs a newer app,
- * `'invalid'` when the CSS fails the floor and `'error'` on a network/fetch
- * failure, so callers can surface it without a try/catch.
+ * `'invalid'` when the CSS or an asset fails the floor and `'error'` on a
+ * network/fetch failure, so callers can surface it without a try/catch.
  */
 export async function installThemeFromRegistry(th: RegistryTheme): Promise<InstallResult> {
   // Refuse before any fetch: a theme built for a newer app may rely on a
@@ -25,6 +28,25 @@ export async function installThemeFromRegistry(th: RegistryTheme): Promise<Insta
     // Don't persist CSS that won't inject — it would show as installed/active
     // but render nothing. Validate before storing.
     if (validateThemeCss(css, th.id) == null) return 'invalid';
+
+    // Local assets: write them before persisting, so the theme is never stored
+    // pointing at files that aren't on disk. A failure removes the partial
+    // directory and aborts the install.
+    let assetBase: string | undefined;
+    let assets: string[] | undefined;
+    if (th.assets && th.assets.length > 0) {
+      const res = await installRegistryAssets(th.id, th.assets);
+      if (!res.ok) {
+        await removeThemeAssets(th.id);
+        return res.reason;
+      }
+      assetBase = res.assetBase;
+      assets = res.rels;
+    } else {
+      // An update that dropped its assets must not keep the old files around.
+      await removeThemeAssets(th.id);
+    }
+
     useInstalledThemesStore.getState().install({
       id: th.id,
       name: th.name,
@@ -35,6 +57,7 @@ export async function installThemeFromRegistry(th: RegistryTheme): Promise<Insta
       tags: th.tags,
       css,
       installedAt: Date.now(),
+      ...(assetBase ? { assetBase, assets } : {}),
     });
     return 'ok';
   } catch {

--- a/src/lib/themes/themeAssetInstall.test.ts
+++ b/src/lib/themes/themeAssetInstall.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const writeThemeAssets = vi.fn();
+vi.mock('@/lib/themes/themeAssetStorage', () => ({
+  writeThemeAssets: (...a: unknown[]) => writeThemeAssets(...a),
+}));
+// installRegistryAssets needs the registry fetch; not exercised here.
+vi.mock('@/lib/themes/themeRegistry', () => ({ fetchThemeAssetBytes: vi.fn() }));
+
+import { installLocalAssets, type LocalAssetInput } from '@/lib/themes/themeAssetInstall';
+
+const bytes = (s: string) => new TextEncoder().encode(s);
+const svg = (body = '<path d="M0 0"/>') => bytes(`<svg xmlns="http://www.w3.org/2000/svg">${body}</svg>`);
+
+beforeEach(() => {
+  writeThemeAssets.mockReset();
+  writeThemeAssets.mockResolvedValue('/data/themes/t');
+});
+
+describe('installLocalAssets', () => {
+  it('writes referenced, in-contract assets and returns the base', async () => {
+    const provided: LocalAssetInput[] = [{ rel: 'assets/logo.svg', bytes: svg() }];
+    const res = await installLocalAssets('t', ['assets/logo.svg'], provided);
+    expect(res).toEqual({ ok: true, assetBase: '/data/themes/t', rels: ['assets/logo.svg'] });
+    expect(writeThemeAssets).toHaveBeenCalledOnce();
+  });
+
+  it('rejects when a referenced asset is missing from the zip', async () => {
+    const res = await installLocalAssets('t', ['assets/logo.svg'], []);
+    expect(res).toEqual({ ok: false, reason: 'invalid' });
+    expect(writeThemeAssets).not.toHaveBeenCalled();
+  });
+
+  it('rejects an SVG carrying active content', async () => {
+    const provided: LocalAssetInput[] = [{ rel: 'assets/x.svg', bytes: svg('<script>x</script>') }];
+    const res = await installLocalAssets('t', ['assets/x.svg'], provided);
+    expect(res).toEqual({ ok: false, reason: 'invalid' });
+    expect(writeThemeAssets).not.toHaveBeenCalled();
+  });
+
+  it('rejects a path that escapes the assets folder', async () => {
+    const provided: LocalAssetInput[] = [{ rel: 'assets/../evil.svg', bytes: svg() }];
+    const res = await installLocalAssets('t', ['assets/../evil.svg'], provided);
+    expect(res).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  it('writes only the referenced subset, dropping unreferenced files', async () => {
+    const provided: LocalAssetInput[] = [
+      { rel: 'assets/logo.svg', bytes: svg() },
+      { rel: 'assets/unused.webp', bytes: bytes('x') },
+    ];
+    const res = await installLocalAssets('t', ['assets/logo.svg'], provided);
+    expect(res.ok).toBe(true);
+    const written = writeThemeAssets.mock.calls[0][1] as { rel: string }[];
+    expect(written.map((e) => e.rel)).toEqual(['assets/logo.svg']);
+  });
+});

--- a/src/lib/themes/themeAssetInstall.ts
+++ b/src/lib/themes/themeAssetInstall.ts
@@ -1,0 +1,114 @@
+import { fetchThemeAssetBytes, type RegistryTheme } from '@/lib/themes/themeRegistry';
+import { ASSET_CAPS, isAllowedAssetPath, svgContentProblems } from '@/lib/themes/themeAssets';
+import { writeThemeAssets, type ThemeAssetEntry } from '@/lib/themes/themeAssetStorage';
+
+/** `invalid` = the asset list violates the contract; `error` = a fetch/write failed. */
+export type AssetInstallResult =
+  | { ok: true; assetBase: string; rels: string[] }
+  | { ok: false; reason: 'invalid' | 'error' };
+
+type RegistryAsset = NonNullable<RegistryTheme['assets']>[number];
+
+/** Strip the `themes/<id>/` prefix to the theme-relative path (`assets/…`). */
+function toRel(id: string, repoPath: string): string | null {
+  const prefix = `themes/${id}/`;
+  return repoPath.startsWith(prefix) ? repoPath.slice(prefix.length) : null;
+}
+
+/** Enforce the contract on the declared list *before* fetching anything. */
+function validateRegistryAssets(id: string, assets: RegistryAsset[]): string[] | null {
+  if (assets.length > ASSET_CAPS.maxFiles) return null;
+  let total = 0;
+  const rels: string[] = [];
+  for (const a of assets) {
+    const rel = toRel(id, a.path);
+    if (rel == null || !isAllowedAssetPath(rel)) return null;
+    if (typeof a.bytes !== 'number' || a.bytes < 0 || a.bytes > ASSET_CAPS.perFileBytes) return null;
+    total += a.bytes;
+    rels.push(rel);
+  }
+  if (total > ASSET_CAPS.perThemeBytes) return null;
+  return rels;
+}
+
+/**
+ * Validate, fetch and write a registry theme's local assets. Returns the
+ * absolute base directory to store as the theme's `assetBase`, plus the written
+ * theme-relative paths. Fails closed: a contract violation is `invalid`, a
+ * network/write failure is `error`, and either way the caller removes the
+ * partially-written directory so no half-installed theme survives.
+ */
+export async function installRegistryAssets(
+  id: string,
+  assets: RegistryAsset[],
+): Promise<AssetInstallResult> {
+  const rels = validateRegistryAssets(id, assets);
+  if (rels == null) return { ok: false, reason: 'invalid' };
+
+  try {
+    const entries: ThemeAssetEntry[] = [];
+    for (let i = 0; i < assets.length; i++) {
+      const bytes = await fetchThemeAssetBytes(assets[i].path);
+      // A lying registry size can't get past the per-file cap.
+      if (bytes.byteLength > ASSET_CAPS.perFileBytes) return { ok: false, reason: 'invalid' };
+      // SVGs are the one asset type that can carry active/exfiltrating content;
+      // sideloaded and store themes alike are checked at write time.
+      if (/\.svg$/i.test(rels[i])) {
+        const text = new TextDecoder().decode(bytes);
+        if (svgContentProblems(text).length > 0) return { ok: false, reason: 'invalid' };
+      }
+      entries.push({ rel: rels[i], bytes });
+    }
+    const assetBase = await writeThemeAssets(id, entries);
+    return { ok: true, assetBase, rels };
+  } catch {
+    return { ok: false, reason: 'error' };
+  }
+}
+
+/** One asset provided by the zip import: a theme-relative path and its bytes. */
+export interface LocalAssetInput {
+  rel: string;
+  bytes: Uint8Array;
+}
+
+/**
+ * Validate and write assets that came from a local zip import (bytes already in
+ * hand, no fetch). Every `assets/…` path the CSS references must be present;
+ * each provided file must pass the same contract as a store asset (path
+ * containment, extension, caps, SVG content). Only referenced assets are
+ * written — an unreferenced file in the zip is dropped, not stored. Fails closed;
+ * the caller removes the directory on `invalid`.
+ */
+export async function installLocalAssets(
+  id: string,
+  cssRefs: string[],
+  provided: LocalAssetInput[],
+): Promise<AssetInstallResult> {
+  const byRel = new Map(provided.map((a) => [a.rel, a]));
+  const refs = [...new Set(cssRefs)];
+
+  if (refs.length > ASSET_CAPS.maxFiles) return { ok: false, reason: 'invalid' };
+  let total = 0;
+  const entries: ThemeAssetEntry[] = [];
+  for (const rel of refs) {
+    if (!isAllowedAssetPath(rel)) return { ok: false, reason: 'invalid' };
+    const a = byRel.get(rel);
+    if (!a) return { ok: false, reason: 'invalid' }; // referenced but not in the zip
+    if (a.bytes.byteLength > ASSET_CAPS.perFileBytes) return { ok: false, reason: 'invalid' };
+    total += a.bytes.byteLength;
+    if (total > ASSET_CAPS.perThemeBytes) return { ok: false, reason: 'invalid' };
+    if (/\.svg$/i.test(rel)) {
+      const text = new TextDecoder().decode(a.bytes);
+      if (svgContentProblems(text).length > 0) return { ok: false, reason: 'invalid' };
+    }
+    entries.push({ rel, bytes: a.bytes });
+  }
+
+  try {
+    const assetBase = await writeThemeAssets(id, entries);
+    return { ok: true, assetBase, rels: refs };
+  } catch {
+    return { ok: false, reason: 'error' };
+  }
+}

--- a/src/lib/themes/themeAssetStorage.ts
+++ b/src/lib/themes/themeAssetStorage.ts
@@ -1,0 +1,74 @@
+import { BaseDirectory, mkdir, writeFile, remove, readDir, exists } from '@tauri-apps/plugin-fs';
+import { appDataDir, join } from '@tauri-apps/api/path';
+import { isTauri } from '@tauri-apps/api/core';
+
+/**
+ * On-disk storage for a theme's local assets, under
+ * `<appDataDir>/themes/<id>/…`. That directory is inside the asset-protocol
+ * scope (`$APPDATA/**`), so `convertFileSrc` can serve the files to the webview
+ * — the same mechanism the cover cache uses. One directory per theme keeps
+ * uninstall and the orphan sweep trivial.
+ */
+
+const THEMES_DIR = 'themes';
+
+/** One asset to write: a theme-relative path (`assets/x.svg`) and its bytes. */
+export interface ThemeAssetEntry {
+  rel: string;
+  bytes: Uint8Array;
+}
+
+/** Absolute on-disk directory for a theme — the base for the inject-time rewrite. */
+export async function themeAssetBaseDir(id: string): Promise<string> {
+  return join(await appDataDir(), THEMES_DIR, id);
+}
+
+/**
+ * Write a theme's assets, replacing any prior set. Removes the theme's directory
+ * first so files dropped by a new version don't linger, then writes each entry
+ * (creating parent directories). Returns the absolute base directory to store as
+ * the theme's `assetBase`. Throws on failure so the caller can fail the install.
+ */
+export async function writeThemeAssets(id: string, entries: ThemeAssetEntry[]): Promise<string> {
+  await removeThemeAssets(id);
+  for (const e of entries) {
+    const rel = `${THEMES_DIR}/${id}/${e.rel}`;
+    const slash = rel.lastIndexOf('/');
+    await mkdir(rel.slice(0, slash), { baseDir: BaseDirectory.AppData, recursive: true });
+    await writeFile(rel, e.bytes, { baseDir: BaseDirectory.AppData });
+  }
+  return themeAssetBaseDir(id);
+}
+
+/** Delete a theme's on-disk directory. Best-effort — a missing directory is fine. */
+export async function removeThemeAssets(id: string): Promise<void> {
+  if (!isTauri()) return;
+  const dir = `${THEMES_DIR}/${id}`;
+  try {
+    if (await exists(dir, { baseDir: BaseDirectory.AppData })) {
+      await remove(dir, { baseDir: BaseDirectory.AppData, recursive: true });
+    }
+  } catch {
+    // best-effort: a leftover directory is caught by the orphan sweep
+  }
+}
+
+/**
+ * Remove theme directories with no matching installed theme. Covers a crash
+ * mid-install and themes removed by an older client that didn't clean up. Runs
+ * once at startup; best-effort.
+ */
+export async function sweepOrphanThemeDirs(keepIds: Set<string>): Promise<void> {
+  if (!isTauri()) return;
+  try {
+    if (!(await exists(THEMES_DIR, { baseDir: BaseDirectory.AppData }))) return;
+    const entries = await readDir(THEMES_DIR, { baseDir: BaseDirectory.AppData });
+    for (const ent of entries) {
+      if (ent.isDirectory && !keepIds.has(ent.name)) {
+        await remove(`${THEMES_DIR}/${ent.name}`, { baseDir: BaseDirectory.AppData, recursive: true });
+      }
+    }
+  } catch {
+    // best-effort
+  }
+}

--- a/src/lib/themes/themeAssets.test.ts
+++ b/src/lib/themes/themeAssets.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  // Mimic the asset-protocol transform: an absolute path becomes an
+  // asset.localhost URL; anything else is returned unchanged (out of scope).
+  convertFileSrc: (p: string) =>
+    /^[a-zA-Z]:\//.test(p) || p.startsWith('/') ? `https://asset.localhost/${encodeURIComponent(p)}` : p,
+}));
+
+import {
+  isAllowedAssetPath,
+  classifyUrlTarget,
+  parseAssetRefs,
+  svgContentProblems,
+  rewriteAssetUrls,
+} from './themeAssets';
+
+describe('isAllowedAssetPath', () => {
+  it('accepts in-tree asset paths', () => {
+    expect(isAllowedAssetPath('assets/logo.svg')).toBe(true);
+    expect(isAllowedAssetPath('assets/fonts/display.woff2')).toBe(true);
+    expect(isAllowedAssetPath('assets/bg.webp')).toBe(true);
+  });
+
+  it('rejects traversal, absolute, remote-ish and bad types', () => {
+    expect(isAllowedAssetPath('assets/../secret.svg')).toBe(false);
+    expect(isAllowedAssetPath('/etc/passwd')).toBe(false);
+    expect(isAllowedAssetPath('assets\\logo.svg')).toBe(false);
+    expect(isAllowedAssetPath('logo.svg')).toBe(false);
+    expect(isAllowedAssetPath('assets/logo.exe')).toBe(false);
+    expect(isAllowedAssetPath('assets/')).toBe(false);
+    expect(isAllowedAssetPath('')).toBe(false);
+  });
+});
+
+describe('classifyUrlTarget', () => {
+  it('separates data, asset and reject', () => {
+    expect(classifyUrlTarget('data:image/png;base64,AAAA')).toBe('data');
+    expect(classifyUrlTarget('assets/logo.svg')).toBe('asset');
+    expect(classifyUrlTarget("'assets/logo.svg'")).toBe('asset');
+    expect(classifyUrlTarget('https://evil.example/x.png')).toBe('reject');
+    expect(classifyUrlTarget('//evil.example/x.png')).toBe('reject');
+    expect(classifyUrlTarget('../x.png')).toBe('reject');
+  });
+});
+
+describe('parseAssetRefs', () => {
+  it('extracts and dedupes only asset paths', () => {
+    const css = `
+      .a { background: url("assets/one.webp"); }
+      .b { background: url(assets/one.webp); }
+      .c { background: url('assets/two.svg'); }
+      .d { background: url(data:image/gif;base64,AA); }
+      .e { background: url(https://x.example/three.png); }
+    `;
+    expect(parseAssetRefs(css)).toEqual(['assets/one.webp', 'assets/two.svg']);
+  });
+});
+
+describe('svgContentProblems', () => {
+  it('flags active or exfiltrating SVGs', () => {
+    expect(svgContentProblems('<svg><script>x</script></svg>').length).toBeGreaterThan(0);
+    expect(svgContentProblems('<svg onload="x()"></svg>').length).toBeGreaterThan(0);
+    expect(svgContentProblems('<svg><foreignObject/></svg>').length).toBeGreaterThan(0);
+    expect(svgContentProblems('<svg><a href="javascript:x"/></svg>').length).toBeGreaterThan(0);
+    expect(svgContentProblems('<image href="https://x.example/a.png"/>').length).toBeGreaterThan(0);
+  });
+
+  it('passes a clean decorative SVG', () => {
+    const clean = '<svg xmlns="http://www.w3.org/2000/svg"><use href="#g"/><path d="M0 0h10v10H0z"/></svg>';
+    expect(svgContentProblems(clean)).toEqual([]);
+  });
+});
+
+describe('rewriteAssetUrls', () => {
+  const BASE = 'C:/Users/me/AppData/Roaming/dev.psysonic.player/themes/t';
+
+  it('rewrites an asset url to an asset.localhost URL with no query', () => {
+    const out = rewriteAssetUrls('.a{background:url("assets/logo.svg")}', BASE);
+    expect(out).toContain('https://asset.localhost/');
+    // No cache-busting query — it breaks the Windows WebView2 asset protocol (404).
+    expect(out).not.toContain('?v=');
+    expect(out).not.toContain('url("assets/logo.svg")');
+  });
+
+  it('leaves data: URIs and non-asset urls untouched', () => {
+    const css = '.a{background:url(data:image/gif;base64,AA)} .b{background:url(https://x/y.png)}';
+    expect(rewriteAssetUrls(css, BASE)).toBe(css);
+  });
+
+  it('is a no-op without an asset base', () => {
+    const css = '.a{background:url("assets/logo.svg")}';
+    expect(rewriteAssetUrls(css, '')).toBe(css);
+  });
+});

--- a/src/lib/themes/themeAssets.ts
+++ b/src/lib/themes/themeAssets.ts
@@ -1,0 +1,113 @@
+import { convertFileSrc } from '@tauri-apps/api/core';
+
+/**
+ * Local theme assets — the in-app mirror of the repo's `scripts/theme-assets.mjs`.
+ *
+ * A theme may ship images and fonts in an `assets/` folder and reference them
+ * with a relative `url("assets/…")`. Themes still never reach the network: a
+ * `url()` is a `data:` URI or a local `assets/` path, nothing else. These rules
+ * are the security boundary, so they are kept byte-for-byte in step with the CI
+ * validator and covered by the same test cases.
+ */
+
+/** Extensions an asset file may use. Images plus web fonts — nothing executable. */
+export const ASSET_EXTS = ['webp', 'png', 'jpg', 'jpeg', 'gif', 'avif', 'svg', 'woff2', 'woff'] as const;
+
+/** Budgets. Small on purpose; the 256 KB CSS cap is separate and unchanged. */
+export const ASSET_CAPS = {
+  perFileBytes: 1 * 1024 * 1024, // 1 MB
+  perThemeBytes: 4 * 1024 * 1024, // 4 MB
+  maxFiles: 32,
+};
+
+const EXT_RE = new RegExp(`\\.(${ASSET_EXTS.join('|')})$`, 'i');
+
+/** True when a relative path is a safe, in-tree `assets/…` reference. */
+export function isAllowedAssetPath(p: string): boolean {
+  if (typeof p !== 'string' || p.length === 0) return false;
+  if (p.includes('\\')) return false; // backslash — never a web path
+  if (p.startsWith('/')) return false; // absolute
+  if (!p.startsWith('assets/')) return false; // must live under assets/
+  const segments = p.split('/');
+  if (segments.some((s) => s === '..' || s === '')) return false; // no traversal / empty segment
+  return EXT_RE.test(p);
+}
+
+/** Classify a raw url() target: 'data' | 'asset' | 'reject'. */
+export function classifyUrlTarget(inner: string): 'data' | 'asset' | 'reject' {
+  const s = inner.trim().replace(/^['"]/, '').replace(/['"]$/, '').trim();
+  if (/^data:/i.test(s)) return 'data';
+  if (isAllowedAssetPath(s)) return 'asset';
+  return 'reject';
+}
+
+/** Every `assets/…` path referenced by the CSS (deduped, first-seen order). */
+export function parseAssetRefs(css: string): string[] {
+  const refs: string[] = [];
+  const seen = new Set<string>();
+  const urlRe = /url\(\s*(['"]?)([^'")]*)\1\s*\)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = urlRe.exec(css)) !== null) {
+    const target = m[2].trim();
+    if (isAllowedAssetPath(target) && !seen.has(target)) {
+      seen.add(target);
+      refs.push(target);
+    }
+  }
+  return refs;
+}
+
+/**
+ * Inspect an SVG that will be referenced from CSS `url()`. Rendered that way a
+ * browser does not run scripts, but sideloaded themes are not moderated, so the
+ * app runs the same defence-in-depth check the CI validator does. Returns the
+ * list of problems (empty = clean).
+ */
+export function svgContentProblems(text: string): string[] {
+  const problems: string[] = [];
+  if (/<\s*script\b/i.test(text)) problems.push('contains <script>');
+  if (/\son\w+\s*=/i.test(text)) problems.push('contains an inline event handler (on…=)');
+  if (/<\s*foreignObject\b/i.test(text)) problems.push('contains <foreignObject>');
+  if (/javascript:/i.test(text)) problems.push('contains a javascript: URI');
+  const refRe = /(?:xlink:href|href|src)\s*=\s*(['"])([^'"]*)\1/gi;
+  let m: RegExpExecArray | null;
+  while ((m = refRe.exec(text)) !== null) {
+    const v = m[2].trim();
+    if (v && !v.startsWith('#') && !/^data:/i.test(v)) {
+      problems.push(`references an external resource (${v.slice(0, 40)})`);
+    }
+  }
+  return problems;
+}
+
+/** Windows: forward slashes before `convertFileSrc` (tauri#7970). */
+function normalizeAbsPath(fsPath: string): string {
+  return /^[a-zA-Z]:[\\/]/.test(fsPath) ? fsPath.replace(/\\/g, '/') : fsPath;
+}
+
+/**
+ * Rewrite each `url("assets/…")` in the CSS to a webview-loadable `asset:` URL
+ * under `assetBaseDir` (the theme's absolute on-disk directory). `data:` URIs and
+ * everything else are left untouched, so a theme with no assets is unchanged.
+ * Synchronous (`convertFileSrc` is a pure string transform), so this runs inside
+ * the pre-paint injection.
+ *
+ * No cache-busting query is appended: on Windows WebView2 the asset-protocol
+ * handler resolves the file path *including* a trailing `?v=…`, so a query turns
+ * a valid asset into a 404. This mirrors the cover cache, which also serves disk
+ * files via `convertFileSrc` with no query and relies on the asset protocol
+ * serving current bytes. The only cost is that an updated asset behind an
+ * unchanged filename may show stale in the webview until the next launch; the
+ * on-disk file is always current (install rewrites it).
+ */
+export function rewriteAssetUrls(css: string, assetBaseDir: string): string {
+  if (!assetBaseDir) return css;
+  return css.replace(/url\(\s*(['"]?)([^'")]*)\1\s*\)/gi, (whole, _q: string, target: string) => {
+    const t = target.trim();
+    if (!isAllowedAssetPath(t)) return whole; // data: and anything else untouched
+    const abs = normalizeAbsPath(`${assetBaseDir}/${t}`);
+    const src = convertFileSrc(abs);
+    if (!src || src === abs) return whole; // not in Tauri / outside asset scope
+    return `url("${src}")`;
+  });
+}

--- a/src/lib/themes/themeInjection.test.ts
+++ b/src/lib/themes/themeInjection.test.ts
@@ -49,6 +49,14 @@ describe('validateThemeCss (security floor)', () => {
     expect(validateThemeCss(css, 'x')).not.toBeNull();
   });
 
+  it('accepts a local assets/ url()', () => {
+    expect(validateThemeCss(block('x', `--brand: url("assets/logo.svg");`), 'x')).not.toBeNull();
+  });
+
+  it('rejects an assets/ path that escapes the folder', () => {
+    expect(validateThemeCss(block('x', `--brand: url("assets/../secret.svg");`), 'x')).toBeNull();
+  });
+
   it('rejects @keyframes not namespaced with the theme id', () => {
     expect(validateThemeCss(`@keyframes pulse { from {} to {} } ${block('x')}`, 'x')).toBeNull();
   });

--- a/src/lib/themes/themeInjection.ts
+++ b/src/lib/themes/themeInjection.ts
@@ -1,4 +1,5 @@
 import type { InstalledTheme } from '@/store/installedThemesStore';
+import { classifyUrlTarget, rewriteAssetUrls } from '@/lib/themes/themeAssets';
 
 /**
  * Runtime CSS injection for installed community themes. Built-in themes are
@@ -23,7 +24,8 @@ const MAX_CSS_BYTES = 256 * 1024;
  *
  *  - can't break out of its `<style>` element (`</style>` / `<script>`),
  *  - can't pull anything off the network — no `@import`, and `url()` may only be
- *    an inline `data:` URI (prevents tracking/exfiltration on every app start),
+ *    an inline `data:` URI or a local `assets/…` path (both stay off the network;
+ *    the relative path is rewritten to an `asset:` URL at inject time),
  *  - no `@property` (would register global custom properties that could clash
  *    with the app or other themes),
  *  - no legacy script-in-CSS vectors (`expression()`, `javascript:`,
@@ -47,12 +49,12 @@ export function validateThemeCss(css: string, id: string): string | null {
   // No legacy script-in-CSS vectors.
   if (/expression\s*\(/i.test(s) || /javascript:/i.test(s) || /-moz-binding/i.test(s)) return null;
 
-  // url() may only be an inline data: URI. Match each `url(` and inspect the
-  // start of its content — a non-data target never starts with `data:`.
+  // url() may only be an inline data: URI or a local `assets/…` path. Match each
+  // `url(` and classify its target; anything else would reach the network.
   const urls = s.match(/url\(\s*['"]?\s*[^'")]*/gi) || [];
   for (const u of urls) {
     const inner = u.replace(/^url\(\s*['"]?\s*/i, '');
-    if (!/^data:/i.test(inner)) return null;
+    if (classifyUrlTarget(inner) === 'reject') return null;
   }
 
   // @keyframes (and vendor-prefixed) must start with `<id>-`.
@@ -68,6 +70,10 @@ export function validateThemeCss(css: string, id: string): string | null {
 export function injectTheme(theme: InstalledTheme): void {
   const clean = validateThemeCss(theme.css, theme.id);
   if (clean == null) return;
+  // Rewrite relative `url("assets/…")` to the theme's on-disk asset directory.
+  // No-op for themes without assets (no base, or no asset urls). Runs after
+  // validation, so we never validate a url() we produced ourselves.
+  const css = theme.assetBase ? rewriteAssetUrls(clean, theme.assetBase) : clean;
   const selector = `style[${ATTR}="${CSS.escape(theme.id)}"]`;
   let el = document.head.querySelector<HTMLStyleElement>(selector);
   if (!el) {
@@ -75,7 +81,7 @@ export function injectTheme(theme: InstalledTheme): void {
     el.setAttribute(ATTR, theme.id);
     document.head.appendChild(el);
   }
-  if (el.textContent !== clean) el.textContent = clean;
+  if (el.textContent !== css) el.textContent = css;
 }
 
 export function removeInjectedTheme(id: string): void {

--- a/src/lib/themes/themeRegistry.ts
+++ b/src/lib/themes/themeRegistry.ts
@@ -47,6 +47,13 @@ export interface RegistryTheme {
    * install. Absent for themes with no floor.
    */
   minAppVersion?: string;
+  /**
+   * Optional local asset files shipped with the theme, discovered by the registry
+   * build. `path` is repo-relative (`themes/<id>/assets/…`); `bytes` is the file
+   * size. The install path fetches and writes each one. Absent for themes with no
+   * assets, which is almost all of them.
+   */
+  assets?: { path: string; bytes: number }[];
 }
 
 export interface Registry {
@@ -162,6 +169,13 @@ export async function fetchThemeCss(relPath: string): Promise<string> {
   const res = await fetch(assetUrl(relPath), { cache: 'no-cache' });
   if (!res.ok) throw new Error(`theme css fetch failed: ${res.status}`);
   return res.text();
+}
+
+/** Fetch a theme asset's raw bytes from GitHub raw (repo-relative path). */
+export async function fetchThemeAssetBytes(relPath: string): Promise<Uint8Array> {
+  const res = await fetch(assetUrl(relPath), { cache: 'no-cache' });
+  if (!res.ok) throw new Error(`theme asset fetch failed: ${res.status}`);
+  return new Uint8Array(await res.arrayBuffer());
 }
 
 /**

--- a/src/lib/themes/uninstallTheme.test.ts
+++ b/src/lib/themes/uninstallTheme.test.ts
@@ -2,7 +2,11 @@
  * Tests for uninstallTheme — removing a community theme must repair every
  * selection slot that referenced it (active + scheduler day/night).
  */
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The on-disk asset removal is a best-effort side effect, not under test here.
+vi.mock('@/lib/themes/themeAssetStorage', () => ({ removeThemeAssets: vi.fn().mockResolvedValue(undefined) }));
+
 import { uninstallTheme } from '@/lib/themes/uninstallTheme';
 import { useInstalledThemesStore, type InstalledTheme } from '@/store/installedThemesStore';
 import { useThemeStore } from '@/store/themeStore';

--- a/src/lib/themes/uninstallTheme.ts
+++ b/src/lib/themes/uninstallTheme.ts
@@ -1,5 +1,6 @@
 import { useInstalledThemesStore } from '@/store/installedThemesStore';
 import { useThemeStore } from '@/store/themeStore';
+import { removeThemeAssets } from '@/lib/themes/themeAssetStorage';
 
 /**
  * Uninstall a community theme and repair any theme selection that pointed at it.
@@ -18,6 +19,9 @@ export function uninstallTheme(id: string): void {
   const installed = useInstalledThemesStore.getState();
   const wasLight = installed.getInstalled(id)?.mode === 'light';
   installed.uninstall(id);
+  // Drop any on-disk assets. Best-effort and off the critical path — the startup
+  // orphan sweep removes it anyway if this fails.
+  void removeThemeAssets(id);
 
   const t = useThemeStore.getState();
   if (t.theme === id) t.setTheme(wasLight ? 'latte' : 'mocha');

--- a/src/lib/themes/validateThemePackage.test.ts
+++ b/src/lib/themes/validateThemePackage.test.ts
@@ -88,4 +88,12 @@ describe('validateThemePackage', () => {
     const r = validateThemePackage(manifest(), `@keyframes pulse { from {} to {} } ${css()}`);
     expect(hasError(r, /failed the safety check/)).toBe(true);
   });
+
+  it('accepts a theme that references local assets (written separately at import)', () => {
+    const r = validateThemePackage(
+      manifest(),
+      `[data-theme='my-theme'] { background: url("assets/bg.webp"); }`,
+    );
+    expect(r.ok).toBe(true);
+  });
 });

--- a/src/locales/bg/settings.ts
+++ b/src/locales/bg/settings.ts
@@ -492,6 +492,8 @@ export const settings = {
   themeImporting: 'Импортиране…',
   themeImportHint: 'Зареди тема, пакетирана като .zip (manifest.json + theme.css).',
   themeImportSuccess: '„{{name}}“ е импортирана.',
+  themeImportAssetInvalid: 'Приложен ресурс не премина проверката за безопасност, затова темата не беше инсталирана.',
+  themeImportAssetError: 'Файловете с ресурси на темата не можаха да бъдат записани, затова тя не беше инсталирана.',
   themeImportErrorTitle: 'Тази тема не можа да бъде импортирана',
   themeImportErrorBody: 'Не съответства на формата на темите на Psysonic. Може да е направена за друга версия, или файлът е непълен — провери дали си избрал правилния .zip, или се свържи с автора на темата.',
   themeImportErrorDetails: 'Технически подробности',

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -448,6 +448,8 @@ export const settings = {
   themeImporting: 'Importiere…',
   themeImportHint: 'Lädt ein als .zip verpacktes Theme (manifest.json + theme.css).',
   themeImportSuccess: '„{{name}}“ importiert.',
+  themeImportAssetInvalid: 'Eine mitgelieferte Asset-Datei hat die Sicherheitsprüfung nicht bestanden, das Theme wurde nicht installiert.',
+  themeImportAssetError: 'Die Asset-Dateien des Themes konnten nicht geschrieben werden, es wurde nicht installiert.',
   themeImportErrorTitle: 'Dieses Theme konnte nicht importiert werden',
   themeImportErrorBody: 'Es entspricht nicht dem Psysonic-Theme-Format. Vielleicht wurde es für eine andere Version erstellt oder die Datei ist unvollständig — prüfe, ob du die richtige .zip gewählt hast, oder frag den Autor des Themes.',
   themeImportErrorDetails: 'Technische Details',

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -492,6 +492,8 @@ export const settings = {
   themeImporting: 'Importing…',
   themeImportHint: 'Load a theme packaged as a .zip (manifest.json + theme.css).',
   themeImportSuccess: '"{{name}}" imported.',
+  themeImportAssetInvalid: 'A bundled asset failed the safety check, so the theme was not installed.',
+  themeImportAssetError: 'The theme\'s asset files could not be written, so it was not installed.',
   themeImportErrorTitle: 'This theme could not be imported',
   themeImportErrorBody: "It doesn't match the Psysonic theme format. It may have been made for a different version, or the file is incomplete — check that you picked the right .zip, or ask the theme's author.",
   themeImportErrorDetails: 'Technical details',

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -446,6 +446,8 @@ export const settings = {
   themeImporting: 'Importando…',
   themeImportHint: 'Carga un tema empaquetado como .zip (manifest.json + theme.css).',
   themeImportSuccess: '«{{name}}» importado.',
+  themeImportAssetInvalid: 'Un recurso incluido no superó la comprobación de seguridad, por lo que el tema no se instaló.',
+  themeImportAssetError: 'No se pudieron escribir los archivos de recursos del tema, por lo que no se instaló.',
   themeImportErrorTitle: 'No se pudo importar este tema',
   themeImportErrorBody: 'No coincide con el formato de temas de Psysonic. Puede que se haya creado para otra versión o que el archivo esté incompleto: comprueba que elegiste el .zip correcto o pregunta al autor del tema.',
   themeImportErrorDetails: 'Detalles técnicos',

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -434,6 +434,8 @@ export const settings = {
   themeImporting: 'Importation…',
   themeImportHint: 'Charge un thème empaqueté en .zip (manifest.json + theme.css).',
   themeImportSuccess: '« {{name}} » importé.',
+  themeImportAssetInvalid: "Une ressource incluse n'a pas passé le contrôle de sécurité, le thème n'a pas été installé.",
+  themeImportAssetError: "Les fichiers de ressources du thème n'ont pas pu être écrits, il n'a pas été installé.",
   themeImportErrorTitle: "Ce thème n'a pas pu être importé",
   themeImportErrorBody: "Il ne correspond pas au format de thème Psysonic. Il a peut-être été conçu pour une autre version, ou le fichier est incomplet — vérifiez que vous avez choisi le bon .zip, ou contactez l'auteur du thème.",
   themeImportErrorDetails: 'Détails techniques',

--- a/src/locales/hu/settings.ts
+++ b/src/locales/hu/settings.ts
@@ -492,6 +492,8 @@ export const settings = {
   themeImporting: 'Importálás…',
   themeImportHint: 'Tölts be egy .zip-ként csomagolt témát (manifest.json + theme.css).',
   themeImportSuccess: '„{{name}}" importálva.',
+  themeImportAssetInvalid: 'Egy mellékelt erőforrás nem ment át a biztonsági ellenőrzésen, ezért a téma nem lett telepítve.',
+  themeImportAssetError: 'A téma erőforrásfájljait nem sikerült kiírni, ezért nem lett telepítve.',
   themeImportErrorTitle: 'Ezt a témát nem sikerült importálni',
   themeImportErrorBody: 'Nem felel meg a Psysonic témaformátumának. Lehet, hogy másik verzióhoz készült, vagy a fájl hiányos — ellenőrizd, hogy a megfelelő .zip-et választottad-e, vagy kérdezd meg a téma szerzőjét.',
   themeImportErrorDetails: 'Technikai részletek',

--- a/src/locales/it/settings.ts
+++ b/src/locales/it/settings.ts
@@ -492,6 +492,8 @@ export const settings = {
   themeImporting: 'Importazione in corso…',
   themeImportHint: 'Carica un tema pacchettizzato come .zip (manifest.json + theme.css).',
   themeImportSuccess: '"{{name}}" importato.',
+  themeImportAssetInvalid: 'Una risorsa inclusa non ha superato il controllo di sicurezza, quindi il tema non è stato installato.',
+  themeImportAssetError: 'Non è stato possibile scrivere i file delle risorse del tema, quindi non è stato installato.',
   themeImportErrorTitle: 'Impossibile importare questo tema',
   themeImportErrorBody: 'Non corrisponde al formato dei temi di Psysonic. Potrebbe essere stato creato per una versione diversa, oppure il file è incompleto — verifica di aver scelto il file .zip giusto, o contatta l\'autore del tema.',
   themeImportErrorDetails: 'Dettagli tecnici',

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -486,6 +486,8 @@ export const settings = {
   themeImporting: 'インポート中…',
   themeImportHint: '.zip としてパッケージされたテーマを読み込みます (manifest.json + theme.css)。',
   themeImportSuccess: '"{{name}}" をインポートしました。',
+  themeImportAssetInvalid: '同梱アセットが安全性チェックに通らなかったため、テーマはインストールされませんでした。',
+  themeImportAssetError: 'テーマのアセットファイルを書き込めなかったため、インストールされませんでした。',
   themeImportErrorTitle: 'このテーマはインポートできませんでした',
   themeImportErrorBody: 'Psysonic のテーマ形式と一致しません。別バージョン向けに作られたか、ファイルが不完全な可能性があります。正しい .zip を選んだか確認するか、テーマ作者に問い合わせてください。',
   themeImportErrorDetails: '技術的詳細',

--- a/src/locales/nb/settings.ts
+++ b/src/locales/nb/settings.ts
@@ -437,6 +437,8 @@ export const settings = {
   themeImporting: 'Importerer…',
   themeImportHint: 'Laster inn et tema pakket som .zip (manifest.json + theme.css).',
   themeImportSuccess: '«{{name}}» importert.',
+  themeImportAssetInvalid: 'En medfølgende ressurs bestod ikke sikkerhetskontrollen, så temaet ble ikke installert.',
+  themeImportAssetError: 'Temaets ressursfiler kunne ikke skrives, så det ble ikke installert.',
   themeImportErrorTitle: 'Dette temaet kunne ikke importeres',
   themeImportErrorBody: 'Det samsvarer ikke med Psysonic-temaformatet. Det kan være laget for en annen versjon, eller filen er ufullstendig — sjekk at du valgte riktig .zip, eller spør temaets forfatter.',
   themeImportErrorDetails: 'Tekniske detaljer',

--- a/src/locales/nl/settings.ts
+++ b/src/locales/nl/settings.ts
@@ -434,6 +434,8 @@ export const settings = {
   themeImporting: 'Importeren…',
   themeImportHint: 'Laadt een thema verpakt als .zip (manifest.json + theme.css).',
   themeImportSuccess: '"{{name}}" geïmporteerd.',
+  themeImportAssetInvalid: 'Een meegeleverd bestand kwam niet door de veiligheidscontrole, dus het thema is niet geïnstalleerd.',
+  themeImportAssetError: 'De bestanden van het thema konden niet worden weggeschreven, dus het is niet geïnstalleerd.',
   themeImportErrorTitle: 'Dit thema kon niet worden geïmporteerd',
   themeImportErrorBody: 'Het komt niet overeen met het Psysonic-themaformaat. Mogelijk is het voor een andere versie gemaakt of is het bestand onvolledig — controleer of je de juiste .zip hebt gekozen, of vraag de maker van het thema.',
   themeImportErrorDetails: 'Technische details',

--- a/src/locales/pl/settings.ts
+++ b/src/locales/pl/settings.ts
@@ -492,6 +492,8 @@ export const settings = {
   themeImporting: 'Importowanie…',
   themeImportHint: 'Załaduj motyw zapakowany jako .zip (manifest.json + theme.css).',
   themeImportSuccess: 'Zaimportowano "{{name}}".',
+  themeImportAssetInvalid: 'Dołączony zasób nie przeszedł kontroli bezpieczeństwa, więc motyw nie został zainstalowany.',
+  themeImportAssetError: 'Nie udało się zapisać plików zasobów motywu, więc nie został zainstalowany.',
   themeImportErrorTitle: 'Ten motyw nie mógł być zaimportowany',
   themeImportErrorBody: 'Nie pasuje do formatu motywów PsySonic. Mógł zostać utworzony dla innej wersji albo plik jest niekompletny — sprawdź, czy wybrano właściwy plik .zip, albo zapytaj autora motywu.',
   themeImportErrorDetails: 'Szczegóły techniczne',

--- a/src/locales/ro/settings.ts
+++ b/src/locales/ro/settings.ts
@@ -450,6 +450,8 @@ export const settings = {
   themeImporting: 'Se importă…',
   themeImportHint: 'Încarcă o temă împachetată ca .zip (manifest.json + theme.css).',
   themeImportSuccess: '„{{name}}” importată.',
+  themeImportAssetInvalid: 'O resursă inclusă nu a trecut verificarea de siguranță, așa că tema nu a fost instalată.',
+  themeImportAssetError: 'Fișierele de resurse ale temei nu au putut fi scrise, așa că nu a fost instalată.',
   themeImportErrorTitle: 'Această temă nu a putut fi importată',
   themeImportErrorBody: 'Nu corespunde formatului de teme Psysonic. Poate a fost creată pentru altă versiune sau fișierul este incomplet — verifică dacă ai ales arhiva .zip corectă sau întreabă autorul temei.',
   themeImportErrorDetails: 'Detalii tehnice',

--- a/src/locales/ru/settings.ts
+++ b/src/locales/ru/settings.ts
@@ -502,6 +502,8 @@ export const settings = {
   themeImporting: 'Импорт…',
   themeImportHint: 'Загружает тему, упакованную в .zip (manifest.json + theme.css).',
   themeImportSuccess: '«{{name}}» импортирована.',
+  themeImportAssetInvalid: 'Вложенный ресурс не прошёл проверку безопасности, поэтому тема не была установлена.',
+  themeImportAssetError: 'Не удалось записать файлы ресурсов темы, поэтому она не была установлена.',
   themeImportErrorTitle: 'Не удалось импортировать эту тему',
   themeImportErrorBody: 'Он не соответствует формату тем Psysonic. Возможно, он создан для другой версии или файл неполный — проверьте, что выбрали правильный .zip, или обратитесь к автору темы.',
   themeImportErrorDetails: 'Технические подробности',

--- a/src/locales/zh/settings.ts
+++ b/src/locales/zh/settings.ts
@@ -433,6 +433,8 @@ export const settings = {
   themeImporting: '正在导入…',
   themeImportHint: '加载打包为 .zip 的主题（manifest.json + theme.css）。',
   themeImportSuccess: '已导入“{{name}}”。',
+  themeImportAssetInvalid: '随附的资源未通过安全检查，因此未安装该主题。',
+  themeImportAssetError: '无法写入该主题的资源文件，因此未安装。',
   themeImportErrorTitle: '无法导入此主题',
   themeImportErrorBody: '它不符合 Psysonic 主题格式。可能是为其他版本制作的，或文件不完整——请确认选择了正确的 .zip，或联系主题作者。',
   themeImportErrorDetails: '技术细节',

--- a/src/store/installedThemesStore.ts
+++ b/src/store/installedThemesStore.ts
@@ -21,6 +21,16 @@ export interface InstalledTheme {
   css: string;
   installedAt: number;
   /**
+   * Absolute on-disk directory of this theme (`<appDataDir>/themes/<id>`) when
+   * it ships local assets, used to rewrite `url("assets/…")` at inject time.
+   * Absent for the vast majority of themes, which have no assets. Repaired at
+   * startup if the profile directory moved (see `healThemeAssetBases`).
+   */
+  assetBase?: string;
+  /** Theme-relative asset paths written to disk (e.g. `assets/logo.svg`), for
+   *  uninstall and update cleanup. Absent when the theme has no assets. */
+  assets?: string[];
+  /**
    * Session-only copy pushed by the dev `--theme-watch` sweep. Never written
    * to storage (see partialize/merge below), so a dev session leaves no trace
    * in the user's installed themes.


### PR DESCRIPTION
A theme can ship images and fonts in an `assets/` folder and reference them with a relative `url("assets/…")` instead of embedding everything as `data:` URIs. Themes still never reach the network — a `url()` is a `data:` URI or a local `assets/` path, nothing else. Companion to the registry contract (psysonic-themes #81) and the `minAppVersion` gate (#1344).

- `themeAssets.ts` mirrors the repo contract (path containment, extension whitelist, budgets, SVG content check) and rewrites `url("assets/…")` to an `asset:` URL at inject time — synchronously, so it stays on the pre-paint path.
- Assets live under `<appDataDir>/themes/<id>/assets/`, served through the same asset protocol the cover cache uses. Store install fetches and writes them; **zip import** extracts them in Rust (capped, whitelisted, traversal-checked) and the frontend writes them through the same path.
- Uninstall removes the theme directory; a startup sweep clears orphans and self-heals a moved profile's asset base. The floor now accepts a relative `assets/` url; a bundled asset that fails the contract aborts the install and cleans up.

No cache-busting query is appended to the asset URL: on Windows WebView2 the asset protocol resolves the file path *including* a trailing `?v=…`, turning a valid asset into a 404. This matches the cover cache, which serves disk files with no query.

Test plan
- New tests: the asset contract (mirrors the CI validator's cases), the URL rewrite, store-install cleanup/abort, zip `installLocalAssets` (missing/oversized/bad-SVG/traversal), and Rust `read_asset_entries` (whitelist, caps, wrapping folder, traversal). Sideload-reject and install-guard verified red when removed.
- `npx tsc --noEmit`, `npm run lint`, `npm run dep:check` clean; full `npx vitest run` green (3482 / 497). Rust `theme_import` tests, `committed_bindings_are_fresh`, and clippy clean.
- **Verified end-to-end in a dev build against a real asset theme**: the bundled SVG loads (200) and renders in the sidebar.