### PR TITLE
fix(audio): support AIFF stream playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The service behind this option no longer has a single working server, and its operator states publicly that a replacement cannot be funded, so the option has been removed rather than left pointing at dead addresses. If it was the only lyrics source you had switched on, LRCLIB is enabled for you automatically.
 * Word-by-word highlighting is unaffected: it also comes from lyrics embedded in your files and from Navidrome 0.63+.
 
+### AIFF playback — streamed and cached files play reliably
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1396](https://github.com/Psychotoxical/psysonic/pull/1396)**
+
+* AIFF, AIF and AIFC tracks now play from servers, local files and playback caches, including files whose metadata appears after their audio data.
+* Servers without byte-range support now fall back to a complete download instead of leaving the track unable to start.
+
 ## [1.50.0]
 
 ## Added

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,7 +56,7 @@ tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rodio = { version = "0.22", default-features = false, features = ["playback"] }
-symphonia = { version = "0.6", default-features = false, features = ["flac", "mp3", "pcm", "aac", "alac", "isomp4", "vorbis", "ogg", "wav", "adpcm", "all-meta"] }
+symphonia = { version = "0.6", default-features = false, features = ["flac", "mp3", "pcm", "aac", "alac", "isomp4", "vorbis", "ogg", "wav", "aiff", "adpcm", "all-meta"] }
 reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "multipart", "query", "form", "rustls", "blocking", "gzip", "brotli"] }
 futures-util = "0.3"
 md5 = "0.8"

--- a/src-tauri/crates/psysonic-analysis/Cargo.toml
+++ b/src-tauri/crates/psysonic-analysis/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = "0.3"
 ebur128 = "0.1"
 md5 = "0.8"
 rusqlite = { version = "0.40", features = ["bundled"] }
-symphonia = { version = "0.6", default-features = false, features = ["flac", "mp3", "pcm", "aac", "alac", "isomp4", "vorbis", "ogg", "wav", "adpcm", "all-meta"] }
+symphonia = { version = "0.6", default-features = false, features = ["flac", "mp3", "pcm", "aac", "alac", "isomp4", "vorbis", "ogg", "wav", "aiff", "adpcm", "all-meta"] }
 symphonia-adapter-libopus = "0.3"
 oximedia-mir = { version = "0.1.7", default-features = false, features = ["tempo", "mood"] }
 

