### PR TITLE
fix(browse): keep album pagination going when the sentinel stays in view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Opening or pinning an album no longer stamps its tracks with a seconds-based timestamp that makes them look as if they were indexed in 1970 and moves them to the front of stale-track verification.
 
+### Album grids — scrolling no longer stalls partway down the list
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1367](https://github.com/Psychotoxical/psysonic/pull/1367)**
+
+* New Releases and Lossless Albums stopped fetching further albums after a few pages, and only picked up again once you scrolled up and back down. Both now keep loading while you are at the bottom of the list, and stop once it is exhausted.
+
 ## [1.50.0]
 
 ## Added

--- a/src/features/album/pages/LosslessAlbums.tsx
+++ b/src/features/album/pages/LosslessAlbums.tsx
@@ -228,13 +228,32 @@ export default function LosslessAlbums() {
     return () => { cancelled = true; };
   }, [activeServerId, indexEnabled, loadMoreNetwork, serverId, sort, librarySyncRevision]);
 
+  // An IntersectionObserver reports changes, and a sentinel inside the rootMargin
+  // stays visible after a page is appended — so no second callback arrives and
+  // pagination halts until the user scrolls away and back. The flag carries that
+  // standing visibility so the page can ask for the next one itself.
+  const sentinelIntersectingRef = useRef(false);
+  const pagedAlbumCountRef = useRef(0);
+
   const bindLoadMoreSentinel = useInpageScrollSentinel({
     active: hasMore && useLocalIndex !== null,
     getScrollRoot,
     scrollRootEl: scrollBodyEl,
     onIntersect: () => { void loadMore(); },
     rootMargin: '200px',
+    intersectingRef: sentinelIntersectingRef,
   });
+
+  // Keyed to the album count, never to a loading transition. The Navidrome song
+  // walk can return a page that yields no new album while still reporting more to
+  // come; keying off the count stops the chain there instead of walking the whole
+  // catalogue back to back.
+  useEffect(() => {
+    if (albums.length === pagedAlbumCountRef.current) return;
+    pagedAlbumCountRef.current = albums.length;
+    if (!hasMore || useLocalIndex === null || !sentinelIntersectingRef.current) return;
+    void loadMore();
+  }, [albums.length, hasMore, useLocalIndex, loadMore]);
 
   const handleEnqueueSelected = async () => {
     if (selectedAlbums.length === 0) return;

--- a/src/features/album/pages/NewReleases.tsx
+++ b/src/features/album/pages/NewReleases.tsx
@@ -361,12 +361,31 @@ export default function NewReleases() {
     requestNextPage(offset => load(offset, true, selectedGenres));
   }, [gridHasMore, genreFiltered, textSearchActive, isBlocked, requestNextPage, load, selectedGenres]);
 
+  // The sentinel lives inside a 400px rootMargin, so after a page is appended it
+  // usually stays visible, and an IntersectionObserver only reports *changes* —
+  // no second callback arrives and pagination stalls until the user scrolls away
+  // and back. The flag below carries that standing visibility so the page can
+  // ask for the next one itself.
+  const sentinelIntersectingRef = useRef(false);
+  const pagedAlbumCountRef = useRef(0);
+
   const bindLoadMoreSentinel = useInpageScrollSentinel({
     active: gridHasMore,
     getScrollRoot,
     scrollRootEl: scrollBodyEl,
     onIntersect: loadMore,
+    intersectingRef: sentinelIntersectingRef,
   });
