### PR TITLE
fix(playback): keep Hot Cache files scoped to queue servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * On large libraries the Artists page could show nothing but a spinner, indefinitely. It now loads in well under a second.
 * Root cause: the query that collects the artists in the selected music folders was combining two steps in the wrong order, redoing the expensive one once per artist instead of once in total. On a library of this size that meant the query never finished at all.
 
+### Hot Cache — prefetch mixed-server queues from the right server
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1363](https://github.com/Psychotoxical/psysonic/pull/1363)**
+
+* Hot Cache now downloads each upcoming track from its owning server instead of sending the whole prefetch window to whichever server is currently playing. Replacing the queue can no longer leave a delayed job caching the wrong copy when two servers reuse the same track ID.
+
 
 ## [1.50.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#1363](https://github.com/Psychotoxical/psysonic/pull/1363)**
 
 * Hot Cache now downloads each upcoming track from its owning server instead of sending the whole prefetch window to whichever server is currently playing. Replacing the queue can no longer leave a delayed job caching the wrong copy when two servers reuse the same track ID.
+* When the cache is full, the current and next tracks stay protected per server, so an identically numbered track on another server cannot evict the queued copy and trigger a download loop.
 
 ### AppImage — installing through an AppImage manager
 

--- a/src/hotCachePrefetch.test.ts
+++ b/src/hotCachePrefetch.test.ts
@@ -1,0 +1,106 @@
+import { waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { initHotCachePrefetch } from '@/hotCachePrefetch';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { useLocalPlaybackStore } from '@/store/localPlaybackStore';
+import { useAuthStore } from '@/store/authStore';
+import { setDeferHotCachePrefetch } from '@/lib/cache/hotCacheGate';
+import { makeServer, makeTrack, seedQueue } from '@/test/helpers/factories';
+import { resetAuthStore, resetPlayerStore } from '@/test/helpers/storeReset';
+import { invokeMock, onInvoke } from '@/test/mocks/tauri';
+
+describe('hot-cache prefetch server scope', () => {
+  let cleanup: (() => void) | null = null;
+
+  beforeEach(() => {
+    resetAuthStore();
+    resetPlayerStore();
+    useLocalPlaybackStore.setState({ entries: {} });
+
+    const serverA = makeServer({ id: 'a', url: 'http://a.test' });
+    const serverB = makeServer({ id: 'b', url: 'http://b.test' });
+    useAuthStore.setState({
+      servers: [serverA, serverB],
+      activeServerId: serverA.id,
+      isLoggedIn: true,
+      hotCacheEnabled: true,
+      hotCacheMaxMb: 64,
+      hotCacheDebounceSec: 0,
+    });
+
+    const current = makeTrack({ id: 'track-a', serverId: serverA.id, suffix: 'mp3' });
+    const upcoming = makeTrack({ id: 'track-b', serverId: serverB.id, suffix: 'mp3' });
+    seedQueue([current, upcoming], { index: 0, serverId: serverA.id });
+
+    onInvoke('prune_empty_media_tier_dirs', () => undefined);
+    onInvoke('get_media_tier_size', () => 0);
+    onInvoke('probe_media_files', args => {
+      const paths = (args as { localPaths: string[] }).localPaths;
+      return paths.map(() => true);
+    });
+    onInvoke('download_track_local', args => ({
+      path: `/media/cache/${(args as { serverIndexKey: string }).serverIndexKey}/track-b.mp3`,
+      size: 1024,
+      layoutFingerprint: 'fp',
+    }));
+  });
+
+  afterEach(() => {
+    setDeferHotCachePrefetch(false);
+    cleanup?.();
+    cleanup = null;
+    usePlayerStore.setState({ queueItems: [], queueIndex: 0, currentTrack: null, queueServerId: null });
+    useLocalPlaybackStore.setState({ entries: {} });
+  });
+
+  it('uses each upcoming queue item server for its download directory', async () => {
+    cleanup = initHotCachePrefetch();
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        'download_track_local',
+        expect.objectContaining({
+          trackId: 'track-b',
+          serverIndexKey: 'b.test',
+          libraryServerId: 'b.test',
+        }),
+      );
+    });
+  });
+
+  it('drops a stale server job after the queue switches to another server', async () => {
+    const currentB = makeTrack({ id: 'shared-current', serverId: 'b', suffix: 'mp3' });
+    const upcomingB = makeTrack({ id: 'shared-next', serverId: 'b', suffix: 'mp3' });
+    seedQueue([currentB, upcomingB], { index: 0, serverId: 'b' });
+    setDeferHotCachePrefetch(true);
+    cleanup = initHotCachePrefetch();
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('get_media_tier_size', {
+        tier: 'ephemeral',
+        mediaDir: null,
+      });
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const currentA = makeTrack({ id: 'shared-current', serverId: 'a', suffix: 'mp3' });
+    const upcomingA = makeTrack({ id: 'shared-next', serverId: 'a', suffix: 'mp3' });
+    seedQueue([currentA, upcomingA], { index: 0, serverId: 'a' });
+    setDeferHotCachePrefetch(false);
+
+    await waitFor(() => {
+      const downloadCalls = invokeMock.mock.calls.filter(([command]) => command === 'download_track_local');
+      const downloadCall = downloadCalls.find(([, args]) => (
+        (args as { serverIndexKey?: string }).serverIndexKey === 'a.test'
+      ));
+      expect(downloadCall?.[1]).toEqual(expect.objectContaining({
+        trackId: 'shared-next',
+        serverIndexKey: 'a.test',
+        libraryServerId: 'a.test',
+      }));
+      expect(downloadCalls.some(([, args]) => (
+        (args as { serverIndexKey?: string }).serverIndexKey === 'b.test'
+      ))).toBe(false);
+    });
+  });
+});