--- a/src-tauri/crates/psysonic-analysis/src/analysis_cache/compute.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_cache/compute.rs
@@ -327,6 +327,12 @@ fn format_hint_from_bytes(bytes: &[u8]) -> Option<String> {
     if bytes.len() >= 12 && bytes[0..4] == *b"RIFF" && bytes[8..12] == *b"WAVE" {
         return Some("wav".into());
     }
+    if bytes.len() >= 12
+        && bytes[0..4] == *b"FORM"
+        && (bytes[8..12] == *b"AIFF" || bytes[8..12] == *b"AIFC")
+    {
+        return Some("aiff".into());
+    }
     let scan = bytes.len().min(4096).saturating_sub(4);
     for i in 0..=scan {
         if bytes[i..i + 4] == *b"ftyp" {
@@ -954,6 +960,28 @@ mod tests {
         out
     }
 
+    fn build_mono_pcm16_aiff(samples: &[i16]) -> Vec<u8> {
+        let data_size = (samples.len() * 2) as u32;
+        let form_size = 4 + (8 + 18) + (8 + 8 + data_size);
+        let mut out = Vec::with_capacity((form_size + 8) as usize);
+        out.extend_from_slice(b"FORM");
+        out.extend_from_slice(&form_size.to_be_bytes());
+        out.extend_from_slice(b"AIFFCOMM");
+        out.extend_from_slice(&18u32.to_be_bytes());
+        out.extend_from_slice(&1u16.to_be_bytes());
+        out.extend_from_slice(&(samples.len() as u32).to_be_bytes());
+        out.extend_from_slice(&16u16.to_be_bytes());
+        out.extend_from_slice(&[0x40, 0x0e, 0xac, 0x44, 0, 0, 0, 0, 0, 0]);
+        out.extend_from_slice(b"SSND");
+        out.extend_from_slice(&(8 + data_size).to_be_bytes());
+        out.extend_from_slice(&0u32.to_be_bytes());
+        out.extend_from_slice(&0u32.to_be_bytes());
+        for sample in samples {
+            out.extend_from_slice(&sample.to_be_bytes());
+        }
+        out
+    }
+
     /// Generate a 1-second 440 Hz sine wave at -6 dBFS as a Vec<i16>.
     fn sine_440_at_minus_6db(sample_rate: u32, secs: f32) -> Vec<i16> {
         let n = (sample_rate as f32 * secs) as usize;
@@ -977,6 +1005,16 @@ mod tests {
             (43_900..=44_300).contains(&frames),
             "expected ~44100 frames, got {frames}"
         );
+    }
+
+    #[test]
+    fn count_mono_frames_decodes_synthetic_aiff_without_external_hint() {
+        let aiff = build_mono_pcm16_aiff(&sine_440_at_minus_6db(44_100, 1.0));
+        assert_eq!(format_hint_from_bytes(&aiff), Some("aiff".into()));
+        let (frames, hint) =
+            count_mono_frames_from_audio_bytes(&aiff, None).expect("AIFF decode must succeed");
+        assert!((43_900..=44_300).contains(&frames), "expected ~44100 frames, got {frames}");
+        assert_eq!(hint, Some(44_100));
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-audio/Cargo.toml
+++ b/src-tauri/crates/psysonic-audio/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["rt", "time", "sync"] }
 reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "rustls", "blocking", "gzip", "brotli"] }
 futures-util = "0.3"
 rodio = { version = "0.22", default-features = false, features = ["playback"] }
-symphonia = { version = "0.6", default-features = false, features = ["flac", "mp3", "pcm", "aac", "alac", "isomp4", "vorbis", "ogg", "wav", "adpcm", "all-meta"] }
+symphonia = { version = "0.6", default-features = false, features = ["flac", "mp3", "pcm", "aac", "alac", "isomp4", "vorbis", "ogg", "wav", "aiff", "adpcm", "all-meta"] }
 symphonia-adapter-libopus = "0.3"
 ringbuf = "0.5"
 biquad = "0.6"

--- a/src-tauri/crates/psysonic-audio/src/commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/commands.rs
@@ -780,9 +780,7 @@ pub async fn audio_chain_preload(
     // Always 0 unless hi-res gapless blend resampling is active.
     let blend_rate = hi_res_blend::blend_rate_hz(hi_res_enabled, hi_res_enabled, hi_res_crossfade_resample_hz);
     let target_rate: u32 = blend_rate.unwrap_or(0);
-    let format_hint = url.rsplit('.').next()
-        .and_then(|ext| ext.split('?').next())
-        .map(|s| s.to_lowercase());
+    let format_hint = url_format_hint(&url);
     let built = build_source(
         (*raw_bytes).clone(),
         duration_hint,

--- a/src-tauri/crates/psysonic-audio/src/decode.rs
+++ b/src-tauri/crates/psysonic-audio/src/decode.rs
@@ -244,6 +244,9 @@ pub(crate) struct SizedDecoder {
 impl SizedDecoder {
     pub(crate) fn new(data: Vec<u8>, format_hint: Option<&str>, hi_res: bool) -> Result<Self, String> {
         let data_len = data.len() as u64;
+        let sniffed_hint = crate::helpers::sniff_stream_format_extension(&data);
+        let format_hint = format_hint.or(sniffed_hint.as_deref());
+        let gate_hint = sniffed_hint.as_deref().or(format_hint);
         let source = SizedCursorSource {
             inner: Cursor::new(data),
             len: data_len,
@@ -252,12 +255,13 @@ impl SizedDecoder {
         // seekability during probe (same as `new_streaming`) so preview does not
         // read the entire in-memory file before the first sample.
         //
-        // Exception: Ogg (Vorbis/Opus/…) must stay seekable through the probe,
-        // otherwise its demuxer never records `phys_byte_range_end` and the first
-        // seek panics (see `container_hint_is_ogg`). This source is fully
-        // in-memory, so the trailing-metadata scan it re-enables is free.
-        let gate_needed = !crate::stream::container_hint_is_mp4(format_hint)
-            && !crate::stream::container_hint_is_ogg(format_hint);
+        // Exception: Ogg (Vorbis/Opus/…) and AIFF must stay seekable through the
+        // probe. Ogg records its physical byte range there; AIFF permits `SSND`
+        // before `COMM` and must scan then seek back. This source is fully
+        // in-memory, so the trailing scan these exceptions enable is free.
+        let gate_needed = !crate::stream::container_hint_is_mp4(gate_hint)
+            && !crate::stream::container_hint_is_ogg(gate_hint)
+            && !crate::stream::container_hint_is_aiff(gate_hint);
         let probe_seek_gate = gate_needed.then(|| Arc::new(AtomicBool::new(false)));
         let media: Box<dyn MediaSource> = match &probe_seek_gate {
             Some(gate) => Box::new(ProbeSeekGate {
@@ -420,17 +424,17 @@ impl SizedDecoder {
         // MP4 keeps seekability (its demuxer needs it to find `moov`; tail is
         // prefetched separately).
         //
-        // Ogg also keeps seekability through the probe, but only on random-access
-        // sources: its demuxer records `phys_byte_range_end` during the probe and
-        // panics on the first seek otherwise (see `container_hint_is_ogg`). On a
-        // local file the stream-end scan is cheap; on a progressive ranged stream
-        // it would force a full download, so there we keep the gate and accept
-        // that seeking is a no-op (the panic itself is contained in `try_seek`).
+        // Ogg and AIFF also keep seekability through the probe on random-access
+        // sources. Ogg records its physical byte range there; AIFF may need to
+        // scan past `SSND` to find `COMM`, then seek back. Local files, Hot Cache,
+        // and ranged sources with on-demand fetches all make those seeks cheap.
+        // Legacy non-seekable AIFF retries from completed full-buffer bytes.
         let stream_len = media.byte_len();
-        let ogg_needs_seekable_probe =
-            source_random_access && crate::stream::container_hint_is_ogg(format_hint);
+        let random_access_needs_seekable_probe = source_random_access
+            && (crate::stream::container_hint_is_ogg(format_hint)
+                || crate::stream::container_hint_is_aiff(format_hint));
         let gate_needed = !crate::stream::container_hint_is_mp4(format_hint)
-            && !ogg_needs_seekable_probe;
+            && !random_access_needs_seekable_probe;
         let probe_seek_gate = gate_needed.then(|| Arc::new(AtomicBool::new(false)));
         let media: Box<dyn MediaSource> = match &probe_seek_gate {
             Some(gate) => Box::new(ProbeSeekGate { inner: media, seekable: gate.clone() }),
@@ -1132,6 +1136,57 @@ mod tests {
         build_mono_pcm16_wav(&samples, sample_rate)
     }
 
+    fn build_mono_pcm16_aiff(
+        samples: &[i16],
+        form: &[u8; 4],
+        sound_before_common: bool,
+    ) -> Vec<u8> {
+        let data_size = (samples.len() * 2) as u32;
+        let mut common = Vec::with_capacity(if form == b"AIFC" { 24 } else { 18 });
+        common.extend_from_slice(&1u16.to_be_bytes());
+        common.extend_from_slice(&(samples.len() as u32).to_be_bytes());
+        common.extend_from_slice(&16u16.to_be_bytes());
+        common.extend_from_slice(&[0x40, 0x0e, 0xac, 0x44, 0, 0, 0, 0, 0, 0]);
+        if form == b"AIFC" {
+            common.extend_from_slice(b"NONE");
+            common.extend_from_slice(&[0, 0]);
+        }
+
+        let mut sound = Vec::with_capacity((8 + data_size) as usize);
+        sound.extend_from_slice(&0u32.to_be_bytes());
+        sound.extend_from_slice(&0u32.to_be_bytes());
+        for sample in samples {
+            sound.extend_from_slice(&sample.to_be_bytes());
+        }
+
+        let mut body = Vec::new();
+        body.extend_from_slice(form);
+        let mut append_chunk = |id: &[u8; 4], data: &[u8]| {
+            body.extend_from_slice(id);
+            body.extend_from_slice(&(data.len() as u32).to_be_bytes());
+            body.extend_from_slice(data);
+            if !data.len().is_multiple_of(2) {
+                body.push(0);
+            }
+        };
+        if form == b"AIFC" {
+            append_chunk(b"FVER", &0xa280_5140u32.to_be_bytes());
+        }
+        if sound_before_common {
+            append_chunk(b"SSND", &sound);
+            append_chunk(b"COMM", &common);
+        } else {
+            append_chunk(b"COMM", &common);
+            append_chunk(b"SSND", &sound);
+        }
+
+        let mut out = Vec::with_capacity(body.len() + 8);
+        out.extend_from_slice(b"FORM");
+        out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+        out.extend_from_slice(&body);
+        out
+    }
+
     #[test]
     fn sized_decoder_constructs_from_synthetic_wav() {
         let wav = synthetic_wav_bytes(0.5);
@@ -1169,6 +1224,52 @@ mod tests {
         assert_eq!(decoder.spec.channels().count(), 1);
         // Live streams report no total duration.
         assert!(decoder.total_duration.is_none());
+    }
+
+    #[test]
+    fn new_streaming_decodes_synthetic_aiff() {
+        let aiff = build_mono_pcm16_aiff(&[16_384; 64], b"AIFF", false);
+        let mut decoder =
+            SizedDecoder::new_streaming(seekable_source(aiff), Some("aiff"), "test-stream", true)
+                .expect("streaming AIFF decode setup");
+        assert_eq!(decoder.spec.rate(), 44_100);
+        assert_eq!(decoder.spec.channels().count(), 1);
+        let sample = decoder.next().expect("AIFF should yield decoded PCM");
+        assert!((sample - 0.5).abs() < 0.01, "decoded sample was {sample}");
+    }
+
+    #[test]
+    fn random_access_stream_decodes_aiff_with_sound_before_common() {
+        let aiff = build_mono_pcm16_aiff(&[16_384; 64], b"AIFF", true);
+        let mut decoder =
+            SizedDecoder::new_streaming(seekable_source(aiff), Some("aif"), "hot-cache", true)
+                .expect("seekable AIFF should allow chunks in either order");
+        assert!(decoder.next().is_some());
+    }
+
+    #[test]
+    fn hintless_sized_decoder_decodes_aiff_with_sound_before_common() {
+        let aiff = build_mono_pcm16_aiff(&[16_384; 64], b"AIFF", true);
+        let mut decoder = SizedDecoder::new(aiff, None, false)
+            .expect("hintless in-memory AIFF should be sniffed before the seek gate");
+        assert!(decoder.next().is_some());
+    }
+
+    #[test]
+    fn misleading_hint_does_not_hide_seekability_for_sniffed_aiff() {
+        let aiff = build_mono_pcm16_aiff(&[16_384; 64], b"AIFF", true);
+        let mut decoder = SizedDecoder::new(aiff, Some("view"), false)
+            .expect("AIFF magic should control the seek gate despite a misleading URL tail");
+        assert!(decoder.next().is_some());
+    }
+
+    #[test]
+    fn sized_decoder_decodes_uncompressed_aifc() {
+        let aifc = build_mono_pcm16_aiff(&[16_384; 64], b"AIFC", false);
+        let mut decoder =
+            SizedDecoder::new(aifc, Some("aifc"), false).expect("AIFC decode setup");
+        let sample = decoder.next().expect("AIFC should yield decoded PCM");
+        assert!((sample - 0.5).abs() < 0.01, "decoded sample was {sample}");
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-audio/src/device_resume.rs
+++ b/src-tauri/crates/psysonic-audio/src/device_resume.rs
@@ -87,6 +87,7 @@ pub(crate) async fn try_resume_after_device_change(
                     reader: Box::new(LocalFileSource { file, len }),
                     format_hint: url_format_hint(url),
                     tag: "LocalFile[device-resume]",
+                    download_control: None,
                     random_access: true,
                     mp4_probe_gate: None,
                 }

--- a/src-tauri/crates/psysonic-audio/src/helpers.rs
+++ b/src-tauri/crates/psysonic-audio/src/helpers.rs
@@ -34,6 +34,7 @@ pub(crate) fn content_type_to_hint(ct: &str) -> Option<String> {
     else if ct.contains("ogg") { Some("ogg".into()) }
     else if ct.contains("flac") { Some("flac".into()) }
     else if ct.contains("wav") || ct.contains("wave") { Some("wav".into()) }
+    else if ct.contains("aiff") || ct.contains("aifc") { Some("aiff".into()) }
     else if ct.contains("opus") { Some("opus".into()) }
     // AAC/ALAC in MP4 — Navidrome/nginx often send `audio/mp4`; without a hint we skipped ranged open.
     else if ct.contains("audio/mp4") || ct.contains("x-m4a") || ct.contains("/m4a") {
@@ -42,26 +43,25 @@ pub(crate) fn content_type_to_hint(ct: &str) -> Option<String> {
     else { None }
 }
 
+pub(crate) fn normalize_audio_extension_for_hint(ext: &str) -> Option<String> {
+    let ext = ext.trim();
+    if !(1..=5).contains(&ext.len()) || !ext.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    let ext = ext.to_ascii_lowercase();
+    matches!(
+        ext.as_str(),
+        "mp3" | "flac" | "ogg" | "oga" | "opus" | "m4a" | "mp4" | "aac" | "wav"
+            | "wave" | "aiff" | "aif" | "aifc" | "ape" | "wv" | "webm" | "mka"
+    )
+    .then_some(ext)
+}
+
 /// `Content-Disposition: attachment; filename="…"` from some Subsonic proxies.
 pub(crate) fn format_hint_from_content_disposition(cd: &str) -> Option<String> {
     fn ext_ok(ext: &str) -> Option<String> {
         let ext = ext.trim_matches(|c| c == '"' || c == '\'' || c == ' ').split(';').next()?.trim();
-        if !(1..=5).contains(&ext.len()) {
-            return None;
-        }
-        if !ext.chars().all(|c| c.is_ascii_alphanumeric()) {
-            return None;
-        }
-        let e = ext.to_ascii_lowercase();
-        if matches!(
-            e.as_str(),
-            "mp3" | "flac" | "ogg" | "oga" | "opus" | "m4a" | "mp4" | "aac" | "wav" | "wave" | "ape" | "wv"
-                | "webm" | "mka"
-        ) {
-            Some(e)
-        } else {
-            None
-        }
+        normalize_audio_extension_for_hint(ext)
     }
     fn ext_from_filename(path: &str) -> Option<String> {
         let base = path.rsplit('/').next()?.trim_matches(|c| c == '"' || c == ' ');
@@ -110,20 +110,7 @@ pub(crate) fn resolve_playback_format_hint(
 /// Subsonic [`song.suffix`](https://www.subsonic.org/pages/api.jsp#getSong) — stream.view URLs
 /// usually have no file extension; this supplies `format_hint` for ranged open.
 pub(crate) fn normalize_stream_suffix_for_hint(suffix: Option<&str>) -> Option<String> {
-    let s = suffix?.trim();
-    if s.is_empty() {
-        return None;
-    }
-    let e = s.to_ascii_lowercase();
-    if matches!(
-        e.as_str(),
-        "mp3" | "flac" | "ogg" | "oga" | "opus" | "m4a" | "mp4" | "aac" | "wav" | "wave" | "ape" | "wv"
-            | "webm" | "mka"
-    ) {
-        Some(e)
-    } else {
-        None
-    }
+    normalize_audio_extension_for_hint(suffix?)
 }
 
 /// Max prefix length for an optional `Range` probe GET when ranged open needs a format hint.
@@ -163,6 +150,12 @@ pub(crate) fn sniff_stream_format_extension(data: &[u8]) -> Option<String> {
     }
     if data.len() >= 12 && data[0..4] == *b"RIFF" && data[8..12] == *b"WAVE" {
         return Some("wav".into());
+    }
+    if data.len() >= 12
+        && data[0..4] == *b"FORM"
+        && (data[8..12] == *b"AIFF" || data[8..12] == *b"AIFC")
+    {
+        return Some("aiff".into());
     }
     // ISO-BMFF — `ftyp` inside a box; scan a small window (large `free`/`skip` before `ftyp` is rare but exists).
     let scan = data.len().min(4096).saturating_sub(4);
@@ -574,6 +567,22 @@ pub(crate) fn take_stream_completed_spill_from_slot(
     None
 }
 
+pub(crate) fn stream_spill_file_paths(
+    app: &AppHandle,
+    track_id: &str,
+) -> Result<(std::path::PathBuf, std::path::PathBuf), String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("stream-spill");
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    Ok((
+        dir.join(format!("{track_id}.complete")),
+        dir.join(format!("{track_id}.complete.part")),
+    ))
+}
+
 /// Atomically write completed stream bytes under `dir` (`{track_id}.complete.part` → rename).
 pub(crate) fn write_stream_spill_bytes_in_dir(
     dir: &std::path::Path,
@@ -622,18 +631,25 @@ pub fn cleanup_orphan_stream_spill_dir(app: &AppHandle) {
     }
 }
 
-pub(crate) fn install_stream_completed_spill(
+pub(crate) fn install_stream_completed_spill_if(
     slot: &std::sync::Arc<std::sync::Mutex<Option<crate::state::StreamCompletedSpill>>>,
     url: String,
     path: std::path::PathBuf,
-) {
+    should_install: impl FnOnce() -> bool,
+) -> bool {
     let mut guard = slot.lock().unwrap();
+    if !should_install() {
+        drop(guard);
+        let _ = std::fs::remove_file(path);
+        return false;
+    }
     if let Some(old) = guard.take() {
         if old.path != path {
             let _ = std::fs::remove_file(&old.path);
         }
     }
     *guard = Some(crate::state::StreamCompletedSpill { url, path });
+    true
 }
 
 /// Fetch track bytes from the preload cache or via HTTP.
@@ -697,6 +713,17 @@ pub(crate) async fn fetch_data(
         return Ok(Some(data));
     }
 
+    fetch_http_data(url, state, gen, app).await
+}
+
+/// Fetch bytes directly from HTTP, bypassing preload/completed caches.
+/// Used when a cached buffer failed validation and a genuinely fresh body is required.
+pub(crate) async fn fetch_http_data(
+    url: &str,
+    state: &AudioEngine,
+    gen: u64,
+    app: &AppHandle,
+) -> Result<Option<Vec<u8>>, String> {
     let response = crate::engine::playback_scoped_get(state, app, url, None)
         .send()
         .await
@@ -926,6 +953,9 @@ mod tests {
         assert_eq!(content_type_to_hint("audio/flac"), Some("flac".into()));
         assert_eq!(content_type_to_hint("audio/wav"), Some("wav".into()));
         assert_eq!(content_type_to_hint("audio/wave"), Some("wav".into()));
+        assert_eq!(content_type_to_hint("audio/aiff"), Some("aiff".into()));
+        assert_eq!(content_type_to_hint("audio/x-aiff"), Some("aiff".into()));
+        assert_eq!(content_type_to_hint("audio/aifc"), Some("aiff".into()));
         assert_eq!(content_type_to_hint("audio/opus"), Some("opus".into()));
         assert_eq!(content_type_to_hint("audio/mp4"), Some("m4a".into()));
         assert_eq!(content_type_to_hint("audio/x-m4a"), Some("m4a".into()));
@@ -951,6 +981,10 @@ mod tests {
         assert_eq!(
             format_hint_from_content_disposition("attachment; filename=\"track.flac\""),
             Some("flac".into()),
+        );
+        assert_eq!(
+            format_hint_from_content_disposition("attachment; filename=\"track.aiff\""),
+            Some("aiff".into()),
         );
     }
 
@@ -1014,6 +1048,8 @@ mod tests {
     fn suffix_normalises_known_extensions_lowercase() {
         assert_eq!(normalize_stream_suffix_for_hint(Some("MP3")), Some("mp3".into()));
         assert_eq!(normalize_stream_suffix_for_hint(Some("Flac")), Some("flac".into()));
+        assert_eq!(normalize_stream_suffix_for_hint(Some("AIFF")), Some("aiff".into()));
+        assert_eq!(normalize_stream_suffix_for_hint(Some("AIF")), Some("aif".into()));
     }
 
     #[test]
@@ -1047,6 +1083,19 @@ mod tests {
         buf.extend_from_slice(&[0u8; 4]);
         buf.extend_from_slice(b"WAVE");
         assert_eq!(sniff_stream_format_extension(&buf), Some("wav".into()));
+    }
+
+    #[test]
+    fn sniff_detects_aiff_and_aifc() {
+        let mut aiff = b"FORM".to_vec();
+        aiff.extend_from_slice(&[0u8; 4]);
+        aiff.extend_from_slice(b"AIFF");
+        assert_eq!(sniff_stream_format_extension(&aiff), Some("aiff".into()));
+
+        let mut aifc = b"FORM".to_vec();
+        aifc.extend_from_slice(&[0u8; 4]);
+        aifc.extend_from_slice(b"AIFC");
+        assert_eq!(sniff_stream_format_extension(&aifc), Some("aiff".into()));
     }
 
     #[test]
@@ -1574,18 +1623,39 @@ mod stream_spill_tests {
         std::fs::write(&new_path, b"new").unwrap();
         let slot: Arc<Mutex<Option<crate::state::StreamCompletedSpill>>> =
             Arc::new(Mutex::new(None));
-        install_stream_completed_spill(
+        assert!(install_stream_completed_spill_if(
             &slot,
             "http://example/a".into(),
             old_path.clone(),
-        );
-        install_stream_completed_spill(
+            || true,
+        ));
+        assert!(install_stream_completed_spill_if(
             &slot,
             "http://example/b".into(),
             new_path.clone(),
-        );
+            || true,
+        ));
         assert!(!old_path.exists(), "previous spill file must be removed");
         assert!(new_path.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn conditional_spill_install_rejects_and_removes_candidate() {
+        let dir = scratch_dir("conditional-install");
+        let path = dir.join("candidate.complete");
+        std::fs::write(&path, b"candidate").unwrap();
+        let slot: Arc<Mutex<Option<crate::state::StreamCompletedSpill>>> =
+            Arc::new(Mutex::new(None));
+
+        assert!(!install_stream_completed_spill_if(
+            &slot,
+            "http://example/a".into(),
+            path.clone(),
+            || false,
+        ));
+        assert!(slot.lock().unwrap().is_none());
+        assert!(!path.exists());
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -1597,10 +1667,16 @@ mod stream_spill_tests {
         let slot: Arc<Mutex<Option<crate::state::StreamCompletedSpill>>> =
             Arc::new(Mutex::new(None));
         let url = "https://server/stream?id=1";
-        install_stream_completed_spill(&slot, url.into(), path.clone());
+        assert!(install_stream_completed_spill_if(
+            &slot,
+            url.into(),
+            path.clone(),
+            || true,
+        ));
         let taken = take_stream_completed_spill_from_slot(&slot, url);
         assert_eq!(taken.as_deref(), Some(path.as_path()));
         assert!(take_stream_completed_spill_from_slot(&slot, url).is_none());
         let _ = std::fs::remove_dir_all(&dir);
     }
+
 }

--- a/src-tauri/crates/psysonic-audio/src/hi_res_blend.rs
+++ b/src-tauri/crates/psysonic-audio/src/hi_res_blend.rs
@@ -101,6 +101,7 @@ fn resolve_cached_play_input(engine: &AudioEngine, url: &str) -> Option<PlayInpu
             reader: Box::new(LocalFileSource { file, len }),
             format_hint: url_format_hint(url),
             tag: "LocalFile[hi-res-blend]",
+            download_control: None,
             random_access: true,
             mp4_probe_gate: None,
         });

--- a/src-tauri/crates/psysonic-audio/src/play_input.rs
+++ b/src-tauri/crates/psysonic-audio/src/play_input.rs
@@ -18,7 +18,8 @@ use super::analysis_dispatch::{
 use super::engine::{audio_http_client, AudioEngine, PlaybackHttpHeaders};
 use super::helpers::{
     content_type_to_hint, fetch_data, format_hint_from_content_disposition,
-    normalize_stream_suffix_for_hint, sniff_stream_format_extension,
+    normalize_audio_extension_for_hint, normalize_stream_suffix_for_hint,
+    sniff_stream_format_extension,
     same_playback_target,
     STREAM_FORMAT_SNIFF_PROBE_BYTES,
 };
@@ -40,6 +41,7 @@ pub(crate) enum PlayInput {
         reader: Box<dyn MediaSource>,
         format_hint: Option<String>,
         tag: &'static str,
+        download_control: Option<Arc<super::stream::StreamDownloadControl>>,
         /// Source can cheaply seek to EOF (local file). Drives whether Ogg keeps
         /// seekability through the probe so its seek path does not panic.
         random_access: bool,
@@ -49,6 +51,7 @@ pub(crate) enum PlayInput {
     Streaming {
         reader: AudioStreamReader,
         format_hint: Option<String>,
+        download_control: Arc<super::stream::StreamDownloadControl>,
     },
 }
 
@@ -210,6 +213,7 @@ fn open_local_file_input(
         reader: Box::new(reader),
         format_hint: local_hint,
         tag: "local-file",
+        download_control: None,
         random_access: true,
         mp4_probe_gate: None,
     })
@@ -261,6 +265,7 @@ async fn open_ranged_or_streaming_input(
         .and_then(|v| v.to_str().ok())
         .is_some_and(|v| v.to_ascii_lowercase().contains("bytes"));
     let total_size = response.content_length();
+    let ranged_total_size = total_size.filter(|&total| total > 0);
 
     if stream_hint.is_none() && supports_range {
         if let Some(total_u64) = total_size.filter(|&t| t > 0) {
@@ -295,7 +300,7 @@ async fn open_ranged_or_streaming_input(
         }
     }
 
-    if let (true, Some(total), true) = (supports_range, total_size, stream_hint.is_some()) {
+    if let (true, Some(total), true) = (supports_range, ranged_total_size, stream_hint.is_some()) {
         let total_usize = total as usize;
         crate::app_deprintln!(
             "[stream] RangedHttpSource selected — total={} KB, hint={:?}",
@@ -304,7 +309,8 @@ async fn open_ranged_or_streaming_input(
         );
         let buf = Arc::new(Mutex::new(vec![0u8; total_usize]));
         let downloaded_to = Arc::new(AtomicUsize::new(0));
-        let done = Arc::new(AtomicBool::new(false));
+        let download_control = super::stream::StreamDownloadControl::new();
+        let done = download_control.done.clone();
         state.stream_playback_armed.store(false, Ordering::SeqCst);
         let playback_armed = state.stream_playback_armed.clone();
         let tail_ready = Arc::new(AtomicBool::new(false));
@@ -338,7 +344,7 @@ async fn open_ranged_or_streaming_input(
             response,
             buf.clone(),
             downloaded_to.clone(),
-            done.clone(),
+            download_control.clone(),
             state.stream_completed_cache.clone(),
             state.stream_completed_spill.clone(),
             state.normalization_engine.clone(),
@@ -385,6 +391,7 @@ async fn open_ranged_or_streaming_input(
             reader: Box::new(reader),
             format_hint: stream_hint,
             tag: "ranged-stream",
+            download_control: Some(download_control),
             // The on-demand fetcher makes a seek-to-EOF during the probe cheap,
             // so Ogg can stay seekable through the probe (records its byte range
             // → real seeking) without forcing a full download.
@@ -404,7 +411,8 @@ async fn open_ranged_or_streaming_input(
         .clamp(TRACK_STREAM_MIN_BUF_CAPACITY, TRACK_STREAM_MAX_BUF_CAPACITY);
     let rb = HeapRb::<u8>::new(buffer_cap);
     let (prod, cons) = rb.split();
-    let done = Arc::new(AtomicBool::new(false));
+    let download_control = super::stream::StreamDownloadControl::new();
+    let done = download_control.done.clone();
     state.stream_playback_armed.store(false, Ordering::SeqCst);
     let playback_armed = state.stream_playback_armed.clone();
     let analysis_seed_hold = super::stream::AnalysisSeedHoldGuard::arm(
@@ -420,8 +428,9 @@ async fn open_ranged_or_streaming_input(
         ctx.url.to_string(),
         response,
         prod,
-        done.clone(),
+        download_control.clone(),
         state.stream_completed_cache.clone(),
+        state.stream_completed_spill.clone(),
         ctx.cache_id_for_tasks.map(|s| s.to_string()),
         ctx.server_id.map(|s| s.to_string()),
         analysis_seed_hold,
@@ -445,6 +454,7 @@ async fn open_ranged_or_streaming_input(
     Ok(Some(PlayInput::Streaming {
         reader,
         format_hint: stream_hint,
+        download_control,
     }))
 }
 
@@ -455,16 +465,7 @@ async fn open_ranged_or_streaming_input(
 pub(crate) fn url_format_hint(url: &str) -> Option<String> {
     url.split('?').next()
         .and_then(|path| path.rsplit('.').next())
-        .filter(|ext| {
-            (1..=5).contains(&ext.len())
-                && ext.chars().all(|c| c.is_ascii_alphanumeric())
-                && matches!(
-                    ext.to_ascii_lowercase().as_str(),
-                    "mp3" | "flac" | "ogg" | "oga" | "opus" | "m4a" | "mp4"
-                    | "aac" | "wav" | "wave" | "ape" | "wv" | "webm" | "mka"
-                )
-        })
-        .map(|s| s.to_lowercase())
+        .and_then(normalize_audio_extension_for_hint)
 }
 
 /// The `maxBitRate` cap (kbps) a `stream.view` URL was opened with, if any.
@@ -482,7 +483,15 @@ pub(crate) fn url_stream_cap_kbps(url: &str) -> Option<u32> {
 
 #[cfg(test)]
 mod url_param_tests {
-    use super::url_stream_cap_kbps;
+    use super::{url_format_hint, url_stream_cap_kbps};
+
+    #[test]
+    fn extracts_aiff_format_hint_from_url_path() {
+        assert_eq!(
+            url_format_hint("https://s.example/music/track.AIFF?token=x"),
+            Some("aiff".into()),
+        );
+    }
 
     #[test]
     fn parses_max_bit_rate_from_stream_url() {

--- a/src-tauri/crates/psysonic-audio/src/preview.rs
+++ b/src-tauri/crates/psysonic-audio/src/preview.rs
@@ -227,7 +227,8 @@ async fn open_preview_decoder(
         );
         let buf = Arc::new(Mutex::new(vec![0u8; total_usize]));
         let downloaded_to = Arc::new(AtomicUsize::new(0));
-        let done = Arc::new(AtomicBool::new(false));
+        let download_control = super::stream::StreamDownloadControl::new();
+        let done = download_control.done.clone();
         let playback_armed = Arc::new(AtomicBool::new(false));
         let tail_ready = Arc::new(AtomicBool::new(false));
         let tail_filled_from = Arc::new(AtomicU64::new(0));
@@ -250,7 +251,7 @@ async fn open_preview_decoder(
             response,
             buf.clone(),
             downloaded_to.clone(),
-            done.clone(),
+            download_control,
             state.stream_completed_cache.clone(),
             state.stream_completed_spill.clone(),
             state.normalization_engine.clone(),

--- a/src-tauri/crates/psysonic-audio/src/source_build.rs
+++ b/src-tauri/crates/psysonic-audio/src/source_build.rs
@@ -1,7 +1,7 @@
 //! Source-building pipeline for `audio_play`: turn a resolved [`PlayInput`]
 //! into a fully wrapped rodio source, including the ranged-stream probe
 //! fallback (wait for / fetch a full download and retry from in-memory bytes
-//! when a partial ranged buffer can't be probed yet). Split out of
+//! when a partial stream buffer can't be probed yet). Split out of
 //! `play_input.rs` so source *selection* stays separate from source *building*.
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -15,9 +15,15 @@ use super::analysis_dispatch::{
 };
 use super::decode::{build_source, build_streaming_source, BuiltSource, SizedDecoder};
 use super::engine::AudioEngine;
-use super::helpers::{fetch_data, resolve_playback_format_hint, same_playback_target};
+use super::helpers::{
+    fetch_http_data, resolve_playback_format_hint, same_playback_target,
+    write_stream_spill_file,
+};
 use super::play_input::PlayInput;
-use super::stream::TRACK_READ_TIMEOUT_SECS;
+use super::state::{PreloadedTrack, StreamCompletedSpill};
+use super::stream::{
+    StreamDownloadControl, TRACK_READ_TIMEOUT_SECS, TRACK_STREAM_PROMOTE_MAX_BYTES,
+};
 
 /// Arguments forwarded from `audio_play` into the source-build pipeline.
 /// Bundles the format-hint inputs, playback-shaping parameters and the shared
@@ -47,6 +53,11 @@ struct PlaybackSourceShape {
     duration_hint: f64,
 }
 
+struct FallbackBytes {
+    data: Vec<u8>,
+    consumed_spill_path: Option<std::path::PathBuf>,
+}
+
 /// Output of `build_source_from_play_input`: the wrapped rodio source plus
 /// whether the chosen source path is seekable (only the Streaming variant
 /// is not).
@@ -64,34 +75,133 @@ fn play_media_format_hint(input: &PlayInput) -> Option<String> {
     }
 }
 
-/// Ranged HTTP probe/decode failed in a way that may succeed after the
-/// background download finishes (moov-at-end, demuxer EOF during partial buffer).
-fn is_ranged_stream_probe_failure(err: &str) -> bool {
-    err.contains("ranged-stream")
-        && (err.contains("format probe failed")
-            || err.contains("moov metadata")
-            || err.contains("end of stream"))
+fn play_input_download_control(input: &PlayInput) -> Option<Arc<StreamDownloadControl>> {
+    match input {
+        PlayInput::SeekableMedia {
+            download_control, ..
+        } => download_control.clone(),
+        PlayInput::Streaming {
+            download_control, ..
+        } => Some(download_control.clone()),
+        PlayInput::Bytes(_) => None,
+    }
 }
 
-/// Completed ranged download or spill file for `url`, if ready.
+fn publish_validated_fallback_bytes(
+    state: &AudioEngine,
+    app: &AppHandle,
+    url: &str,
+    track_id: Option<&str>,
+    gen: u64,
+    data: &[u8],
+) -> bool {
+    let candidate_spill = if data.len() > TRACK_STREAM_PROMOTE_MAX_BYTES {
+        let Some(track_id) = track_id.map(str::trim).filter(|id| !id.is_empty()) else {
+            return state.generation.load(Ordering::SeqCst) == gen;
+        };
+        match write_stream_spill_file(app, &format!("{track_id}-fallback-{gen}"), data) {
+            Ok(path) => Some(path),
+            Err(e) => {
+                crate::app_eprintln!(
+                    "[stream] validated fallback spill failed track_id={track_id}: {e}"
+                );
+                return state.generation.load(Ordering::SeqCst) == gen;
+            }
+        }
+    } else {
+        None
+    };
+
+    let mut cache = state.stream_completed_cache.lock().unwrap();
+    let mut spill = state.stream_completed_spill.lock().unwrap();
+    if state.generation.load(Ordering::SeqCst) != gen {
+        drop(spill);
+        drop(cache);
+        if let Some(path) = candidate_spill {
+            let _ = std::fs::remove_file(path);
+        }
+        return false;
+    }
+    let old_spill = spill.take().map(|entry| entry.path);
+    if let Some(path) = candidate_spill {
+        *cache = None;
+        *spill = Some(StreamCompletedSpill {
+            url: url.to_string(),
+            path,
+        });
+    } else {
+        *cache = Some(PreloadedTrack {
+            url: url.to_string(),
+            data: data.to_vec(),
+        });
+    }
+    drop(spill);
+    drop(cache);
+    if let Some(path) = old_spill {
+        let _ = std::fs::remove_file(path);
+    }
+    true
+}
+
+/// A stream probe/decode failed in a way that may succeed after the background
+/// download finishes (moov-at-end, demuxer EOF, or non-seekable AIFF chunks).
+fn is_stream_probe_failure_with_full_buffer_retry(err: &str, format_hint: Option<&str>) -> bool {
+    let probe_failed = err.contains("format probe failed")
+        || err.contains("format probe timed out")
+        || err.contains("end of stream");
+    let ranged_failure = err.contains("ranged-stream")
+        && (probe_failed || err.contains("moov metadata"));
+    let legacy_aiff_failure = err.contains("track-stream")
+        && probe_failed
+        && (super::stream::container_hint_is_aiff(format_hint) || err.contains("aiff:"));
+    ranged_failure || legacy_aiff_failure
+}
+
+/// Take ownership of completed download bytes so they cannot be promoted while
+/// fallback validation is in progress. Valid bytes are republished afterwards.
 async fn try_take_completed_stream_bytes(
     url: &str,
+    gen: u64,
     state: &State<'_, AudioEngine>,
-) -> Option<Vec<u8>> {
-    if let Some(data) = super::helpers::take_stream_completed_for_url(state, url) {
-        return Some(data);
+) -> Option<FallbackBytes> {
+    let ram = {
+        let mut guard = state.stream_completed_cache.lock().unwrap();
+        if state.generation.load(Ordering::SeqCst) == gen
+            && guard
+                .as_ref()
+                .is_some_and(|p| same_playback_target(&p.url, url))
+        {
+            guard.take().map(|p| p.data)
+        } else {
+            None
+        }
+    };
+    if let Some(data) = ram {
+        return Some(FallbackBytes {
+            data,
+            consumed_spill_path: None,
+        });
     }
     let spill_path = {
-        let guard = state.stream_completed_spill.lock().unwrap();
-        guard
-            .as_ref()
-            .filter(|p| same_playback_target(&p.url, url))
-            .map(|p| p.path.clone())
+        let mut guard = state.stream_completed_spill.lock().unwrap();
+        if state.generation.load(Ordering::SeqCst) == gen
+            && guard
+                .as_ref()
+                .is_some_and(|p| same_playback_target(&p.url, url))
+        {
+            guard.take().map(|p| p.path)
+        } else {
+            None
+        }
     };
     if let Some(path) = spill_path {
-        let data = tokio::fs::read(&path).await.ok()?;
+        let data = tokio::fs::read(&path).await.ok();
+        let data = data?;
         if !data.is_empty() {
-            return Some(data);
+            return Some(FallbackBytes {
+                data,
+                consumed_spill_path: Some(path),
+            });
         }
     }
     None
@@ -103,28 +213,32 @@ async fn prefer_clean_http_bytes_for_fallback(
     gen: u64,
     state: &State<'_, AudioEngine>,
     app: &AppHandle,
-    ranged_data: Vec<u8>,
+    fallback: FallbackBytes,
     format_hint: Option<&str>,
     label: &str,
-) -> Result<Option<Vec<u8>>, String> {
+) -> Result<Option<FallbackBytes>, String> {
     let is_mp4 = super::stream::container_hint_is_mp4(format_hint);
     if is_mp4 {
-        super::stream::log_isobmff_buffer_diagnostic(&ranged_data, format_hint, label);
-        if !super::stream::isobmff_buffer_looks_complete(&ranged_data)
-            || super::stream::mp4_suspect_zero_holes(&ranged_data)
+        super::stream::log_isobmff_buffer_diagnostic(&fallback.data, format_hint, label);
+        if !super::stream::isobmff_buffer_looks_complete(&fallback.data)
+            || super::stream::mp4_suspect_zero_holes(&fallback.data)
         {
             crate::app_deprintln!(
                 "[stream] ranged buffer looks incomplete or holey — refetching via sequential HTTP"
             );
-            if let Some(fresh) = fetch_data(url, state, gen, app).await? {
-                if super::stream::isobmff_buffer_looks_complete(&fresh) {
-                    return Ok(Some(fresh));
-                }
+            let Some(fresh) = fetch_http_data(url, state, gen, app).await? else {
+                return Ok(None);
+            };
+            if !super::stream::isobmff_buffer_looks_complete(&fresh) {
                 super::stream::log_isobmff_buffer_diagnostic(&fresh, format_hint, "http-refetch");
             }
+            return Ok(Some(FallbackBytes {
+                data: fresh,
+                consumed_spill_path: fallback.consumed_spill_path,
+            }));
         }
     }
-    Ok(Some(ranged_data))
+    Ok(Some(fallback))
 }
 
 /// Wait for the in-flight ranged download to finish, then HTTP-fetch if needed.
@@ -134,7 +248,8 @@ async fn wait_or_fetch_bytes_for_stream_fallback(
     state: &State<'_, AudioEngine>,
     app: &AppHandle,
     format_hint: Option<&str>,
-) -> Result<Option<Vec<u8>>, String> {
+    download_control: &StreamDownloadControl,
+) -> Result<Option<FallbackBytes>, String> {
     use std::time::Instant;
 
     let deadline = Instant::now() + Duration::from_secs(TRACK_READ_TIMEOUT_SECS);
@@ -142,10 +257,10 @@ async fn wait_or_fetch_bytes_for_stream_fallback(
         if state.generation.load(Ordering::SeqCst) != gen {
             return Ok(None);
         }
-        if let Some(data) = try_take_completed_stream_bytes(url, state).await {
+        if let Some(data) = try_take_completed_stream_bytes(url, gen, state).await {
             crate::app_deprintln!(
                 "[stream] full-buffer fallback: using completed download ({} KiB)",
-                data.len() / 1024
+                data.data.len() / 1024
             );
             return prefer_clean_http_bytes_for_fallback(
                 url,
@@ -158,6 +273,12 @@ async fn wait_or_fetch_bytes_for_stream_fallback(
             )
             .await;
         }
+        if download_control.ended_without_reusable_bytes() {
+            crate::app_deprintln!(
+                "[stream] full-buffer fallback: download ended without reusable bytes — HTTP fetch"
+            );
+            break;
+        }
         if Instant::now() >= deadline {
             break;
         }
@@ -167,7 +288,12 @@ async fn wait_or_fetch_bytes_for_stream_fallback(
         "[stream] full-buffer fallback: download still in progress after {}s — HTTP fetch",
         TRACK_READ_TIMEOUT_SECS
     );
-    fetch_data(url, state, gen, app).await
+    Ok(fetch_http_data(url, state, gen, app)
+        .await?
+        .map(|data| FallbackBytes {
+            data,
+            consumed_spill_path: None,
+        }))
 }
 
 fn is_in_memory_probe_failure(err: &str) -> bool {
@@ -176,8 +302,8 @@ fn is_in_memory_probe_failure(err: &str) -> bool {
         || err.contains("no playable audio track")
 }
 
-/// Like [`build_source_from_play_input`], but on ranged-stream probe failure waits
-/// for a full download (or fetches it) and retries from in-memory bytes.
+/// Like [`build_source_from_play_input`], but on a retryable stream probe failure
+/// waits for a full download (or fetches it) and retries from in-memory bytes.
 pub(crate) async fn build_playback_source_with_probe_fallback(
     play_input: PlayInput,
     args: BuildSourceArgs<'_>,
@@ -198,6 +324,7 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
         duration_hint,
     } = args;
     let media_hint = play_media_format_hint(&play_input);
+    let download_control = play_input_download_control(&play_input);
     let effective_hint = resolve_playback_format_hint(
         url_format_hint,
         stream_format_suffix,
@@ -220,23 +347,37 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
     .await
     {
         Ok(p) => Ok(p),
-        Err(e) if is_ranged_stream_probe_failure(&e) => {
+        Err(e)
+            if is_stream_probe_failure_with_full_buffer_retry(
+                &e,
+                effective_hint.as_deref(),
+            ) =>
+        {
             crate::app_deprintln!(
-                "[stream] ranged-stream probe failed — trying full-buffer fallback: {}",
+                "[stream] stream probe failed — trying full-buffer fallback: {}",
                 e
             );
-            let data = match wait_or_fetch_bytes_for_stream_fallback(
+            let Some(download_control) = download_control.as_ref() else {
+                return Err(e);
+            };
+            download_control.request_fallback_analysis();
+            let fallback = match wait_or_fetch_bytes_for_stream_fallback(
                 url,
                 gen,
                 state,
                 app,
                 effective_hint.as_deref(),
+                download_control,
             )
             .await?
             {
-                Some(d) => d,
+                Some(fallback) => fallback,
                 None => return Err(e),
             };
+            let FallbackBytes {
+                data,
+                consumed_spill_path,
+            } = fallback;
             if state.generation.load(Ordering::SeqCst) != gen {
                 return Err("ranged-stream: superseded during full-buffer fallback".into());
             }
@@ -253,23 +394,29 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
                     effective_hint
                 );
             }
-            if let Some(track_id) = cache_id_for_tasks
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-            {
-                let (sid, high) =
-                    prepare_playback_analysis(app, state, server_id, track_id, None);
-                spawn_track_analysis_bytes(
-                    app.clone(),
-                    TrackAnalysisOrigin::StreamDownloadComplete,
-                    sid,
-                    track_id.to_string(),
-                    data.clone(),
-                    Some(url.to_string()),
-                    high,
-                    Some((gen, state.generation.clone())),
-                );
-            }
+            let dispatch_fallback_analysis = |analysis_data: Vec<u8>| -> bool {
+                if !download_control.claim_fallback_analysis() {
+                    return false;
+                }
+                if let Some(track_id) = cache_id_for_tasks
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                {
+                    let (sid, high) =
+                        prepare_playback_analysis(app, state, server_id, track_id, None);
+                    spawn_track_analysis_bytes(
+                        app.clone(),
+                        TrackAnalysisOrigin::StreamDownloadComplete,
+                        sid,
+                        track_id.to_string(),
+                        analysis_data,
+                        Some(url.to_string()),
+                        high,
+                        Some((gen, state.generation.clone())),
+                    );
+                }
+                true
+            };
             match build_source_from_play_input(
                 PlayInput::Bytes(data.clone()),
                 state,
@@ -278,7 +425,32 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
             )
             .await
             {
-                Ok(p) => Ok(p),
+                Ok(p) => {
+                    if state.generation.load(Ordering::SeqCst) != gen {
+                        return Err(
+                            "ranged-stream: superseded during full-buffer fallback".into()
+                        );
+                    }
+                    download_control.mark_fallback_succeeded();
+                    if !publish_validated_fallback_bytes(
+                        state,
+                        app,
+                        url,
+                        cache_id_for_tasks,
+                        gen,
+                        &data,
+                    ) {
+                        return Err(
+                            "ranged-stream: superseded during full-buffer fallback".into()
+                        );
+                    }
+                    if dispatch_fallback_analysis(data) {
+                        if let Some(path) = consumed_spill_path {
+                            let _ = std::fs::remove_file(path);
+                        }
+                    }
+                    Ok(p)
+                }
                 Err(pe) if is_in_memory_probe_failure(&pe) => {
                     if super::stream::container_hint_is_mp4(bytes_hint.as_deref()) {
                         super::stream::log_isobmff_buffer_diagnostic(
@@ -291,21 +463,27 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
                         "[stream] in-memory probe failed — sequential HTTP refetch: {}",
                         pe
                     );
-                    let fresh = match fetch_data(url, state, gen, app).await? {
+                    let fresh = match fetch_http_data(url, state, gen, app).await? {
                         Some(d) => d,
                         None => return Err(pe),
                     };
-                    if super::stream::container_hint_is_mp4(bytes_hint.as_deref()) {
+                    let fresh_hint = resolve_playback_format_hint(
+                        url_format_hint,
+                        stream_format_suffix,
+                        media_hint.as_deref(),
+                        Some(&fresh),
+                    );
+                    if super::stream::container_hint_is_mp4(fresh_hint.as_deref()) {
                         super::stream::log_isobmff_buffer_diagnostic(
                             &fresh,
-                            bytes_hint.as_deref(),
+                            fresh_hint.as_deref(),
                             "http-refetch-after-probe-fail",
                         );
                     }
-                    build_source_from_play_input(
-                        PlayInput::Bytes(fresh),
+                    let result = build_source_from_play_input(
+                        PlayInput::Bytes(fresh.clone()),
                         state,
-                        bytes_hint.as_deref(),
+                        fresh_hint.as_deref(),
                         &PlaybackSourceShape {
                             done_flag,
                             fade_in_dur,
@@ -314,7 +492,33 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
                             duration_hint,
                         },
                     )
-                    .await
+                    .await;
+                    if result.is_ok() {
+                        if state.generation.load(Ordering::SeqCst) != gen {
+                            return Err(
+                                "ranged-stream: superseded during full-buffer fallback".into()
+                            );
+                        }
+                        download_control.mark_fallback_succeeded();
+                        if !publish_validated_fallback_bytes(
+                            state,
+                            app,
+                            url,
+                            cache_id_for_tasks,
+                            gen,
+                            &fresh,
+                        ) {
+                            return Err(
+                                "ranged-stream: superseded during full-buffer fallback".into()
+                            );
+                        }
+                        if dispatch_fallback_analysis(fresh) {
+                            if let Some(path) = consumed_spill_path {
+                                let _ = std::fs::remove_file(path);
+                            }
+                        }
+                    }
+                    result
                 }
                 Err(pe) => Err(pe),
             }
@@ -363,6 +567,7 @@ async fn build_source_from_play_input(
             tag,
             random_access,
             mp4_probe_gate,
+            ..
         } => {
             if let Some(gate) = mp4_probe_gate.as_ref() {
                 super::stream::wait_for_ranged_mp4_probe_ready(gate).await?;
@@ -389,7 +594,11 @@ async fn build_source_from_play_input(
                 None,
             )
         }
-        PlayInput::Streaming { reader, format_hint: stream_hint } => {
+        PlayInput::Streaming {
+            reader,
+            format_hint: stream_hint,
+            ..
+        } => {
             is_seekable = false;
             let decoder = tokio::task::spawn_blocking(move || {
                 SizedDecoder::new_streaming(
@@ -417,4 +626,37 @@ async fn build_source_from_play_input(
         }
     }?;
     Ok(PlaybackSource { built, is_seekable })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_stream_probe_failure_with_full_buffer_retry;
+
+    #[test]
+    fn retries_ranged_probe_timeouts_from_full_buffer() {
+        assert!(is_stream_probe_failure_with_full_buffer_retry(
+            "ranged-stream: format probe timed out after 20s",
+            Some("aiff"),
+        ));
+    }
+
+    #[test]
+    fn retries_legacy_aiff_probe_failures_from_full_buffer() {
+        assert!(is_stream_probe_failure_with_full_buffer_retry(
+            "track-stream: format probe failed: malformed stream: aiff: missing common element",
+            None,
+        ));
+        assert!(is_stream_probe_failure_with_full_buffer_retry(
+            "track-stream: format probe timed out after 20s",
+            Some("aif"),
+        ));
+    }
+
+    #[test]
+    fn does_not_retry_unrelated_legacy_stream_failures() {
+        assert!(!is_stream_probe_failure_with_full_buffer_retry(
+            "track-stream: format probe failed: unsupported format",
+            Some("mp3"),
+        ));
+    }
 }

--- a/src-tauri/crates/psysonic-audio/src/stream/mod.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream/mod.rs
@@ -17,6 +17,7 @@ mod ranged_http;
 mod reader;
 mod track_stream;
 
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 
 pub(crate) use mp4::{
@@ -40,6 +41,13 @@ pub(crate) fn container_hint_is_ogg(hint: Option<&str>) -> bool {
         "ogg" | "oga" | "ogx" | "opus" | "spx"
     )
 }
+
+/// AIFF permits chunks in any order. Symphonia must keep seekability during
+/// probing so it can scan past `SSND`, find `COMM`, then return to the audio.
+pub(crate) fn container_hint_is_aiff(hint: Option<&str>) -> bool {
+    let Some(h) = hint else { return false };
+    matches!(h.to_ascii_lowercase().as_str(), "aiff" | "aif" | "aifc")
+}
 pub(crate) use local_file::LocalFileSource;
 pub(crate) use radio::{RadioLiveState, RadioSharedFlags, radio_download_task};
 pub(crate) use ranged_http::{OnDemand, RangedHttpSource, ranged_download_task};
@@ -47,6 +55,61 @@ pub(crate) use reader::AudioStreamReader;
 pub(crate) use track_stream::track_download_task;
 
 pub(crate) type AnalysisSeedHold = Arc<Mutex<Option<(String, u64)>>>;
+
+/// Shared ownership state between an HTTP downloader and a full-buffer fallback.
+pub(crate) struct StreamDownloadControl {
+    pub(crate) done: Arc<AtomicBool>,
+    analysis_owner: AtomicU8,
+    fallback_succeeded: AtomicBool,
+    ended_without_reusable_bytes: AtomicBool,
+}
+
+impl StreamDownloadControl {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            done: Arc::new(AtomicBool::new(false)),
+            analysis_owner: AtomicU8::new(0),
+            fallback_succeeded: AtomicBool::new(false),
+            ended_without_reusable_bytes: AtomicBool::new(false),
+        })
+    }
+
+    pub(crate) fn claim_downloader_analysis(&self) -> bool {
+        self.analysis_owner
+            .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    pub(crate) fn mark_fallback_succeeded(&self) {
+        self.fallback_succeeded.store(true, Ordering::SeqCst);
+    }
+
+    pub(crate) fn request_fallback_analysis(&self) {
+        let _ = self
+            .analysis_owner
+            .compare_exchange(0, 2, Ordering::SeqCst, Ordering::SeqCst);
+    }
+
+    pub(crate) fn claim_fallback_analysis(&self) -> bool {
+        self.analysis_owner
+            .compare_exchange(2, 3, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    pub(crate) fn fallback_succeeded(&self) -> bool {
+        self.fallback_succeeded.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn mark_ended_without_reusable_bytes(&self) {
+        self.ended_without_reusable_bytes
+            .store(true, Ordering::SeqCst);
+        self.done.store(true, Ordering::SeqCst);
+    }
+
+    pub(crate) fn ended_without_reusable_bytes(&self) -> bool {
+        self.ended_without_reusable_bytes.load(Ordering::SeqCst)
+    }
+}
 
 /// Keeps HTTP backfill from downloading the same original while a playback
 /// stream is already collecting bytes that will seed analysis on completion.
@@ -185,6 +248,48 @@ pub(crate) async fn wait_for_ranged_mp4_probe_ready(gate: &RangedMp4ProbeGate) -
 
 /// Sleep interval when ring buffer is empty (prevents CPU spin).
 pub(crate) const RADIO_YIELD_MS: u64 = 2;
+
+#[cfg(test)]
+mod container_hint_tests {
+    use super::*;
+
+    #[test]
+    fn recognises_all_aiff_extensions() {
+        assert!(container_hint_is_aiff(Some("AIFF")));
+        assert!(container_hint_is_aiff(Some("aif")));
+        assert!(container_hint_is_aiff(Some("aifc")));
+        assert!(!container_hint_is_aiff(Some("wav")));
+    }
+}
+
+#[cfg(test)]
+mod stream_download_control_tests {
+    use super::*;
+
+    #[test]
+    fn analysis_has_one_owner_and_fallback_state_is_shared() {
+        let control = StreamDownloadControl::new();
+        control.request_fallback_analysis();
+        assert!(!control.claim_downloader_analysis());
+        assert!(control.claim_fallback_analysis());
+        assert!(!control.claim_fallback_analysis());
+        assert!(!control.fallback_succeeded());
+        assert!(!control.ended_without_reusable_bytes());
+        control.mark_fallback_succeeded();
+        assert!(control.fallback_succeeded());
+        control.mark_ended_without_reusable_bytes();
+        assert!(control.ended_without_reusable_bytes());
+        assert!(control.done.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn downloader_claim_prevents_late_fallback_claim() {
+        let control = StreamDownloadControl::new();
+        assert!(control.claim_downloader_analysis());
+        control.request_fallback_analysis();
+        assert!(!control.claim_fallback_analysis());
+    }
+}
 
 #[cfg(test)]
 mod analysis_seed_hold_tests {

--- a/src-tauri/crates/psysonic-audio/src/stream/ranged_http.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream/ranged_http.rs
@@ -25,13 +25,13 @@ use super::super::engine::PlaybackHttpHeaders;
 use super::super::state::PreloadedTrack;
 use super::{
     AnalysisSeedHoldGuard, RADIO_YIELD_MS, TRACK_READ_TIMEOUT_SECS, TRACK_STREAM_MAX_RECONNECTS,
-    TRACK_STREAM_PROMOTE_MAX_BYTES,
+    TRACK_STREAM_PROMOTE_MAX_BYTES, StreamDownloadControl,
 };
 use crate::analysis_dispatch::{
     analysis_priority_for_app, dispatch_track_analysis_bytes, resolve_server_id_for_app,
     spawn_track_analysis_file, TrackAnalysisDispatchOptions, TrackAnalysisOrigin,
 };
-use crate::helpers::{install_stream_completed_spill, write_stream_spill_file};
+use crate::helpers::{install_stream_completed_spill_if, write_stream_spill_file};
 use crate::state::StreamCompletedSpill;
 
 /// Minimum bytes fetched per on-demand Range request. A seek often triggers a
@@ -606,7 +606,7 @@ pub(crate) async fn ranged_download_task(
     initial_response: reqwest::Response,
     buf: Arc<Mutex<Vec<u8>>>,
     downloaded_to: Arc<AtomicUsize>,
-    done: Arc<AtomicBool>,
+    download_control: Arc<StreamDownloadControl>,
     promote_cache_slot: Arc<Mutex<Option<PreloadedTrack>>>,
     spill_cache_slot: Arc<Mutex<Option<StreamCompletedSpill>>>,
     normalization_engine: Arc<AtomicU32>,
@@ -625,6 +625,7 @@ pub(crate) async fn ranged_download_task(
     tail_ready: Arc<AtomicBool>,
     tail_filled_from: Arc<AtomicU64>,
 ) {
+    let done = download_control.done.clone();
     let total_size = buf.lock().unwrap().len();
     let dl_started = Instant::now();
     let mut last_partial_loudness_emit = Instant::now() - Duration::from_secs(5);
@@ -737,6 +738,9 @@ pub(crate) async fn ranged_download_task(
     if matches!(outcome, RangedHttpLoopOutcome::Superseded) {
         return;
     }
+    if download_control.fallback_succeeded() {
+        return;
+    }
 
     if downloaded < total_size {
         crate::app_eprintln!(
@@ -746,6 +750,8 @@ pub(crate) async fn ranged_download_task(
             dl_started.elapsed().as_secs_f64(),
             cache_track_id
         );
+        download_control.mark_ended_without_reusable_bytes();
+        return;
     } else {
         crate::app_deprintln!(
             "[stream] dl done: {} / {} bytes in {:.2}s",
@@ -757,7 +763,7 @@ pub(crate) async fn ranged_download_task(
 
     if downloaded == total_size && total_size > 0 {
         if total_size <= TRACK_STREAM_PROMOTE_MAX_BYTES {
-            if super::container_hint_is_mp4(format_hint.as_deref()) {
+            let invalid_mp4 = if super::container_hint_is_mp4(format_hint.as_deref()) {
                 let guard = buf.lock().unwrap();
                 if !super::isobmff_buffer_looks_complete(&guard) {
                     super::log_isobmff_buffer_diagnostic(
@@ -765,13 +771,23 @@ pub(crate) async fn ranged_download_task(
                         format_hint.as_deref(),
                         "ranged-dl-complete-incomplete",
                     );
+                    true
                 } else if super::mp4_suspect_zero_holes(&guard) {
                     super::log_isobmff_buffer_diagnostic(
                         &guard,
                         format_hint.as_deref(),
                         "ranged-dl-complete-zero-holes",
                     );
+                    true
+                } else {
+                    false
                 }
+            } else {
+                false
+            };
+            if invalid_mp4 {
+                download_control.mark_ended_without_reusable_bytes();
+                return;
             }
             if let Some(ref tid) = cache_track_id {
                 crate::app_deprintln!(
@@ -789,7 +805,20 @@ pub(crate) async fn ranged_download_task(
                     t_clone.elapsed().as_millis()
                 );
             }
-            if let Some(track_id) = cache_track_id {
+            let analysis_input = cache_track_id.clone().map(|track_id| (track_id, data.clone()));
+            {
+                let mut slot = promote_cache_slot.lock().unwrap();
+                if gen_arc.load(Ordering::SeqCst) != gen
+                    || download_control.fallback_succeeded()
+                {
+                    return;
+                }
+                *slot = Some(PreloadedTrack { url: url.clone(), data });
+            }
+            crate::app_deprintln!("[stream] promoted to stream_completed_cache for replay");
+            if let Some((track_id, analysis_data)) = analysis_input
+                .filter(|_| download_control.claim_downloader_analysis())
+            {
                 let sid = resolve_server_id_for_app(&app, server_id.as_deref());
                 let priority = analysis_priority_for_app(&app, &sid, &track_id, None);
                 let guard = (gen, gen_arc.clone());
@@ -798,7 +827,7 @@ pub(crate) async fn ranged_download_task(
                     TrackAnalysisOrigin::StreamDownloadComplete,
                     &sid,
                     &track_id,
-                    data.clone(),
+                    analysis_data,
                     Some(&url),
                     TrackAnalysisDispatchOptions {
                         priority,
@@ -813,11 +842,6 @@ pub(crate) async fn ranged_download_task(
                     }
                 }
             }
-            if gen_arc.load(Ordering::SeqCst) != gen {
-                return;
-            }
-            *promote_cache_slot.lock().unwrap() = Some(PreloadedTrack { url, data });
-            crate::app_deprintln!("[stream] promoted to stream_completed_cache for replay");
         } else if let Some(track_id) = cache_track_id.clone() {
             if gen_arc.load(Ordering::SeqCst) != gen {
                 return;
@@ -827,7 +851,11 @@ pub(crate) async fn ranged_download_task(
                 if gen_arc.load(Ordering::SeqCst) != gen {
                     return;
                 }
-                write_stream_spill_file(&app, &track_id, &spill_bytes)
+                write_stream_spill_file(
+                    &app,
+                    &format!("{track_id}-ranged-{gen}"),
+                    &spill_bytes,
+                )
             };
             match spill_result {
                 Ok(path) => {
@@ -842,19 +870,31 @@ pub(crate) async fn ranged_download_task(
                         return;
                     }
                     let spill_stream_url = url.clone();
-                    install_stream_completed_spill(&spill_cache_slot, url, path.clone());
+                    if !install_stream_completed_spill_if(
+                        &spill_cache_slot,
+                        url,
+                        path.clone(),
+                        || {
+                            gen_arc.load(Ordering::SeqCst) == gen
+                                && !download_control.fallback_succeeded()
+                        },
+                    ) {
+                        return;
+                    }
                     let sid = resolve_server_id_for_app(&app, server_id.as_deref());
                     let priority = analysis_priority_for_app(&app, &sid, &track_id, None);
-                    spawn_track_analysis_file(
-                        app.clone(),
-                        TrackAnalysisOrigin::StreamSpillFile,
-                        sid,
-                        track_id,
-                        path,
-                        Some(spill_stream_url), // spilled HTTP bytes keep stream provenance
-                        priority,
-                        Some((gen, gen_arc.clone())),
-                    );
+                    if download_control.claim_downloader_analysis() {
+                        spawn_track_analysis_file(
+                            app.clone(),
+                            TrackAnalysisOrigin::StreamSpillFile,
+                            sid,
+                            track_id,
+                            path,
+                            Some(spill_stream_url), // spilled HTTP bytes keep stream provenance
+                            priority,
+                            Some((gen, gen_arc.clone())),
+                        );
+                    }
                 }
                 Err(e) => {
                     crate::app_eprintln!(
@@ -862,8 +902,11 @@ pub(crate) async fn ranged_download_task(
                         track_id,
                         e
                     );
+                    download_control.mark_ended_without_reusable_bytes();
                 }
             }
+        } else {
+            download_control.mark_ended_without_reusable_bytes();
         }
     }
 }

--- a/src-tauri/crates/psysonic-audio/src/stream/track_stream.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream/track_stream.rs
@@ -12,29 +12,111 @@ use std::time::Duration;
 
 use futures_util::StreamExt;
 use ringbuf::HeapProd;
-use ringbuf::traits::Producer;
+use ringbuf::traits::{Observer, Producer};
 use tauri::AppHandle;
+use tokio::io::AsyncWriteExt;
 
 use super::super::engine::PlaybackHttpHeaders;
-use super::super::state::PreloadedTrack;
+use super::super::helpers::{install_stream_completed_spill_if, stream_spill_file_paths};
+use super::super::state::{PreloadedTrack, StreamCompletedSpill};
 use super::{
     AnalysisSeedHoldGuard, TRACK_STREAM_MAX_RECONNECTS, TRACK_STREAM_PROMOTE_MAX_BYTES,
-    maybe_arm_stream_playback,
+    StreamDownloadControl, maybe_arm_stream_playback,
 };
+
+struct LegacySpillCapture {
+    file: Option<tokio::fs::File>,
+    part_path: std::path::PathBuf,
+    final_path: std::path::PathBuf,
+    track_id: String,
+}
+
+impl LegacySpillCapture {
+    async fn start(
+        app: &AppHandle,
+        track_id: &str,
+        spill_key: &str,
+        buffered: &[u8],
+        next: &[u8],
+    ) -> Result<Self, String> {
+        let (final_path, part_path) = stream_spill_file_paths(app, spill_key)?;
+        let mut file = tokio::fs::File::create(&part_path)
+            .await
+            .map_err(|e| e.to_string())?;
+        if let Err(e) = file.write_all(buffered).await {
+            drop(file);
+            let _ = tokio::fs::remove_file(&part_path).await;
+            return Err(e.to_string());
+        }
+        if let Err(e) = file.write_all(next).await {
+            drop(file);
+            let _ = tokio::fs::remove_file(&part_path).await;
+            return Err(e.to_string());
+        }
+        Ok(Self {
+            file: Some(file),
+            part_path,
+            final_path,
+            track_id: track_id.to_string(),
+        })
+    }
+
+    async fn finish(mut self) -> Result<(String, std::path::PathBuf), String> {
+        if let Some(mut file) = self.file.take() {
+            file.flush().await.map_err(|e| e.to_string())?;
+        }
+        if self.final_path.exists() {
+            let _ = tokio::fs::remove_file(&self.final_path).await;
+        }
+        tokio::fs::rename(&self.part_path, &self.final_path)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok((self.track_id.clone(), self.final_path.clone()))
+    }
+}
+
+impl Drop for LegacySpillCapture {
+    fn drop(&mut self) {
+        drop(self.file.take());
+        let _ = std::fs::remove_file(&self.part_path);
+    }
+}
 
 fn finish_legacy_stream_download(
     completed: Option<PreloadedTrack>,
     promote_cache_slot: &Mutex<Option<PreloadedTrack>>,
+    download_control: &StreamDownloadControl,
+    gen: u64,
+    gen_arc: &AtomicU64,
     playback_armed: &AtomicBool,
-    done: &AtomicBool,
     after_publish: impl FnOnce(),
 ) {
-    if let Some(completed) = completed {
-        *promote_cache_slot.lock().unwrap() = Some(completed);
-    }
+    let run_after_publish = if let Some(completed) = completed {
+        let mut slot = promote_cache_slot.lock().unwrap();
+        if gen_arc.load(Ordering::SeqCst) == gen && !download_control.fallback_succeeded() {
+            *slot = Some(completed);
+            true
+        } else {
+            false
+        }
+    } else {
+        true
+    };
     playback_armed.store(true, Ordering::SeqCst);
-    done.store(true, Ordering::SeqCst);
-    after_publish();
+    download_control.done.store(true, Ordering::SeqCst);
+    if run_after_publish {
+        after_publish();
+    }
+}
+
+fn push_slice_or_skip_closed_consumer(prod: &mut HeapProd<u8>, bytes: &[u8]) -> (usize, bool) {
+    if prod.read_is_held() {
+        (prod.push_slice(bytes), true)
+    } else {
+        // Decoder setup failed and dropped the consumer. Keep downloading into
+        // the bounded capture so the full-buffer retry and Hot Cache can reuse it.
+        (bytes.len(), false)
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -46,8 +128,9 @@ pub(crate) async fn track_download_task(
     url: String,
     initial_response: reqwest::Response,
     mut prod: HeapProd<u8>,
-    done: Arc<AtomicBool>,
+    download_control: Arc<StreamDownloadControl>,
     promote_cache_slot: Arc<Mutex<Option<PreloadedTrack>>>,
+    spill_cache_slot: Arc<Mutex<Option<StreamCompletedSpill>>>,
     cache_track_id: Option<String>,
     // Playback server scope for the analysis-cache write key (empty/`None` → legacy '').
     server_id: Option<String>,
@@ -55,11 +138,13 @@ pub(crate) async fn track_download_task(
     http_headers: PlaybackHttpHeaders,
     playback_armed: Arc<AtomicBool>,
 ) {
+    let done = download_control.done.clone();
     let mut downloaded: u64 = 0;
     let mut reconnects: u32 = 0;
     let mut next_response: Option<reqwest::Response> = Some(initial_response);
     let mut capture: Vec<u8> = Vec::new();
     let mut capture_over_limit = false;
+    let mut spill_capture: Option<LegacySpillCapture> = None;
     'outer: loop {
         let response = if let Some(r) = next_response.take() {
             r
@@ -77,7 +162,7 @@ pub(crate) async fn track_download_task(
                             "[audio] streaming reconnect failed after {} attempts: {}",
                             reconnects, err
                         );
-                        done.store(true, Ordering::SeqCst);
+                        download_control.mark_ended_without_reusable_bytes();
                         return;
                     }
                     reconnects += 1;
@@ -91,12 +176,12 @@ pub(crate) async fn track_download_task(
                 "[audio] streaming reconnect returned {}, expected 206 for range resume",
                 response.status()
             );
-            done.store(true, Ordering::SeqCst);
+            download_control.mark_ended_without_reusable_bytes();
             return;
         }
         if downloaded == 0 && !response.status().is_success() {
             crate::app_eprintln!("[audio] streaming HTTP {}", response.status());
-            done.store(true, Ordering::SeqCst);
+            download_control.mark_ended_without_reusable_bytes();
             return;
         }
 
@@ -118,7 +203,7 @@ pub(crate) async fn track_download_task(
                             "[audio] streaming download error after {} reconnects: {}",
                             reconnects, e
                         );
-                        done.store(true, Ordering::SeqCst);
+                        download_control.mark_ended_without_reusable_bytes();
                         return;
                     }
                     reconnects += 1;
@@ -139,25 +224,133 @@ pub(crate) async fn track_download_task(
                     done.store(true, Ordering::SeqCst);
                     return;
                 }
-                let pushed = prod.push_slice(&chunk[offset..]);
+                let (pushed, consumer_active) =
+                    push_slice_or_skip_closed_consumer(&mut prod, &chunk[offset..]);
                 if pushed == 0 {
                     tokio::time::sleep(Duration::from_millis(5)).await;
                 } else {
-                    if !capture_over_limit {
-                        if capture.len().saturating_add(pushed) <= TRACK_STREAM_PROMOTE_MAX_BYTES {
-                            let from = offset;
-                            let to = offset + pushed;
-                            capture.extend_from_slice(&chunk[from..to]);
+                    let from = offset;
+                    let to = offset + pushed;
+                    let pushed_bytes = &chunk[from..to];
+                    if let Some(spill) = spill_capture.as_mut() {
+                        if let Some(file) = spill.file.as_mut() {
+                            if let Err(e) = file.write_all(pushed_bytes).await {
+                                crate::app_eprintln!(
+                                    "[stream] legacy spill append failed track_id={:?}: {}",
+                                    cache_track_id,
+                                    e
+                                );
+                                spill_capture = None;
+                            }
+                        }
+                    } else if !capture_over_limit {
+                        if capture.len().saturating_add(pushed)
+                            <= TRACK_STREAM_PROMOTE_MAX_BYTES
+                        {
+                            capture.extend_from_slice(pushed_bytes);
                         } else {
+                            if let Some(track_id) = cache_track_id.as_deref() {
+                                match LegacySpillCapture::start(
+                                    &app,
+                                    track_id,
+                                    &format!("{track_id}-legacy-{gen}"),
+                                    &capture,
+                                    pushed_bytes,
+                                )
+                                .await
+                                {
+                                    Ok(spill) => {
+                                        crate::app_deprintln!(
+                                            "[stream] legacy stream exceeded RAM capture cap — spilling track_id={track_id}"
+                                        );
+                                        spill_capture = Some(spill);
+                                    }
+                                    Err(e) => crate::app_eprintln!(
+                                        "[stream] legacy spill start failed track_id={track_id}: {e}"
+                                    ),
+                                }
+                            }
                             capture.clear();
                             capture_over_limit = true;
                         }
                     }
                     offset += pushed;
                     downloaded += pushed as u64;
-                    maybe_arm_stream_playback(downloaded, &playback_armed);
+                    if consumer_active {
+                        maybe_arm_stream_playback(downloaded, &playback_armed);
+                    }
                 }
             }
+        }
+        let completed_spill = match spill_capture.take() {
+            Some(spill) => match spill.finish().await {
+                Ok(completed) => Some(completed),
+                Err(e) => {
+                    crate::app_eprintln!("[stream] legacy spill finalize failed: {e}");
+                    None
+                }
+            },
+            None => None,
+        };
+        if let Some((track_id, path)) = completed_spill {
+            if gen_arc.load(Ordering::SeqCst) != gen {
+                let _ = tokio::fs::remove_file(path).await;
+                done.store(true, Ordering::SeqCst);
+                return;
+            }
+            crate::app_deprintln!(
+                "[stream] legacy stream spilled to disk track_id={} size_mib={:.2} path={}",
+                track_id,
+                downloaded as f64 / (1024.0 * 1024.0),
+                path.display()
+            );
+            if !install_stream_completed_spill_if(
+                &spill_cache_slot,
+                url.clone(),
+                path.clone(),
+                || {
+                    gen_arc.load(Ordering::SeqCst) == gen
+                        && !download_control.fallback_succeeded()
+                },
+            ) {
+                done.store(true, Ordering::SeqCst);
+                return;
+            }
+            let analysis_gen_arc = gen_arc.clone();
+            finish_legacy_stream_download(
+                None,
+                &promote_cache_slot,
+                &download_control,
+                gen,
+                &gen_arc,
+                &playback_armed,
+                || {
+                    let sid = crate::analysis_dispatch::resolve_server_id_for_app(
+                        &app,
+                        server_id.as_deref(),
+                    );
+                    let priority = crate::analysis_dispatch::analysis_priority_for_app(
+                        &app, &sid, &track_id, None,
+                    );
+                    if download_control.claim_downloader_analysis() {
+                        crate::analysis_dispatch::spawn_track_analysis_file(
+                            app,
+                            crate::analysis_dispatch::TrackAnalysisOrigin::StreamSpillFile,
+                            sid,
+                            track_id,
+                            path,
+                            Some(url),
+                            priority,
+                            Some((gen, analysis_gen_arc)),
+                        );
+                    }
+                },
+            );
+            return;
+        }
+        if download_control.fallback_succeeded() {
+            done.store(true, Ordering::SeqCst);
+            return;
         }
         let (completed, analysis_capture) = if !capture_over_limit && !capture.is_empty() {
             if gen_arc.load(Ordering::SeqCst) != gen {
@@ -175,13 +368,22 @@ pub(crate) async fn track_download_task(
         } else {
             (None, None)
         };
+        if completed.is_none() {
+            download_control.mark_ended_without_reusable_bytes();
+        }
+        let analysis_gen_arc = gen_arc.clone();
         finish_legacy_stream_download(
             completed,
             &promote_cache_slot,
+            &download_control,
+            gen,
+            &gen_arc,
             &playback_armed,
-            &done,
             || {
                 if let (Some(track_id), Some(capture)) = (cache_track_id, analysis_capture) {
+                    if !download_control.claim_downloader_analysis() {
+                        return;
+                    }
                     crate::app_deprintln!(
                         "[stream] legacy stream: capture complete track_id={} capture_mib={:.2} — full-track analysis (cpu-seed queue)",
                         track_id,
@@ -202,7 +404,7 @@ pub(crate) async fn track_download_task(
                         capture,
                         Some(url),
                         priority,
-                        Some((gen, gen_arc)),
+                        Some((gen, analysis_gen_arc)),
                     );
                 }
             },
@@ -214,14 +416,31 @@ pub(crate) async fn track_download_task(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ringbuf::HeapRb;
+    use ringbuf::traits::Split;
+
+    #[test]
+    fn closed_consumer_advances_without_filling_the_ring() {
+        let rb = HeapRb::<u8>::new(8);
+        let (mut prod, cons) = rb.split();
+        drop(cons);
+
+        let (advanced, consumer_active) =
+            push_slice_or_skip_closed_consumer(&mut prod, &[1, 2, 3, 4]);
+        assert_eq!(advanced, 4);
+        assert!(!consumer_active);
+        assert_eq!(prod.occupied_len(), 0);
+    }
 
     #[test]
     fn completion_publishes_before_analysis_callback() {
         let body = vec![0xAB; 2048];
-        let done = Arc::new(AtomicBool::new(false));
+        let download_control = StreamDownloadControl::new();
+        let done = download_control.done.clone();
         let completed = Arc::new(Mutex::new(None));
         let playback_armed = Arc::new(AtomicBool::new(false));
         let analysis_started = AtomicBool::new(false);
+        let generation = AtomicU64::new(7);
 
         finish_legacy_stream_download(
             Some(PreloadedTrack {
@@ -229,8 +448,10 @@ mod tests {
                 data: body.clone(),
             }),
             &completed,
+            &download_control,
+            7,
+            &generation,
             &playback_armed,
-            &done,
             || {
                 let completed = completed.lock().unwrap();
                 assert_eq!(completed.as_ref().unwrap().data, body);

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -212,6 +212,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Multi-server scope recovery and redacted selectable-depth diagnostics for reachability, music folders, and New Releases (PR #1331)',
       'Cover pipeline — Navidrome per-disc art in queue, playbar and Who is listening?; All Albums warm no longer creates mf-* album dirs (PR #1336)',
       'Performance benchmark CLI and faster scoped library browsing (PR #1382)',
+      'AIFF/AIF/AIFC playback across streamed, cached, and local sources (PR #1396)',
     ],
   },
   {

--- a/src/lib/media/streamFormat.test.ts
+++ b/src/lib/media/streamFormat.test.ts
@@ -29,9 +29,10 @@ describe('isStreamTranscoded', () => {
     expect(isStreamTranscoded('ogg', 'opus')).toBe(false);
   });
 
-  it('normalizes pcm_* decoder names against wav', () => {
+  it('normalizes pcm_* decoder names against PCM containers', () => {
     expect(isStreamTranscoded('wav', 'pcm_s16le')).toBe(false);
     expect(isStreamTranscoded('wav', 'pcm_f32le')).toBe(false);
+    expect(isStreamTranscoded('aifc', 'pcm_alaw')).toBe(false);
   });
 
   it('is conservative for unknown suffix / missing codec', () => {

--- a/src/lib/media/streamFormat.ts
+++ b/src/lib/media/streamFormat.ts
@@ -71,6 +71,7 @@ const SUFFIX_CODECS: Record<string, readonly string[]> = {
   wave: ['pcm'],
   aiff: ['pcm'],
   aif: ['pcm'],
+  aifc: ['pcm'],
   wv: ['wavpack'],
   wavpack: ['wavpack'],
   ape: ['monkeys-audio'],


### PR DESCRIPTION
## Summary
- enable Symphonia AIFF/AIF/AIFC decoding across playback and analysis crates
- detect AIFF from suffixes, URLs, MIME headers, content disposition, and FORM magic
- preserve seekability for valid AIFF chunk ordering such as SSND before COMM
- add generation-safe full-buffer fallback ownership for ranged and non-ranged streams, including large-file spill and Hot Cache promotion
- report AIFC as a PCM container in the frontend

Closes #1258

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (547 files, 4,014 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- `cargo clippy --workspace --all-targets -- -D warnings`
- targeted AIFF, analysis, source fallback, and stream tests
- full Rust workspace: 772 passed; two unrelated SQLite wall-clock budget tests exceeded their thresholds only under parallel load and both passed individually in about 70 ms
- production decoder opened and decoded the reported 48 MB AIFF file

## Tauri boundary
No commands, events, or payload shapes were added or changed.

## Runtime benchmark
- Applicability: not applicable (`core-pages`/`all-pages` measure route readiness and do not exercise audio decoding or stream fallback)
- Focused runtime evidence: reported AIFF file decoded through the production source path

## Follow-up
`source_build.rs` is above the project soft size trigger after the ownership-safe fallback work; extracting the fallback pipeline is a reasonable follow-up once this bug fix lands.