### PR TITLE
feat(themes): spotlight a random older theme in the store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Themes can ship their own images and fonts in an `assets/` folder and reference them with a relative `url("assets/…")`, instead of embedding everything as inline data. Assets are written to disk on install and served locally — themes still never reach the network. Works for both Theme Store installs and imported `.zip` themes; uninstalling a theme removes its files.
 
+### Theme store — a random theme of the moment
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1357](https://github.com/Psychotoxical/psysonic/pull/1357)**
+
+* The store now suggests one theme above the search box, picked from further down the catalogue and preferring themes you have not installed. The store lists themes by last change, so older ones were only ever found by paging to the end. **Show another** picks a different one; installing or applying the suggestion leaves it in place.
+
 ## Changed
 
 ### Library index — designed for several live servers at once

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -436,6 +436,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Artist page — add the whole discography to the queue (PR #1321)',
       'Fullscreen player — volume slider added to the Minimal and Immersive styles (PR #1340)',
       'Multi-disc albums — disc covers next to "CD N" in the album track list (PR #1336)',
+      'Theme Store — a random theme of the moment, surfacing older themes above the search box (PR #1357)',
     ],
   },
   {

--- a/src/features/settings/components/ThemeSpotlightCard.tsx
+++ b/src/features/settings/components/ThemeSpotlightCard.tsx
@@ -1,0 +1,134 @@
+import { useTranslation } from 'react-i18next';
+import { Check, Download, Shuffle, Sparkles } from 'lucide-react';
+import { AnimatedThemeBadge } from '@/features/settings/components/AnimatedThemeBadge';
+import { SettingsGroup } from '@/features/settings/components/SettingsGroup';
+import type { RegistryTheme } from '@/lib/themes/themeRegistry';
+
+interface Props {
+  theme: RegistryTheme;
+  /** Cache-busted thumbnail URL, resolved by the store. */
+  thumbSrc: string;
+  installed: boolean;
+  active: boolean;
+  busy: boolean;
+  /** True when the app warns about animated themes on this machine. */
+  showAnimatedBadge: boolean;
+  onInstall: () => void;
+  onApply: () => void;
+  onShuffle: () => void;
+  onEnlarge: () => void;
+}
+
+/**
+ * The store's spotlight slot: one theme from further down the catalogue, offered
+ * above the search box so themes that stopped being "recently changed" still get
+ * discovered.
+ *
+ * Layout follows the Themes tab's own section pattern: an accent-icon heading
+ * standing above the panel (`h3` — the tab's section titles are `h2`), and a
+ * title-less `SettingsGroup` for the offset panel underneath. Deliberately more
+ * compact than a store row — it must not push the catalogue off-screen.
+ */
+export function ThemeSpotlightCard({
+  theme,
+  thumbSrc,
+  installed,
+  active,
+  busy,
+  showAnimatedBadge,
+  onInstall,
+  onApply,
+  onShuffle,
+  onEnlarge,
+}: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <h3 style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 15, fontWeight: 600, margin: '0 0 0.75rem' }}>
+        <span style={{ display: 'inline-flex', color: 'var(--accent)' }}><Sparkles size={16} /></span>
+        {t('settings.themeStoreSpotlightTitle')}
+      </h3>
+
+      <SettingsGroup>
+        <div style={{ display: 'flex', gap: 14, alignItems: 'flex-start' }}>
+          <button
+            type="button"
+            onClick={onEnlarge}
+            aria-label={t('settings.themeStoreEnlarge')}
+            data-tooltip={t('settings.themeStoreEnlarge')}
+            data-tooltip-pos="right"
+            style={{ padding: 0, border: 'none', background: 'none', cursor: 'zoom-in', flexShrink: 0, lineHeight: 0, borderRadius: 6 }}
+          >
+            <img
+              src={thumbSrc}
+              alt=""
+              loading="lazy"
+              width={140}
+              height={79}
+              onError={e => { e.currentTarget.style.opacity = '0'; }}
+              style={{ width: 140, height: 79, objectFit: 'cover', borderRadius: 6, background: 'var(--bg-deep)' }}
+            />
+          </button>
+
+          <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontWeight: 600 }}>{theme.name}</span>
+              {active && (
+                <span style={{ fontSize: 11, color: 'var(--accent)', display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                  <Check size={12} /> {t('settings.themeStoreActive')}
+                </span>
+              )}
+              {showAnimatedBadge && theme.animated && <AnimatedThemeBadge variant="inline" />}
+            </div>
+
+            <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+              {t('settings.themeStoreByAuthor', { author: theme.author })}
+              {' · '}v{theme.version}
+            </div>
+
+            <p
+              style={{
+                fontSize: 12.5,
+                color: 'var(--text-secondary)',
+                lineHeight: 1.4,
+                margin: '6px 0 0',
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {theme.description}
+            </p>
+
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 10 }}>
+              {!installed && (
+                <button
+                  className="btn btn-primary"
+                  style={{ fontSize: 12, padding: '4px 12px', display: 'inline-flex', alignItems: 'center', gap: 5 }}
+                  onClick={onInstall}
+                  disabled={busy}
+                >
+                  <Download size={14} /> {busy ? t('settings.themeStoreInstalling') : t('settings.themeStoreInstall')}
+                </button>
+              )}
+              {installed && !active && (
+                <button className="btn btn-ghost" style={{ fontSize: 12, padding: '4px 12px' }} onClick={onApply}>
+                  {t('settings.themeStoreApply')}
+                </button>
+              )}
+              <button
+                className="btn btn-ghost"
+                style={{ fontSize: 12, padding: '4px 12px', display: 'inline-flex', alignItems: 'center', gap: 5 }}
+                onClick={onShuffle}
+              >
+                <Shuffle size={14} /> {t('settings.themeStoreSpotlightShuffle')}
+              </button>
+            </div>
+          </div>
+        </div>
+      </SettingsGroup>
+    </>
+  );
+}

