### PR TITLE
chore(build): fail the build and dev start when node_modules is stale

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check:css-imports": "node scripts/check-css-import-graph.mjs",
     "check:deps": "node scripts/check-deps-fresh.mjs",
     "prebuild:release-notes": "node scripts/generate-release-notes-bundle.mjs",
-    "dev": "npm run prebuild:release-notes && vite",
+    "dev": "npm run check:deps && npm run prebuild:release-notes && vite",
     "build": "npm run check:deps && npm run prebuild:release-notes && tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   },
   "scripts": {
     "check:css-imports": "node scripts/check-css-import-graph.mjs",
+    "check:deps": "node scripts/check-deps-fresh.mjs",
     "prebuild:release-notes": "node scripts/generate-release-notes-bundle.mjs",
     "dev": "npm run prebuild:release-notes && vite",
-    "build": "npm run prebuild:release-notes && tsc && vite build",
+    "build": "npm run check:deps && npm run prebuild:release-notes && tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "npm run prebuild:release-notes && tauri dev --config src-tauri/tauri.dev.conf.json",

--- a/scripts/check-deps-fresh.mjs
+++ b/scripts/check-deps-fresh.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Pre-build guard: node_modules must match package-lock.json.
+ *
+ * A stale install is silent. npm keeps whatever is already on disk, the build
+ * succeeds without a single warning, and the resulting bundle can be split into
+ * different chunks than the locked toolchain produces. The app then hangs on the
+ * splash screen with a TDZ-style "X is not a function" from a chunk that was
+ * never initialised — a failure that looks nothing like its cause.
+ *
+ * Observed 2026-08-04: a contributor's tree carried rolldown 1.0.0-rc.17 while
+ * the lockfile pinned 1.0.3. That build emitted no authStore chunk at all and
+ * folded it into a 3.7 MB index chunk, so the offline chunk called an
+ * uninitialised import. Deleting node_modules and running `npm ci` fixed it.
+ *
+ * Related but distinct: check-boot-chunk-lucide.mjs inspects the built output
+ * for one known cause of the same symptom. This one checks the input instead.
+ *
+ * npm already detects the drift (`npm ls` exits non-zero with ELSPROBLEMS);
+ * this only runs it before the build and explains what to do.
+ */
+import { spawnSync } from 'node:child_process';
+
+// `shell: true` is required, not cosmetic: npm is a .cmd shim on Windows, and
+// Node refuses to spawn .cmd/.bat directly (EINVAL) since the CVE-2024-27980
+// fix. Without it this guard fails to launch on exactly the platform it is
+// meant to protect, and a silent EINVAL would look identical to "all good".
+// Arguments are fixed literals, so there is nothing to inject here.
+const result = spawnSync('npm', ['ls', '--depth=0'], { encoding: 'utf8', shell: true });
+
+if (result.error) {
+  console.warn(`  Dependency freshness check could not run: ${result.error.message}`);
+  process.exit(0);
+}
+
+if (result.status === 0) process.exit(0);
+
+const offenders = `${result.stdout ?? ''}`
+  .split('\n')
+  .filter(line => /invalid|missing|extraneous/i.test(line))
+  .slice(0, 12);
+
+console.error('');
+console.error('  Installed dependencies do not match package-lock.json.');
+console.error('');
+if (offenders.length > 0) {
+  for (const line of offenders) console.error(`    ${line.trim()}`);
+  console.error('');
+}
+console.error('  A stale node_modules still builds without errors, but can emit a');
+console.error('  broken bundle — the app then hangs on the splash screen.');
+console.error('');
+console.error('  Fix:  npm ci');
+console.error('');
+
+process.exit(1);

--- a/scripts/check-deps-fresh.mjs
+++ b/scripts/check-deps-fresh.mjs
@@ -16,8 +16,13 @@
  * Related but distinct: check-boot-chunk-lucide.mjs inspects the built output
  * for one known cause of the same symptom. This one checks the input instead.
  *
+ * It runs before `dev` as well as `build`, for a second reason: the runtime
+ * benchmark procedure measures the app through `npm run dev`. A stale install
+ * would produce timings for a bundle that does not match the lockfile, and
+ * those numbers can end up in a PR as evidence.
+ *
  * npm already detects the drift (`npm ls` exits non-zero with ELSPROBLEMS);
- * this only runs it before the build and explains what to do.
+ * this only surfaces it early and explains what to do.
  */
 import { spawnSync } from 'node:child_process';
 


### PR DESCRIPTION
A stale `node_modules` is silent. npm keeps whatever is already on disk, the build succeeds without a single warning, and the bundle can be split into different chunks than the locked toolchain produces. The app then hangs on the splash screen with a TDZ-style `X is not a function` from a chunk that was never initialised — a failure that looks nothing like its cause.

Seen this week on a contributor's tree carrying `rolldown 1.0.0-rc.17` against a lockfile pinning `1.0.3`: that build emitted no `authStore` chunk at all and folded it into a 3.7 MB `index` chunk, so the `offline` chunk called an uninitialised import. Deleting `node_modules` and running `npm ci` fixed it.

- Adds `scripts/check-deps-fresh.mjs`, which runs `npm ls --depth=0` and turns its `ELSPROBLEMS` output into an actionable message naming the offending packages
- Wires it into `build` **and** `dev`; Tauri inherits both through `beforeBuildCommand` / `beforeDevCommand`
- `dev` matters because the runtime benchmark procedure measures the app through `npm run dev` — a stale install there yields timings for a bundle that does not match the lockfile
- Complements `check-boot-chunk-lucide.mjs`, which inspects the built output for one known cause of the same symptom; this checks the input instead

CI is unaffected: it installs with `npm ci`, so the check passes silently. Cost is roughly one second per build or dev start.

## Test plan

- Positive case (clean tree): `npm run check:deps` exits 0 with no output
- Negative case: with a dependency range deliberately raised so the installed version no longer satisfies it, the guard exits 1 and prints the offending package plus `Fix: npm ci`
- Mutation-probed the guard itself: the first draft spawned `npm.cmd` directly, which fails with `EINVAL` on Node since the CVE-2024-27980 fix and was being swallowed as success. That would have made the guard silently inert on Windows while looking green on Linux CI. Fixed with `shell: true`; an unrunnable check now reports itself instead of passing
- `npm run build` runs the guard as its first step and completes; `npm run dev` chain verified up to `vite`
- `npm run lint`, `npm run dep:check`, `npx tsc --noEmit` pass

### Runtime benchmark

- Applicability: not applicable — build tooling only; no application code, route, or bundle output change
