### PR TITLE
fix(navigation): return to the immediate detail page on back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Genre Detail no longer presents the first 60 loaded albums as the total. Multi-server pages show a cached value immediately when available, then settle on the exact de-duplicated count.
 * All Albums genre counters follow every selected server and music folder instead of the active server or a temporary server-wide fallback. Genre album pages now drive from the indexed genre rows, cutting the measured first-page database read from about 1.1 seconds to about 0.37 seconds on a large three-server library.
 
+### Back navigation — return to the page you just left
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1383](https://github.com/Psychotoxical/psysonic/pull/1383)**
+
+* Back from an album opened on an artist page now returns to that artist, and Back from a related album returns to the previous album. A second Back continues to the original Albums or Artists page with its browse state intact.
+
 ## [1.50.0]
 
 ## Added

--- a/src/lib/navigation/albumDetailNavigation.test.ts
+++ b/src/lib/navigation/albumDetailNavigation.test.ts
@@ -51,7 +51,7 @@ describe('albumDetailNavigation', () => {
     });
   });
 
-  it('preserves returnTo when opening a related album', () => {
+  it('returns from a related album to the immediate album detail', () => {
     const navigate = vi.fn();
     navigateToAlbumDetail(
       navigate,
@@ -63,7 +63,33 @@ describe('albumDetailNavigation', () => {
       },
       'child',
     );
-    expect(navigate).toHaveBeenCalledWith('/album/child', { state: { returnTo: '/albums' } });
+    expect(navigate).toHaveBeenCalledWith('/album/child', {
+      state: {
+        returnTo: '/album/parent',
+        returnState: { returnTo: '/albums' },
+      },
+    });
+  });
+
+  it('returns from an artist album to the immediate artist detail', () => {
+    const navigate = vi.fn();
+    navigateToAlbumDetail(
+      navigate,
+      {
+        pathname: '/artist/art-1',
+        search: '?server=srv-b',
+        hash: '',
+        state: { returnTo: '/artists?letter=A' },
+      },
+      'alb-1',
+      { serverId: 'srv-b' },
+    );
+    expect(navigate).toHaveBeenCalledWith('/album/alb-1?server=srv-b', {
+      state: {
+        returnTo: '/artist/art-1?server=srv-b',
+        returnState: { returnTo: '/artists?letter=A' },
+      },
+    });
   });
 
   it('routes album paths through returnTo helper', () => {
@@ -80,6 +106,19 @@ describe('albumDetailNavigation', () => {
     const navigate = vi.fn();
     navigateAlbumDetailBack(navigate, { state: { returnTo: '/genres/Rock' } });
     expect(navigate).toHaveBeenCalledWith('/genres/Rock', { state: { albumBrowseRestore: true } });
+  });
+
+  it('restores the previous detail return state', () => {
+    const navigate = vi.fn();
+    navigateAlbumDetailBack(navigate, {
+      state: {
+        returnTo: '/album/parent',
+        returnState: { returnTo: '/albums' },
+      },
+    });
+    expect(navigate).toHaveBeenCalledWith('/album/parent', {
+      state: { returnTo: '/albums' },
+    });
   });
 
   it('flags All Albums return for browse restore', () => {

--- a/src/lib/navigation/albumDetailNavigation.ts
+++ b/src/lib/navigation/albumDetailNavigation.ts
@@ -21,6 +21,7 @@ import {
 
 export type AlbumDetailLocationState = {
   returnTo?: string;
+  returnState?: AlbumDetailLocationState;
 };
 
 export type AlbumsBrowseRestoreLocationState = {
@@ -157,14 +158,17 @@ function browseReturnRestoreState(returnTo: string): AlbumsBrowseRestoreLocation
   return undefined;
 }
 
-function buildReturnTo(
+function buildDetailLocationState(
   location: Pick<Location, 'pathname' | 'search' | 'hash' | 'state'>,
-): string {
-  const existing = readAlbumDetailReturnTo(location.state);
+): AlbumDetailLocationState {
+  const returnTo = buildReturnToFromLocation(location);
   const onDetail = isAlbumDetailPath(location.pathname)
     || isArtistDetailPath(location.pathname)
     || isComposerDetailPath(location.pathname);
-  return onDetail && existing ? existing : buildReturnToFromLocation(location);
+  const existing = readAlbumDetailReturnTo(location.state);
+  return onDetail && existing
+    ? { returnTo, returnState: location.state as AlbumDetailLocationState }
+    : { returnTo };
 }
 
 function saveSearchLeaveIfNeeded(
@@ -182,9 +186,8 @@ export function navigateToAlbumDetail(
   opts?: ArtistDetailPathOptions,
 ): void {
   saveSearchLeaveIfNeeded(location);
-  const returnTo = buildReturnTo(location);
   navigate(buildAlbumDetailPath(albumId, opts), {
-    state: { returnTo } satisfies AlbumDetailLocationState,
+    state: buildDetailLocationState(location),
   });
 }
 
@@ -195,9 +198,8 @@ export function navigateToArtistDetail(
   opts?: ArtistDetailPathOptions,
 ): void {
   saveSearchLeaveIfNeeded(location);
-  const returnTo = buildReturnTo(location);
   navigate(buildArtistDetailPath(artistId, opts), {
-    state: { returnTo } satisfies AlbumDetailLocationState,
+    state: buildDetailLocationState(location),
   });
 }
 
@@ -208,9 +210,8 @@ export function navigateToComposerDetail(
   opts?: ArtistDetailPathOptions,
 ): void {
   saveSearchLeaveIfNeeded(location);
-  const returnTo = buildReturnTo(location);
   navigate(buildComposerDetailPath(composerId, opts), {
-    state: { returnTo } satisfies AlbumDetailLocationState,
+    state: buildDetailLocationState(location),
   });
 }
 
@@ -237,7 +238,9 @@ export function navigateAlbumDetailBack(
   const returnTo = readAlbumDetailReturnTo(location.state);
   if (returnTo) {
     const restoreState = browseReturnRestoreState(returnTo);
-    navigate(returnTo, restoreState ? { state: restoreState } : undefined);
+    const returnState = (location.state as AlbumDetailLocationState | null)?.returnState;
+    const state = readAlbumDetailReturnTo(returnState) ? returnState : restoreState;
+    navigate(returnTo, state ? { state } : undefined);
     return;
   }
   if (window.history.length > 1) navigate(-1);


### PR DESCRIPTION
## Summary

- preserve the immediate artist or album detail page as the Back target instead of collapsing the chain to its browse root
- carry the parent detail state forward so repeated Back actions continue to the original Albums or Artists page
- add regression coverage for both artist-to-album and related-album navigation

Closes #1121

## Verification

- `npm run lint`
- `npm run dep:check`
- `npm test` (546 files, 4010 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npm run test:coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`

## Runtime benchmark

- Applicability: final smoke required because detail-route behavior changed
- Final code: `aa2b906b`; final PR head `1e9aee9d` adds changelog only
- Report: `2026-08-04T22-49-47-030Z`
- Command: `psysonic benchmark run --scenario all-pages --runs 2 --profile realistic --json`
- Environment: Linux WebKit, 1223x694 at DPR 2, 3 selected servers; scope fingerprint recorded locally
- Affected routes: album and artist detail routes both reached the requested route in cold and warm samples
- Result: no errors or timeouts; album detail median 870 ms, artist detail median 778 ms
- Skips: `/label/:name` only, because no reachable owned album had a record label

## Tauri boundary

Not changed. No commands, events, or payloads were added or modified.