+
+  // Keyed to the album count, never to a loading transition: a request that fails
+  // or returns nothing leaves the count untouched, so the chain stops instead of
+  // re-issuing the same failing page forever.
+  useEffect(() => {
+    if (displayAlbums.length === pagedAlbumCountRef.current) return;
+    pagedAlbumCountRef.current = displayAlbums.length;
+    if (!gridHasMore || !sentinelIntersectingRef.current) return;
+    loadMore();
+  }, [displayAlbums.length, gridHasMore, loadMore]);
 
   const { isScrollRestorePending } = useAlbumBrowseScrollRestore({
     serverId,

--- a/src/lib/hooks/useInpageScrollSentinel.test.ts
+++ b/src/lib/hooks/useInpageScrollSentinel.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useInpageScrollSentinel } from '@/lib/hooks/useInpageScrollSentinel';
+import { intersectionObserverCount, latestIntersectionObserver } from '@/test/mocks/browser';
+
+/** The observer the hook just bound, failing loudly when it bound none. */
+function boundObserver() {
+  const observer = latestIntersectionObserver();
+  expect(observer, 'the hook bound no IntersectionObserver').toBeDefined();
+  return observer!;
+}
 
 describe('useInpageScrollSentinel', () => {
   it('returns a callback ref function', () => {
@@ -12,5 +20,108 @@ describe('useInpageScrollSentinel', () => {
       }),
     );
     expect(typeof result.current).toBe('function');
+  });
+
+  it('calls onIntersect when the sentinel comes into view', () => {
+    const onIntersect = vi.fn();
+    const { result } = renderHook(() =>
+      useInpageScrollSentinel({ active: true, onIntersect }),
+    );
+
+    result.current(document.createElement('div'));
+    boundObserver().emit(true);
+
+    expect(onIntersect).toHaveBeenCalledTimes(1);
+  });
+
+  // Why both album grids stalled: an observer reports *changes*, so a sentinel
+  // that stays inside the rootMargin after a page is appended produces no second
+  // callback. Re-rendering does not conjure one either. The flag is therefore the
+  // only thing left that tells a consumer more content is still wanted.
+  it('keeps the visibility flag set without firing again while it stays in view', () => {
+    const onIntersect = vi.fn();
+    const intersectingRef = { current: false };
+
+    const { result, rerender } = renderHook(() =>
+      useInpageScrollSentinel({ active: true, onIntersect, intersectingRef }),
+    );
+
+    result.current(document.createElement('div'));
+    boundObserver().emit(true);
+    expect(onIntersect).toHaveBeenCalledTimes(1);
+
+    rerender();
+
+    expect(onIntersect).toHaveBeenCalledTimes(1);
+    expect(intersectingRef.current).toBe(true);
+  });
+
+  it('replays a pending record when the drain signal changes', () => {
+    const onIntersect = vi.fn();
+    const intersectingRef = { current: false };
+
+    const { result, rerender } = renderHook(
+      ({ drainSignal }) =>
+        useInpageScrollSentinel({ active: true, onIntersect, intersectingRef, drainSignal }),
+      { initialProps: { drainSignal: false } },
+    );
+
+    result.current(document.createElement('div'));
+    const observer = boundObserver();
+    observer.takeRecords.mockReturnValue([
+      { isIntersecting: true } as IntersectionObserverEntry,
+    ]);
+
+    rerender({ drainSignal: true });
+
+    expect(onIntersect).toHaveBeenCalledTimes(1);
+    expect(intersectingRef.current).toBe(true);
+  });
+
+  it('clears the visibility flag when the sentinel leaves the viewport', () => {
+    const onIntersect = vi.fn();
+    const intersectingRef = { current: false };
+
+    const { result } = renderHook(() =>
+      useInpageScrollSentinel({ active: true, onIntersect, intersectingRef }),
+    );
+
+    result.current(document.createElement('div'));
+    boundObserver().emit(true);
+    expect(intersectingRef.current).toBe(true);
+
+    boundObserver().emit(false);
+    expect(intersectingRef.current).toBe(false);
+  });
+
+  it('clears the visibility flag when the sentinel node is detached', () => {
+    const onIntersect = vi.fn();
+    const intersectingRef = { current: false };
+
+    const { result } = renderHook(() =>
+      useInpageScrollSentinel({ active: true, onIntersect, intersectingRef }),
+    );
+
+    result.current(document.createElement('div'));
+    boundObserver().emit(true);
+    expect(intersectingRef.current).toBe(true);
+
+    result.current(null);
+    expect(intersectingRef.current).toBe(false);
+  });
+
+  it('does not observe while inactive', () => {
+    const onIntersect = vi.fn();
+    const intersectingRef = { current: true };
+
+    const { result } = renderHook(() =>
+      useInpageScrollSentinel({ active: false, onIntersect, intersectingRef }),
+    );
+
+    result.current(document.createElement('div'));
+
+    expect(intersectionObserverCount()).toBe(0);
+    expect(intersectingRef.current).toBe(false);
+    expect(onIntersect).not.toHaveBeenCalled();
   });
 });

