### PR TITLE
fix(ui): give ghost buttons a resting outline and correct three layout deviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * New Releases and Lossless Albums stopped fetching further albums after a few pages, and only picked up again once you scrolled up and back down. Both now keep loading while you are at the bottom of the list, and stop once it is exhausted.
 
+### Buttons — outlines are visible without hovering first
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1379](https://github.com/Psychotoxical/psysonic/pull/1379)**
+
+* Secondary buttons such as **Back** on artist and album pages, **Cancel** in the server form and the connect actions under **Music Network** showed no outline until the pointer was over them. They now look clickable at rest. Reported by zunoz.
+* The row for a custom HTTP header no longer pushes its remove button onto a second line where it filled a whole column and looked like another input field.
+* On a genre page, the add-to-queue button now matches the height of **Play** and carries a proper label for screen readers.
+* Internet radio shows its sort picker next to the browse and add buttons instead of on a separate line below them.
+
 ## [1.50.0]
 
 ## Added

--- a/src/features/genre/pages/GenreDetail.tsx
+++ b/src/features/genre/pages/GenreDetail.tsx
@@ -196,10 +196,15 @@ export default function GenreDetail() {
                   <span className="toolbar-btn-label">{t('common.play')}</span>
                 </span>
               </button>
+              {/* Stretch instead of a fixed height: this button holds only an
+                  icon, so its content box is shorter than the play button's
+                  text line and it would otherwise sit smaller beside it. */}
               <button
                 className="btn btn-surface"
+                style={{ alignSelf: 'stretch' }}
                 onClick={handleEnqueueAll}
                 disabled={bulkLoading}
+                aria-label={t('genres.addToQueue')}
                 data-tooltip={t('genres.addToQueue')}
               >
                 <ListPlus size={16} />

--- a/src/features/radio/components/RadioToolbar.tsx
+++ b/src/features/radio/components/RadioToolbar.tsx
@@ -1,24 +1,16 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import CustomSelect from '@/ui/CustomSelect';
 
 export type RadioSortBy = 'manual' | 'az' | 'za' | 'newest';
 
 interface RadioToolbarProps {
-  sortBy: RadioSortBy;
   activeFilter: string;
-  onSortChange: (s: RadioSortBy) => void;
   onFilterChange: (f: string) => void;
 }
 
-export default function RadioToolbar({ sortBy, activeFilter, onSortChange, onFilterChange }: RadioToolbarProps) {
+/** Filter chips only — the sort picker sits in the page header beside the actions. */
+export default function RadioToolbar({ activeFilter, onFilterChange }: RadioToolbarProps) {
   const { t } = useTranslation();
-  const sortOptions = [
-    { value: 'manual', label: t('radio.sortManual') },
-    { value: 'az',     label: t('radio.sortAZ') },
-    { value: 'za',     label: t('radio.sortZA') },
-    { value: 'newest', label: t('radio.sortNewest') },
-  ];
   return (
     <div className="radio-toolbar">
       <div className="radio-toolbar-chips">
@@ -32,12 +24,6 @@ export default function RadioToolbar({ sortBy, activeFilter, onSortChange, onFil
           </button>
         ))}
       </div>
-      <CustomSelect
-        value={sortBy}
-        options={sortOptions}
-        onChange={v => onSortChange(v as RadioSortBy)}
-        style={{ width: 'max-content', minWidth: 130, maxWidth: 220, flexShrink: 0 }}
-      />
     </div>
   );
 }

--- a/src/features/radio/pages/InternetRadio.tsx
+++ b/src/features/radio/pages/InternetRadio.tsx
@@ -16,7 +16,8 @@ import { fadeOut } from '@/features/playback/utils/playback/fadeOut';
 import { invalidateRadioCoverArtCache } from '@/cover/radioCoverInvalidation';
 import { useTranslation } from 'react-i18next';
 import { showToast } from '@/lib/dom/toast';
-import RadioToolbar from '@/features/radio/components/RadioToolbar';
+import RadioToolbar, { type RadioSortBy } from '@/features/radio/components/RadioToolbar';
+import CustomSelect from '@/ui/CustomSelect';
 import AlphabetFilterBar from '@/features/radio/components/AlphabetFilterBar';
 import RadioCard from '@/features/radio/components/RadioCard';
 import RadioEditModal from '@/features/radio/components/RadioEditModal';
@@ -72,7 +73,13 @@ export default function InternetRadio() {
   const mutationGenerationRef = useRef(0);
   const reloadGenerationByServerRef = useRef(new Map<string, number>());
 
-  const [sortBy, setSortBy] = useState<'manual' | 'az' | 'za' | 'newest'>('manual');
+  const [sortBy, setSortBy] = useState<RadioSortBy>('manual');
+  const sortOptions = [
+    { value: 'manual', label: t('radio.sortManual') },
+    { value: 'az', label: t('radio.sortAZ') },
+    { value: 'za', label: t('radio.sortZA') },
+    { value: 'newest', label: t('radio.sortNewest') },
+  ];
   const [activeFilter, setActiveFilter] = useState('all');
   const [activeLetter, setActiveLetter] = useState<string | null>(null);
   const [favorites, setFavorites] = useState<Set<string>>(() => {
@@ -348,7 +355,15 @@ export default function InternetRadio() {
       {/* ── Header ── */}
       <div className="playlists-header">
         <h1 className="page-title" style={{ marginBottom: 0 }}>{t('radio.title')}</h1>
-        <div className="compact-action-bar" style={{ display: 'flex', gap: 8 }}>
+        <div className="compact-action-bar" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {stations.length > 0 && (
+            <CustomSelect
+              value={sortBy}
+              options={sortOptions}
+              onChange={v => setSortBy(v as RadioSortBy)}
+              style={{ width: 'max-content', minWidth: 130, maxWidth: 220, flexShrink: 0 }}
+            />
+          )}
           {targetServerId && (<>
               <button className="btn btn-primary" onClick={() => setDirectoryOpen(true)} aria-label={t('radio.browseDirectory')} data-tooltip={t('radio.browseDirectory')}>
                 <Search size={14} /> <span className="compact-btn-label">{t('radio.browseDirectory')}</span>
@@ -366,9 +381,7 @@ export default function InternetRadio() {
       ) : (
         <>
           <RadioToolbar
-            sortBy={sortBy}
             activeFilter={activeFilter}
-            onSortChange={setSortBy}
             onFilterChange={f => { setActiveFilter(f); setActiveLetter(null); }}
           />
           <AlphabetFilterBar

--- a/src/features/settings/components/CustomHttpHeadersEditor.test.tsx
+++ b/src/features/settings/components/CustomHttpHeadersEditor.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/helpers/renderWithProviders';
+import { CustomHttpHeadersEditor } from './CustomHttpHeadersEditor';
+
+function render(open = true) {
+  return renderWithProviders(
+    <CustomHttpHeadersEditor
+      headers={[{ name: '', value: '' }]}
+      applyTo="public"
+      open={open}
+      onOpenChange={() => {}}
+      onHeadersChange={() => {}}
+      onApplyToChange={() => {}}
+    />,
+  );
+}
+
+describe('CustomHttpHeadersEditor', () => {
+  it('keeps the header row out of the two-column form grid', () => {
+    const { container } = render();
+
+    // `form-row` is a two-column grid. This row has three children — name,
+    // value, remove — so the third wrapped onto its own line and stretched to
+    // a full column, reading as another input rather than a button.
+    expect(container.querySelector('.form-row')).toBeNull();
+  });
+
+  it('leaves the row buttons outlined', () => {
+    render();
+
+    // These are ordinary actions, so they keep the outline `.btn-ghost` gives
+    // them rather than opting out of it.
+    for (const name of [/remove/i, /add header/i]) {
+      expect(screen.getByRole('button', { name })).not.toHaveClass('btn-ghost--flat');
+    }
+  });
+
+  it('keeps the disclosure toggle flat', () => {
+    render(false);
+
+    // The section header reads as a heading, not as a button — it is one of
+    // the deliberate opt-outs from the ghost outline.
+    expect(screen.getByRole('button')).toHaveClass('btn-ghost--flat');
+  });
+});

--- a/src/features/settings/components/CustomHttpHeadersEditor.tsx
+++ b/src/features/settings/components/CustomHttpHeadersEditor.tsx
@@ -28,7 +28,8 @@ export function CustomHttpHeadersEditor({
     <div className="form-group" style={{ marginBottom: '0.75rem' }}>
       <button
         type="button"
-        className="btn btn-ghost"
+        // Reads as a section heading, so it opts out of the ghost outline.
+        className="btn btn-ghost btn-ghost--flat"
         style={{ fontSize: 13, padding: '4px 0' }}
         onClick={() => onOpenChange(!open)}
       >
@@ -39,10 +40,17 @@ export function CustomHttpHeadersEditor({
           <p style={{ fontSize: 11, opacity: 0.75, margin: '0 0 8px' }}>
             {t('settings.customHeadersHelp')}
           </p>
+          {/* Deliberately not `form-row`: that is a two-column grid, and this
+              row has a third child, so the remove button wrapped onto its own
+              line and stretched to a full column — reading as another input. */}
           {headers.map((row, index) => (
-            <div key={index} className="form-row" style={{ marginBottom: 6, gap: 8 }}>
+            <div
+              key={index}
+              style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}
+            >
               <input
                 className="input"
+                style={{ flex: 1, minWidth: 0 }}
                 type="text"
                 value={row.name}
                 onChange={e => {
@@ -54,6 +62,7 @@ export function CustomHttpHeadersEditor({
               />
               <input
                 className="input"
+                style={{ flex: 1, minWidth: 0 }}
                 type="password"
                 value={row.value}
                 onChange={e => {
@@ -66,7 +75,9 @@ export function CustomHttpHeadersEditor({
               <button
                 type="button"
                 className="btn btn-ghost"
+                style={{ flexShrink: 0, padding: '4px 12px' }}
                 aria-label={t('settings.customHeadersRemoveRow')}
+                data-tooltip={t('settings.customHeadersRemoveRow')}
                 onClick={() =>
                   onHeadersChange(
                     headers.length <= 1

--- a/src/features/settings/components/musicNetwork/ConnectProviderForm.test.tsx
+++ b/src/features/settings/components/musicNetwork/ConnectProviderForm.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/helpers/renderWithProviders';
+import { ConnectProviderForm } from './ConnectProviderForm';
+
+describe('ConnectProviderForm', () => {
+  it('leaves the connect buttons outlined', () => {
+    renderWithProviders(
+      <ConnectProviderForm connectedPresetIds={[]} onConnect={async () => {}} />,
+    );
+
+    // `.btn-ghost` carries its own outline; `btn-ghost--flat` removes it and is
+    // meant for icons repeated per list row or a close cross on a framed
+    // surface. A connect action is neither, so it must not opt out.
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      expect(button).not.toHaveClass('btn-ghost--flat');
+    }
+  });
+});

--- a/src/features/settings/components/musicNetwork/ScrobbleDestinationCard.test.tsx
+++ b/src/features/settings/components/musicNetwork/ScrobbleDestinationCard.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@/test/helpers/renderWithProviders';
+import type { Account } from '@/music-network';
+import { ScrobbleDestinationCard } from './ScrobbleDestinationCard';
+
+const account = {
+  id: 'acc-1',
+  presetId: 'custom',
+  wireId: 'audioscrobbler',
+  label: 'Test service',
+  baseUrl: '',
+  scrobbleEnabled: true,
+  sessionKey: '',
+  username: 'tester',
+  apiKey: '',
+  apiSecret: '',
+  sessionError: false,
+  capabilities: {},
+  roles: { scrobble: true, enrichmentEligible: false },
+} as unknown as Account;
+
+describe('ScrobbleDestinationCard', () => {
+  it('leaves the disconnect button outlined', () => {
+    renderWithProviders(
+      <ScrobbleDestinationCard
+        account={account}
+        profile={null}
+        onToggleScrobble={() => {}}
+        onDisconnect={() => {}}
+      />,
+    );
+
+    // `btn-ghost--flat` strips the outline and is for repeated row icons or a
+    // close cross; a disconnect action is neither.
+    const button = screen.getByRole('button');
+    expect(button).not.toHaveClass('btn-ghost--flat');
+  });
+});

--- a/src/styles/components/normalization-block-per-mode-sub-section.css
+++ b/src/styles/components/normalization-block-per-mode-sub-section.css
@@ -21,19 +21,13 @@
 .settings-segmented-auto > .btn {
   flex: 0 0 auto;
 }
-.settings-segmented > .btn-ghost {
-  border: 1px solid var(--border-subtle);
-  background: color-mix(in srgb, var(--text-primary) 4%, transparent);
-}
+/* The resting outline now comes from `.btn-ghost` itself; only the accent-tinted
+   hover is specific to a segmented group. */
 .settings-segmented > .btn-ghost:hover {
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border-subtle));
   background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
-.settings-norm-block .btn-ghost {
-  border: 1px solid var(--border-subtle);
-  background: color-mix(in srgb, var(--text-primary) 4%, transparent);
-}
 .settings-norm-block .btn-ghost:hover {
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border-subtle));
   background: color-mix(in srgb, var(--accent) 8%, transparent);

--- a/src/styles/themes/button-variants.css
+++ b/src/styles/themes/button-variants.css
@@ -33,13 +33,30 @@
 }
 
 .btn-ghost {
-  background: transparent;
+  background: var(--button-ghost-bg);
   color: var(--text-secondary);
+  border: 1px solid var(--button-ghost-border);
 }
 
 .btn-ghost:hover {
   background: var(--button-hover);
   color: var(--text-primary);
+}
+
+/**
+ * Opt out for ghost buttons that must stay flat: an icon repeated in every row
+ * of a list (the track star), or a close cross sitting on top of a surface that
+ * already has its own frame. Outlining those would add a box per list row.
+ *
+ * New cases set `btn-ghost--flat`; the component classes below are the ones
+ * that already existed when the outline moved into `.btn-ghost`.
+ */
+.btn-ghost--flat,
+.btn-ghost.track-star-btn,
+.btn-ghost.modal-close,
+.btn-ghost.song-info-close {
+  background: transparent;
+  border-color: transparent;
 }
 
 .btn-surface {

--- a/src/styles/themes/semantic-cascade.css
+++ b/src/styles/themes/semantic-cascade.css
@@ -65,6 +65,11 @@
   --input-border: var(--border);
   --input-focus-border: var(--accent);
   --button-hover: var(--bg-hover);
+  /* Ghost buttons carry their own outline so they read as clickable at rest,
+     not only on hover. Themes can retune the pair; a button that is meant to
+     stay flat opts out with `btn-ghost--flat` rather than redefining these. */
+  --button-ghost-border: var(--border-subtle);
+  --button-ghost-bg: color-mix(in srgb, var(--text-primary) 4%, transparent);
   --slider-track: var(--bg-elevated);
   --slider-thumb: var(--text-primary);
   --slider-thumb-hover: var(--accent);


### PR DESCRIPTION
Four GUI reports against 1.50.0-RC3, one of which turned out to be app-wide.

- **Ghost buttons draw their own outline.** `.btn-ghost` had none, so anywhere outside the few containers that supplied one it read as plain text and appeared only on hover — the back button, the server form's cancel, the music network connect actions. Three surfaces had already re-declared the same outline locally; that pair of values now sits with the other button tokens in `semantic-cascade.css`, and two redundant context rules are gone. Buttons that must stay flat opt out via `btn-ghost--flat`: an icon repeated in every list row (track star), a close cross on an already framed surface, a disclosure toggle that reads as a heading.
- **Custom HTTP headers row.** It used `form-row`, a two-column grid, while carrying three children — so the remove button wrapped onto its own line and stretched across a full column, reading as another input. It now sits in a flex row at its content width, with the existing i18n string as a tooltip.
- **Genre page.** The queue button holds only an icon, so its content box was shorter than the play button's text line and it rendered visibly smaller beside it; it now stretches to the row height. Its tooltip was also its only label — screen readers got nothing.
- **Internet radio.** The sort picker moved from its own line below the header into the header row beside the browse and add actions.

## Test plan

- `npm run lint`, `npm run dep:check`, `npx tsc --noEmit` — clean
- `npx vitest run` — full suite green
- New tests cover the flat opt-out in both directions and the header row layout; each was verified red against the unfixed code first.
- The outline reaches every ghost button, so it was also checked in the running build.