--- a/src/hotCachePrefetch.ts
+++ b/src/hotCachePrefetch.ts
@@ -1,5 +1,8 @@
 import { buildStreamUrlForServer } from '@/lib/api/subsonicStreamUrl';
-import { getPlaybackCacheServerKey } from '@/features/playback/utils/playback/playbackServer';
+import {
+  getPlaybackCacheServerKey,
+  playbackCacheKeyForRef,
+} from '@/features/playback/utils/playback/playbackServer';
 import type { QueueItemRef } from '@/lib/media/trackTypes';
 import { resolveQueueTrack } from '@/features/playback/store/queueTrackView';
 import { invoke } from '@tauri-apps/api/core';
@@ -137,11 +140,15 @@ async function runWorker() {
       const player = usePlayerStore.getState();
       const { queueItems, queueIndex } = player;
       const upcomingRefs = queueItems.slice(queueIndex + 1, queueIndex + 1 + PREFETCH_AHEAD);
-      const wantIds = new Set(upcomingRefs.map(r => r.trackId));
-      if (!wantIds.has(job.trackId)) {
+      const jobKey = entryKey(job.serverId, job.trackId);
+      const jobRef = upcomingRefs.find(ref => (
+        entryKey(playbackCacheKeyForRef(ref), ref.trackId) === jobKey
+      ));
+      if (!jobRef) {
         hotCacheFrontendDebug({
           event: 'prefetch-skip-job',
           trackId: job.trackId,
+          serverId: job.serverId,
           reason: 'not-in-upcoming-window',
           queueIndex,
           window: PREFETCH_AHEAD,
@@ -152,20 +159,14 @@ async function runWorker() {
       // Thin-state: the upcoming window sits inside the resolver-warm range, so
       // resolveQueueTrack returns the full Track (placeholder only on a cold
       // miss, where the size estimate falls back to the bitrate heuristic).
-      const jobRef = upcomingRefs.find(r => r.trackId === job.trackId);
-      if (!jobRef) {
-        hotCacheFrontendDebug({
-          event: 'prefetch-skip-job',
-          trackId: job.trackId,
-          reason: 'track-not-in-queue',
-        });
-        continue;
-      }
       const track = resolveQueueTrack(jobRef);
       const hotEntries = selectHotCacheEntries(useLocalPlaybackStore.getState().entries);
-      const occupied = sumCachedBytesInProtectedWindow(queueItems, queueIndex, job.serverId, hotEntries);
+      const occupied = sumCachedBytesInProtectedWindow(queueItems, queueIndex, hotEntries);
       const est = estimateTrackHotCacheBytes(track);
-      const isImmediateNext = queueItems[queueIndex + 1]?.trackId === job.trackId;
+      const immediateNextRef = queueItems[queueIndex + 1];
+      const isImmediateNext = immediateNextRef
+        ? entryKey(playbackCacheKeyForRef(immediateNextRef), immediateNextRef.trackId) === jobKey
+        : false;
       if (!isImmediateNext && occupied + est > maxBytes) {
         hotCacheFrontendDebug({
           event: 'prefetch-skip-job',
@@ -255,7 +256,6 @@ async function replanNow() {
   const playbackSid = getPlaybackCacheServerKey();
   if (!auth.isLoggedIn || !auth.hotCacheEnabled || !playbackSid) return;
 
-  const serverId = playbackSid;
   const maxBytes = Math.max(0, auth.hotCacheMaxMb) * 1024 * 1024;
   const mediaDir = getMediaDir();
   if (maxBytes <= 0) return;
@@ -266,7 +266,7 @@ async function replanNow() {
     return;
   }
 
-  await useHotCacheStore.getState().evictToFit(queueItems, queueIndex, maxBytes, serverId, mediaDir);
+  await useHotCacheStore.getState().evictToFit(queueItems, queueIndex, maxBytes, playbackSid, mediaDir);
 
   // Must read entries after eviction: the pre-evict snapshot still lists removed keys and would
   // skip prefetch for upcoming tracks that no longer have on-disk rows.
@@ -275,12 +275,15 @@ async function replanNow() {
   // Thin-state: resolve only the small upcoming window (within the resolver-warm
   // range) to full Tracks for the size estimates / suffix.
   const targetRefs = queueItems.slice(queueIndex + 1, queueIndex + 1 + PREFETCH_AHEAD);
-  const targets = targetRefs.map(r => resolveQueueTrack(r));
-  const immediateNextId = queueItems[queueIndex + 1]?.trackId;
-  let projectedOccupied = sumCachedBytesInProtectedWindow(queueItems, queueIndex, serverId, hotEntries);
+  const targets = targetRefs.map(ref => ({
+    track: resolveQueueTrack(ref),
+    serverId: playbackCacheKeyForRef(ref),
+  }));
+  let projectedOccupied = sumCachedBytesInProtectedWindow(queueItems, queueIndex, hotEntries);
   const jobs: PrefetchJob[] = [];
   const skipped: { trackId: string; reason: string }[] = [];
-  for (const t of targets) {
+  for (const [index, target] of targets.entries()) {
+    const { track: t, serverId } = target;
     if (hasLocalPersistentPlaybackBytes(t.id, serverId)) {
       skipped.push({ trackId: t.id, reason: 'persistent-local-bytes' });
       continue;
@@ -289,7 +292,7 @@ async function replanNow() {
       skipped.push({ trackId: t.id, reason: 'already-in-hot-index' });
       continue;
     }
-    const isImmediateNext = t.id === immediateNextId;
+    const isImmediateNext = index === 0;
     if (isImmediateNext) {
       jobs.push({ trackId: t.id, serverId, suffix: t.suffix || 'mp3' });
       continue;

--- a/src/hotCachePrefetch.ts
+++ b/src/hotCachePrefetch.ts
@@ -281,15 +281,15 @@ async function replanNow() {
   }));
   let projectedOccupied = sumCachedBytesInProtectedWindow(queueItems, queueIndex, hotEntries);
   const jobs: PrefetchJob[] = [];
-  const skipped: { trackId: string; reason: string }[] = [];
+  const skipped: { trackId: string; serverId: string; reason: string }[] = [];
   for (const [index, target] of targets.entries()) {
     const { track: t, serverId } = target;
     if (hasLocalPersistentPlaybackBytes(t.id, serverId)) {
-      skipped.push({ trackId: t.id, reason: 'persistent-local-bytes' });
+      skipped.push({ trackId: t.id, serverId, reason: 'persistent-local-bytes' });
       continue;
     }
     if (hotEntries[entryKey(serverId, t.id)]) {
-      skipped.push({ trackId: t.id, reason: 'already-in-hot-index' });
+      skipped.push({ trackId: t.id, serverId, reason: 'already-in-hot-index' });
       continue;
     }
     const isImmediateNext = index === 0;
@@ -299,7 +299,7 @@ async function replanNow() {
     }
     const est = estimateTrackHotCacheBytes(t);
     if (projectedOccupied + est > maxBytes) {
-      skipped.push({ trackId: t.id, reason: 'budget-cap-rest-deferred' });
+      skipped.push({ trackId: t.id, serverId, reason: 'budget-cap-rest-deferred' });
       break;
     }
     projectedOccupied += est;

--- a/src/hotCachePrefetch/helpers.ts
+++ b/src/hotCachePrefetch/helpers.ts
@@ -1,5 +1,6 @@
 import { frontendDebugLog } from '@/lib/api/debugLog';
 import type { QueueItemRef, Track } from '@/lib/media/trackTypes';
+import { canonicalQueueServerKey } from '@/lib/server/serverIndexKey';
 import { useAuthStore } from '../store/authStore';
 import { HOT_CACHE_PROTECT_AFTER_CURRENT, type HotCacheEntry } from '@/features/playback/store/hotCacheStore';
 
@@ -22,13 +23,14 @@ export function entryKey(serverId: string, trackId: string): string {
 export function sumCachedBytesInProtectedWindow(
   queue: QueueItemRef[],
   queueIndex: number,
-  serverId: string,
   entries: Record<string, HotCacheEntry>,
 ): number {
   const protectLo = Math.max(0, queueIndex);
   const protectHi = Math.min(queue.length - 1, queueIndex + HOT_CACHE_PROTECT_AFTER_CURRENT);
   let sum = 0;
   for (let i = protectLo; i <= protectHi; i++) {
+    const serverId = canonicalQueueServerKey(queue[i].serverId) || queue[i].serverId;
+    if (!serverId) continue;
     const e = entries[entryKey(serverId, queue[i].trackId)];
     if (e) sum += e.sizeBytes || 0;
   }

--- a/src/store/localPlaybackStore.test.ts
+++ b/src/store/localPlaybackStore.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAuthStore } from '@/store/authStore';
+import { localPlaybackEntryKey } from '@/store/localPlaybackKeys';
+import { useLocalPlaybackStore, type LocalPlaybackEntry } from '@/store/localPlaybackStore';
+import { makeServer } from '@/test/helpers/factories';
+import { resetAuthStore } from '@/test/helpers/storeReset';
+import { invokeMock, onInvoke } from '@/test/mocks/tauri';
+
+function ephemeralEntry(
+  serverIndexKey: string,
+  trackId: string,
+  localPath: string,
+): LocalPlaybackEntry {
+  return {
+    serverIndexKey,
+    trackId,
+    localPath,
+    layoutFingerprint: 'fp',
+    sizeBytes: 80,
+    tier: 'ephemeral',
+    cachedAt: 1,
+    suffix: 'mp3',
+  };
+}
+
+describe('local playback eviction server scope', () => {
+  beforeEach(() => {
+    resetAuthStore();
+    useLocalPlaybackStore.setState({ entries: {} });
+    useAuthStore.setState({
+      servers: [
+        makeServer({ id: 'a', url: 'http://a.test' }),
+        makeServer({ id: 'b', url: 'http://b.test' }),
+      ],
+      activeServerId: 'a',
+    });
+
+    onInvoke('probe_media_files', args => {
+      const paths = (args as { localPaths: string[] }).localPaths;
+      return paths.map(() => true);
+    });
+    onInvoke('prune_empty_media_tier_dirs', () => ({ status: 'ok', data: null }));
+    onInvoke('delete_media_file', () => ({ status: 'ok', data: null }));
+  });
+
+  it('keeps a protected foreign-server track when the active server reuses its id', async () => {
+    const activeKey = localPlaybackEntryKey('a.test', 'shared');
+    const protectedKey = localPlaybackEntryKey('b.test', 'shared');
+    useLocalPlaybackStore.setState({
+      entries: {
+        [activeKey]: ephemeralEntry('a.test', 'shared', '/cache/a/shared.mp3'),
+        [protectedKey]: ephemeralEntry('b.test', 'shared', '/cache/b/shared.mp3'),
+      },
+    });
+
+    let sizeRead = 0;
+    onInvoke('get_media_tier_size', () => {
+      sizeRead += 1;
+      return sizeRead === 1 ? 160 : 80;
+    });
+
+    await useLocalPlaybackStore.getState().evictEphemeralToFit(
+      [
+        { serverId: 'a', trackId: 'current' },
+        { serverId: 'b', trackId: 'shared' },
+      ],
+      0,
+      80,
+      'a.test',
+      null,
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith('delete_media_file', {
+      localPath: '/cache/a/shared.mp3',
+      mediaDir: null,
+    });
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      'delete_media_file',
+      expect.objectContaining({ localPath: '/cache/b/shared.mp3' }),
+    );
+    expect(useLocalPlaybackStore.getState().entries[activeKey]).toBeUndefined();
+    expect(useLocalPlaybackStore.getState().entries[protectedKey]).toBeDefined();
+  });
+});

--- a/src/store/localPlaybackStore.ts
+++ b/src/store/localPlaybackStore.ts
@@ -17,6 +17,7 @@ import {
   getEphemeralDiskBytes,
   reconcileEphemeralCache,
 } from '@/lib/cache/ephemeralTierReconcile';
+import { canonicalQueueServerKey } from '@/lib/server/serverIndexKey';
 
 export type LocalPlaybackTier = 'ephemeral' | 'library' | 'favorite-auto';
 
@@ -220,15 +221,20 @@ export const useLocalPlaybackStore = create<LocalPlaybackState>()(
 
         const protectLo = Math.max(0, queueIndex);
         const protectHi = Math.min(queue.length - 1, queueIndex + LOCAL_PLAYBACK_PROTECT_AFTER_CURRENT);
-        const protectedIds = new Set<string>();
+        const queueEntryKey = (ref: QueueItemRef): string => localPlaybackEntryKey(
+          canonicalQueueServerKey(ref.serverId) || activeServerIndexKey,
+          ref.trackId,
+        );
+        const protectedKeys = new Set<string>();
         for (let i = protectLo; i <= protectHi; i++) {
-          protectedIds.add(queue[i].trackId);
+          protectedKeys.add(queueEntryKey(queue[i]));
         }
 
-        const indexOfInQueue = (trackId: string): number | null => {
-          const idx = queue.findIndex(r => r.trackId === trackId);
-          return idx >= 0 ? idx : null;
-        };
+        const queueIndexByKey = new Map<string, number>();
+        queue.forEach((ref, index) => {
+          const key = queueEntryKey(ref);
+          if (!queueIndexByKey.has(key)) queueIndexByKey.set(key, index);
+        });
 
         const entries = { ...get().entries };
         let sum = Object.values(entries)
@@ -243,7 +249,7 @@ export const useLocalPlaybackStore = create<LocalPlaybackState>()(
           const parsed = parseLocalPlaybackEntryKey(key);
           if (!parsed) continue;
           const { serverIndexKey, trackId } = parsed;
-          if (protectedIds.has(trackId) && serverIndexKey === activeServerIndexKey) continue;
+          if (protectedKeys.has(key)) continue;
           if (isHotCachePreviousTrackUnderGrace(trackId, serverIndexKey)) continue;
 
           const lru = lruStamp(meta);
@@ -251,7 +257,7 @@ export const useLocalPlaybackStore = create<LocalPlaybackState>()(
             cands.push({ key, tier: 0, primary: 0, lru });
             continue;
           }
-          const qIdx = indexOfInQueue(trackId);
+          const qIdx = queueIndexByKey.get(key) ?? null;
           if (qIdx === null) {
             cands.push({ key, tier: 1, primary: 0, lru });
           } else if (qIdx > protectHi) {


### PR DESCRIPTION
## Summary

- resolve each Hot Cache prefetch job from the upcoming queue item's canonical server instead of applying the current playback server to the whole window
- revalidate pending jobs with the full `serverId:trackId` identity so a stale job cannot survive a queue switch to the same track ID on another server
- key eviction protection and queue tier lookup by canonical `serverId:trackId`, preserving current/next tracks from every server before inactive-server eviction
- calculate protected-window cache usage with each queue item's own server scope
- add regression coverage for mixed-server prefetch, delayed stale-job replacement, and over-budget eviction with reused track IDs

## User impact

Hot Cache downloads now stay with the server that owns each queued track, including mixed-server queues, queue replacements where servers reuse track IDs, and full-cache eviction passes.

## Verification

- `npm run lint`
- `npm run dep:check`
- `npm test` (505 files, 3563 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh` (15/15 files at or above 70%)

## Tauri boundary

No commands, events, or payload shapes changed. The existing `download_track_local` call now receives the correct per-item server scope.