### PR TITLE
fix(packaging): declare the GStreamer plugins Linux radio playback needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Sustained CPU-heavy work no longer starves Psysonic's audio threads and causes playback stutter or dropouts. The player now asks Linux's realtime service to prioritise both its output callback and PipeWire processing, while keeping the previous scheduling when that service is unavailable.
 
+### Linux — internet radio no longer blanks the window
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1390](https://github.com/Psychotoxical/psysonic/pull/1390)**
+
+* Starting an internet radio station no longer clears the whole window on systems installed from the AUR, `.deb` or `.rpm` packages. Those packages now ask for the GStreamer plugins that radio playback needs.
+* Root cause: radio is the one path that plays through the WebView rather than the audio engine, so it relies on GStreamer plugins the distributions treat as optional and do not install on their own. AppImage builds were never affected because they carry the plugins with them.
+
 ## [1.50.0]
 
 ## Added

--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -11,6 +11,16 @@ depends=(
   'gtk3'
   'openssl'
   'alsa-lib'
+  # Internet radio is the one playback path that does not go through the Rust
+  # audio engine: it plays in a WebView <audio> element, so WebKitGTK decodes it
+  # through GStreamer. webkit2gtk-4.1 lists these only as optdepends, which
+  # pacman does not install, and without them there is no autoaudiosink at all —
+  # playing a station blanks the whole window.
+  'gst-plugins-good'  # autodetect (autoaudiosink) + mpg123 (MP3 stations)
+  'gst-plugins-bad'   # faad (AAC / HE-AAC stations)
+)
+optdepends=(
+  'gst-libav: additional codecs for internet radio stations'
 )
 makedepends=(
   'npm'

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -67,6 +67,12 @@
     "linux": {
       "appimage": {
         "bundleMediaFramework": true
+      },
+      "deb": {
+        "depends": ["gstreamer1.0-plugins-good", "gstreamer1.0-plugins-bad"]
+      },
+      "rpm": {
+        "recommends": ["gstreamer1-plugins-good", "gstreamer1-plugins-bad-free"]
       }
     },
     "macOS": {


### PR DESCRIPTION
## Summary

- Internet radio is the one playback path that bypasses the Rust audio engine: it plays in a WebView `<audio>` element, so WebKitGTK decodes and outputs it through GStreamer. Arch lists those plugins only as `optdepends` of `webkit2gtk-4.1`, which pacman does not install — without `gst-plugins-good` there is no `autoaudiosink` at all and starting a station blanks the whole window (issue #1387).
- The AppImage already ships the plugins through `bundleMediaFramework`, and the Nix package puts them on `GST_PLUGIN_PATH`. AUR, deb and rpm were the channels that never declared them.
- AUR gets `gst-plugins-good` (autodetect, mpg123) and `gst-plugins-bad` (faad) as `depends`, plus `gst-libav` as `optdepends`; deb gets the same two under their Debian names.
- rpm declares them as **`recommends`, not `depends`**: Fedora and openSUSE name these packages differently, and an unresolvable hard dependency would make the rpm uninstallable — worse than the bug it fixes.

## Test plan

- Package names verified against the distribution indexes rather than assumed: `gst-plugins-good` / `gst-plugins-bad` (Arch), `gstreamer1.0-plugins-good` / `-bad` (Debian stable), `gstreamer1-plugins-good` / `gstreamer1-plugins-bad-free` (Fedora). `gstreamer1-plugins-bad-freeworld` is RPMFusion, not Fedora, and is deliberately not referenced.
- Plugin-to-element mapping verified against the Arch file lists: `libgstautodetect.so` and `libgstmpg123.so` ship in `gst-plugins-good`, `libgstfaad.so` in `gst-plugins-bad`.
- `tauri.conf.json` validated against `config.schema.json` (`deb.depends` and `rpm.recommends` both exist) and loaded by the Tauri CLI without complaint.
- `pkgrel` intentionally left at 1: this ships with the next version bump, so no separate AUR revision is needed.

### Runtime benchmark

Runtime benchmark: not applicable - packaging metadata only, no application code path is touched.

### Not covered

The AUR clone still has to be pushed by the maintainer, and openSUSE keeps a different package name, so its rpm will ignore the recommendation. Whether the blank window is a WebKit process crash — and therefore whether the app could show an error instead — is untested; it needs a Linux box and is tracked separately in the issue.
