### PR TITLE
fix(library): stop the artists browse from hanging on large libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * On large libraries the page showed its first albums quickly and then sat for roughly three quarters of a minute before loading any more. Leaving the page during that pause could lock the window up entirely. Both are gone; scrolling now loads continuously.
 * Root cause: a database lookup the page performs once per album was scanning the whole track table instead of using its index, which on a library of this size cost close to a second every time.
 
+### Artists — the page that never finished loading
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1360](https://github.com/Psychotoxical/psysonic/pull/1360)**
+
+* On large libraries the Artists page could show nothing but a spinner, indefinitely. It now loads in well under a second.
+* Root cause: the query that collects the artists in the selected music folders was combining two steps in the wrong order, redoing the expensive one once per artist instead of once in total. On a library of this size that meant the query never finished at all.
+
 
 ## [1.50.0]
 

--- a/src-tauri/crates/psysonic-library/src/lib.rs
+++ b/src-tauri/crates/psysonic-library/src/lib.rs
@@ -42,6 +42,8 @@ pub mod mood_groups;
 pub mod most_played;
 pub mod orphan_cleanup;
 pub mod payload;
+#[cfg(test)]
+mod perf_probe;
 pub mod random_artists;
 pub mod repos;
 pub mod runtime;

--- a/src-tauri/crates/psysonic-library/src/perf_probe.rs
+++ b/src-tauri/crates/psysonic-library/src/perf_probe.rs
@@ -1,0 +1,399 @@
+//! Local perf probes against a **copy** of a real library database.
+//!
+//! Ignored by default: they need a database this repository does not ship, and
+//! they measure wall clock, which no CI machine can hold steady. Run one by
+//! pointing `PSYSONIC_PERF_DB` at a copy of `library.sqlite` (with its
+//! `library-cluster.db` sidecar beside it) and naming the test:
+//!
+//! ```text
+//! PSYSONIC_PERF_DB=/path/to/copy/library.sqlite \
+//!   cargo test -p psysonic-library --lib perf_probe -- --ignored --nocapture
+//! ```
+//!
+//! Point it at a copy, never at the live file: opening runs migrations.
+//!
+//! These probes identify scopes by **index**, never by server address. Their
+//! output ends up pasted into PRs and handoffs, and a hostname or IP from a real
+//! user's library does not belong there.
+//!
+//! These exist because two stalls in a row (#1359 and #1360) were first
+//! diagnosed wrong from reasoning alone. A query that
+//! reads the whole `track` table looks fine on a seeded three-row test and
+//! costs tens of seconds on a real one; nothing but a real one shows that.
+
+use std::time::Instant;
+
+use crate::dto::{LibraryAdvancedSearchRequest, LibraryScopePair, LibrarySortClause, SortDir};
+use crate::filter::EntityKind;
+use crate::store::LibraryStore;
+
+fn probe_db_path() -> Option<std::path::PathBuf> {
+    let raw = std::env::var("PSYSONIC_PERF_DB").ok()?;
+    let path = std::path::PathBuf::from(raw);
+    path.exists().then_some(path)
+}
+
+/// Every `(server_id, library_id)` pair that actually carries tracks, in the
+/// order the browse UI would hand them over.
+fn scopes_from_db(store: &LibraryStore) -> Vec<LibraryScopePair> {
+    store
+        .with_read_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT DISTINCT server_id, library_id FROM track WHERE deleted = 0 \
+                 ORDER BY server_id, library_id",
+            )?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok(LibraryScopePair {
+                        server_id: row.get(0)?,
+                        library_id: row.get::<_, Option<String>>(1)?,
+                    })
+                })?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(rows)
+        })
+        .expect("scope pairs")
+}
+
+/// Index of the scope with the most live tracks — the one a stall shows up on.
+fn largest_scope_index(store: &LibraryStore, scopes: &[LibraryScopePair]) -> usize {
+    let mut best = (0usize, -1i64);
+    for (index, scope) in scopes.iter().enumerate() {
+        let count = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM track \
+                     WHERE server_id = ? AND library_id IS ? AND deleted = 0",
+                    rusqlite::params![scope.server_id, scope.library_id],
+                    |r| r.get::<_, i64>(0),
+                )
+            })
+            .unwrap_or(0);
+        if count > best.1 {
+            best = (index, count);
+        }
+    }
+    best.0
+}
+
+fn row_counts(store: &LibraryStore) -> (i64, i64, i64) {
+    store
+        .with_read_conn(|conn| {
+            Ok((
+                conn.query_row("SELECT COUNT(*) FROM track WHERE deleted = 0", [], |r| {
+                    r.get(0)
+                })?,
+                conn.query_row("SELECT COUNT(*) FROM album", [], |r| r.get(0))?,
+                conn.query_row("SELECT COUNT(*) FROM artist", [], |r| r.get(0))?,
+            ))
+        })
+        .expect("row counts")
+}
+
+fn artist_browse_request(
+    scopes: &[LibraryScopePair],
+    limit: u32,
+    offset: u32,
+) -> LibraryAdvancedSearchRequest {
+    LibraryAdvancedSearchRequest {
+        server_id: scopes[0].server_id.clone(),
+        library_scope: None,
+        library_scopes: Some(scopes.to_vec()),
+        query: None,
+        entity_types: vec![EntityKind::Artist],
+        filters: Vec::new(),
+        starred_only: None,
+        restrict_album_ids: None,
+        query_album_title_only: None,
+        sort: vec![LibrarySortClause {
+            field: "name".to_string(),
+            dir: SortDir::Asc,
+        }],
+        limit,
+        offset,
+        skip_totals: true,
+        artist_credit_mode: None,
+        artist_letter_bucket: None,
+    }
+}
+
+/// What the Artists page does on entry: a small bootstrap chunk, then the tail,
+/// then the pages the infinite scroller asks for.
+#[test]
+#[ignore = "needs PSYSONIC_PERF_DB pointing at a copy of a real library"]
+fn artist_browse_first_chunks_on_a_real_library() {
+    let Some(db) = probe_db_path() else {
+        eprintln!("PSYSONIC_PERF_DB unset or missing — skipping");
+        return;
+    };
+    let open_start = Instant::now();
+    let store = LibraryStore::open_path_for_test(&db).expect("open probe db");
+    eprintln!("open_ms={}", open_start.elapsed().as_millis());
+
+    let (tracks, albums, artists) = row_counts(&store);
+    let scopes = scopes_from_db(&store);
+    eprintln!(
+        "tracks={tracks} albums={albums} artists={artists} scopes={}",
+        scopes.len(),
+    );
+
+    for (label, limit, offset) in [
+        ("bootstrap", 30u32, 0u32),
+        ("tail", 170, 30),
+        ("page2", 200, 200),
+    ] {
+        let req = artist_browse_request(&scopes, limit, offset);
+        let started = Instant::now();
+        let result = crate::advanced_search::run_advanced_search(&store, &req).expect("search");
+        eprintln!(
+            "{label}: limit={limit} offset={offset} artists={} elapsed_ms={}",
+            result.artists.len(),
+            started.elapsed().as_millis(),
+        );
+    }
+}
+
+/// The request the app actually sends on entering /artists: **one** scope, not
+/// all of them. One pair takes `build_layer1_scope_artist`, a different branch
+/// from the multi-scope merge above — measuring the wrong one is how the first
+/// reading of this stall came out looking harmless.
+#[test]
+#[ignore = "needs PSYSONIC_PERF_DB pointing at a copy of a real library"]
+fn artist_browse_single_scope_bootstrap_on_a_real_library() {
+    let Some(db) = probe_db_path() else {
+        eprintln!("PSYSONIC_PERF_DB unset or missing — skipping");
+        return;
+    };
+    let store = LibraryStore::open_path_for_test(&db).expect("open probe db");
+    let all = scopes_from_db(&store);
+
+    for (index, scope) in all.iter().enumerate() {
+        let one = vec![scope.clone()];
+        // `chunkSize: 60` in the trace = ARTIST_BROWSE_BOOTSTRAP_CHUNK.
+        let req = artist_browse_request(&one, 60, 0);
+        let started = Instant::now();
+        let result = crate::advanced_search::run_advanced_search(&store, &req).expect("search");
+        eprintln!(
+            "scope {index}: artists={} elapsed_ms={}",
+            result.artists.len(),
+            started.elapsed().as_millis(),
+        );
+    }
+}
+
+/// Splits the **layer-1** (single-scope) artist query, the one the app sends.
+/// Two things in `list_index_artists_layer1_filtered` can run unbounded — the
+/// cluster-key rebuild it calls first, and the `scoped_ids` join — and from the
+/// outside they are indistinguishable.
+#[test]
+#[ignore = "needs PSYSONIC_PERF_DB pointing at a copy of a real library"]
+fn artist_browse_layer1_phase_breakdown_on_a_real_library() {
+    let Some(db) = probe_db_path() else {
+        eprintln!("PSYSONIC_PERF_DB unset or missing — skipping");
+        return;
+    };
+    let store = LibraryStore::open_path_for_test(&db).expect("open probe db");
+    // Defaults to the scope holding the most tracks, which is the one worth
+    // measuring. `PSYSONIC_PERF_SCOPE` picks a different index into the list.
+    let all = scopes_from_db(&store);
+    let index: usize = std::env::var("PSYSONIC_PERF_SCOPE")
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or_else(|| largest_scope_index(&store, &all));
+    let Some(scope) = all.get(index) else {
+        eprintln!("no scope at index {index} — skipping");
+        return;
+    };
+    let server = scope.server_id.clone();
+    let library = scope.library_id.clone().unwrap_or_default();
+    let scopes = vec![scope.clone()];
+    eprintln!("scope index={index} of {}", all.len());
+
+    let started = Instant::now();
+    let cluster = crate::scope_merge::ensure_cluster_keys_for_scopes(&store, &scopes);
+    eprintln!(
+        "ensure_cluster_keys: ok={} elapsed_ms={}",
+        cluster.is_ok(),
+        started.elapsed().as_millis()
+    );
+
+    let scope_cte = "WITH scope(pr, server_id, library_id) AS (SELECT 0, ?, ?)";
+    let album_scoped = format!(
+        "{scope_cte}, album_scoped AS ( \
+           SELECT t.album_id, \
+                  COALESCE(NULLIF(MAX(trim(t.album_artist)), ''), MIN(t.artist)) AS credit_name \
+           FROM scope s \
+           CROSS JOIN track t ON t.server_id = s.server_id AND t.library_id = s.library_id \
+           WHERE t.deleted = 0 AND t.album_id IS NOT NULL AND t.album_id != '' \
+           GROUP BY t.album_id \
+         )"
+    );
+
+    let binds = rusqlite::params![server.clone(), library.clone(), server.clone()];
+    let started = Instant::now();
+    let credits: i64 = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                &format!("{album_scoped} SELECT COUNT(*) FROM album_scoped"),
+                rusqlite::params![server.clone(), library.clone()],
+                |r| r.get(0),
+            )
+        })
+        .expect("album_scoped");
+    eprintln!(
+        "album_scoped: rows={credits} elapsed_ms={}",
+        started.elapsed().as_millis()
+    );
+
+    // The join the app's request actually runs, taken from the shipped constant
+    // so this probe cannot drift away from it. Its plan is printed before it is
+    // executed, so the plan is on record even when the query does not return.
+    let scoped_ids = format!(
+        "{album_scoped} SELECT COUNT(*) FROM ( \
+           SELECT DISTINCT ar.id \
+           FROM album_scoped ac {} \
+         )",
+        crate::scope_merge::LAYER1_ARTIST_CREDIT_JOIN_SQL,
+    );
+    store
+        .with_read_conn(|conn| {
+            let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {scoped_ids}"))?;
+            let rows = stmt
+                .query_map(binds, |r| r.get::<_, String>(3))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            for line in rows {
+                eprintln!("plan: {line}");
+            }
+            Ok(())
+        })
+        .expect("plan");
+
+    let started = Instant::now();
+    let ids: i64 = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                &scoped_ids,
+                rusqlite::params![server.clone(), library.clone(), server.clone()],
+                |r| r.get(0),
+            )
+        })
+        .expect("scoped_ids");
+    eprintln!(
+        "scoped_ids: rows={ids} elapsed_ms={}",
+        started.elapsed().as_millis()
+    );
+}
+
+/// Splits the multi-scope artist query into the pieces it is built from, so a
+/// slow total can be attributed instead of guessed at.
+#[test]
+#[ignore = "needs PSYSONIC_PERF_DB pointing at a copy of a real library"]
+fn artist_browse_phase_breakdown_on_a_real_library() {
+    let Some(db) = probe_db_path() else {
+        eprintln!("PSYSONIC_PERF_DB unset or missing — skipping");
+        return;
+    };
+    let store = LibraryStore::open_path_for_test(&db).expect("open probe db");
+    let scopes = scopes_from_db(&store);
+
+    let scope_values: Vec<String> = scopes
+        .iter()
+        .map(|s| {
+            format!(
+                "('{}', {})",
+                s.server_id.replace('\'', "''"),
+                match &s.library_id {
+                    Some(id) => format!("'{}'", id.replace('\'', "''")),
+                    None => "NULL".to_string(),
+                },
+            )
+        })
+        .collect();
+    let scope_rows = scope_values
+        .iter()
+        .enumerate()
+        .map(|(i, v)| format!("SELECT {i} AS pr, * FROM (VALUES {v})"))
+        .collect::<Vec<_>>()
+        .join(" UNION ALL ");
+    let scope_cte = format!(
+        "WITH scope(pr, server_id, library_id) AS ({scope_rows})"
+    );
+
+    let phases: [(&str, String); 4] = [
+        (
+            "count_scoped_tracks",
+            format!(
+                "{scope_cte} SELECT COUNT(*) FROM scope s \
+                 CROSS JOIN track t ON t.server_id = s.server_id AND t.library_id = s.library_id \
+                 WHERE t.deleted = 0 AND t.album_id IS NOT NULL AND t.album_id != ''"
+            ),
+        ),
+        (
+            "album_credits_cte",
+            format!(
+                "{scope_cte}, album_credits AS ( \
+                   SELECT t.server_id, t.album_id, s.pr, \
+                          COALESCE(NULLIF(MAX(trim(t.album_artist)), ''), MIN(t.artist)) AS credit_name \
+                   FROM scope s \
+                   CROSS JOIN track t ON t.server_id = s.server_id AND t.library_id = s.library_id \
+                   WHERE t.deleted = 0 AND t.album_id IS NOT NULL AND t.album_id != '' \
+                   GROUP BY t.server_id, t.album_id, s.pr \
+                 ) SELECT COUNT(*) FROM album_credits"
+            ),
+        ),
+        (
+            "matched_join_artist",
+            format!(
+                "{scope_cte}, album_credits AS ( \
+                   SELECT t.server_id, t.album_id, s.pr, \
+                          COALESCE(NULLIF(MAX(trim(t.album_artist)), ''), MIN(t.artist)) AS credit_name \
+                   FROM scope s \
+                   CROSS JOIN track t ON t.server_id = s.server_id AND t.library_id = s.library_id \
+                   WHERE t.deleted = 0 AND t.album_id IS NOT NULL AND t.album_id != '' \
+                   GROUP BY t.server_id, t.album_id, s.pr \
+                 ) SELECT COUNT(*) FROM album_credits ac \
+                   INNER JOIN artist ar ON ar.server_id = ac.server_id \
+                     AND ar.name_fold = psysonic_lower_name(ac.credit_name) \
+                   WHERE ar.album_count IS NOT NULL"
+            ),
+        ),
+        (
+            "artist_table_only",
+            "SELECT COUNT(*) FROM artist WHERE album_count IS NOT NULL".to_string(),
+        ),
+    ];
+
+    for (label, sql) in phases {
+        let started = Instant::now();
+        let count: i64 = store
+            .with_read_conn(|conn| conn.query_row(&sql, [], |r| r.get(0)))
+            .expect(label);
+        eprintln!(
+            "{label}: rows={count} elapsed_ms={}",
+            started.elapsed().as_millis()
+        );
+    }
+
+    let plan_sql = format!(
+        "{scope_cte}, album_credits AS ( \
+           SELECT t.server_id, t.album_id, s.pr, \
+                  COALESCE(NULLIF(MAX(trim(t.album_artist)), ''), MIN(t.artist)) AS credit_name \
+           FROM scope s \
+           CROSS JOIN track t ON t.server_id = s.server_id AND t.library_id = s.library_id \
+           WHERE t.deleted = 0 AND t.album_id IS NOT NULL AND t.album_id != '' \
+           GROUP BY t.server_id, t.album_id, s.pr \
+         ) SELECT COUNT(*) FROM album_credits"
+    );
+    store
+        .with_read_conn(|conn| {
+            let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {plan_sql}"))?;
+            let rows = stmt
+                .query_map([], |r| r.get::<_, String>(3))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            for line in rows {
+                eprintln!("plan: {line}");
+            }
+            Ok(())
+        })
+        .expect("plan");
+}

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -872,6 +872,28 @@ pub(crate) fn list_artists_layer1_filtered(
 /// Layer-1 scoped browse over the `artist` table (#1209) — drive from the scoped
 /// track set (sargable `scope` CTE join), then join `artist` rows. Avoids a
 /// correlated EXISTS over the full server-wide `artist` table.
+///
+/// The `CROSS JOIN` in `scoped_ids` is what makes that description true rather
+/// than merely intended. `album_scoped` is a CTE, so SQLite has no row estimate
+/// for it, and the only thing tying `artist` to it is a function call
+/// (`psysonic_lower_name`) — not a column it can index on. Left as a plain
+/// `INNER JOIN` the planner drove from `artist` instead and re-scanned the whole
+/// CTE per artist row: on a 172k-track library that is 4.9k × 11.2k rows and the
+/// query never returns. `CROSS JOIN` fixes the order; the `INDEXED BY` then
+/// guarantees the inner lookup uses `(server_id, name_fold)` and fails loudly if
+/// that index is ever dropped.
+///
+/// The multi-scope sibling does not need this: its join carries
+/// `ar.server_id = ac.server_id`, a real column equality the planner can cost.
+///
+/// Held as a constant so a test can assert the two keywords are still there —
+/// dropping either one produces a query that is correct and never returns, which
+/// no result-based test can catch.
+pub(crate) const LAYER1_ARTIST_CREDIT_JOIN_SQL: &str =
+    "CROSS JOIN artist ar INDEXED BY idx_artist_name_fold \
+       ON ar.server_id = ? AND ar.album_count IS NOT NULL \
+       AND ar.name_fold = psysonic_lower_name(ac.credit_name)";
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn list_index_artists_layer1_filtered(
     store: &LibraryStore,
@@ -905,8 +927,7 @@ pub(crate) fn list_index_artists_layer1_filtered(
              scoped_ids AS ( \
                SELECT DISTINCT ar.id \
                FROM album_scoped ac \
-                INNER JOIN artist ar ON ar.server_id = ? AND ar.album_count IS NOT NULL \
-                  AND ar.name_fold = psysonic_lower_name(ac.credit_name) \
+                {LAYER1_ARTIST_CREDIT_JOIN_SQL} \
              )"
         )
     } else {
@@ -5468,6 +5489,47 @@ mod tests {
         assert!(
             plan.iter().any(|detail| detail.contains("idx_artist_name_fold")),
             "expected name-fold index lookup, got: {plan:?}"
+        );
+    }
+
+    /// #1360: the layer-1 artist browse joins a CTE to `artist` through
+    /// `psysonic_lower_name`, which the planner cannot cost. Left to choose, it
+    /// drove from `artist` and re-scanned the CTE per row — on a 172k-track
+    /// library that query never returned.
+    ///
+    /// Unlike the index-choice guard in #1359, a plan assertion **does** work
+    /// here, and it was checked rather than assumed: with the `CROSS` removed
+    /// this same empty database reports `SEARCH ar … / SCAN ac`, the exact bad
+    /// order measured on the real library. Nothing about the choice depends on
+    /// row counts — a CTE has no statistics, so SQLite applies the same default
+    /// estimate whether the table holds three rows or three hundred thousand.
+    ///
+    /// `EXPLAIN` also prepares the statement, so a dropped or narrowed
+    /// `idx_artist_name_fold` fails here too: `INDEXED BY` on an unusable index
+    /// is a prepare-time error.
+    #[test]
+    fn layer1_artist_credit_join_drives_from_the_cte() {
+        let store = LibraryStore::open_in_memory();
+        let sql = format!(
+            "EXPLAIN QUERY PLAN \
+             WITH album_scoped(album_id, credit_name) AS (SELECT NULL, NULL) \
+             SELECT DISTINCT ar.id FROM album_scoped ac {LAYER1_ARTIST_CREDIT_JOIN_SQL}"
+        );
+        let plan: Vec<String> = store
+            .with_read_conn(|conn| {
+                let mut stmt = conn.prepare(&sql)?;
+                let rows = stmt.query_map(rusqlite::params!["s1"], |row| row.get(3))?;
+                rows.collect()
+            })
+            .unwrap();
+
+        let scan_ac = plan.iter().position(|step| step.contains("SCAN ac"));
+        let search_ar = plan
+            .iter()
+            .position(|step| step.contains("SEARCH ar USING INDEX idx_artist_name_fold"));
+        assert!(
+            scan_ac.is_some() && search_ar.is_some() && scan_ac < search_ar,
+            "the CTE must be the outer loop and `artist` the indexed inner lookup, got: {plan:?}"
         );
     }
 

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -5707,10 +5707,10 @@ mod tests {
     }
 
     /// Local benchmark on a real library DB:
-    /// `PSYSONIC_LIBRARY_DB=~/.local/share/.../library.sqlite cargo test --workspace perf_probe_stellmacher_db -- --ignored --nocapture`
+    /// `PSYSONIC_LIBRARY_DB=~/.local/share/.../library.sqlite cargo test --workspace perf_probe_real_db -- --ignored --nocapture`
     #[test]
     #[ignore]
-    fn perf_probe_stellmacher_db() {
+    fn perf_probe_real_db() {
         use std::path::PathBuf;
         use std::time::Instant;
 


### PR DESCRIPTION
## What

Entering **Artists** on a large library showed a spinner that never resolved. This makes the page load.

## Evidence

The `artists-browse` trace, with PsyLab → Toggles → Artists → Browse perf trace enabled:

```
397.985  rust_advanced_search_start   offset=0 chunkSize=60
   …     (nothing)
446.819  reachability_probe_done      ← 49s later
```

No `rust_advanced_search_done`, and no `[library-db][advanced-search] entity_types=[Artist]` line — that one is written *after* the query returns. The command never came back. The app was not otherwise blocked: `mainstage-browse` answered 0.4s after the artist request started, with `lockWaitMs: 0`.

Reproduced against a copy of a real 172k-track library (`perf_probe.rs`, included here). One scope per row, bootstrap chunk of 60 — the request the page actually sends:

```
small scope        artists=2     1 ms
medium scope       artists=60  207 ms
medium scope       artists=20  154 ms
large scope        ← killed after 10 minutes
```

## Root cause

`list_index_artists_layer1_filtered` builds `scoped_ids` by joining the `album_scoped` CTE to `artist`:

```sql
FROM album_scoped ac
INNER JOIN artist ar ON ar.server_id = ?
  AND ar.name_fold = psysonic_lower_name(ac.credit_name)
```

A CTE has no row estimate, and `psysonic_lower_name(...)` is a function call rather than a column the planner can index on. The only remaining cost signal was `ar.server_id = ?`, so SQLite drove the join from `artist` and re-scanned the entire CTE per artist row:

```
SEARCH ar USING INDEX sqlite_autoindex_artist_1 (server_id=?)
SCAN ac
```

The CTE aggregates 172k tracks into 11.190 album credits and costs ~430 ms on its own; there are 4.867 qualifying artist rows to pair it against. The function's doc comment already described the intended shape ("drive from the scoped track set, then join `artist` rows") — it was simply never enforced.

## The fix

`CROSS JOIN` fixes the join order so the CTE stays the outer loop; `INDEXED BY` then pins the inner lookup to `idx_artist_name_fold (server_id, name_fold)` — an index that already existed and was never chosen.

```
SCAN ac
SEARCH ar USING INDEX idx_artist_name_fold (server_id=? AND name_fold=?)
```

Same measurement afterwards, same database:

| scope | before | after |
| --- | --- | --- |
| large | never returned | **500 ms** |
| medium | — | 323 ms |
| small | — | 171 ms |
| medium (other server) | 207 ms | 93 ms |

Whole probe: 1,21 s instead of unbounded. Numbers are from an unoptimised debug build.

The multi-scope sibling `list_index_artists_multi_scope_album_filtered` is deliberately untouched — its join carries `ar.server_id = ac.server_id`, a real column equality the planner can cost, and it already ran in 585 ms. It was the only other place in the crate with this join shape.

## Tests

`layer1_artist_credit_join_drives_from_the_cte` asserts the plan puts `SCAN ac` before the indexed `artist` lookup.

Unlike the index guard added in #1359, a plan assertion **does** work here, and that was checked rather than assumed: with `CROSS` removed, the same empty in-memory database reports `SEARCH ar … / SCAN ac` — the exact bad order measured on the real library. Nothing about this choice depends on row counts, because a CTE has no statistics for SQLite to weigh. `EXPLAIN` also prepares the statement, so a dropped or narrowed `idx_artist_name_fold` fails the same test: `INDEXED BY` on an unusable index is a prepare-time error.

`perf_probe.rs` holds the measurements themselves. They are `#[ignore]`d — they need a database this repository does not ship and they measure wall clock, which no CI machine holds steady:

```
PSYSONIC_PERF_DB=/path/to/copy/library.sqlite \
  cargo test -p psysonic-library --lib perf_probe -- --ignored --nocapture
```

They exist because two stalls in a row were first diagnosed wrong from reasoning alone. A query that reads a whole table looks fine on a seeded three-row test and hangs forever on a real one.

## What was not verified

* **No measurement on a small library.** The pinned index is the one the predicate already implies, so it should be neutral or better there, but that is reasoning rather than a run.
* **`album_scoped` is still rebuilt per chunk.** Each page of the artist catalogue re-aggregates the scoped track set (~430 ms). That is now the dominant cost of a page and is worth attacking separately; it was never what made the page hang.

## Verification

* `cargo clippy --workspace --all-targets -- -D warnings` — clean.
* `cargo test --workspace` — 708 pass. The one failure is `repos::track::tests::upsert_500_rows_completes_well_under_perf_budget`, the known wall-clock budget test; green in isolation.
* Frontend `lint`, `tsc --noEmit`, `vitest run` — clean, 3560 tests. No frontend change in this PR.
* All `scope_merge` tests pass, including the multi-server identity ones. `CROSS JOIN` and `INDEXED BY` change the access path, not the result set.
* Confirmed on the reporting user's own build after rebuild: the page loads.
