### PR TITLE
fix(themes): keep the dev brand marker out of the theme watcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,13 @@ export default function App() {
         const css = payload?.css;
         const id = css?.match(/\[data-theme=['"]([^'"]+)['"]\]/)?.[1];
         if (!id) return;
+        // The watcher has spoken, so this dev build is being used to author
+        // themes. Marks the root once so dev-only chrome that would sit on top
+        // of themed surfaces can step aside — see dev-build-chrome.css. Keyed
+        // off the watcher rather than the theme's own `dev` flag: a
+        // store-installed theme being watched keeps `dev: false` (below), and
+        // its author would otherwise still be looking at the marker.
+        document.documentElement.setAttribute('data-theme-watch', 'true');
         // Manifest metadata wins, then a store-installed copy's, then dev
         // placeholders — watched themes keep their real identity, and only
         // the CSS is the live payload. Fresh seeds are marked dev

--- a/src/styles/layout/dev-build-chrome.css
+++ b/src/styles/layout/dev-build-chrome.css
@@ -1,10 +1,16 @@
-/* Dev-only chrome: shared data dir with prod, but visually unmistakable. */
-html[data-dev-build] .sidebar-brand {
+/* Dev-only chrome: shared data dir with prod, but visually unmistakable.
+ *
+ * The brand block steps aside while the theme watcher is running (`--theme-watch`
+ * sets `data-theme-watch` on the root). Authoring a theme means judging the
+ * sidebar's real colours, and a red bar across the brand makes that impossible —
+ * it also covers exactly the area a theme may replace with its own wordmark.
+ * Every other dev marker below stays put, so a dev build is still unmistakable. */
+html[data-dev-build]:not([data-theme-watch]) .sidebar-brand {
   background: #b91c1c;
   border-bottom-color: rgba(0, 0, 0, 0.22);
 }
 
-html[data-dev-build] .sidebar-brand svg {
+html[data-dev-build]:not([data-theme-watch]) .sidebar-brand svg {
   --logo-color-start: #fff;
   --logo-color-end: #fecaca;
 }


### PR DESCRIPTION
The dev build paints the sidebar brand red so a development window is unmistakable. While authoring a theme, that bar sits exactly where a theme may place its own wordmark, and it makes the sidebar's real colours impossible to judge.

- The root carries `data-theme-watch` once the watcher pushes anything; only the two brand rules opt out of it.
- Every other dev marker stays put — grey title-bar buttons, DEV badge, window title.
- Keyed off the watcher rather than the theme's own `dev` flag: a store-installed theme being watched keeps `dev: false` and its author would otherwise still see the marker.

## Test plan

- `npm run lint`, `npm run dep:check`, `npx tsc --noEmit` — clean.
- `npx vitest run` — 502 files / 3557 tests pass.
- Verified in a dev build with `--theme-watch`: the bar is gone while authoring and returns in a plain dev build.
- No test added: the theme-watch path has no harness today (no `App.test.tsx`), and covering two lines of dev-only chrome would mean standing up the whole app mount plus Tauri event mocks.