### PR TITLE
fix(library): pin the partial track index on the album key lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Joining an invite could fail with "You don't have access to …" even for guests with a working account on that very server — they could browse and play music, only joining was refused. An invite carries the server address in its full form, while the check compared it against the address exactly as saved, so one entered without `http://` never matched.
 * The same check now also recognises a server saved under its second address. Hosts who configure a local and a public address share invites pointing at the public one, which previously matched no account at all.
 
+### New Releases — the long pause before more albums appear
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1359](https://github.com/Psychotoxical/psysonic/pull/1359)**
+
+* On large libraries the page showed its first albums quickly and then sat for roughly three quarters of a minute before loading any more. Leaving the page during that pause could lock the window up entirely. Both are gone; scrolling now loads continuously.
+* Root cause: a database lookup the page performs once per album was scanning the whole track table instead of using its index, which on a library of this size cost close to a second every time.
+
 
 ## [1.50.0]
 

--- a/src-tauri/crates/psysonic-library/src/album_overlay.rs
+++ b/src-tauri/crates/psysonic-library/src/album_overlay.rs
@@ -92,12 +92,18 @@ pub fn resolve_album_overlay(
         ));
     }
 
-    store
-        .with_mainstage_read_conn(|conn| {
+    let (resolutions, timing) = store
+        .with_mainstage_read_conn_timed::<((u128, u128, u128, usize), Vec<_>)>(|conn| {
             let mut group_by_identity = HashMap::<String, u32>::new();
             let mut representative_group_keys = HashMap::<u32, String>::new();
             let mut direct_representatives = HashMap::<u32, (String, String)>::new();
             let mut groups = Vec::with_capacity(request.albums.len());
+            // Split the per-album probes from the single representative query.
+            // Both scale differently — the probes with the album count, the
+            // representative query with the identity groups — so a total tells
+            // you nothing about which one to fix.
+            let mut lookup_key_ms = 0u128;
+            let mut exists_ms = 0u128;
 
             for album in &request.albums {
                 let server_id = album.server_id.trim();
@@ -109,9 +115,13 @@ pub fn resolve_album_overlay(
                     ));
                 }
 
+                let lookup_started = std::time::Instant::now();
                 let indexed_key = lookup_album_key(conn, server_id, album_id)?;
+                lookup_key_ms += lookup_started.elapsed().as_millis();
+                let exists_started = std::time::Instant::now();
                 let exists =
                     indexed_key.is_some() || indexed_album_exists(conn, server_id, album_id)?;
+                exists_ms += exists_started.elapsed().as_millis();
                 let artist = album
                     .artist
                     .as_deref()
@@ -143,22 +153,55 @@ pub fn resolve_album_overlay(
             }
 
             let representative_groups = representative_group_keys.into_iter().collect::<Vec<_>>();
+            let representatives_started = std::time::Instant::now();
             let representatives = resolve_representatives(conn, scopes, &representative_groups)?;
-            Ok(groups
-                .into_iter()
-                .map(|group| {
-                    let representative = representatives
-                        .get(&group)
-                        .or_else(|| direct_representatives.get(&group));
-                    LibraryAlbumOverlayResolutionDto {
-                        group,
-                        representative_server_id: representative.map(|value| value.0.clone()),
-                        representative_id: representative.map(|value| value.1.clone()),
-                    }
-                })
-                .collect())
-        })
-        .map_err(|error| error.to_string())
+            let representatives_ms = representatives_started.elapsed().as_millis();
+            let phase_timings = (lookup_key_ms, exists_ms, representatives_ms, representative_groups.len());
+            Ok((
+                phase_timings,
+                groups
+                    .into_iter()
+                    .map(|group| {
+                        let representative = representatives
+                            .get(&group)
+                            .or_else(|| direct_representatives.get(&group));
+                        LibraryAlbumOverlayResolutionDto {
+                            group,
+                            representative_server_id: representative.map(|value| value.0.clone()),
+                            representative_id: representative.map(|value| value.1.clone()),
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            ))
+        })?;
+    let ((lookup_key_ms, exists_ms, representatives_ms, representative_groups), resolutions) =
+        resolutions;
+    if psysonic_core::logging::should_log_debug() {
+        // This runs on the same connection as the chronological feeds and their
+        // genre counts. A large `lockWaitMs` here means the overlay was ready
+        // and queuing, not slow — the frontend cannot tell those apart, since it
+        // only observes the round trip. The phase fields split the per-album
+        // probes from the single representative query, which scale with
+        // different inputs.
+        crate::app_deprintln!(
+            "[frontend][album-overlay] {}",
+            serde_json::json!({
+                "albumCount": request.albums.len(),
+                "scopeCount": scopes.len(),
+                "lockWaitMs": timing.lock_wait_ms,
+                "queryMs": timing.exec_ms,
+                "lookupKeyMs": lookup_key_ms,
+                "existsMs": exists_ms,
+                "representativesMs": representatives_ms,
+                "representativeGroups": representative_groups,
+                "blockedBy": timing
+                    .blocked_by
+                    .map(|owner| format!("{}:{}", owner.file, owner.line))
+                    .unwrap_or_else(|| "none".to_string()),
+            })
+        );
+    }
+    Ok(resolutions)
 }
 
 #[cfg(test)]
@@ -236,6 +279,63 @@ mod tests {
             resolution.representative_server_id.as_deref() == Some("s1")
                 && resolution.representative_id.as_deref() == Some("a-priority")
         }));
