### PR TITLE
fix(radio): preserve station homepage URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,6 +379,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * AIFF, AIF and AIFC tracks now play from servers, local files and playback caches, including files whose metadata appears after their audio data.
 * Servers without byte-range support now fall back to a complete download instead of leaving the track unable to start.
 
+### Internet radio — keep homepage URLs when editing stations
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1397](https://github.com/Psychotoxical/psysonic/pull/1397)**, reported by [@vt100-music](https://github.com/vt100-music)
+
+* Homepage URLs supplied by Navidrome no longer disappear from station cards or the edit form after saving or reloading the station.
+
 ## [1.50.0]
 
 ## Added

--- a/src/lib/api/subsonicRadio.server.test.ts
+++ b/src/lib/api/subsonicRadio.server.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/lib/server/serverEndpoint', () => ({
 import {
   createInternetRadioStationForServer,
   deleteInternetRadioStationForServer,
+  getInternetRadioStationsForServer,
   getInternetRadioStationsForServersSettled,
   updateInternetRadioStationForServer,
   uploadRadioCoverArtBytesForServer,
@@ -88,6 +89,27 @@ describe('subsonicRadio explicit server ownership', () => {
       ],
       failedServerIds: ['srv-b'],
     });
+  });
+
+  it('normalises the Subsonic homePageUrl response field', async () => {
+    hoisted.apiForServer.mockResolvedValue({
+      internetRadioStations: {
+        internetRadioStation: [{
+          id: 'radio-1',
+          name: 'Station',
+          streamUrl: 'https://radio.test/live',
+          homePageUrl: 'https://radio.test',
+        }],
+      },
+    });
+
+    await expect(getInternetRadioStationsForServer('srv-owner')).resolves.toEqual([{
+      id: 'radio-1',
+      serverId: 'srv-owner',
+      name: 'Station',
+      streamUrl: 'https://radio.test/live',
+      homepageUrl: 'https://radio.test',
+    }]);
   });
 
   it('routes create, update, delete, and cover upload to the captured owner', async () => {

--- a/src/lib/api/subsonicRadio.ts
+++ b/src/lib/api/subsonicRadio.ts
@@ -7,12 +7,20 @@ import { shouldAttemptSubsonicForServer } from '@/lib/network/subsonicNetworkGua
 import { findServerByIdOrIndexKey } from '@/lib/server/serverLookup';
 import { connectBaseUrlForServer } from '@/lib/server/serverEndpoint';
 
+type InternetRadioStationResponse = InternetRadioStation & {
+  homePageUrl?: string;
+};
+
 type InternetRadioResponse = {
-  internetRadioStations?: { internetRadioStation?: InternetRadioStation[] };
+  internetRadioStations?: { internetRadioStation?: InternetRadioStationResponse[] };
 };
 
 function radioStationsFromResponse(data: InternetRadioResponse): InternetRadioStation[] {
-  return data.internetRadioStations?.internetRadioStation ?? [];
+  return (data.internetRadioStations?.internetRadioStation ?? []).map(({ homePageUrl, ...station }) => (
+    homePageUrl && station.homepageUrl === undefined
+      ? { ...station, homepageUrl: homePageUrl }
+      : station
+  ));
 }
 
 export async function getInternetRadioStations(): Promise<InternetRadioStation[]> {


### PR DESCRIPTION
## Summary
- normalize Navidrome/Subsonic `homePageUrl` responses to Psysonic's internal `homepageUrl` field
- keep homepage URLs visible when reopening an internet radio station for editing
- add regression coverage using the real response field casing

Closes #1395

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (547 files, 4015 tests)
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`

## Runtime benchmark
- Applicability: smoke, because `/radio` is covered by `all-pages` and its load behaviour changes
- Final: `78370b33` / report `2026-08-07T10-09-32-775Z`
- Command: `psysonic benchmark run --scenario all-pages --runs 2 --profile realistic --json`
- Environment: 1282x694 viewport, 1 selected server, stable library scope
- Affected route: `/radio`
- Result: cold `765 ms`, warm `772 ms`; no errors, timeouts, readiness timeouts, or route mismatch
- Skips: unrelated composer and label detail routes lacked representative data

## Boundary and storage
- Tauri commands/events: unchanged
- Persisted settings/on-disk layout: unchanged