### PR TITLE
fix(themes): resolve local assets in the dev theme watcher

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -527,6 +527,43 @@ pub fn run() {
                                 }
                             }
 
+                            // Absolute, webview-loadable form of a watched
+                            // path: canonicalize resolves a relative
+                            // `--theme-watch` argument, and the `\\?\` prefix
+                            // Windows canonicalization adds would not survive
+                            // `convertFileSrc` on the frontend.
+                            fn abs_watch_path(p: &std::path::Path) -> String {
+                                let abs =
+                                    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+                                let s = abs.to_string_lossy().into_owned();
+                                s.strip_prefix(r"\\?\").map(String::from).unwrap_or(s)
+                            }
+
+                            // A watched theme's `url("assets/…")` resolves to
+                            // an `asset:` URL under its own directory, but the
+                            // configured asset-protocol scope only covers the
+                            // app data dirs — a themes checkout lives outside
+                            // it and would 403. Widen the scope at runtime,
+                            // here in the debug-only block, so the shipped
+                            // tauri.conf.json keeps its narrow file access.
+                            {
+                                let dir = match &target {
+                                    WatchTarget::Dir(d) => d.clone(),
+                                    WatchTarget::File(f) => {
+                                        f.parent().map(PathBuf::from).unwrap_or_default()
+                                    }
+                                };
+                                let dir = PathBuf::from(abs_watch_path(&dir));
+                                if let Err(e) =
+                                    app.asset_protocol_scope().allow_directory(&dir, true)
+                                {
+                                    eprintln!(
+                                        "[theme-watch] could not grant asset access to {} — local theme assets will not load: {e}",
+                                        dir.display()
+                                    );
+                                }
+                            }
+
                             // Per-file state: css + manifest mtimes (gate the
                             // reads while both files are unchanged) and last
                             // pushed payload (change detection + ready
@@ -631,6 +668,12 @@ pub fn run() {
                                             .and_then(|v| v.as_str())
                                             .map(String::from)
                                     };
+                                    // The theme's own directory travels with
+                                    // the payload: the frontend rewrites
+                                    // `url("assets/…")` against it, so a
+                                    // watched theme loads its local assets
+                                    // from the checkout instead of falling
+                                    // back to unrewritten (app-root) URLs.
                                     let payload = serde_json::json!({
                                         "css": css,
                                         "name": meta("name"),
@@ -638,6 +681,7 @@ pub fn run() {
                                         "version": meta("version"),
                                         "description": meta("description"),
                                         "mode": meta("mode"),
+                                        "assetBase": f.parent().map(abs_watch_path),
                                     });
                                     let event = match m.get_mut(&f) {
                                         // mtime-only touch — restamp quietly.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,8 @@ export default function App() {
         version?: string | null;
         description?: string | null;
         mode?: string | null;
+        /** The watched theme's directory, for `url("assets/…")` rewriting. */
+        assetBase?: string | null;
       };
       const install = (payload: WatchPayload, apply: boolean) => {
         const css = payload?.css;
@@ -80,7 +82,12 @@ export default function App() {
         // placeholders — watched themes keep their real identity, and only
         // the CSS is the live payload. Fresh seeds are marked dev
         // (session-only, never persisted); a store-installed theme being
-        // watched keeps its persisted entry.
+        // watched keeps its persisted entry. `install` replaces the entry
+        // wholesale, so the previous copy's asset fields are carried over —
+        // dropping them would strand its on-disk assets (broken urls, and an
+        // uninstall that leaves the files behind). The watched directory
+        // rides along separately as `devAssetBase`, which wins at inject time
+        // without overwriting where the installed copy lives.
         const prev = useInstalledThemesStore.getState().getInstalled(id);
         useInstalledThemesStore.getState().install({
           id,
@@ -94,6 +101,9 @@ export default function App() {
           tags: prev?.tags,
           css,
           installedAt: prev?.installedAt ?? Date.now(),
+          assetBase: prev?.assetBase,
+          assets: prev?.assets,
+          devAssetBase: payload.assetBase ?? prev?.devAssetBase,
           dev: prev ? prev.dev ?? false : true,
         });
         if (apply) {

--- a/src/lib/themes/themeInjection.test.ts
+++ b/src/lib/themes/themeInjection.test.ts
@@ -3,7 +3,12 @@
  * Community themes are free-form; the floor only blocks the hard safety
  * invariants (network, scripts, breakout, unscoped @keyframes, size).
  */
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  convertFileSrc: (p: string) => `https://asset.localhost/${encodeURIComponent(p)}`,
+}));
+
 import {
   validateThemeCss,
   injectTheme,
@@ -93,6 +98,30 @@ describe('validateThemeCss (security floor)', () => {
     expect(validateThemeCss(`/* hi */ ${block('x')}`, 'x')).not.toBeNull();
     // A comment cannot smuggle an @import past the floor.
     expect(validateThemeCss(`${block('x')} /* */ @import 'x';`, 'x')).toBeNull();
+  });
+});
+
+describe('injectTheme asset rewriting', () => {
+  const withAssets = (over: Partial<InstalledTheme>): InstalledTheme => ({
+    ...mk('x', `[data-theme='x']{ background: url("assets/logo.svg"); }`),
+    ...over,
+  });
+  const css = () => document.head.querySelector(`style[${ATTR}="x"]`)?.textContent ?? '';
+
+  it('leaves asset urls alone without a base', () => {
+    injectTheme(withAssets({}));
+    expect(css()).toContain('url("assets/logo.svg")');
+  });
+
+  it('rewrites against the installed copy-s base', () => {
+    injectTheme(withAssets({ assetBase: '/data/themes/x' }));
+    expect(css()).toContain(encodeURIComponent('/data/themes/x/assets/logo.svg'));
+  });
+
+  it('prefers the dev watch base over the installed one', () => {
+    injectTheme(withAssets({ assetBase: '/data/themes/x', devAssetBase: '/checkout/themes/x' }));
+    expect(css()).toContain(encodeURIComponent('/checkout/themes/x/assets/logo.svg'));
+    expect(css()).not.toContain(encodeURIComponent('/data/themes/x/assets/logo.svg'));
   });
 });
 

--- a/src/lib/themes/themeInjection.ts
+++ b/src/lib/themes/themeInjection.ts
@@ -72,8 +72,11 @@ export function injectTheme(theme: InstalledTheme): void {
   if (clean == null) return;
   // Rewrite relative `url("assets/…")` to the theme's on-disk asset directory.
   // No-op for themes without assets (no base, or no asset urls). Runs after
-  // validation, so we never validate a url() we produced ourselves.
-  const css = theme.assetBase ? rewriteAssetUrls(clean, theme.assetBase) : clean;
+  // validation, so we never validate a url() we produced ourselves. A dev
+  // `--theme-watch` base wins, so an author editing a checkout sees their
+  // assets rather than the installed copy's.
+  const base = theme.devAssetBase ?? theme.assetBase;
+  const css = base ? rewriteAssetUrls(clean, base) : clean;
   const selector = `style[${ATTR}="${CSS.escape(theme.id)}"]`;
   let el = document.head.querySelector<HTMLStyleElement>(selector);
   if (!el) {

--- a/src/store/installedThemesStore.test.ts
+++ b/src/store/installedThemesStore.test.ts
@@ -62,6 +62,37 @@ describe('installedThemesStore', () => {
     expect(useInstalledThemesStore.getState().getInstalled('real')?.version).toBe('2.0.0');
   });
 
+  it('keeps a watched theme-s dev asset base out of persisted storage', () => {
+    useInstalledThemesStore.getState().install(
+      theme('real', { assetBase: '/data/themes/real', devAssetBase: '/checkout/themes/real' }),
+    );
+    const raw = localStorage.getItem('psysonic_installed_themes');
+    const stored = JSON.parse(raw ?? '{}') as { state?: { themes?: InstalledTheme[] } };
+    expect(stored.state?.themes?.[0].devAssetBase).toBeUndefined();
+    // The installed copy's own base survives — only the dev overlay is dropped.
+    expect(stored.state?.themes?.[0].assetBase).toBe('/data/themes/real');
+    expect(useInstalledThemesStore.getState().getInstalled('real')?.devAssetBase).toBe(
+      '/checkout/themes/real',
+    );
+  });
+
+  it('restores the dev asset base on rehydrate', async () => {
+    useInstalledThemesStore.getState().install(
+      theme('real', { assetBase: '/data/themes/real', devAssetBase: '/checkout/themes/real' }),
+    );
+    localStorage.setItem(
+      'psysonic_installed_themes',
+      JSON.stringify({
+        state: { themes: [theme('real', { assetBase: '/data/themes/real' })] },
+        version: 1,
+      }),
+    );
+    await useInstalledThemesStore.persist.rehydrate();
+    const t = useInstalledThemesStore.getState().getInstalled('real');
+    expect(t?.devAssetBase).toBe('/checkout/themes/real');
+    expect(t?.assetBase).toBe('/data/themes/real');
+  });
+
   it('drops a dev theme on rehydrate when storage has a real install of the same id', async () => {
     useInstalledThemesStore.getState().install(theme('x', { dev: true }));
     localStorage.setItem(

--- a/src/store/installedThemesStore.ts
+++ b/src/store/installedThemesStore.ts
@@ -31,6 +31,14 @@ export interface InstalledTheme {
    *  uninstall and update cleanup. Absent when the theme has no assets. */
   assets?: string[];
   /**
+   * Dev `--theme-watch` only: the watched theme's directory on disk, which
+   * takes precedence over `assetBase` at inject time so assets resolve out of
+   * the author's checkout. Kept separate (and stripped from storage, see
+   * partialize) so watching a store-installed theme cannot overwrite the
+   * persisted `assetBase` pointing at its installed copy.
+   */
+  devAssetBase?: string;
+  /**
    * Session-only copy pushed by the dev `--theme-watch` sweep. Never written
    * to storage (see partialize/merge below), so a dev session leaves no trace
    * in the user's installed themes.
@@ -71,13 +79,25 @@ export const useInstalledThemesStore = create<InstalledThemesState>()(
       // storage, and merge keeps the in-memory ones across a rehydrate (the
       // cross-window storage sync rehydrates on every write from the other
       // window — without this, a persisted change would wipe them).
-      partialize: (s) => ({ themes: s.themes.filter((t) => !t.dev) }),
+      // A watched *store-installed* theme is persisted (it is not a dev copy),
+      // so its dev-only asset base is stripped on the way out and restored on
+      // the way back in — the stored entry keeps pointing at its installed
+      // copy either way.
+      partialize: (s) => ({
+        themes: s.themes
+          .filter((t) => !t.dev)
+          .map(({ devAssetBase: _devAssetBase, ...t }) => t),
+      }),
       merge: (persisted, current) => {
         const stored = (persisted as { themes?: InstalledTheme[] } | undefined)?.themes ?? [];
         const dev = current.themes.filter(
           (t) => t.dev && !stored.some((p) => p.id === t.id),
         );
-        return { ...current, themes: [...stored, ...dev] };
+        const rehydrated = stored.map((t) => {
+          const live = current.themes.find((c) => c.id === t.id)?.devAssetBase;
+          return live ? { ...t, devAssetBase: live } : t;
+        });
+        return { ...current, themes: [...rehydrated, ...dev] };
       },
     }
   )


### PR DESCRIPTION
## Summary

- `--theme-watch` now ships each theme's directory in its payload, so injected CSS rewrites `url("assets/…")` against the checkout instead of the app root
- The asset-protocol scope is widened at runtime inside the existing `debug_assertions` block, so a checkout outside the app data dirs stops returning 403 without broadening the shipped `tauri.conf.json`
- Watching a store-installed theme no longer drops its `assetBase`/`assets`; the watched directory is a separate session-only field that wins at inject time and is stripped from storage
- Reported by a theme author, who tracked down the first two causes

## Test plan

- `npm run lint`, `npm run dep:check`, `npx tsc --noEmit`, `npx vitest run --coverage`, hot-path coverage gate: pass
- `npm test`: 3538 tests pass; the trailing `dep:check:barrels` step fails on two barrel violations that are identical on `main`
- New unit tests cover the inject-time precedence and that the dev base is stripped from storage but restored on rehydrate
- `cargo test --workspace --all-targets` and `cargo clippy --workspace --all-targets -- -D warnings` were run on Windows; both hit pre-existing failures unrelated to this change (a `psysonic-library` sync test that fails identically on `main`, and two `needless_return` lints inside `cfg(not(target_os = "linux"))` blocks that CI's ubuntu runner never compiles)
- Manual verification of the watcher itself still pending — it needs a dev build with a themes checkout
