### PR TITLE
fix(audio): prevent Linux playback stutter under CPU load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Back from an album opened on an artist page now returns to that artist, and Back from a related album returns to the previous album. A second Back continues to the original Albums or Artists page with its browse state intact.
 
+### Linux playback — keep audio smooth under heavy CPU load
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1385](https://github.com/Psychotoxical/psysonic/pull/1385)**
+
+* Sustained CPU-heavy work no longer starves Psysonic's audio threads and causes playback stutter or dropouts. The player now asks Linux's realtime service to prioritise both its output callback and PipeWire processing, while keeping the previous scheduling when that service is unavailable.
+
 ## [1.50.0]
 
 ## Added

--- a/src-tauri/crates/psysonic-audio/src/engine.rs
+++ b/src-tauri/crates/psysonic-audio/src/engine.rs
@@ -177,7 +177,10 @@ fn finalize_mixer_device_sink(mut handle: rodio::MixerDeviceSink) -> Arc<rodio::
     if !crate::logging::should_log_debug() {
         handle.log_on_drop(false);
     }
-    Arc::new(handle)
+    let handle = Arc::new(handle);
+    #[cfg(target_os = "linux")]
+    crate::linux_realtime::promote_audio_threads();
+    handle
 }
 
 /// Returns `(stream_handle, actual_sample_rate)`.

--- a/src-tauri/crates/psysonic-audio/src/lib.rs
+++ b/src-tauri/crates/psysonic-audio/src/lib.rs
@@ -26,6 +26,8 @@ pub mod transport_commands;
 mod device_resume;
 mod device_watcher;
 mod engine;
+#[cfg(target_os = "linux")]
+mod linux_realtime;
 mod stream_idle;
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 mod power_resume;

--- a/src-tauri/crates/psysonic-audio/src/linux_realtime.rs
+++ b/src-tauri/crates/psysonic-audio/src/linux_realtime.rs
@@ -1,0 +1,143 @@
+//! Best-effort RealtimeKit scheduling for Linux audio callback threads.
+
+use std::collections::HashSet;
+use std::fs;
+use std::thread;
+use std::time::Duration;
+
+const RTKIT_SERVICE: &str = "org.freedesktop.RealtimeKit1";
+const RTKIT_PATH: &str = "/org/freedesktop/RealtimeKit1";
+const RTKIT_INTERFACE: &str = "org.freedesktop.RealtimeKit1";
+const CPAL_PRIORITY: u32 = 10;
+const PIPEWIRE_PRIORITY: u32 = 5;
+const DISCOVERY_ATTEMPTS: usize = 20;
+const DISCOVERY_INTERVAL: Duration = Duration::from_millis(10);
+
+pub(crate) fn promote_audio_threads() {
+    if let Err(error) = thread::Builder::new()
+        .name("psysonic-rtkit".into())
+        .spawn(|| {
+            if let Err(error) = promote_audio_threads_blocking() {
+                crate::app_deprintln!(
+                    "[psysonic] Linux realtime audio scheduling unavailable: {error}"
+                );
+            }
+        })
+    {
+        crate::app_deprintln!("[psysonic] could not spawn Linux realtime audio scheduler: {error}");
+    }
+}
+
+fn promote_audio_threads_blocking() -> Result<(), String> {
+    let connection = zbus::blocking::Connection::system()
+        .map_err(|error| format!("RealtimeKit system bus: {error}"))?;
+    let proxy = zbus::blocking::Proxy::new(&connection, RTKIT_SERVICE, RTKIT_PATH, RTKIT_INTERFACE)
+        .map_err(|error| format!("RealtimeKit proxy: {error}"))?;
+    let max_priority = proxy
+        .get_property::<i32>("MaxRealtimePriority")
+        .map_err(|error| format!("RealtimeKit MaxRealtimePriority: {error}"))?;
+    if max_priority <= 0 {
+        return Err("RealtimeKit reports no available realtime priority".into());
+    }
+
+    let process_id = u64::from(std::process::id());
+    let mut promoted = HashSet::new();
+    let mut found_pipewire = false;
+    let mut promoted_cpal = false;
+    let mut promoted_pipewire = false;
+    let mut last_error = None;
+
+    for attempt in 0..DISCOVERY_ATTEMPTS {
+        for (thread_id, thread_name) in audio_threads()? {
+            let Some(priority) = realtime_priority_for_thread(&thread_name, max_priority as u32)
+            else {
+                continue;
+            };
+
+            found_pipewire |= thread_name.starts_with("data-loop.");
+            if promoted.contains(&thread_id) {
+                continue;
+            }
+
+            let result: zbus::Result<()> = proxy.call(
+                "MakeThreadRealtimeWithPID",
+                &(process_id, thread_id, priority),
+            );
+            if let Err(error) = result {
+                last_error = Some(format!(
+                    "RealtimeKit could not promote {thread_name} (tid {thread_id}, priority {priority}): {error}"
+                ));
+                continue;
+            }
+            promoted.insert(thread_id);
+            promoted_cpal |= thread_name == "cpal_alsa_out";
+            promoted_pipewire |= thread_name.starts_with("data-loop.");
+        }
+
+        if promoted_cpal && promoted_pipewire {
+            break;
+        }
+        if attempt + 1 < DISCOVERY_ATTEMPTS {
+            thread::sleep(DISCOVERY_INTERVAL);
+        }
+    }
+
+    if !promoted_cpal || (found_pipewire && !promoted_pipewire) {
+        return Err(last_error
+            .unwrap_or_else(|| "CPAL/PipeWire audio threads could not be promoted".into()));
+    }
+
+    crate::app_deprintln!(
+        "[psysonic] promoted {} Linux audio thread(s) through RealtimeKit",
+        promoted.len()
+    );
+    Ok(())
+}
+
+fn audio_threads() -> Result<Vec<(u64, String)>, String> {
+    let entries = fs::read_dir("/proc/self/task")
+        .map_err(|error| format!("read /proc/self/task: {error}"))?;
+    let mut threads = Vec::new();
+
+    for entry in entries.flatten() {
+        let Some(thread_id) = entry
+            .file_name()
+            .to_str()
+            .and_then(|value| value.parse().ok())
+        else {
+            continue;
+        };
+        let Ok(thread_name) = fs::read_to_string(entry.path().join("comm")) else {
+            continue;
+        };
+        threads.push((thread_id, thread_name.trim().to_string()));
+    }
+
+    Ok(threads)
+}
+
+fn realtime_priority_for_thread(thread_name: &str, max_priority: u32) -> Option<u32> {
+    let requested = if thread_name == "cpal_alsa_out" {
+        CPAL_PRIORITY
+    } else if thread_name.starts_with("data-loop.") {
+        PIPEWIRE_PRIORITY
+    } else {
+        return None;
+    };
+    (max_priority > 0).then(|| requested.min(max_priority))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognises_audio_threads_and_caps_priority() {
+        assert_eq!(realtime_priority_for_thread("cpal_alsa_out", 20), Some(10));
+        assert_eq!(realtime_priority_for_thread("data-loop.0", 20), Some(5));
+        assert_eq!(realtime_priority_for_thread("cpal_alsa_out", 3), Some(3));
+        assert_eq!(realtime_priority_for_thread("data-loop.12", 2), Some(2));
+        assert_eq!(realtime_priority_for_thread("psysonic-audio", 20), None);
+        assert_eq!(realtime_priority_for_thread("cpal_alsa_out", 0), None);
+    }
+}