+    }
+
+    /// The overlay probes one album key per candidate, so this query runs 24
+    /// times for a single New Releases page. Left to the planner it drives the
+    /// join from the attached cluster database and scans `track` on every probe:
+    /// ~830ms per call against a ~172k-track library, 19.9s of a 19.9s request.
+    ///
+    /// The hint is asserted on the statement text, not on the query plan. A plan
+    /// assertion passes here for the wrong reason: the test database holds a
+    /// handful of rows, so SQLite picks the index either way and the test stays
+    /// green with the hint removed — verified by removing it. Only the text can
+    /// distinguish "we told it" from "it guessed right on toy data".
+    #[test]
+    fn album_key_lookup_pins_the_partial_track_index() {
+        let sql = crate::scope_merge::LOOKUP_ALBUM_KEY_SQL;
+        assert!(
+            sql.contains("track t INDEXED BY idx_track_album"),
+            "album key lookup no longer pins the partial track index: {sql}"
+        );
+        // The index is partial; without this predicate SQLite rejects the hint.
+        assert!(
+            sql.contains("t.deleted = 0"),
+            "album key lookup dropped the predicate the partial index needs: {sql}"
+        );
+    }
+
+    /// Complements the text assertion above: proves the pinned index is one
+    /// SQLite actually accepts here, so the hint cannot be a statement that
+    /// fails at runtime against the real schema.
+    #[test]
+    fn album_key_lookup_uses_the_partial_track_index() {
+        let store = LibraryStore::open_in_memory();
+        insert_album_track(&store, "s1", "t-plan", "a-plan", "l1");
+        ensure_cluster_keys_built(&store, "s1").unwrap();
+
+        let plan = store
+            .with_mainstage_read_conn_timed(|conn| {
+                let mut stmt = conn.prepare(&format!(
+                    "EXPLAIN QUERY PLAN {}",
+                    crate::scope_merge::LOOKUP_ALBUM_KEY_SQL
+                ))?;
+                let details = stmt
+                    .query_map(params!["s1", "a-plan"], |row| row.get::<_, String>(3))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                Ok(details)
+            })
+            .unwrap()
+            .0;
+
+        assert!(
+            plan.iter().any(|detail| detail.contains("idx_track_album")),
+            "album key lookup stopped using the partial track index: {plan:#?}"
+        );
+        assert!(
+            !plan.iter().any(|detail| detail.contains("SCAN track")),
+            "album key lookup fell back to scanning track: {plan:#?}"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/album_overlay.rs
+++ b/src-tauri/crates/psysonic-library/src/album_overlay.rs
@@ -13,6 +13,23 @@ use crate::store::LibraryStore;
 
 const MAX_OVERLAY_ALBUMS: usize = 128;
 
+/// Where an overlay resolution spent its time.
+///
+/// The two probes scale with the album count, the representative query with the
+/// number of identity groups, so a single total cannot say which one to fix.
+#[derive(Default)]
+struct OverlayPhases {
+    lookup_key_ms: u128,
+    /// Time inside `indexed_album_exists`, together with how often it actually
+    /// ran. The call is short-circuited whenever the key probe already found a
+    /// key, so a duration alone cannot distinguish "fast" from "never called" —
+    /// and reading `0` as "this variant is cheap" would be an unmeasured claim.
+    exists_ms: u128,
+    exists_calls: usize,
+    representatives_ms: u128,
+    representative_groups: usize,
+}
+
 fn indexed_album_exists(
     conn: &rusqlite::Connection,
     server_id: &str,
@@ -92,18 +109,13 @@ pub fn resolve_album_overlay(
         ));
     }
 
-    let (resolutions, timing) = store
-        .with_mainstage_read_conn_timed::<((u128, u128, u128, usize), Vec<_>)>(|conn| {
+    let ((resolutions, phases), timing) = store
+        .with_mainstage_read_conn_timed(|conn| {
             let mut group_by_identity = HashMap::<String, u32>::new();
             let mut representative_group_keys = HashMap::<u32, String>::new();
             let mut direct_representatives = HashMap::<u32, (String, String)>::new();
             let mut groups = Vec::with_capacity(request.albums.len());
-            // Split the per-album probes from the single representative query.
-            // Both scale differently — the probes with the album count, the
-            // representative query with the identity groups — so a total tells
-            // you nothing about which one to fix.
-            let mut lookup_key_ms = 0u128;
-            let mut exists_ms = 0u128;
+            let mut phases = OverlayPhases::default();
 
             for album in &request.albums {
                 let server_id = album.server_id.trim();
@@ -117,11 +129,19 @@ pub fn resolve_album_overlay(
 
                 let lookup_started = std::time::Instant::now();
                 let indexed_key = lookup_album_key(conn, server_id, album_id)?;
-                lookup_key_ms += lookup_started.elapsed().as_millis();
-                let exists_started = std::time::Instant::now();
-                let exists =
-                    indexed_key.is_some() || indexed_album_exists(conn, server_id, album_id)?;
-                exists_ms += exists_started.elapsed().as_millis();
+                phases.lookup_key_ms += lookup_started.elapsed().as_millis();
+                // Written out rather than short-circuited with `||`, so the
+                // fallback probe is only timed when it is actually run.
+                let exists = match indexed_key.is_some() {
+                    true => true,
+                    false => {
+                        let started = std::time::Instant::now();
+                        let found = indexed_album_exists(conn, server_id, album_id)?;
+                        phases.exists_ms += started.elapsed().as_millis();
+                        phases.exists_calls += 1;
+                        found
+                    }
+                };
                 let artist = album
                     .artist
                     .as_deref()
@@ -153,29 +173,25 @@ pub fn resolve_album_overlay(
             }
 
             let representative_groups = representative_group_keys.into_iter().collect::<Vec<_>>();
+            phases.representative_groups = representative_groups.len();
             let representatives_started = std::time::Instant::now();
             let representatives = resolve_representatives(conn, scopes, &representative_groups)?;
-            let representatives_ms = representatives_started.elapsed().as_millis();
-            let phase_timings = (lookup_key_ms, exists_ms, representatives_ms, representative_groups.len());
-            Ok((
-                phase_timings,
-                groups
-                    .into_iter()
-                    .map(|group| {
-                        let representative = representatives
-                            .get(&group)
-                            .or_else(|| direct_representatives.get(&group));
-                        LibraryAlbumOverlayResolutionDto {
-                            group,
-                            representative_server_id: representative.map(|value| value.0.clone()),
-                            representative_id: representative.map(|value| value.1.clone()),
-                        }
-                    })
-                    .collect::<Vec<_>>(),
-            ))
+            phases.representatives_ms = representatives_started.elapsed().as_millis();
+            let resolutions = groups
+                .into_iter()
+                .map(|group| {
+                    let representative = representatives
+                        .get(&group)
+                        .or_else(|| direct_representatives.get(&group));
+                    LibraryAlbumOverlayResolutionDto {
+                        group,
+                        representative_server_id: representative.map(|value| value.0.clone()),
+                        representative_id: representative.map(|value| value.1.clone()),
+                    }
+                })
+                .collect::<Vec<_>>();
+            Ok((resolutions, phases))
         })?;
-    let ((lookup_key_ms, exists_ms, representatives_ms, representative_groups), resolutions) =
-        resolutions;
     if psysonic_core::logging::should_log_debug() {
         // This runs on the same connection as the chronological feeds and their
         // genre counts. A large `lockWaitMs` here means the overlay was ready
@@ -190,10 +206,11 @@ pub fn resolve_album_overlay(
                 "scopeCount": scopes.len(),
                 "lockWaitMs": timing.lock_wait_ms,
                 "queryMs": timing.exec_ms,
-                "lookupKeyMs": lookup_key_ms,
-                "existsMs": exists_ms,
-                "representativesMs": representatives_ms,
-                "representativeGroups": representative_groups,
+                "lookupKeyMs": phases.lookup_key_ms,
+                "existsMs": phases.exists_ms,
+                "existsCalls": phases.exists_calls,
+                "representativesMs": phases.representatives_ms,
+                "representativeGroups": phases.representative_groups,
                 "blockedBy": timing
                     .blocked_by
                     .map(|owner| format!("{}:{}", owner.file, owner.line))
@@ -281,10 +298,11 @@ mod tests {
         }));
     }
 
-    /// The overlay probes one album key per candidate, so this query runs 24
-    /// times for a single New Releases page. Left to the planner it drives the
-    /// join from the attached cluster database and scans `track` on every probe:
-    /// ~830ms per call against a ~172k-track library, 19.9s of a 19.9s request.
+    /// The overlay probes one album key per candidate, so this query runs once
+    /// per album on a New Releases page. Left to the planner it drives the join
+    /// from the attached cluster database and scans `track` on every probe:
+    /// ~830ms per call against a ~172k-track library, 19.9s of a 19.9s request
+    /// for 24 albums.
     ///
     /// The hint is asserted on the statement text, not on the query plan. A plan
     /// assertion passes here for the wrong reason: the test database holds a

--- a/src-tauri/crates/psysonic-library/src/mainstage_browse.rs
+++ b/src-tauri/crates/psysonic-library/src/mainstage_browse.rs
@@ -243,7 +243,7 @@ pub fn list_mainstage_albums(
     let requested_results = offset.saturating_add(fetch_limit);
     let initial_candidates = candidate_limit(offset, fetch_limit);
 
-    store.with_mainstage_read_conn(|conn| {
+    let (result, timing) = store.with_mainstage_read_conn_timed(|conn| {
         let genre_counts_start = std::time::Instant::now();
         let genre_counts = if request.include_genre_counts
             && request.feed == LibraryMainstageAlbumFeed::NewReleases
@@ -295,23 +295,41 @@ pub fn list_mainstage_albums(
             albums.truncate(limit as usize);
             overlay_album_starred_at_rows(conn, &mut albums);
             overlay_album_artist_links(conn, &mut albums);
-            if psysonic_core::logging::should_log_debug() {
-                crate::app_deprintln!(
-                    "[frontend][mainstage-browse] {}",
-                    serde_json::json!({
-                        "feed": request.feed,
-                        "scopeCount": scopes.len(),
-                        "includeGenreCounts": request.include_genre_counts,
-                        "genreCountMs": genre_counts_ms,
-                        "feedMs": feed_start.elapsed().as_millis(),
-                        "candidateLimit": bounded_candidates,
-                        "resultCount": albums.len(),
-                    })
-                );
-            }
-            return Ok(LibraryMainstageAlbumsResponse { albums, has_more, genre_counts });
+            let result_count = albums.len();
+            return Ok((
+                LibraryMainstageAlbumsResponse { albums, has_more, genre_counts },
+                genre_counts_ms,
+                feed_start.elapsed().as_millis(),
+                bounded_candidates,
+                result_count,
+            ));
         }
-    }).map_err(|e| e.to_string())
+    })?;
+    let (response, genre_counts_ms, feed_ms, bounded_candidates, result_count) = result;
+    if psysonic_core::logging::should_log_debug() {
+        // `lockWaitMs` separates "this query is slow" from "this query waited
+        // for someone else's". The feeds, their genre counts, the hot-release
+        // overlay and the sidebar badge all share this connection, so the two
+        // look identical from the frontend — it only ever sees total duration.
+        crate::app_deprintln!(
+            "[frontend][mainstage-browse] {}",
+            serde_json::json!({
+                "feed": request.feed,
+                "scopeCount": scopes.len(),
+                "includeGenreCounts": request.include_genre_counts,
+                "genreCountMs": genre_counts_ms,
+                "feedMs": feed_ms,
+                "lockWaitMs": timing.lock_wait_ms,
+                "blockedBy": timing
+                    .blocked_by
+                    .map(|owner| format!("{}:{}", owner.file, owner.line))
+                    .unwrap_or_else(|| "none".to_string()),
+                "candidateLimit": bounded_candidates,
+                "resultCount": result_count,
+            })
+        );
+    }
+    Ok(response)
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -1659,9 +1659,8 @@ pub fn search_tracks(
 /// this join from `cluster.track_cluster_key` — an attached database, whose
 /// statistics it weighs separately — and scans `track` on every probe. Measured
 /// against a ~172k-track library that is ~830ms per call, and the New Releases
-/// overlay makes one call per album: 24 albums accounted for 19.9s of a 19.9s
-/// request. The sibling probe in `album_overlay.rs` pins the same index and
-/// costs nothing.
+/// overlay makes one call per album: 24 albums accounted for **19.9s of a 19.9s
+/// request**, with the rest of that request costing 2ms.
 ///
 /// The index is partial (`WHERE deleted = 0`), so the predicate below is part of
 /// the contract rather than just a filter: without it the index does not apply

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -1653,18 +1653,34 @@ pub fn search_tracks(
     })
 }
 
+/// The album's cluster key, or `None` when its tracks disagree on one.
+///
+/// `INDEXED BY idx_track_album` is load-bearing. Without it the planner drives
+/// this join from `cluster.track_cluster_key` — an attached database, whose
+/// statistics it weighs separately — and scans `track` on every probe. Measured
+/// against a ~172k-track library that is ~830ms per call, and the New Releases
+/// overlay makes one call per album: 24 albums accounted for 19.9s of a 19.9s
+/// request. The sibling probe in `album_overlay.rs` pins the same index and
+/// costs nothing.
+///
+/// The index is partial (`WHERE deleted = 0`), so the predicate below is part of
+/// the contract rather than just a filter: without it the index does not apply
+/// and SQLite rejects the hint outright.
+pub(crate) const LOOKUP_ALBUM_KEY_SQL: &str =
+    "SELECT CASE WHEN COUNT(*) = COUNT(ck.album_key) \
+                       AND COUNT(DISTINCT ck.album_key) = 1 \
+                 THEN MIN(ck.album_key) END \
+     FROM track t INDEXED BY idx_track_album \
+     INNER JOIN cluster.track_cluster_key ck ON ck.server_id = t.server_id AND ck.track_id = t.id \
+     WHERE t.server_id = ? AND t.album_id = ? AND t.deleted = 0";
+
 pub(crate) fn lookup_album_key(
     conn: &rusqlite::Connection,
     server_id: &str,
     album_id: &str,
 ) -> rusqlite::Result<Option<String>> {
     conn.query_row(
-        "SELECT CASE WHEN COUNT(*) = COUNT(ck.album_key) \
-                           AND COUNT(DISTINCT ck.album_key) = 1 \
-                     THEN MIN(ck.album_key) END \
-         FROM track t \
-         INNER JOIN cluster.track_cluster_key ck ON ck.server_id = t.server_id AND ck.track_id = t.id \
-         WHERE t.server_id = ? AND t.album_id = ? AND t.deleted = 0",
+        LOOKUP_ALBUM_KEY_SQL,
         rusqlite::params![server_id, album_id],
         |r| r.get::<_, Option<String>>(0),
     )

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -204,6 +204,11 @@ pub struct LibraryStore {
     /// Current holder of `read_conn`, used only to attribute contention in
     /// targeted diagnostics such as the Favorites initial snapshot.
     read_op_owner: Mutex<Option<ReadOpOwner>>,
+    /// Same, for `mainstage_read_conn`. That connection is shared by the
+    /// chronological feeds, their genre counts, the hot-release overlay and the
+    /// sidebar unread badge, so "who is holding it" is the question worth
+    /// answering when a browse page stalls.
+    mainstage_read_op_owner: Mutex<Option<ReadOpOwner>>,
     /// IS-3 bulk ingest in progress — read paths skip write-lock work.
     bulk_ingest_active: AtomicBool,
     /// `swap_database_file` / `restore_database_backup` — fail fast instead of
@@ -229,6 +234,7 @@ impl LibraryStore {
             mainstage_read_conn: Mutex::new(mainstage_read_conn),
             scope_detail_read_conn: Mutex::new(scope_detail_read_conn),
             read_op_owner: Mutex::new(None),
+            mainstage_read_op_owner: Mutex::new(None),
             bulk_ingest_active: AtomicBool::new(false),
             swap_in_progress: AtomicBool::new(false),
         })
@@ -275,6 +281,7 @@ impl LibraryStore {
             mainstage_read_conn: Mutex::new(mainstage_read_conn),
             scope_detail_read_conn: Mutex::new(scope_detail_read_conn),
             read_op_owner: Mutex::new(None),
+            mainstage_read_op_owner: Mutex::new(None),
             bulk_ingest_active: AtomicBool::new(false),
             swap_in_progress: AtomicBool::new(false),
         }
@@ -444,12 +451,37 @@ impl LibraryStore {
 
     /// Isolated reader for wide Mainstage scans. All other browse paths retain
     /// `read_conn`, keeping short local reads responsive while Home loads.
-    pub(crate) fn with_mainstage_read_conn<R>(
+    ///
+    /// Always reports how long the caller queued for the connection and who held
+    /// it. Several unrelated surfaces share this reader — the chronological
+    /// feeds, the genre-count aggregate that accompanies them, the hot-release
+    /// overlay and the sidebar unread badge. When one of them is slow the others
+    /// simply stop, and from the outside that is indistinguishable from a slow
+    /// query of their own. `blocked_by` names the caller that held the lock, so
+    /// the distinction survives into the log. There is deliberately no untimed
+    /// variant: the measurement costs two `Instant::now` calls, and every caller
+    /// here is a surface where the answer has already been needed once.
+    #[track_caller]
+    pub(crate) fn with_mainstage_read_conn_timed<R>(
         &self,
         f: impl FnOnce(&Connection) -> rusqlite::Result<R>,
-    ) -> Result<R, String> {
+    ) -> Result<(R, ReadOpTiming), String> {
+        let blocked_by = self.mainstage_read_op_owner();
+        let lock_start = std::time::Instant::now();
         let conn = self.lock_mainstage_read_conn()?;
-        run_conn_closure(&conn, f)
+        let lock_wait_ms = lock_start.elapsed().as_millis() as u64;
+        let _owner = self.mark_mainstage_read_owner(std::panic::Location::caller());
+        let exec_start = std::time::Instant::now();
+        let value = run_conn_closure(&conn, f)?;
+        let exec_ms = exec_start.elapsed().as_millis() as u64;
+        Ok((
+            value,
+            ReadOpTiming {
+                lock_wait_ms,
+                exec_ms,
+                blocked_by: (lock_wait_ms > 0).then_some(blocked_by).flatten(),
+            },
+        ))
     }
 
     /// Isolated reader for heavy derived reads, which can be much wider than
@@ -483,6 +515,30 @@ impl LibraryStore {
         }
         ReadOpOwnerGuard {
             owner: &self.read_op_owner,
+        }
+    }
+
+    fn mainstage_read_op_owner(&self) -> Option<ReadOpOwner> {
+        match self.mainstage_read_op_owner.lock() {
+            Ok(owner) => *owner,
+            Err(poisoned) => *poisoned.into_inner(),
+        }
+    }
+
+    fn mark_mainstage_read_owner(
+        &self,
+        caller: &'static std::panic::Location<'static>,
+    ) -> ReadOpOwnerGuard<'_> {
+        let owner = ReadOpOwner {
+            file: caller.file(),
+            line: caller.line(),
+        };
+        match self.mainstage_read_op_owner.lock() {
+            Ok(mut current) => *current = Some(owner),
+            Err(poisoned) => *poisoned.into_inner() = Some(owner),
+        }
+        ReadOpOwnerGuard {
+            owner: &self.mainstage_read_op_owner,
         }
     }
 
@@ -1721,7 +1777,7 @@ mod tests {
         let mainstage_store = std::sync::Arc::clone(&store);
         let mainstage = std::thread::spawn(move || {
             mainstage_store
-                .with_mainstage_read_conn(|_| {
+                .with_mainstage_read_conn_timed(|_| {
                     started_tx.send(()).expect("signal mainstage read start");
                     std::thread::sleep(Duration::from_millis(100));
                     Ok(())

--- a/src/features/album/hooks/useAlbumGridBrowseFilters.test.tsx
+++ b/src/features/album/hooks/useAlbumGridBrowseFilters.test.tsx
@@ -12,7 +12,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 
-vi.mock('react-router-dom', () => ({
+// Only the two entry points the hook reads are overridden; everything else in
+// the router keeps working. Replacing the whole module would make this test
+// break on an unrelated import somewhere in the hook's dependency chain.
+vi.mock('react-router-dom', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
   useNavigationType: () => 'PUSH',
   useLocation: () => ({ pathname: '/new-releases', state: null }),
 }));

--- a/src/features/album/hooks/useAlbumGridBrowseFilters.test.tsx
+++ b/src/features/album/hooks/useAlbumGridBrowseFilters.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * The genre selection is an effect dependency of the pages that use this hook,
+ * and each of their loads is a query on the one shared browse connection. A
+ * reset that hands out a fresh `[]` when the selection was already empty is
+ * therefore not free: it re-runs those loads for no change in state.
+ *
+ * The navigation type is mocked to `PUSH` on purpose. Under the default `POP`
+ * the hook takes its session-restore branch and returns before the reset ever
+ * runs — a test left on the default passes without touching the code it claims
+ * to cover.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+vi.mock('react-router-dom', () => ({
+  useNavigationType: () => 'PUSH',
+  useLocation: () => ({ pathname: '/new-releases', state: null }),
+}));
+
+import { useAlbumGridBrowseFilters } from '@/features/album/hooks/useAlbumGridBrowseFilters';
+
+describe('useAlbumGridBrowseFilters', () => {
+  it('keeps the same empty selection when the reset effect re-runs', () => {
+    const view = renderHook(
+      ({ serverId }) => useAlbumGridBrowseFilters(serverId, 'new-releases'),
+      { initialProps: { serverId: 'server-a' } },
+    );
+
+    const first = view.result.current.selectedGenres;
+    expect(first).toEqual([]);
+
+    // `serverId` is a dependency of the reset effect, so this re-runs it. The
+    // selection is already empty, so consumers must not see a new array.
+    view.rerender({ serverId: 'server-b' });
+
+    expect(view.result.current.selectedGenres).toBe(first);
+  });
+
+  it('still clears a selection that is not empty', () => {
+    const view = renderHook(
+      ({ serverId }) => useAlbumGridBrowseFilters(serverId, 'new-releases'),
+      { initialProps: { serverId: 'server-a' } },
+    );
+
+    act(() => { view.result.current.setSelectedGenres(['metal']); });
+    expect(view.result.current.selectedGenres).toEqual(['metal']);
+
+    view.rerender({ serverId: 'server-b' });
+
+    expect(view.result.current.selectedGenres).toEqual([]);
+  });
+});

--- a/src/features/album/hooks/useAlbumGridBrowseFilters.ts
+++ b/src/features/album/hooks/useAlbumGridBrowseFilters.ts
@@ -85,7 +85,13 @@ export function useAlbumGridBrowseFilters(
 
     useAlbumBrowseSessionStore.getState().clearReturnStash(serverId, surface);
     useLiveSearchScopeStore.getState().setQuery('');
-    setSelectedGenres([]);
+    // Only clear when there is something to clear. A fresh `[]` is a new
+    // reference even when the selection was already empty, and consumers list
+    // `selectedGenres` among their effect dependencies — an unconditional reset
+    // therefore re-runs their loads, each of which is a query on the one shared
+    // browse connection. The restore branch above already guards for the same
+    // reason.
+    if (filtersRef.current.selectedGenres.length > 0) setSelectedGenres([]);
   }, [serverId, surface, navigationType, location.state]);
 
   useEffect(() => {

--- a/src/features/album/pages/NewReleases.tsx
+++ b/src/features/album/pages/NewReleases.tsx
@@ -286,8 +286,14 @@ export default function NewReleases() {
     });
     try {
       await runLoad(async () => {
+        // Genre counts describe the whole scope, not the page being fetched, so
+        // they are identical on every append — which is why the result is
+        // discarded below when appending. Asking for them anyway is not free:
+        // the count query dominates this request (~3.2s against ~35ms for the
+        // feed itself), and every browse read shares one connection, so a
+        // pointless one stalls the rest of the app behind it.
         const data = await loadLocalNewReleases(
-          anchorServerId ?? '', releaseScopes, PAGE_SIZE, offset, genres,
+          anchorServerId ?? '', releaseScopes, PAGE_SIZE, offset, genres, !append,
         );
         emitMultiServerDebug('new_releases_page_load_apply', {
           anchorServerId,

--- a/src/lib/library/newReleasesLocal.test.ts
+++ b/src/lib/library/newReleasesLocal.test.ts
@@ -30,7 +30,7 @@ describe('loadLocalNewReleases', () => {
       limit: 30,
       offset: 60,
       genres: [],
-      includeGenreCounts: true,
+      includeGenreCounts: false,
     });
     expect(result.albums.map(album => [album.serverId, album.id])).toEqual([
       ['server-b', 'newer'],
@@ -61,7 +61,19 @@ describe('loadLocalNewReleases', () => {
       limit: 30,
       offset: 0,
       genres: [],
-      includeGenreCounts: true,
+      includeGenreCounts: false,
     });
+  });
+
+  // The count query costs ~100x the feed it accompanies and every browse read
+  // shares one connection, so it has to be asked for, never assumed.
+  it('leaves genre counts off unless the caller asks for them', async () => {
+    libraryScopeListMainstageAlbums.mockResolvedValue({ albums: [], hasMore: false, genreCounts: [] });
+
+    await loadLocalNewReleases('server-a', [{ serverId: 'server-a', libraryId: 'a1' }], 30, 0, []);
+    expect(libraryScopeListMainstageAlbums.mock.calls[0][1].includeGenreCounts).toBe(false);
+
+    await loadLocalNewReleases('server-a', [{ serverId: 'server-a', libraryId: 'a1' }], 30, 0, [], true);
+    expect(libraryScopeListMainstageAlbums.mock.calls[1][1].includeGenreCounts).toBe(true);
   });
 });

--- a/src/lib/library/newReleasesLocal.ts
+++ b/src/lib/library/newReleasesLocal.ts
@@ -3,13 +3,24 @@ import { albumToAlbum } from '@/lib/library/advancedSearchLocal';
 import type { GenreAlbumCountRow } from '@/lib/api/library/dto';
 import { describeMultiServerError, emitMultiServerDebug } from '@/lib/library/multiServerDebug';
 
+/**
+ * Reads the new-releases feed out of the local index.
+ *
+ * `includeGenreCounts` defaults to **off**, and deliberately so: the count query
+ * dominates the request — roughly 3.2s against 35ms for the feed itself on a
+ * large library — while every browse read shares a single connection, so one
+ * unnecessary count stalls whatever the app does next. Only the caller that
+ * actually renders a genre filter should ask for it, and only when it is about
+ * to use the result. Both callers that got this wrong (the sidebar unread badge,
+ * and this feed's own pagination) did so by leaving the argument off.
+ */
 export async function loadLocalNewReleases(
   anchorServerId: string,
   scopes: LibraryScopePair[],
   limit: number,
   offset = 0,
   genres: string[] = [],
-  includeGenreCounts = true,
+  includeGenreCounts = false,
 ): Promise<{ albums: ReturnType<typeof albumToAlbum>[]; hasMore: boolean; genreCounts: GenreAlbumCountRow[] }> {
   if (!anchorServerId) {
     emitMultiServerDebug('new_releases_local_skip', {


### PR DESCRIPTION
New Releases took ~45s before its first auto-load, and the app froze if you navigated away meanwhile. Three findings, one of them the cause.

- **`lookup_album_key` scanned `track` on every probe.** It joins against the attached cluster database, and without an index hint the planner drives the join from that side. The overlay calls it once per album: **19.9s of a 19.9s request for 24 albums**, ~830ms per call on a ~172k-track library. Pinned to `idx_track_album`, which the sibling probe in the same module already used.
- **New Releases requested genre counts on every load**, including appends that discard them. The count query dominates the request. The default flipped with it — the expensive path was the one a caller got by omission, and both callers that got it wrong did so by leaving the argument off.
- **The genre reset handed out a fresh `[]` even when empty**, so consumers re-ran their loads for no change in state: four page loads in ten milliseconds, each with its own count query.

## Diagnosis

The first two attempts blamed lock contention, because the frontend only sees a round trip and cannot separate \\waited\\ from \\computed\\. `with_mainstage_read_conn_timed` now reports `lock_wait_ms`, `exec_ms` and the caller holding the lock; the overlay splits its per-album probes from the representative query. That is what identified the real cause, after two wrong ones.

## Checks

- `cargo test --workspace` — 707 pass; the one failure is the known wall-clock `upsert_500_rows` budget test, green in isolation.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `npm run lint`, `npm run dep:check`, `npx tsc --noEmit`, `npx vitest run` — clean, 3560 tests.
- All 48 `scope_merge` tests pass, including the multi-server identity ones. `INDEXED BY` changes the access path, not the result set; an unusable hint is rejected by SQLite rather than silently answered wrong.
- Both new tests verified against the unfixed code: `expected true to be false`, `expected [] to be []`. The index guard asserts the statement text — a plan assertion passes on a three-row test database with the hint removed, which was checked.

Verified on the reporter's library: the wait is gone.