### PR TITLE
fix(audio): silence the windows-only clippy lints, and run clippy there

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -75,6 +75,23 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  # Same blind spot as `test-windows`: the lints in the Windows-only cfg
+  # branches are invisible to the ubuntu clippy job above.
+  clippy-windows:
+    name: cargo clippy --workspace (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: cargo clippy --workspace
+        working-directory: src-tauri
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
   coverage:
     name: cargo llvm-cov (baseline + hot-path file gate)
     runs-on: ubuntu-24.04

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -36,6 +36,24 @@ jobs:
         working-directory: src-tauri
         run: cargo test --workspace --all-targets
 
+  # Windows is the second platform the app ships on, and parts of the backend
+  # are cfg-gated to it — SQLite locking behaviour, path handling, and the
+  # `cfg(not(target_os = "linux"))` branches never compile on the ubuntu jobs
+  # above. A test that only fails there used to reach main unnoticed and stayed
+  # red for a week (see the shared-cache fix in psysonic-library's store).
+  test-windows:
+    name: cargo test --workspace (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: cargo test --workspace
+        working-directory: src-tauri
+        run: cargo test --workspace --all-targets
+
   clippy:
     name: cargo clippy --workspace
     runs-on: ubuntu-24.04

--- a/src-tauri/crates/psysonic-audio/src/dev_io.rs
+++ b/src-tauri/crates/psysonic-audio/src/dev_io.rs
@@ -520,6 +520,11 @@ pub(crate) fn effective_default_output_device_name_for_poll() -> Option<String> 
     resolve_effective_default_output_device_name(false)
 }
 
+// The early `return` is what separates the two cfg branches below. On a
+// non-Linux build the second branch is stripped, leaving a lone block that
+// clippy then reads as a needless return — so the lint is an artefact of the
+// expansion, not of the code as written.
+#[allow(clippy::needless_return)]
 fn resolve_effective_default_output_device_name(enumerate_devices: bool) -> Option<String> {
     // Windows/macOS: single cpal default query (pre-#1274). Full `output_devices()`
     // enumeration contends with WASAPI/CoreAudio and is only needed for Linux/PipeWire

--- a/src-tauri/crates/psysonic-audio/src/device_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/device_commands.rs
@@ -111,6 +111,10 @@ pub fn audio_default_output_device_name_for_poll() -> Option<String> {
 
 /// Find a stored per-device EQ key that denotes the same sink as `candidate`
 /// (exact or Linux ALSA logical match).
+// See `dev_io::resolve_effective_default_output_device_name` — the early
+// `return` separates the cfg branches, and only the stripped non-Linux build
+// makes it look redundant.
+#[allow(clippy::needless_return)]
 #[tauri::command]
 #[specta::specta]
 pub fn audio_match_stored_output_device_key(

--- a/src-tauri/src/lib_commands/app_api/perf.rs
+++ b/src-tauri/src/lib_commands/app_api/perf.rs
@@ -171,7 +171,9 @@ fn collect_relevant_proc_stats(self_pid: i32) -> Vec<(i32, String, i32, u64)> {
 }
 
 /// Map a child process name to a stable perf-probe label (Linux `comm` or macOS name).
-#[cfg(any(test, target_os = "linux", target_os = "macos"))]
+// Matches the gating of its only test: `test` alone would define this on
+// Windows test builds, where nothing calls it.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn child_process_memory_label(name: &str) -> &'static str {
     let lower = name.to_ascii_lowercase();
     if lower.contains("webkitwebproces") || lower.contains("web content") || lower.contains("webcontent") {


### PR DESCRIPTION
## Summary

- Clears the three clippy findings that only a Windows build produces, then adds a `windows-latest` clippy job next to the test job from the base branch
- Two `needless_return`s in `psysonic-audio`: the early return separates the two cfg branches, and only the stripped non-Linux build makes it look redundant. Allowed with a note rather than restructured — the Linux branch cannot be compiled on this machine, and reshaping code I cannot build is not worth the lint
- `child_process_memory_label` was gated on `any(test, linux, macos)` while its only test is gated on `any(linux, macos)`, so a Windows test build defined it with no caller. Both are gated the same way now; Linux and macOS are unaffected, `target_os` already covered them

## Based on #1354

Stacked on the Windows test job, since both edit the same workflow file. Merge
#1354 first and the base retargets to `main` automatically.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` on Windows: clean (was three errors)
- `cargo test --workspace --all-targets` on Windows: one failure, `repos::track::tests::upsert_500_rows_completes_well_under_perf_budget`, a wall-clock budget test that passes on its own and is unrelated to this change