--- a/src/features/settings/components/ThemeStoreSection.test.tsx
+++ b/src/features/settings/components/ThemeStoreSection.test.tsx
@@ -20,7 +20,13 @@ import { fetchRegistry } from '@/lib/themes/themeRegistry';
 const fetchRegistryMock = vi.mocked(fetchRegistry);
 
 /** A registry with `n` themes named `Theme 01`…`Theme NN` (zero-padded so the
- *  component's alphabetical sort matches numeric order). */
+ *  component's alphabetical sort matches numeric order).
+ *
+ *  Note for assertions: the store also renders a spotlight card above the
+ *  toolbar holding one theme drawn from this same catalogue (past the first page
+ *  when `n > 12`, otherwise anything). Scope name checks to the rows — via
+ *  `rowNames`/`rows` — instead of querying the whole document, or the spotlight's
+ *  copy of the name makes the assertion ambiguous and randomly red. */
 function makeRegistry(n: number): Registry {
   const themes = Array.from({ length: n }, (_, i) => {
     const num = String(i + 1).padStart(2, '0');
@@ -92,16 +98,19 @@ describe('ThemeStoreSection — pagination & refresh', () => {
     expect(rows(container)).toHaveLength(12);
     expect(screen.getByRole('button', { name: '1', current: 'page' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '3' })).toBeInTheDocument();
-    // Page-2 themes are not rendered yet.
-    expect(screen.queryByText('Theme 13')).not.toBeInTheDocument();
+    // Page-2 themes are not listed yet. Scoped to the rows: the spotlight above
+    // the toolbar shows a theme from further down the catalogue, so a bare
+    // document-wide query would be about the spotlight as much as the page.
+    expect(rowNames(container)).not.toContain('Theme 13');
   });
 
   it('does not paginate when everything fits on one page', async () => {
     fetchRegistryMock.mockResolvedValue({ registry: makeRegistry(8), stale: false });
     const { container } = renderWithProviders(<ThemeStoreSection />);
 
-    await screen.findByText('Theme 01');
-    expect(rows(container)).toHaveLength(8);
+    // A catalogue this small is entirely on page one, so the spotlight has to
+    // fall back to it and may well be showing 'Theme 01' too — wait on the rows.
+    await waitFor(() => expect(rows(container)).toHaveLength(8));
     expect(screen.queryByLabelText('Next page')).not.toBeInTheDocument();
     expect(screen.queryByText(/page 1 of/i)).not.toBeInTheDocument();
   });
@@ -116,8 +125,8 @@ describe('ThemeStoreSection — pagination & refresh', () => {
 
     await user.click(screen.getByLabelText('Next page'));
     expect(screen.getByRole('button', { name: '2', current: 'page' })).toBeInTheDocument();
-    expect(screen.getByText('Theme 13')).toBeInTheDocument();
-    expect(screen.queryByText('Theme 01')).not.toBeInTheDocument();
+    expect(rowNames(container)).toContain('Theme 13');
+    expect(rowNames(container)).not.toContain('Theme 01');
     expect(screen.getByLabelText('Previous page')).toBeEnabled();
 
     await user.click(screen.getByLabelText('Next page'));
@@ -203,7 +212,7 @@ describe('ThemeStoreSection — pagination & refresh', () => {
     const { container } = renderWithProviders(<ThemeStoreSection />);
     const user = userEvent.setup();
 
-    await screen.findByText('Bravo');
+    await waitFor(() => expect(rows(container)).toHaveLength(3));
     // Default sort is newest first: Bravo (06-05) > Charlie (06-03) > Alpha (06-01).
     expect(rowNames(container)).toEqual(['Bravo', 'Charlie', 'Alpha']);
 
@@ -214,15 +223,15 @@ describe('ThemeStoreSection — pagination & refresh', () => {
 
   it('jumps directly to a page via the numbered pager', async () => {
     fetchRegistryMock.mockResolvedValue({ registry: makeRegistry(30), stale: false });
-    renderWithProviders(<ThemeStoreSection />);
+    const { container } = renderWithProviders(<ThemeStoreSection />);
     const user = userEvent.setup();
 
     await screen.findByText('Theme 01');
     await user.click(screen.getByRole('button', { name: '3' }));
 
     // Page 3 holds items 25–30; page 1 is gone and page 3 is marked current.
-    expect(screen.getByText('Theme 25')).toBeInTheDocument();
-    expect(screen.queryByText('Theme 01')).not.toBeInTheDocument();
+    expect(rowNames(container)).toContain('Theme 25');
+    expect(rowNames(container)).not.toContain('Theme 01');
     expect(screen.getByRole('button', { name: '3', current: 'page' })).toBeInTheDocument();
   });
 
@@ -237,7 +246,7 @@ describe('ThemeStoreSection — pagination & refresh', () => {
     const { container } = renderWithProviders(<ThemeStoreSection />);
     const user = userEvent.setup();
 
-    await screen.findByText('With Log');
+    await waitFor(() => expect(rows(container)).toHaveLength(2));
 
     // Exactly one row (the one shipping a changelog) exposes the toggle.
     const toggles = screen.getAllByRole('button', { name: "What's new" });
@@ -286,6 +295,41 @@ describe('ThemeStoreSection — pagination & refresh', () => {
     await screen.findByText('Zulu');
     // Without the pin, newest-first would order Alpha (06-10) before Zulu (06-01).
     expect(rowNames(container)).toEqual(['Zulu', 'Alpha']);
+  });
+
+  it('spotlights a theme from past the first page, above the search box', async () => {
+    // 13 themes: exactly one sits past the first page of 12, so the pick is
+    // determined rather than random and the assertion cannot flake.
+    fetchRegistryMock.mockResolvedValue({ registry: makeRegistry(13), stale: false });
+    const { container } = renderWithProviders(<ThemeStoreSection />);
+
+    // The pick lands one render after the catalogue, so wait for the card itself.
+    await waitFor(() => expect(container.querySelector('.theme-store-spotlight')).not.toBeNull());
+    const spotlight = container.querySelector('.theme-store-spotlight') as HTMLElement;
+    expect(rows(container)).toHaveLength(12);
+    expect(spotlight.textContent).toContain('Theme 13');
+    // The spotlight is the point: that theme is not on the page being browsed.
+    expect(rowNames(container)).not.toContain('Theme 13');
+
+    // It stands above the toolbar, so it reads as a suggestion rather than a hit.
+    const searchBox = screen.getByRole('searchbox');
+    expect(spotlight.compareDocumentPosition(searchBox) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('offers a different theme when the spotlight is re-rolled', async () => {
+    fetchRegistryMock.mockResolvedValue({ registry: makeRegistry(30), stale: false });
+    const { container } = renderWithProviders(<ThemeStoreSection />);
+    const user = userEvent.setup();
+
+    // The heading also carries an icon span, so read the name out of the text.
+    const spotlit = () =>
+      container.querySelector('.theme-store-spotlight')?.textContent?.match(/Theme \d\d/)?.[0];
+    await waitFor(() => expect(spotlit()).toBeDefined());
+    const first = spotlit();
+
+    await user.click(screen.getByRole('button', { name: 'Show another' }));
+
+    await waitFor(() => expect(spotlit()).not.toBe(first));
   });
 
   it('replaces the install button with a hint when the theme needs a newer app', async () => {

--- a/src/features/settings/components/ThemeStoreSection.tsx
+++ b/src/features/settings/components/ThemeStoreSection.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, ChevronDown, ChevronLeft, ChevronRight, Download, RefreshCw, Trash2, WifiOff } from 'lucide-react';
 import { open as openUrl } from '@tauri-apps/plugin-shell';
 import CoverLightbox from '@/ui/CoverLightbox';
 import { useThemeAnimationRisk } from '@/features/settings/hooks/useThemeAnimationRisk';
 import { AnimatedThemeBadge } from '@/features/settings/components/AnimatedThemeBadge';
+import { ThemeSpotlightCard } from '@/features/settings/components/ThemeSpotlightCard';
 import CustomSelect from '@/ui/CustomSelect';
 import { formatRelativeTime } from '@/lib/format/relativeTime';
 import { useThemeStore } from '@/store/themeStore';
@@ -15,6 +16,8 @@ import {
   themeRequiresNewerApp,
   type RegistryTheme,
 } from '@/lib/themes/themeRegistry';
+import { compareThemesByName, compareThemesByNewest } from '@/lib/themes/themeCatalogSort';
+import { pickSpotlightTheme } from '@/lib/themes/pickSpotlightTheme';
 import { installThemeFromRegistry } from '@/lib/themes/installThemeFromRegistry';
 import { uninstallTheme } from '@/lib/themes/uninstallTheme';
 import { isNewer } from '@/lib/util/appUpdaterHelpers';
@@ -74,7 +77,35 @@ export function ThemeStoreSection() {
   const [failedId, setFailedId] = useState<string | null>(null);
   const [lightbox, setLightbox] = useState<{ src: string; name: string } | null>(null);
   const [openChangelogIds, setOpenChangelogIds] = useState<Set<string>>(() => new Set());
+  const [spotlightId, setSpotlightId] = useState<string | null>(null);
   const topRef = useRef<HTMLDivElement>(null);
+  // Mirrors `spotlightId` so the roll below reads the current pick without
+  // closing over render state — that would make `load` unstable and drag the
+  // whole fetch into the mount effect's dependencies.
+  const spotlightIdRef = useRef<string | null>(null);
+
+  /**
+   * Choose the spotlight theme. `keep` holds the current pick when it is still in
+   * the catalogue — a registry refresh must not swap the card out from under the
+   * user; only the shuffle button asks for a different one.
+   *
+   * Every input is read imperatively so a pick made from an async callback
+   * reflects what is installed and applied *now*, not at call time.
+   */
+  const rollSpotlight = useCallback((catalog: RegistryTheme[], keep: boolean) => {
+    const current = spotlightIdRef.current;
+    if (keep && current && catalog.some(th => th.id === current)) return;
+    const next = pickSpotlightTheme({
+      themes: catalog,
+      installedIds: new Set(useInstalledThemesStore.getState().themes.map(th => th.id)),
+      activeThemeId: useThemeStore.getState().theme,
+      excludeId: keep ? null : current,
+      frontPageSize: PAGE_SIZE,
+      random: Math.random(),
+    });
+    spotlightIdRef.current = next?.id ?? null;
+    setSpotlightId(spotlightIdRef.current);
+  }, []);
 
   const toggleChangelog = (id: string) =>
     setOpenChangelogIds(prev => {
@@ -110,6 +141,11 @@ export function ThemeStoreSection() {
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { load(false); }, []);
 
+  // Pick the spotlight once the catalogue arrives. `keep` makes every later run a
+  // no-op while the pick is still in the catalogue, so neither a refresh nor an
+  // install swaps the card; only the shuffle button does.
+  useEffect(() => { if (themes) rollSpotlight(themes, true); }, [themes, rollSpotlight]);
+
   const installedMap = useMemo(() => {
     const m = new Map<string, InstalledTheme>();
     for (const it of installed) m.set(it.id, it);
@@ -131,14 +167,8 @@ export function ThemeStoreSection() {
         (th.tags || []).some(tag => tag.includes(q))
       );
     });
-    // Name is the stable tie-breaker — keeps ordering deterministic when many
-    // themes share the same last-modified date.
-    const byName = (a: RegistryTheme, b: RegistryTheme) => a.name.localeCompare(b.name);
-    const bySort =
-      sortMode === 'name'
-        ? byName
-        : (a: RegistryTheme, b: RegistryTheme) =>
-            (b.updatedAt || '').localeCompare(a.updatedAt || '') || byName(a, b);
+    // Shared with the spotlight pick so both walk the catalogue in one order.
+    const bySort = sortMode === 'name' ? compareThemesByName : compareThemesByNewest;
     // Installed themes with a pending update float to the top (in either sort
     // mode) so the user finds them instead of hunting through the catalogue.
     const hasUpdate = (th: RegistryTheme) => {
@@ -147,6 +177,13 @@ export function ThemeStoreSection() {
     };
     return matched.sort((a, b) => Number(hasUpdate(b)) - Number(hasUpdate(a)) || bySort(a, b));
   }, [themes, query, mode, sortMode, animFilter, installedMap]);
+
+  // The spotlight is held by id, not by object, so installing or applying it
+  // re-renders the same card instead of rolling a different theme.
+  const spotlight = useMemo(
+    () => (themes && spotlightId ? themes.find(th => th.id === spotlightId) ?? null : null),
+    [themes, spotlightId],
+  );
 
   // A changed filter can shrink the result set below the current page; reset to
   // the first page whenever the query or mode filter changes.
@@ -210,6 +247,26 @@ export function ThemeStoreSection() {
       <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '0 0 1rem', lineHeight: 1.5 }}>
         {t('settings.themeStoreNetworkNotice')}{' '}{t('settings.themeStoreStatsNotice')}
       </p>
+
+      {/* Spotlight: one theme from past the first page, so the catalogue's older
+          entries get seen at all. Sits above the toolbar deliberately — below it
+          it would read as a search result. */}
+      {!loading && !error && spotlight && (
+        <div style={{ marginBottom: '1rem' }}>
+          <ThemeSpotlightCard
+            theme={spotlight}
+            thumbSrc={thumbUrl(spotlight.thumbnail)}
+            installed={installedMap.has(spotlight.id)}
+            active={activeTheme === spotlight.id}
+            busy={busyId === spotlight.id}
+            showAnimatedBadge={animRisk}
+            onInstall={() => handleInstall(spotlight)}
+            onApply={() => setTheme(spotlight.id)}
+            onShuffle={() => { if (themes) rollSpotlight(themes, false); }}
+            onEnlarge={() => setLightbox({ src: thumbUrl(spotlight.thumbnail), name: spotlight.name })}
+          />
+        </div>
+      )}
 
       {/* Toolbar: search + mode filter + refresh. Hidden when offline with no
           catalogue to browse — the offline banner below stands in for it. */}

--- a/src/features/settings/components/ThemeStoreSection.tsx
+++ b/src/features/settings/components/ThemeStoreSection.tsx
@@ -252,7 +252,7 @@ export function ThemeStoreSection() {
           entries get seen at all. Sits above the toolbar deliberately — below it
           it would read as a search result. */}
       {!loading && !error && spotlight && (
-        <div style={{ marginBottom: '1rem' }}>
+        <div className="theme-store-spotlight" style={{ marginBottom: '1rem' }}>
           <ThemeSpotlightCard
             theme={spotlight}
             thumbSrc={thumbUrl(spotlight.thumbnail)}

--- a/src/lib/themes/pickSpotlightTheme.test.ts
+++ b/src/lib/themes/pickSpotlightTheme.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for pickSpotlightTheme — the slot exists to surface themes that sit past
+ * the store's first page, so "prefers the back of the catalogue" is the property
+ * under test, not merely "returns something".
+ */
+import { describe, expect, it } from 'vitest';
+
+import { pickSpotlightTheme } from '@/lib/themes/pickSpotlightTheme';
+import type { RegistryTheme } from '@/lib/themes/themeRegistry';
+
+/** Builds a catalogue where index 0 is the most recently changed theme. */
+function catalogue(count: number, overrides: Partial<RegistryTheme>[] = []): RegistryTheme[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `theme-${i}`,
+    name: `Theme ${String(i).padStart(2, '0')}`,
+    author: 'someone',
+    version: '1.0.0',
+    description: 'A theme.',
+    mode: 'dark' as const,
+    css: `themes/theme-${i}/theme.css`,
+    thumbnail: `themes/theme-${i}/thumbnail.webp`,
+    // Descending dates: theme-0 newest, so the front page is theme-0..theme-N.
+    updatedAt: new Date(Date.UTC(2026, 0, 100 - i)).toISOString(),
+    ...overrides[i],
+  }));
+}
+
+const base = {
+  installedIds: new Set<string>(),
+  activeThemeId: null,
+  frontPageSize: 12,
+};
+
+describe('pickSpotlightTheme', () => {
+  it('returns null for an empty catalogue', () => {
+    expect(pickSpotlightTheme({ ...base, themes: [], random: 0 })).toBeNull();
+  });
+
+  it('never picks from the first page while older themes exist', () => {
+    const themes = catalogue(30);
+    const frontPage = new Set(themes.slice(0, 12).map(th => th.id));
+    // Sweep the whole random range: every draw must land past the fold.
+    for (let r = 0; r < 1; r += 0.01) {
+      const pick = pickSpotlightTheme({ ...base, themes, random: r });
+      expect(pick).not.toBeNull();
+      expect(frontPage.has(pick!.id)).toBe(false);
+    }
+  });
+
+  it('prefers a theme the user has not installed', () => {
+    const themes = catalogue(15);
+    // Everything past the fold except the last one is already installed.
+    const installedIds = new Set(themes.slice(12, 14).map(th => th.id));
+    const pick = pickSpotlightTheme({ ...base, themes, installedIds, random: 0.5 });
+    expect(pick!.id).toBe('theme-14');
+  });
+
+  it('falls back to installed themes when every older one is installed', () => {
+    const themes = catalogue(15);
+    const installedIds = new Set(themes.map(th => th.id));
+    const pick = pickSpotlightTheme({ ...base, themes, installedIds, random: 0 });
+    expect(pick).not.toBeNull();
+    expect(installedIds.has(pick!.id)).toBe(true);
+  });
+
+  it('falls back to the front page on a catalogue smaller than one page', () => {
+    const themes = catalogue(3);
+    const pick = pickSpotlightTheme({ ...base, themes, random: 0 });
+    expect(pick!.id).toBe('theme-0');
+  });
+
+  it('never picks the active theme', () => {
+    const themes = catalogue(2);
+    const pick = pickSpotlightTheme({ ...base, themes, activeThemeId: 'theme-0', random: 0 });
+    expect(pick!.id).toBe('theme-1');
+  });
+
+  it('skips themes that need a newer app', () => {
+    const themes = catalogue(2, [{ minAppVersion: '99.0.0' }]);
+    const pick = pickSpotlightTheme({ ...base, themes, random: 0 });
+    expect(pick!.id).toBe('theme-1');
+  });
+
+  it('returns null when nothing in the catalogue is usable', () => {
+    const themes = catalogue(1, [{ minAppVersion: '99.0.0' }]);
+    expect(pickSpotlightTheme({ ...base, themes, random: 0 })).toBeNull();
+  });
+
+  it('avoids repeating the current pick when shuffling', () => {
+    const themes = catalogue(14);
+    // Two themes past the fold; excluding one must yield the other for any draw.
+    for (const r of [0, 0.4, 0.99]) {
+      const pick = pickSpotlightTheme({ ...base, themes, excludeId: 'theme-12', random: r });
+      expect(pick!.id).toBe('theme-13');
+    }
+  });
+
+  it('still returns the excluded theme when it is the only candidate', () => {
+    const themes = catalogue(1);
+    const pick = pickSpotlightTheme({ ...base, themes, excludeId: 'theme-0', random: 0 });
+    expect(pick!.id).toBe('theme-0');
+  });
+
+  it('clamps a random value of 1 to the last candidate', () => {
+    const themes = catalogue(14);
+    const pick = pickSpotlightTheme({ ...base, themes, random: 1 });
+    expect(pick!.id).toBe('theme-13');
+  });
+});

--- a/src/lib/themes/pickSpotlightTheme.ts
+++ b/src/lib/themes/pickSpotlightTheme.ts
@@ -1,0 +1,77 @@
+/**
+ * Picks the theme shown in the store's spotlight slot.
+ *
+ * The catalogue is sorted newest-changed-first, so a theme that has not been
+ * touched in a while sits several pages down and is effectively invisible: it is
+ * only ever reached by someone who deliberately pages to the end. The spotlight
+ * exists to surface exactly those, which is why the pick is drawn from *behind*
+ * the first page rather than uniformly across the whole registry.
+ *
+ * Preferences degrade instead of failing, so a small catalogue (or one the user
+ * has installed most of) still shows something rather than an empty slot.
+ */
+
+import type { RegistryTheme } from '@/lib/themes/themeRegistry';
+import { themeRequiresNewerApp } from '@/lib/themes/themeRegistry';
+import { compareThemesByNewest } from '@/lib/themes/themeCatalogSort';
+
+export interface SpotlightPickInput {
+  /** The full registry catalogue, in any order. */
+  themes: RegistryTheme[];
+  /** Ids of themes already installed locally. */
+  installedIds: ReadonlySet<string>;
+  /** Id of the theme currently applied, if any. */
+  activeThemeId?: string | null;
+  /**
+   * Id to avoid picking again — the theme the spotlight is showing right now, so
+   * "show another" actually lands on another one. Honoured only while some other
+   * candidate remains; on a one-theme catalogue the same theme is still returned
+   * rather than blanking the slot.
+   */
+  excludeId?: string | null;
+  /**
+   * How many themes the store lists on its first page. Everything ranked at or
+   * beyond this is "past the fold" and counts as undiscovered.
+   */
+  frontPageSize: number;
+  /** Random value in [0, 1). Passed in so the pick is deterministic in tests. */
+  random: number;
+}
+
+/**
+ * Returns the theme to spotlight, or `null` when there is nothing sensible to
+ * show (empty catalogue, or every entry is unusable on this build).
+ */
+export function pickSpotlightTheme(input: SpotlightPickInput): RegistryTheme | null {
+  const { themes, installedIds, activeThemeId, excludeId, frontPageSize, random } = input;
+  if (themes.length === 0) return null;
+
+  const ranked = [...themes].sort(compareThemesByNewest);
+
+  // Recommending the theme that is already applied is noise, and one that needs
+  // a newer app can't be installed from here — neither belongs in the slot.
+  const usable = ranked.filter(th => th.id !== activeThemeId && !themeRequiresNewerApp(th));
+  // Dropping the current pick is a preference, not a requirement: with a single
+  // usable theme, showing it again beats showing nothing.
+  const withoutCurrent = usable.filter(th => th.id !== excludeId);
+  const eligible = withoutCurrent.length > 0 ? withoutCurrent : usable;
+  if (eligible.length === 0) return null;
+
+  const pastFold = (th: RegistryTheme) => ranked.indexOf(th) >= frontPageSize;
+  const notInstalled = (th: RegistryTheme) => !installedIds.has(th.id);
+
+  // Best to worst: undiscovered and new to the user, then merely undiscovered,
+  // then anything the user has not installed, then anything at all.
+  const pools = [
+    eligible.filter(th => pastFold(th) && notInstalled(th)),
+    eligible.filter(pastFold),
+    eligible.filter(notInstalled),
+    eligible,
+  ];
+  const pool = pools.find(p => p.length > 0) ?? eligible;
+
+  // Clamp defensively: a caller handing over exactly 1 (or a hair under, from a
+  // seeded generator) must not index past the end.
+  const index = Math.min(pool.length - 1, Math.max(0, Math.floor(random * pool.length)));
+  return pool[index];
+}

--- a/src/lib/themes/themeCatalogSort.ts
+++ b/src/lib/themes/themeCatalogSort.ts
@@ -1,0 +1,18 @@
+/**
+ * Ordering helpers for the Theme Store catalogue. Kept in one place so every
+ * surface that ranks the registry — the store list, the spotlight pick — walks
+ * the catalogue in the same order.
+ */
+
+import type { RegistryTheme } from '@/lib/themes/themeRegistry';
+
+/** Alphabetical by display name. Also the stable tie-breaker for every other
+ *  ordering, so themes sharing a timestamp never shuffle between renders. */
+export function compareThemesByName(a: RegistryTheme, b: RegistryTheme): number {
+  return a.name.localeCompare(b.name);
+}
+
+/** Most recently changed first. Themes with no `updatedAt` sort last. */
+export function compareThemesByNewest(a: RegistryTheme, b: RegistryTheme): number {
+  return (b.updatedAt || '').localeCompare(a.updatedAt || '') || compareThemesByName(a, b);
+}

--- a/src/locales/bg/settings.ts
+++ b/src/locales/bg/settings.ts
@@ -452,6 +452,8 @@ export const settings = {
   themeStoreNetworkNotice: 'Магазинът за теми зарежда каталога и преглед от GitHub. Не се изпращат лични данни.',
   themeStoreStatsNotice: 'Датите на последна промяна се обновяват веднъж дневно (около 04:17 UTC).',
   themeStoreSearchPlaceholder: 'Търси теми…',
+  themeStoreSpotlightTitle: 'Случайна тема на момента',
+  themeStoreSpotlightShuffle: 'Покажи друга',
   themeStoreFilterMode: 'Филтрирай по режим',
   themeStoreModeAll: 'Всички',
   themeStoreModeDark: 'Тъмна',

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -408,6 +408,8 @@ export const settings = {
   themeStoreNetworkNotice: 'Der Theme-Store lädt Katalog und Vorschauen von GitHub. Es werden keine persönlichen Daten gesendet.',
   themeStoreStatsNotice: 'Die „Zuletzt geändert“-Daten werden einmal täglich aktualisiert (gegen 04:17 UTC).',
   themeStoreSearchPlaceholder: 'Themes suchen…',
+  themeStoreSpotlightTitle: 'Zufalls-Theme des Augenblicks',
+  themeStoreSpotlightShuffle: 'Anderes zeigen',
   themeStoreFilterMode: 'Nach Modus filtern',
   themeStoreModeAll: 'Alle',
   themeStoreModeDark: 'Dunkel',

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -452,6 +452,8 @@ export const settings = {
   themeStoreNetworkNotice: 'The Theme Store loads its catalogue and previews from GitHub. No personal data is sent.',
   themeStoreStatsNotice: 'Last-changed dates refresh once a day (around 04:17 UTC).',
   themeStoreSearchPlaceholder: 'Search themes…',
+  themeStoreSpotlightTitle: 'Random theme of the moment',
+  themeStoreSpotlightShuffle: 'Show another',
   themeStoreFilterMode: 'Filter by mode',
   themeStoreModeAll: 'All',
   themeStoreModeDark: 'Dark',

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -406,6 +406,8 @@ export const settings = {
   themeStoreNetworkNotice: 'La tienda de temas carga el catálogo y las vistas previas desde GitHub. No se envían datos personales.',
   themeStoreStatsNotice: 'Las fechas de última modificación se actualizan una vez al día (sobre las 04:17 UTC).',
   themeStoreSearchPlaceholder: 'Buscar temas…',
+  themeStoreSpotlightTitle: 'Tema aleatorio del momento',
+  themeStoreSpotlightShuffle: 'Mostrar otro',
   themeStoreFilterMode: 'Filtrar por modo',
   themeStoreModeAll: 'Todos',
   themeStoreModeDark: 'Oscuro',

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -394,6 +394,8 @@ export const settings = {
   themeStoreNetworkNotice: 'Le Theme Store charge son catalogue et ses aperçus depuis GitHub. Aucune donnée personnelle n’est envoyée.',
   themeStoreStatsNotice: 'Les dates de dernière modification sont actualisées une fois par jour (vers 04h17 UTC).',
   themeStoreSearchPlaceholder: 'Rechercher des thèmes…',
+  themeStoreSpotlightTitle: 'Thème aléatoire du moment',
+  themeStoreSpotlightShuffle: 'En afficher un autre',
   themeStoreFilterMode: 'Filtrer par mode',
   themeStoreModeAll: 'Tous',
   themeStoreModeDark: 'Sombre',

--- a/src/locales/hu/settings.ts
+++ b/src/locales/hu/settings.ts
@@ -452,6 +452,8 @@ export const settings = {
   themeStoreNetworkNotice: 'A Témabolt a katalógusát és előnézeteit a GitHubról tölti be. Személyes adat nem kerül elküldésre.',
   themeStoreStatsNotice: 'A legutóbbi módosítás dátumai naponta egyszer frissülnek (kb. 04:17 UTC-kor).',
   themeStoreSearchPlaceholder: 'Témák keresése…',
+  themeStoreSpotlightTitle: 'A pillanat véletlen témája',
+  themeStoreSpotlightShuffle: 'Mutass másikat',
   themeStoreFilterMode: 'Szűrés mód szerint',
   themeStoreModeAll: 'Összes',
   themeStoreModeDark: 'Sötét',

--- a/src/locales/it/settings.ts
+++ b/src/locales/it/settings.ts
@@ -452,6 +452,8 @@ export const settings = {
   themeStoreNetworkNotice: 'Lo Store dei temi carica il suo catalogo e le anteprime da GitHub. Nessun dato personale viene inviato.',
   themeStoreStatsNotice: 'Le date di ultima modifica si aggiornano una volta al giorno (intorno alle 04:17 UTC).',
   themeStoreSearchPlaceholder: 'Cerca temi…',
+  themeStoreSpotlightTitle: 'Tema casuale del momento',
+  themeStoreSpotlightShuffle: 'Mostrane un altro',
   themeStoreFilterMode: 'Filtra per modalità',
   themeStoreModeAll: 'Tutte',
   themeStoreModeDark: 'Scura',

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -446,6 +446,8 @@ export const settings = {
   themeStoreNetworkNotice: 'テーマストアはカタログとプレビューを GitHub から読み込みます。個人データは送信されません。',
   themeStoreStatsNotice: '最終変更日は 1 日 1 回更新されます (04:17 UTC 前後)。',
   themeStoreSearchPlaceholder: 'テーマを検索…',
+  themeStoreSpotlightTitle: 'いま注目のランダムテーマ',
+  themeStoreSpotlightShuffle: '別のテーマを見る',
   themeStoreFilterMode: 'モードで絞り込み',
   themeStoreModeAll: 'すべて',
   themeStoreModeDark: 'ダーク',

--- a/src/locales/nb/settings.ts
+++ b/src/locales/nb/settings.ts
@@ -397,6 +397,8 @@ export const settings = {
   themeStoreNetworkNotice: 'Theme Store laster katalogen og forhåndsvisninger fra GitHub. Ingen personopplysninger sendes.',
   themeStoreStatsNotice: 'Sist endret-datoene oppdateres én gang om dagen (rundt 04:17 UTC).',
   themeStoreSearchPlaceholder: 'Søk i temaer…',
+  themeStoreSpotlightTitle: 'Tilfeldig tema for øyeblikket',
+  themeStoreSpotlightShuffle: 'Vis et annet',
   themeStoreFilterMode: 'Filtrer etter modus',
   themeStoreModeAll: 'Alle',
   themeStoreModeDark: 'Mørk',

--- a/src/locales/nl/settings.ts
+++ b/src/locales/nl/settings.ts
@@ -394,6 +394,8 @@ export const settings = {
   themeStoreNetworkNotice: 'De Theme Store laadt de catalogus en previews van GitHub. Er worden geen persoonlijke gegevens verzonden.',
   themeStoreStatsNotice: 'De laatst-gewijzigd-datums worden eenmaal per dag bijgewerkt (rond 04:17 UTC).',
   themeStoreSearchPlaceholder: "Thema's zoeken…",
+  themeStoreSpotlightTitle: 'Willekeurig thema van het moment',
+  themeStoreSpotlightShuffle: 'Toon een ander',
   themeStoreFilterMode: 'Filteren op modus',
   themeStoreModeAll: 'Alle',
   themeStoreModeDark: 'Donker',

--- a/src/locales/pl/settings.ts
+++ b/src/locales/pl/settings.ts
@@ -452,6 +452,8 @@ export const settings = {
   themeStoreNetworkNotice: 'Sklep motywów wczytuje katalog i podglądy z GitHuba. Żadne dane osobowe nie są wysyłane.',
   themeStoreStatsNotice: 'Daty ostatnich zmian są odświeżane raz dziennie (około 04:17 UTC, czyli 05:17/06:17 czasu polskiego).',
   themeStoreSearchPlaceholder: 'Szukaj motywów…',
+  themeStoreSpotlightTitle: 'Losowy motyw chwili',
+  themeStoreSpotlightShuffle: 'Pokaż inny',
   themeStoreFilterMode: 'Filtruj po trybie',
   themeStoreModeAll: 'Wszystkie',
   themeStoreModeDark: 'Ciemne',

--- a/src/locales/ro/settings.ts
+++ b/src/locales/ro/settings.ts
@@ -410,6 +410,8 @@ export const settings = {
   themeStoreNetworkNotice: 'Theme Store încarcă catalogul și previzualizările de la GitHub. Nu se trimit date personale.',
   themeStoreStatsNotice: 'Datele privind ultima modificare se actualizează o dată pe zi (în jurul orei 04:17 UTC).',
   themeStoreSearchPlaceholder: 'Caută teme…',
+  themeStoreSpotlightTitle: 'Temă aleatorie a momentului',
+  themeStoreSpotlightShuffle: 'Arată alta',
   themeStoreFilterMode: 'Filtrează după mod',
   themeStoreModeAll: 'Toate',
   themeStoreModeDark: 'Întunecat',

--- a/src/locales/ru/settings.ts
+++ b/src/locales/ru/settings.ts
@@ -462,6 +462,8 @@ export const settings = {
   themeStoreNetworkNotice: 'Магазин тем загружает каталог и превью с GitHub. Личные данные не отправляются.',
   themeStoreStatsNotice: 'Даты последнего изменения обновляются раз в день (около 04:17 UTC).',
   themeStoreSearchPlaceholder: 'Поиск тем…',
+  themeStoreSpotlightTitle: 'Случайная тема момента',
+  themeStoreSpotlightShuffle: 'Показать другую',
   themeStoreFilterMode: 'Фильтр по режиму',
   themeStoreModeAll: 'Все',
   themeStoreModeDark: 'Тёмные',

--- a/src/locales/zh/settings.ts
+++ b/src/locales/zh/settings.ts
@@ -393,6 +393,8 @@ export const settings = {
   themeStoreNetworkNotice: '主题商店从 GitHub 加载目录和预览。不会发送任何个人数据。',
   themeStoreStatsNotice: '最后更新时间每天更新一次（约 04:17 UTC）。',
   themeStoreSearchPlaceholder: '搜索主题…',
+  themeStoreSpotlightTitle: '随机推荐主题',
+  themeStoreSpotlightShuffle: '换一个',
   themeStoreFilterMode: '按模式筛选',
   themeStoreModeAll: '全部',
   themeStoreModeDark: '深色',


### PR DESCRIPTION
The Theme Store lists the catalogue by last change, so themes that stopped being updated sit several pages down and are effectively never discovered. A spotlight slot above the search box now offers one of them.

- Picks from past the first page, preferring themes that are not installed; falls back through weaker preferences rather than showing an empty slot.
- Skips the active theme and anything requiring a newer app build.
- Held by id, so installing or applying the theme leaves the card in place — only `Show another` re-rolls.
- Catalogue sort comparators extracted to a shared module so the list and the pick agree on the ordering.

## Test plan

- `npm run lint`, `npm run dep:check`, `npx tsc --noEmit` — clean.
- `npx vitest run` — 502 files / 3555 tests pass, including 11 new cases covering the pick: never draws from the first page, prefers uninstalled, degrades on a small catalogue, honours the shuffle exclusion, clamps the random bound.
- Verified the new tests fail against a uniform-random pick (3 of 11 red) before restoring the preference order.