--- a/src-tauri/crates/psysonic-audio/src/sources.rs
+++ b/src-tauri/crates/psysonic-audio/src/sources.rs
@@ -476,12 +476,13 @@ impl<S: Source<Item = f32>> Source for CountingSource<S> {
 // stutter. This wrapper sets the MMCSS "Pro Audio" task class on the first
 // `next()` call so the kernel keeps the render thread on a real-time class
 // alongside other audio applications. On Linux/macOS the wrapper compiles to
-// a no-op — those platforms already promote their audio threads externally
-// (PipeWire/rtkit, CoreAudio).
+// a no-op so platform scheduling stays outside the render callback.
 //
 // Idempotent across track changes: each new track instantiates a fresh
 // PriorityBoostSource, but `AvSetMmThreadCharacteristicsW` can be called
-// repeatedly on the same thread.
+// repeatedly on the same thread. Linux promotes the CPAL and PipeWire threads
+// asynchronously after opening the output stream instead of doing D-Bus work
+// from this callback.
 
 #[cfg(target_os = "windows")]
 fn promote_thread_to_pro_audio() {


### PR DESCRIPTION
## Summary
- promote the Linux CPAL callback and PipeWire client data-loop threads through RealtimeKit after each output stream opens
- keep D-Bus and `/proc` work outside the realtime callback
- cap requested priorities to the host RealtimeKit limit and retain the existing scheduler when RealtimeKit is unavailable
- retry thread discovery so rapid device reopens cannot leave the replacement callback unpromoted

## Root cause
Under sustained CPU load, both `cpal_alsa_out` and PipeWire `data-loop.0` inherited the application process scheduling as ordinary `SCHED_OTHER` threads with nice `+5`. Promoting only the CPAL callback reduced underruns but did not eliminate them; both audio-critical threads need realtime scheduling.

## Verification
- `nix develop -c bash -lc "cargo test --manifest-path src-tauri/Cargo.toml --workspace --all-targets"`
- `nix develop -c bash -lc "cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings"`
- `nix shell nixpkgs#rustfmt -c rustfmt --check --edition 2021 src-tauri/crates/psysonic-audio/src/linux_realtime.rs`
- `nix develop -c bash -lc "npm run prebuild:release-notes"`
- `git diff --check`

## Runtime benchmark
- Applicability: required custom playback stress; the route benchmark harness does not exercise audio playback
- Baseline: `5d5cc595` (the current PR base `b3529546` has an identical `src-tauri` tree)
- Final measured code: `241122ec`
- Current PR head: `524d6610` (changelog-only follow-up)
- Command: `openssl speed -seconds 20 -multi 16 -bytes 8192 sha256` during active playback
- Baseline result: Psysonic PipeWire `ERR 0 -> 67`; both target threads were `SCHED_OTHER`, nice `+5`
- Final result: Psysonic PipeWire `ERR 0 -> 0`; physical sink stayed `ERR 772 -> 772`
- Final scheduling: `cpal_alsa_out` = `SCHED_RR/10`; `data-loop.0` = `SCHED_RR/5`
- Errors/timeouts/skips: none

## Tauri boundary
No commands, events, arguments, payloads, or frontend mocks changed.