### PR TITLE
fix(library): let in-memory reads survive the shared cache

### DIFF
--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -251,17 +251,22 @@ impl LibraryStore {
             .expect("cluster attach write");
         let read_conn = Connection::open(&uri).expect("in-memory read connection");
         configure_read_connection(&read_conn).expect("read pragmas");
+        configure_in_memory_read_connection(&read_conn).expect("in-memory read pragmas");
         // Shared-cache identity DB: write connection created schema first.
         crate::identity::attach_cluster_read_memory(&read_conn, &cluster_uri)
             .expect("cluster attach read");
         let mainstage_read_conn =
             Connection::open(&uri).expect("in-memory mainstage read connection");
         configure_read_connection(&mainstage_read_conn).expect("mainstage read pragmas");
+        configure_in_memory_read_connection(&mainstage_read_conn)
+            .expect("in-memory mainstage read pragmas");
         crate::identity::attach_cluster_read_memory(&mainstage_read_conn, &cluster_uri)
             .expect("cluster attach mainstage read");
         let scope_detail_read_conn =
             Connection::open(&uri).expect("in-memory scope detail read connection");
         configure_read_connection(&scope_detail_read_conn).expect("scope detail read pragmas");
+        configure_in_memory_read_connection(&scope_detail_read_conn)
+            .expect("in-memory scope detail read pragmas");
         crate::identity::attach_cluster_read_memory(&scope_detail_read_conn, &cluster_uri)
             .expect("cluster attach scope detail read");
         Self {
@@ -948,6 +953,21 @@ fn configure_write_connection(conn: &Connection) -> rusqlite::Result<()> {
     conn.pragma_update(None, "temp_store", "MEMORY")?;
     conn.pragma_update(None, "foreign_keys", "ON")?;
     Ok(())
+}
+
+/// Extra read pragma for the in-memory store only (tests).
+///
+/// A file-backed database runs in WAL, where a reader and the single writer
+/// never block each other. The in-memory store cannot use WAL, so it shares one
+/// cache across its connections (`cache=shared`) — and shared-cache mode locks
+/// at *table* granularity: a read on a table the write connection is holding
+/// fails with `SQLITE_LOCKED` ("database table is locked"). That is not a busy
+/// condition, so `busy_timeout` never retries it and the read surfaces as a hard
+/// error. Reading uncommitted rows drops the reader's table lock and restores
+/// the concurrency the production WAL path has. Test-only: it never touches a
+/// file-backed connection.
+fn configure_in_memory_read_connection(conn: &Connection) -> rusqlite::Result<()> {
+    conn.pragma_update(None, "read_uncommitted", true)
 }
 
 fn configure_read_connection(conn: &Connection) -> rusqlite::Result<()> {


### PR DESCRIPTION
## Summary

- `sync::capability::tests::overlapping_probe_phase_guards_do_not_serialize_network_or_clobber_sync` fails on Windows with `Transport("database table is locked: sync_state")`. It is a race, not a constant failure: it reproduced on several consecutive runs (including in isolation) but has also passed on an unfixed branch, so treat it as frequently-but-not-always red
- Cause is the in-memory store, not the test: it cannot run WAL, so it shares one cache across its connections, and shared-cache mode locks at *table* granularity. The test reads the phase over `read_conn` while `set_sync_phase_if` writes it over `write_conn`, which returns `SQLITE_LOCKED` — not a busy condition, so `busy_timeout` never retries it
- Fix sets `read_uncommitted` on the three in-memory read connections, dropping the reader's table lock and restoring the concurrency the file-backed WAL path already has. Production connections are file-backed and untouched
- CI runs the rust jobs on `ubuntu-24.04` only, so this class of breakage is invisible there. Whether the same race can bite on Linux is untested — being timing-dependent, it may well be latent rather than absent

## Test plan

- `cargo test --workspace --all-targets` on Windows with this change: 1383 pass, 0 fail
- Same command without it: the test above fails on most runs
- `cargo clippy --workspace --all-targets`: no new warnings
- No test needed a change, so nothing depended on the reader blocking behind a writer
