### PR TITLE
ci(rust): run the workspace tests on windows too

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Generated sources are written with LF by their generators. Without this, a
+# Windows checkout with the default `core.autocrlf=true` converts them to CRLF,
+# and the bindings freshness test in src-tauri/src/lib.rs compares the CRLF
+# working copy against freshly generated LF output — reporting the committed
+# file as stale when it is not.
+src/generated/** text eol=lf

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -36,6 +36,24 @@ jobs:
         working-directory: src-tauri
         run: cargo test --workspace --all-targets
 
+  # Windows is the second platform the app ships on, and parts of the backend
+  # are cfg-gated to it — SQLite locking behaviour, path handling, and the
+  # `cfg(not(target_os = "linux"))` branches never compile on the ubuntu jobs
+  # above. A test that only fails there used to reach main unnoticed and stayed
+  # red for a week (see the shared-cache fix in psysonic-library's store).
+  test-windows:
+    name: cargo test --workspace (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: cargo test --workspace
+        working-directory: src-tauri
+        run: cargo test --workspace --all-targets
+
   clippy:
     name: cargo clippy --workspace
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

- Adds a `windows-latest` job running `cargo test --workspace --all-targets`, alongside the existing ubuntu jobs
- Windows-only backend behaviour is currently untested in CI: SQLite locking differs, and every `cfg(not(target_os = "linux"))` branch never compiles on an ubuntu runner
- Deliberately a second job, not a matrix on the existing one — a matrix renames the job to `cargo test --workspace (ubuntu-24.04)`, and that name is what the promote workflows and branch protection already reference
- Runners are free on this public repo, and the rust jobs are not required checks (`ci-ok` is the only one), so this adds no cost and blocks nothing

## It already found something

The first run failed on `specta_export::committed_bindings_are_fresh`, reporting
`src/generated/bindings.ts` as stale. It was not stale: the repo has no
`.gitattributes`, so a Windows runner checks the file out as CRLF with the
default `core.autocrlf=true` while the generator writes LF, and the test
compares the two. Reproduced locally by converting the file and getting the
identical failure. The second commit pins `src/generated/**` to LF, which fixes
the cause rather than loosening the test — a genuinely stale file still fails.
`git add --renormalize` reports no change to existing files.

## Test plan

- Both windows jobs green on this branch
- The Windows runner did *not* hit the `sync_state` lock that #1353 fixes. That
  failure is timing-dependent and reproduces often on a local Windows box but
  did not surface here — so this job is not a reliable detector for that
  particular race, and #1353 stands on its own analysis rather than on CI
- Only the rust-tests workflow changes; no other workflow references its job names

## Known noise to expect

`repos::track::tests::upsert_500_rows_completes_well_under_perf_budget` is a
wall-clock budget test that fails under load and passes on its own. On a shared
runner it may occasionally redden this job without a real regression.