--- a/src/test/mocks/browser.ts
+++ b/src/test/mocks/browser.ts
@@ -21,15 +21,49 @@ class MockResizeObserver implements ResizeObserver {
 }
 
 // ─── IntersectionObserver ────────────────────────────────────────────────────
+/**
+ * Records every instance and keeps its callback, so a test can drive an
+ * intersection instead of only asserting that the observer was constructed.
+ * Infinite-scroll code reacts to visibility *changes*, which is untestable
+ * against a stub that never reports one.
+ */
 class MockIntersectionObserver implements IntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
   readonly root: Element | Document | null = null;
   readonly rootMargin: string = '0px';
   readonly scrollMargin: string = '0px';
   readonly thresholds: ReadonlyArray<number> = [];
+  readonly callback: IntersectionObserverCallback;
   observe = vi.fn<(target: Element) => void>();
   unobserve = vi.fn<(target: Element) => void>();
   disconnect = vi.fn<() => void>();
   takeRecords = vi.fn<() => IntersectionObserverEntry[]>(() => []);
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  /** Report a visibility change the way the browser would. */
+  emit(isIntersecting: boolean): void {
+    this.callback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+/**
+ * The observer most recently constructed, for tests that drive intersections.
+ * Returns `undefined` when nothing observed — callers should assert on that
+ * rather than get a `TypeError` from an implicit non-null assumption.
+ */
+export function latestIntersectionObserver(): MockIntersectionObserver | undefined {
+  return MockIntersectionObserver.instances[MockIntersectionObserver.instances.length - 1];
+}
+
+export function intersectionObserverCount(): number {
+  return MockIntersectionObserver.instances.length;
 }
 
 // ─── matchMedia ──────────────────────────────────────────────────────────────
@@ -119,6 +153,8 @@ export function resetBrowserMocks(): void {
   clipboardMock.readText.mockClear();
   createObjectUrlMock.mockClear();
   revokeObjectUrlMock.mockClear();
+  // Unbounded across a whole run otherwise: every observed sentinel adds one.
+  MockIntersectionObserver.instances = [];
 }
 
 export { clipboardMock, createObjectUrlMock, revokeObjectUrlMock };


### PR DESCRIPTION
The New Releases grid stops loading after a few pages. The scroll sentinel sits inside the 400px root margin, so once a page is appended it stays visible — and an IntersectionObserver only reports *changes*, so no further callback arrives. Scrolling away and back is the only way to resume.

* Both grids now track standing sentinel visibility and ask for the next page themselves once the album count grows.
* The re-check is keyed to the album count rather than a loading transition, so a request that fails or returns nothing ends the chain instead of repeating it.
* Lossless Albums carried the same defect and is fixed alongside — its song walk can legitimately return a page that yields no new album while reporting more to come.
* The shared browser mock can now drive intersections, so the sentinel hook has real coverage instead of a single smoke test.

## Test plan

* New Releases scrolled to the end of the catalogue: pages keep arriving without scrolling back and forth, and paging stops once the list is exhausted.
* Lossless Albums on both the local index and the song-walk fallback.
* `npx tsc --noEmit`, `npm run lint`, `npm run dep:check`, and the full `vitest run` (504 files, 3565 tests).
* The sentinel tests were checked against a mutated hook: neutralising the visibility report fails 5 of 7.
