### PR TITLE
Fix Linux playback speed and queue advancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,6 +385,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Homepage URLs supplied by Navidrome no longer disappear from station cards or the edit form after saving or reloading the station.
 
+### Linux playback — keep speed, pitch and queue advancement correct
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1398](https://github.com/Psychotoxical/psysonic/pull/1398)**
+
+* ALSA and PipeWire devices that select a different sample rate no longer play tracks at half or double speed with shifted pitch. Native Hi-Res remains available, and fallback output configurations verify the rate the device actually accepted.
+* Hi-Res and gapless source replacement no longer loses the track-completion signal, so playback advances to the next queued track reliably.
+
 ## [1.50.0]
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,7 +389,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#1398](https://github.com/Psychotoxical/psysonic/pull/1398)**
 
-* ALSA and PipeWire devices that select a different sample rate no longer play tracks at half or double speed with shifted pitch. Native Hi-Res remains available, and fallback output configurations verify the rate the device actually accepted.
+* ALSA and PipeWire devices that select a different sample rate no longer play tracks at half or double speed with shifted pitch. Native Hi-Res remains available, and the selected output configuration verifies the rate the device actually accepted.
 * Hi-Res and gapless source replacement no longer loses the track-completion signal, so playback advances to the next queued track reliably.
 
 ### Servers — prevent duplicate account profiles

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4208,6 +4208,7 @@ dependencies = [
 name = "psysonic-audio"
 version = "1.51.0-dev"
 dependencies = [
+ "alsa",
  "biquad",
  "dasp_sample",
  "futures-util",

--- a/src-tauri/crates/psysonic-audio/Cargo.toml
+++ b/src-tauri/crates/psysonic-audio/Cargo.toml
@@ -34,6 +34,7 @@ pitch_shift = "2.1"
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+alsa = "0.11"
 zbus = { version = "5.16", default-features = false, features = ["blocking-api", "async-io"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/src-tauri/crates/psysonic-audio/src/alsa_rate.rs
+++ b/src-tauri/crates/psysonic-audio/src/alsa_rate.rs
@@ -1,0 +1,103 @@
+//! Linux ALSA sample-rate negotiation guard for CPAL/Rodio output streams.
+
+use alsa::pcm::{Access, Format, HwParams, PCM};
+use alsa::{Direction, ValueOr};
+use rodio::cpal::traits::DeviceTrait;
+use rodio::cpal::{Device, SampleFormat, SupportedStreamConfig};
+
+fn alsa_format_candidates(format: SampleFormat) -> Option<(Format, Option<Format>)> {
+    Some(match format {
+        SampleFormat::I8 => (Format::S8, None),
+        SampleFormat::U8 => (Format::U8, None),
+        #[cfg(target_endian = "little")]
+        SampleFormat::I16 => (Format::S16LE, Some(Format::S16BE)),
+        #[cfg(target_endian = "big")]
+        SampleFormat::I16 => (Format::S16BE, Some(Format::S16LE)),
+        #[cfg(target_endian = "little")]
+        SampleFormat::I24 => (Format::S24LE, Some(Format::S24BE)),
+        #[cfg(target_endian = "big")]
+        SampleFormat::I24 => (Format::S24BE, Some(Format::S24LE)),
+        #[cfg(target_endian = "little")]
+        SampleFormat::I32 => (Format::S32LE, Some(Format::S32BE)),
+        #[cfg(target_endian = "big")]
+        SampleFormat::I32 => (Format::S32BE, Some(Format::S32LE)),
+        #[cfg(target_endian = "little")]
+        SampleFormat::U16 => (Format::U16LE, Some(Format::U16BE)),
+        #[cfg(target_endian = "big")]
+        SampleFormat::U16 => (Format::U16BE, Some(Format::U16LE)),
+        #[cfg(target_endian = "little")]
+        SampleFormat::U24 => (Format::U24LE, Some(Format::U24BE)),
+        #[cfg(target_endian = "big")]
+        SampleFormat::U24 => (Format::U24BE, Some(Format::U24LE)),
+        #[cfg(target_endian = "little")]
+        SampleFormat::U32 => (Format::U32LE, Some(Format::U32BE)),
+        #[cfg(target_endian = "big")]
+        SampleFormat::U32 => (Format::U32BE, Some(Format::U32LE)),
+        #[cfg(target_endian = "little")]
+        SampleFormat::F32 => (Format::FloatLE, Some(Format::FloatBE)),
+        #[cfg(target_endian = "big")]
+        SampleFormat::F32 => (Format::FloatBE, Some(Format::FloatLE)),
+        #[cfg(target_endian = "little")]
+        SampleFormat::F64 => (Format::Float64LE, Some(Format::Float64BE)),
+        #[cfg(target_endian = "big")]
+        SampleFormat::F64 => (Format::Float64BE, Some(Format::Float64LE)),
+        _ => return None,
+    })
+}
+
+fn alsa_format(params: &HwParams<'_>, format: SampleFormat) -> Option<Format> {
+    let (native, opposite) = alsa_format_candidates(format)?;
+    if params.test_format(native).is_ok() {
+        Some(native)
+    } else {
+        opposite.filter(|candidate| params.test_format(*candidate).is_ok())
+    }
+}
+
+/// Mirror CPAL's ALSA format/rate/channel constraints and return the rate ALSA
+/// actually selects. CPAL 0.17 uses `ValueOr::Nearest` but retains the requested
+/// rate in its callback configuration, which changes playback speed when ALSA
+/// silently chooses another rate.
+pub(super) fn negotiated_output_rate(
+    device: &Device,
+    config: &SupportedStreamConfig,
+) -> Option<u32> {
+    let pcm_id = device.description().ok()?.driver()?.to_string();
+    let pcm = PCM::new(&pcm_id, Direction::Playback, true).ok()?;
+    let params = HwParams::any(&pcm).ok()?;
+    params.set_access(Access::RWInterleaved).ok()?;
+    params
+        .set_format(alsa_format(&params, config.sample_format())?)
+        .ok()?;
+    params
+        .set_rate(config.sample_rate(), ValueOr::Nearest)
+        .ok()?;
+    params.set_channels(config.channels() as u32).ok()?;
+    params.get_rate().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_formats_used_by_cpal_alsa_output() {
+        for format in [
+            SampleFormat::I8,
+            SampleFormat::I16,
+            SampleFormat::I24,
+            SampleFormat::I32,
+            SampleFormat::U8,
+            SampleFormat::U16,
+            SampleFormat::U24,
+            SampleFormat::U32,
+            SampleFormat::F32,
+            SampleFormat::F64,
+        ] {
+            assert!(
+                alsa_format_candidates(format).is_some(),
+                "missing mapping for {format}"
+            );
+        }
+    }
+}

--- a/src-tauri/crates/psysonic-audio/src/alsa_rate.rs
+++ b/src-tauri/crates/psysonic-audio/src/alsa_rate.rs
@@ -61,19 +61,36 @@ fn alsa_format(params: &HwParams<'_>, format: SampleFormat) -> Option<Format> {
 pub(super) fn negotiated_output_rate(
     device: &Device,
     config: &SupportedStreamConfig,
-) -> Option<u32> {
-    let pcm_id = device.description().ok()?.driver()?.to_string();
-    let pcm = PCM::new(&pcm_id, Direction::Playback, true).ok()?;
-    let params = HwParams::any(&pcm).ok()?;
-    params.set_access(Access::RWInterleaved).ok()?;
+) -> Result<u32, String> {
+    let description = device
+        .description()
+        .map_err(|error| format!("failed to describe ALSA output device: {error}"))?;
+    let pcm_id = description
+        .driver()
+        .ok_or_else(|| "ALSA output device has no PCM identifier".to_string())?
+        .to_string();
+    let pcm = PCM::new(&pcm_id, Direction::Playback, true)
+        .map_err(|error| format!("failed to open ALSA PCM '{pcm_id}': {error}"))?;
+    let params = HwParams::any(&pcm)
+        .map_err(|error| format!("failed to query ALSA hardware parameters: {error}"))?;
     params
-        .set_format(alsa_format(&params, config.sample_format())?)
-        .ok()?;
+        .set_access(Access::RWInterleaved)
+        .map_err(|error| format!("failed to select ALSA interleaved access: {error}"))?;
+    params
+        .set_format(
+            alsa_format(&params, config.sample_format())
+                .ok_or_else(|| format!("ALSA does not support {} output", config.sample_format()))?,
+        )
+        .map_err(|error| format!("failed to select ALSA sample format: {error}"))?;
     params
         .set_rate(config.sample_rate(), ValueOr::Nearest)
-        .ok()?;
-    params.set_channels(config.channels() as u32).ok()?;
-    params.get_rate().ok()
+        .map_err(|error| format!("failed to negotiate ALSA sample rate: {error}"))?;
+    params
+        .set_channels(config.channels() as u32)
+        .map_err(|error| format!("failed to select ALSA channel count: {error}"))?;
+    params
+        .get_rate()
+        .map_err(|error| format!("failed to read negotiated ALSA sample rate: {error}"))
 }
 
 #[cfg(test)]
@@ -82,22 +99,35 @@ mod tests {
 
     #[test]
     fn maps_formats_used_by_cpal_alsa_output() {
-        for format in [
-            SampleFormat::I8,
-            SampleFormat::I16,
-            SampleFormat::I24,
-            SampleFormat::I32,
-            SampleFormat::U8,
-            SampleFormat::U16,
-            SampleFormat::U24,
-            SampleFormat::U32,
-            SampleFormat::F32,
-            SampleFormat::F64,
-        ] {
-            assert!(
-                alsa_format_candidates(format).is_some(),
-                "missing mapping for {format}"
-            );
+        let mut expected = vec![
+            (SampleFormat::I8, (Format::S8, None)),
+            (SampleFormat::U8, (Format::U8, None)),
+        ];
+        #[cfg(target_endian = "little")]
+        expected.extend([
+            (SampleFormat::I16, (Format::S16LE, Some(Format::S16BE))),
+            (SampleFormat::I24, (Format::S24LE, Some(Format::S24BE))),
+            (SampleFormat::I32, (Format::S32LE, Some(Format::S32BE))),
+            (SampleFormat::U16, (Format::U16LE, Some(Format::U16BE))),
+            (SampleFormat::U24, (Format::U24LE, Some(Format::U24BE))),
+            (SampleFormat::U32, (Format::U32LE, Some(Format::U32BE))),
+            (SampleFormat::F32, (Format::FloatLE, Some(Format::FloatBE))),
+            (SampleFormat::F64, (Format::Float64LE, Some(Format::Float64BE))),
+        ]);
+        #[cfg(target_endian = "big")]
+        expected.extend([
+            (SampleFormat::I16, (Format::S16BE, Some(Format::S16LE))),
+            (SampleFormat::I24, (Format::S24BE, Some(Format::S24LE))),
+            (SampleFormat::I32, (Format::S32BE, Some(Format::S32LE))),
+            (SampleFormat::U16, (Format::U16BE, Some(Format::U16LE))),
+            (SampleFormat::U24, (Format::U24BE, Some(Format::U24LE))),
+            (SampleFormat::U32, (Format::U32BE, Some(Format::U32LE))),
+            (SampleFormat::F32, (Format::FloatBE, Some(Format::FloatLE))),
+            (SampleFormat::F64, (Format::Float64BE, Some(Format::Float64LE))),
+        ]);
+
+        for (format, mapping) in expected {
+            assert_eq!(alsa_format_candidates(format), Some(mapping), "{format}");
         }
     }
 }

--- a/src-tauri/crates/psysonic-audio/src/commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/commands.rs
@@ -399,9 +399,13 @@ pub async fn audio_play(
     }
 
     let current_stream_rate = state.stream_sample_rate.load(Ordering::Relaxed);
+    let current_requested_rate = state.stream_requested_rate.load(Ordering::Relaxed);
     let outgoing_blend: Option<OutgoingBlendSnapshot> =
         if let Some(blend) = blend_rate {
-            if crossfade_enabled && current_stream_rate > 0 && current_stream_rate != blend {
+            if crossfade_enabled
+                && current_requested_rate > 0
+                && current_requested_rate != blend
+            {
                 hi_res_blend::capture_outgoing_blend_snapshot(
                     &state,
                     outgoing_fade_secs,
@@ -433,7 +437,8 @@ pub async fn audio_play(
         } else {
             state.device_default_rate // restore device default
         };
-        let needs_switch = target_rate > 0 && target_rate != current_stream_rate;
+        let needs_switch =
+            super::engine::stream_rate_needs_switch(target_rate, current_requested_rate);
         if needs_switch {
             let dev = state.selected_device.lock().unwrap().clone();
             match super::engine::open_output_stream_blocking(
@@ -816,8 +821,9 @@ pub async fn audio_chain_preload(
     // Hi-res gapless: resample the chained track to the blend rate and realign
     // the output stream when its Hz differs from the current track.
     let stream_rate = state.stream_sample_rate.load(Ordering::Relaxed);
+    let requested_stream_rate = state.stream_requested_rate.load(Ordering::Relaxed);
     if let Some(br) = blend_rate {
-        if stream_rate > 0 && stream_rate != br {
+        if super::engine::stream_rate_needs_switch(br, requested_stream_rate) {
             if let Some(snap) = hi_res_blend::capture_outgoing_blend_snapshot(&state, 0.0, 0.0) {
                 hi_res_blend::detach_current_sink_for_blend_reopen(&state);
                 let dev = state.selected_device.lock().unwrap().clone();
@@ -859,10 +865,12 @@ pub async fn audio_chain_preload(
         }
     } else {
         let next_rate = if hi_res_enabled { built.output_rate } else { 44_100 };
-        if hi_res_enabled && stream_rate > 0 && next_rate != stream_rate {
+        if hi_res_enabled
+            && super::engine::stream_rate_needs_switch(next_rate, requested_stream_rate)
+        {
             crate::app_eprintln!(
                 "[psysonic] gapless chain skipped: next track rate {} Hz ≠ stream {} Hz",
-                next_rate, stream_rate
+                next_rate, requested_stream_rate
             );
             restore_chain_preload_if_current(&state, snapshot, &url, &raw_bytes);
             return Ok(());

--- a/src-tauri/crates/psysonic-audio/src/commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/commands.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::StreamExt;
-use rodio::Player;
 use rodio::Source;
 use tauri::{AppHandle, Emitter, State};
 
@@ -154,7 +153,10 @@ pub async fn audio_play(
 
     // Bump generation first so the old progress task stops before we peel
     // chained_info (avoids a race where it sees current_done + empty chain).
-    let gen = state.generation.fetch_add(1, Ordering::SeqCst) + 1;
+    let gen = {
+        let _commit_guard = state.playback_commit_lock.lock().unwrap();
+        state.generation.fetch_add(1, Ordering::SeqCst) + 1
+    };
     // Ranged/legacy HTTP paths reset this to false in `select_play_input`.
     state.stream_playback_armed.store(true, Ordering::SeqCst);
 
@@ -454,10 +456,11 @@ pub async fn audio_play(
                         tokio::time::sleep(Duration::from_millis(150)).await;
                     }
                 }
-                Err(_) => {
+                Err(error) => {
                     crate::app_eprintln!(
-                        "[psysonic] stream rate switch timed out, keeping {current_stream_rate} Hz"
+                        "[psysonic] stream rate switch failed from {current_stream_rate} Hz: {error}"
                     );
+                    return Err(error);
                 }
             }
         }
@@ -485,8 +488,10 @@ pub async fn audio_play(
         }
     }
 
-    let stream = super::engine::ensure_output_stream_open(&state)?;
-    let sink = Arc::new(Player::connect_new(stream.mixer()));
+    let (sink, stream_attach) = super::engine::connect_new_player(&state)?;
+    if state.generation.load(Ordering::SeqCst) != gen {
+        return Ok(());
+    }
     sink.set_volume(effective_volume);
 
     // ── Sink pre-fill for hi-res tracks ──────────────────────────────────────
@@ -566,6 +571,11 @@ pub async fn audio_play(
         }
     }
 
+    let commit_guard = state.playback_commit_lock.lock().unwrap();
+    if state.generation.load(Ordering::SeqCst) != gen {
+        return Ok(());
+    }
+
     swap_in_new_sink(&state, SinkSwapInputs {
         sink,
         duration_secs,
@@ -578,6 +588,7 @@ pub async fn audio_play(
         outgoing_fade_secs,
         start_paused,
     });
+    drop(stream_attach);
 
     // B-head: `swap_in_new_sink` resets `seek_offset` to 0 and starts the play
     // clock — re-anchor both the wall-clock baseline (`seek_offset`) and the
@@ -597,6 +608,7 @@ pub async fn audio_play(
             Ordering::Relaxed,
         );
     }
+    drop(commit_guard);
 
     if defer_playback_start {
         if !start_paused {

--- a/src-tauri/crates/psysonic-audio/src/commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/commands.rs
@@ -26,7 +26,7 @@ use super::playback_rate::{preserve_pitch_will_run, raw_counter_samples_for_cont
 use super::preview::preview_clear_for_new_main_playback;
 use super::progress_task::spawn_progress_task;
 use super::sources::CancellableSource;
-use super::state::{ChainedInfo, PreloadedTrack};
+use super::state::{install_current_source_done, ChainedInfo, PreloadedTrack};
 
 // ─── Commands ─────────────────────────────────────────────────────────────────
 
@@ -614,6 +614,14 @@ pub async fn audio_play(
     }
 
     // ── Progress + ended detection ────────────────────────────────────────────
+    if !install_current_source_done(
+        &state.current_source_done,
+        &state.generation,
+        gen,
+        done_flag,
+    ) {
+        return Ok(());
+    }
     let analysis_app = app.clone();
     spawn_progress_task(
         gen,
@@ -623,7 +631,7 @@ pub async fn audio_play(
         state.crossfade_enabled.clone(),
         state.crossfade_secs.clone(),
         state.autodj_suppress_autocrossfade.clone(),
-        done_flag,
+        state.current_source_done.clone(),
         app,
         Some(analysis_app),
         state.samples_played.clone(),
@@ -795,6 +803,8 @@ pub async fn audio_chain_preload(
         format_hint.as_deref(),
         hi_res_enabled,
     ).map_err(|e| e.to_string())?;
+    let output_rate = built.output_rate;
+    let output_channels = built.output_channels;
     let source = built.source;
     let duration_secs = built.duration_secs;
 
@@ -884,6 +894,8 @@ pub async fn audio_chain_preload(
         generation: snapshot.generation,
         raw_bytes,
         resolved_format: built.resolved_format,
+        output_rate,
+        output_channels,
         duration_secs,
         replay_gain_linear: gain_linear,
         base_volume: volume.clamp(0.0, 1.0),

--- a/src-tauri/crates/psysonic-audio/src/device_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/device_commands.rs
@@ -147,7 +147,7 @@ pub async fn audio_set_device(
 ) -> Result<(), String> {
     *state.selected_device.lock().unwrap() = device_name.clone();
 
-    let rate = state.stream_sample_rate.load(Ordering::Relaxed);
+    let rate = state.stream_requested_rate.load(Ordering::Relaxed);
     let open_rate = if rate > 0 {
         rate
     } else {

--- a/src-tauri/crates/psysonic-audio/src/device_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/device_commands.rs
@@ -145,7 +145,9 @@ pub async fn audio_set_device(
     state: State<'_, AudioEngine>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    *state.selected_device.lock().unwrap() = device_name.clone();
+    let stream_guard = state.stream_open_lock.lock().unwrap();
+    super::engine::wait_for_stream_attachments_locked(&state);
+    let previous_device = state.selected_device.lock().unwrap().clone();
 
     let rate = state.stream_requested_rate.load(Ordering::Relaxed);
     let open_rate = if rate > 0 {
@@ -153,22 +155,66 @@ pub async fn audio_set_device(
     } else {
         state.device_default_rate
     };
-    super::engine::open_output_stream_blocking(&state, open_rate, false, device_name.clone())
-        .map_err(|_| "device open timed out".to_string())?;
 
-    // Capture position and drop the active sink atomically so the position
-    // reading is still valid (play_started / paused_at intact before take).
-    let current_time = {
+    // Capture position and detach players before releasing the old stream. The
+    // generation bump prevents the old progress task from reporting a false
+    // completion while the replacement or rollback is opening.
+    let (current_time, switch_generation) = {
+        let _commit_guard = state.playback_commit_lock.lock().unwrap();
         let mut cur = state.current.lock().unwrap();
         let pos = cur.position();
+        let generation = state.generation.fetch_add(1, Ordering::SeqCst) + 1;
         if let Some(s) = cur.sink.take() { s.stop(); }
-        pos
+        (pos, generation)
     };
     if let Some(s) = state.fading_out_sink.lock().unwrap().take() { s.stop(); }
+
+    if let Err(error) = super::engine::open_output_stream_blocking_locked(
+        &state,
+        open_rate,
+        false,
+        device_name.clone(),
+        true,
+    ) {
+        // Keep Rust and Settings on the previous selection. Reopen that known
+        // device once so the existing device-changed path can resume playback.
+        let rolled_back = previous_device != device_name
+            && super::engine::open_output_stream_blocking_locked(
+                &state,
+                open_rate,
+                false,
+                previous_device.clone(),
+                true,
+            )
+            .is_ok();
+        drop(stream_guard);
+        if rolled_back {
+            let _commit_guard = state.playback_commit_lock.lock().unwrap();
+            if state.generation.load(Ordering::SeqCst) == switch_generation {
+                app.emit("audio:device-changed", current_time).ok();
+            }
+        } else {
+            let _commit_guard = state.playback_commit_lock.lock().unwrap();
+            if state.generation.load(Ordering::SeqCst) == switch_generation {
+                let mut cur = state.current.lock().unwrap();
+                cur.play_started = None;
+                cur.paused_at = Some(current_time);
+                state.stream_sample_rate.store(0, Ordering::Relaxed);
+                app.emit("audio:output-released", ()).ok();
+            }
+        }
+        return Err(error);
+    }
+
+    *state.selected_device.lock().unwrap() = device_name;
+    drop(stream_guard);
 
     // Emit the saved position so the frontend can use seekFallbackVisualTarget
     // and resume from where the track was, rather than restarting from the beginning.
     // null is reserved for "Rust already resumed internally" (see reopen_output_stream).
-    app.emit("audio:device-changed", current_time).map_err(|e| e.to_string())?;
+    let _commit_guard = state.playback_commit_lock.lock().unwrap();
+    if state.generation.load(Ordering::SeqCst) == switch_generation {
+        app.emit("audio:device-changed", current_time).map_err(|e| e.to_string())?;
+    }
     Ok(())
 }

--- a/src-tauri/crates/psysonic-audio/src/device_resume.rs
+++ b/src-tauri/crates/psysonic-audio/src/device_resume.rs
@@ -28,6 +28,7 @@ use super::source_build::{
     build_playback_source_with_probe_fallback, BuildSourceArgs, PlaybackSource,
 };
 use super::sink_swap::{swap_in_new_sink, SinkSwapInputs};
+use super::state::install_current_source_done;
 use super::progress_task::spawn_progress_task;
 use super::stream::LocalFileSource;
 
@@ -266,6 +267,14 @@ pub(crate) async fn try_resume_after_device_change(
         app.emit("audio:format", ev).ok();
     }
 
+    if !install_current_source_done(
+        &engine.current_source_done,
+        &engine.generation,
+        gen,
+        done_flag,
+    ) {
+        return false;
+    }
     let analysis_app = app.clone();
     spawn_progress_task(
         gen,
@@ -275,7 +284,7 @@ pub(crate) async fn try_resume_after_device_change(
         engine.crossfade_enabled.clone(),
         engine.crossfade_secs.clone(),
         engine.autodj_suppress_autocrossfade.clone(),
-        done_flag,
+        engine.current_source_done.clone(),
         app.clone(),
         Some(analysis_app),
         engine.samples_played.clone(),

--- a/src-tauri/crates/psysonic-audio/src/device_resume.rs
+++ b/src-tauri/crates/psysonic-audio/src/device_resume.rs
@@ -18,7 +18,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-use rodio::Player;
 use tauri::Emitter;
 use tauri::Manager;
 
@@ -41,6 +40,14 @@ pub(crate) struct ResumeSnapshot {
     pub(crate) gain_linear: f32,
     pub(crate) analysis_track_id: Option<String>,
     pub(crate) is_playing: bool,
+    pub(crate) generation: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResumeOutcome {
+    Resumed,
+    Fallback,
+    Superseded,
 }
 
 /// Try to replay the current track on the new device without involving the
@@ -55,23 +62,38 @@ pub(crate) struct ResumeSnapshot {
 pub(crate) async fn try_resume_after_device_change(
     app: &tauri::AppHandle,
     snap: &ResumeSnapshot,
-) -> bool {
+) -> ResumeOutcome {
     // Only resume actively-playing (not paused) tracks.
     if !snap.is_playing {
-        return false;
+        return ResumeOutcome::Fallback;
     }
     let url = match snap.url.as_deref() {
         Some(u) if !u.is_empty() => u,
-        _ => return false,
+        _ => return ResumeOutcome::Fallback,
     };
 
     let Some(engine) = app.try_state::<AudioEngine>() else {
-        return false;
+        return ResumeOutcome::Fallback;
     };
 
     // Skip radio — live streams don't have a resume position.
     if engine.radio_state.lock().unwrap().is_some() {
-        return false;
+        return ResumeOutcome::Fallback;
+    }
+
+    // Claim this snapshot before any file/cache work so the old progress task
+    // cannot report completion after its sink was stopped. A later play/stop
+    // command bumps the generation again and cancels this resume normally.
+    let gen = snap.generation + 1;
+    {
+        let _commit_guard = engine.playback_commit_lock.lock().unwrap();
+        if engine
+            .generation
+            .compare_exchange(snap.generation, gen, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return ResumeOutcome::Superseded;
+        }
     }
 
     // Build a PlayInput without re-downloading:
@@ -95,7 +117,7 @@ pub(crate) async fn try_resume_after_device_change(
             }
             Err(e) => {
                 crate::app_eprintln!("[device-resume] cannot open local file: {e}");
-                return false;
+                return ResumeOutcome::Fallback;
             }
         }
     } else {
@@ -118,23 +140,21 @@ pub(crate) async fn try_resume_after_device_change(
                     Ok(b) => b,
                     Err(e) => {
                         crate::app_eprintln!("[device-resume] spill read failed: {e}");
-                        return false;
+                        return ResumeOutcome::Fallback;
                     }
                 },
-                None => return false, // not fully cached yet — frontend will re-fetch
+                None => return ResumeOutcome::Fallback, // frontend will re-fetch
             }
         };
         PlayInput::Bytes(bytes)
     };
 
-    // Bump generation so the old progress task exits cleanly.
-    let gen = engine.generation.fetch_add(1, Ordering::SeqCst) + 1;
     engine.stream_playback_armed.store(true, Ordering::SeqCst);
     *engine.chained_info.lock().unwrap() = None;
     *engine.current_playback_url.lock().unwrap() = Some(url.to_owned());
 
     if engine.generation.load(Ordering::SeqCst) != gen {
-        return false; // raced with another audio_play
+        return ResumeOutcome::Superseded;
     }
 
     let format_hint = url_format_hint(url);
@@ -174,12 +194,16 @@ pub(crate) async fn try_resume_after_device_change(
         Ok(ps) => ps,
         Err(e) => {
             crate::app_eprintln!("[device-resume] source build failed: {e}");
-            return false;
+            return if engine.generation.load(Ordering::SeqCst) == gen {
+                ResumeOutcome::Fallback
+            } else {
+                ResumeOutcome::Superseded
+            };
         }
     };
 
     if engine.generation.load(Ordering::SeqCst) != gen {
-        return false;
+        return ResumeOutcome::Superseded;
     }
 
     engine
@@ -192,17 +216,28 @@ pub(crate) async fn try_resume_after_device_change(
         .current_channels
         .store(ps.built.output_channels as u32, Ordering::Relaxed);
 
-    let stream = match super::engine::ensure_output_stream_open(&engine) {
-        Ok(s) => s,
+    let (sink, stream_attach) = match super::engine::connect_new_player(&engine) {
+        Ok(connected) => connected,
         Err(e) => {
             crate::app_eprintln!("[device-resume] output stream open failed: {e}");
-            return false;
+            return if engine.generation.load(Ordering::SeqCst) == gen {
+                ResumeOutcome::Fallback
+            } else {
+                ResumeOutcome::Superseded
+            };
         }
     };
-    let sink = Arc::new(Player::connect_new(stream.mixer()));
+    if engine.generation.load(Ordering::SeqCst) != gen {
+        return ResumeOutcome::Superseded;
+    }
     let effective_volume = (snap.base_volume * snap.gain_linear).clamp(0.0, 1.0);
     sink.set_volume(effective_volume);
     sink.append(ps.built.source);
+
+    let commit_guard = engine.playback_commit_lock.lock().unwrap();
+    if engine.generation.load(Ordering::SeqCst) != gen {
+        return ResumeOutcome::Superseded;
+    }
 
     swap_in_new_sink(
         &engine,
@@ -219,6 +254,8 @@ pub(crate) async fn try_resume_after_device_change(
             start_paused: false,
         },
     );
+    drop(stream_attach);
+    drop(commit_guard);
 
     // Seek to the saved position for seekable sources (local files, ranged HTTP).
     if ps.is_seekable && snap.current_time_secs > 0.5 {
@@ -273,7 +310,7 @@ pub(crate) async fn try_resume_after_device_change(
         gen,
         done_flag,
     ) {
-        return false;
+        return ResumeOutcome::Superseded;
     }
     let analysis_app = app.clone();
     spawn_progress_task(
@@ -301,5 +338,5 @@ pub(crate) async fn try_resume_after_device_change(
         snap.current_time_secs,
         ps.is_seekable
     );
-    true
+    ResumeOutcome::Resumed
 }

--- a/src-tauri/crates/psysonic-audio/src/device_watcher.rs
+++ b/src-tauri/crates/psysonic-audio/src/device_watcher.rs
@@ -39,7 +39,7 @@ pub(crate) async fn reopen_output_stream(
         return false;
     };
 
-    let rate = engine.stream_sample_rate.load(Ordering::Relaxed);
+    let rate = engine.stream_requested_rate.load(Ordering::Relaxed);
     let open_rate = if rate > 0 {
         rate
     } else {

--- a/src-tauri/crates/psysonic-audio/src/device_watcher.rs
+++ b/src-tauri/crates/psysonic-audio/src/device_watcher.rs
@@ -5,18 +5,25 @@ use std::time::{Duration, Instant};
 use tauri::Emitter;
 use tauri::Manager;
 
-use super::device_resume::{try_resume_after_device_change, ResumeSnapshot};
+use super::device_resume::{try_resume_after_device_change, ResumeOutcome, ResumeSnapshot};
 use super::engine::AudioEngine;
 #[cfg(not(target_os = "linux"))]
 use super::dev_io::output_enumeration_includes_pinned;
 
 /// What to tell the frontend after a successful stream reopen.
+#[derive(Clone, Copy)]
 pub(crate) enum ReopenNotify {
     /// Normal path — same as `audio_set_device`.
     DeviceChanged,
     /// Pinned device unplugged (Windows/macOS only); Rust cleared the pin — clear Settings + restart playback.
     #[cfg(not(target_os = "linux"))]
     DeviceReset,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ReopenOutcome {
+    Reopened,
+    Superseded,
 }
 
 /// Opens a new CPAL/rodio output stream with the given rate and device name (same path as
@@ -30,77 +37,140 @@ pub(crate) enum ReopenNotify {
 /// For radio, partially-buffered HTTP tracks, or paused playback, it falls back to the
 /// previous behaviour: emit with the captured `current_time_secs` so the frontend calls
 /// `playTrack`.
-pub(crate) async fn reopen_output_stream(
+async fn reopen_output_stream(
     app: &tauri::AppHandle,
     device_name: Option<String>,
     notify: ReopenNotify,
-) -> bool {
+    required_generation: Option<u64>,
+) -> Result<ReopenOutcome, String> {
+    enum ReopenPrepared {
+        Superseded,
+        Notify {
+            snapshot: ResumeSnapshot,
+            stream_reopened: bool,
+        },
+    }
+
     let Some(engine) = app.try_state::<AudioEngine>() else {
-        return false;
+        return Err("audio engine is unavailable".to_string());
     };
-
-    let rate = engine.stream_requested_rate.load(Ordering::Relaxed);
-    let open_rate = if rate > 0 {
-        rate
-    } else {
-        engine.device_default_rate
-    };
-    let current = engine.current.clone();
-    let fading_out = engine.fading_out_sink.clone();
-
-    // Snapshot state we need BEFORE the blocking stream reopen (while the old sink
-    // is still live and position() is still valid).
-    let snapshot = {
-        let cur = current.lock().unwrap();
-        let is_playing = cur.play_started.is_some() && cur.paused_at.is_none();
-        ResumeSnapshot {
-            url: engine.current_playback_url.lock().unwrap().clone(),
-            current_time_secs: cur.position(),
-            duration_secs: cur.duration_secs,
-            base_volume: cur.base_volume,
-            gain_linear: cur.replay_gain_linear,
-            analysis_track_id: engine.current_analysis_track_id.lock().unwrap().clone(),
-            is_playing,
-        }
-    };
-
+    let expected_generation = required_generation
+        .unwrap_or_else(|| engine.generation.load(Ordering::SeqCst));
     let app_for_open = app.clone();
-    let device_name_for_open = device_name.clone();
-    let opened = tauri::async_runtime::spawn_blocking(move || {
+    let expected_device = device_name.clone();
+    let snapshot = tauri::async_runtime::spawn_blocking(move || {
         let engine = app_for_open.state::<AudioEngine>();
-        super::engine::open_output_stream_blocking(
+        let _stream_guard = engine.stream_open_lock.lock().unwrap();
+        super::engine::wait_for_stream_attachments_locked(&engine);
+
+        // A manual switch or a new playback command completed while this
+        // watcher request was queued. Its state is authoritative; do not reopen
+        // the device or replay the stale snapshot.
+        if engine.generation.load(Ordering::SeqCst) != expected_generation
+            || *engine.selected_device.lock().unwrap() != expected_device
+        {
+            return Ok(ReopenPrepared::Superseded);
+        }
+
+        let rate = engine.stream_requested_rate.load(Ordering::Relaxed);
+        let open_rate = if rate > 0 {
+            rate
+        } else {
+            engine.device_default_rate
+        };
+        let mut snapshot = {
+            let cur = engine.current.lock().unwrap();
+            let is_playing = cur.play_started.is_some() && cur.paused_at.is_none();
+            ResumeSnapshot {
+                url: engine.current_playback_url.lock().unwrap().clone(),
+                current_time_secs: cur.position(),
+                duration_secs: cur.duration_secs,
+                base_volume: cur.base_volume,
+                gain_linear: cur.replay_gain_linear,
+                analysis_track_id: engine.current_analysis_track_id.lock().unwrap().clone(),
+                is_playing,
+                generation: expected_generation,
+            }
+        };
+
+        if let Err(error) = super::engine::open_output_stream_blocking_locked(
             &engine,
             open_rate,
             false,
-            device_name_for_open,
-        )
-        .is_ok()
+            device_name,
+            false,
+        ) {
+            let _commit_guard = engine.playback_commit_lock.lock().unwrap();
+            if engine.generation.load(Ordering::SeqCst) != expected_generation {
+                super::stream_idle::teardown_playback_sinks_for_idle_release(&engine);
+                snapshot.current_time_secs = 0.0;
+                snapshot.is_playing = false;
+                return Ok(ReopenPrepared::Notify {
+                    snapshot,
+                    stream_reopened: false,
+                });
+            }
+            engine.generation.fetch_add(1, Ordering::SeqCst);
+            super::stream_idle::teardown_playback_sinks_for_idle_release(&engine);
+            engine.current.lock().unwrap().paused_at = Some(snapshot.current_time_secs);
+            return Err(error);
+        }
+
+        // `audio_play` can bump the generation before it reaches the stream
+        // lock. Leave the newly opened stream for that command, stop players
+        // tied to the replaced mixer, and ask the frontend to retry whichever
+        // track is current now rather than replaying this stale snapshot.
+        let _commit_guard = engine.playback_commit_lock.lock().unwrap();
+        if engine.generation.load(Ordering::SeqCst) != expected_generation {
+            super::stream_idle::teardown_playback_sinks_for_idle_release(&engine);
+            snapshot.current_time_secs = 0.0;
+            snapshot.is_playing = false;
+            return Ok(ReopenPrepared::Notify {
+                snapshot,
+                stream_reopened: true,
+            });
+        }
+
+        if !snapshot.is_playing {
+            engine.generation.fetch_add(1, Ordering::SeqCst);
+        }
+        if let Some(sink) = engine.current.lock().unwrap().sink.take() {
+            sink.stop();
+        }
+        if let Some(sink) = engine.fading_out_sink.lock().unwrap().take() {
+            sink.stop();
+        }
+        snapshot.generation = engine.generation.load(Ordering::SeqCst);
+        Ok(ReopenPrepared::Notify {
+            snapshot,
+            stream_reopened: true,
+        })
     })
     .await
-    .unwrap_or(false);
-
-    if !opened {
-        return false;
-    }
-    // When we're not actively playing (paused/stopped), bump the generation
-    // before stopping the old sink so the still-running progress task sees the
-    // mismatch and bails out instead of emitting a spurious `audio:ended` —
-    // which would otherwise trigger a frontend restart of paused playback
-    // (#1094). The active-playback path bumps inside
-    // `try_resume_after_device_change`, so only guard the non-playing case here.
-    if !snapshot.is_playing {
-        engine.generation.fetch_add(1, Ordering::SeqCst);
-    }
-    if let Some(s) = current.lock().unwrap().sink.take() {
-        s.stop();
-    }
-    if let Some(s) = fading_out.lock().unwrap().take() {
-        s.stop();
-    }
+    .map_err(|error| format!("audio stream reopen task failed: {error}"))?;
+    let (snapshot, stream_reopened) = match snapshot {
+        Ok(ReopenPrepared::Notify {
+            snapshot,
+            stream_reopened,
+        }) => (snapshot, stream_reopened),
+        Ok(ReopenPrepared::Superseded) => return Ok(ReopenOutcome::Superseded),
+        Err(error) => {
+            app.emit("audio:output-released", ()).ok();
+            return Err(error);
+        }
+    };
 
     // Attempt a Rust-side internal replay (no frontend involvement).
     // Falls back gracefully to the frontend path if conditions aren't met.
-    let resumed = try_resume_after_device_change(app, &snapshot).await;
+    let resume_outcome = try_resume_after_device_change(app, &snapshot).await;
+    if resume_outcome == ResumeOutcome::Superseded {
+        return Ok(if stream_reopened {
+            ReopenOutcome::Reopened
+        } else {
+            ReopenOutcome::Superseded
+        });
+    }
+    let resumed = resume_outcome == ResumeOutcome::Resumed;
 
     match notify {
         ReopenNotify::DeviceChanged => {
@@ -121,12 +191,57 @@ pub(crate) async fn reopen_output_stream(
             }
         }
     }
-    true
+    Ok(if stream_reopened {
+        ReopenOutcome::Reopened
+    } else {
+        ReopenOutcome::Superseded
+    })
 }
 
+/// Retry one transient backend failure after the OS audio stack settles. Abort
+/// the retry if a manual device selection superseded the original request.
+pub(crate) async fn reopen_output_stream_with_retry(
+    app: &tauri::AppHandle,
+    device_name: Option<String>,
+    notify: ReopenNotify,
+) -> Result<ReopenOutcome, String> {
+    let Some(engine) = app.try_state::<AudioEngine>() else {
+        return Err("audio engine is unavailable".to_string());
+    };
+    let first_generation = {
+        let _commit_guard = engine.playback_commit_lock.lock().unwrap();
+        engine.generation.load(Ordering::SeqCst)
+    };
+    let first_error = match reopen_output_stream(
+        app,
+        device_name.clone(),
+        notify,
+        Some(first_generation),
+    )
+    .await
+    {
+        Ok(outcome) => return Ok(outcome),
+        Err(error) => error,
+    };
+
+    let retry_generation = first_generation.wrapping_add(1);
+    {
+        let _commit_guard = engine.playback_commit_lock.lock().unwrap();
+        if engine.generation.load(Ordering::SeqCst) != retry_generation {
+            return Ok(ReopenOutcome::Superseded);
+        }
+    };
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+
+    reopen_output_stream(app, device_name, notify, Some(retry_generation))
+        .await
+        .map_err(|retry_error| format!("{first_error}; retry failed: {retry_error}"))
+}
 
 pub fn start_device_watcher(engine: &AudioEngine, app: tauri::AppHandle) {
     let selected_device = engine.selected_device.clone();
+    #[cfg(not(target_os = "linux"))]
+    let stream_open_lock = engine.stream_open_lock.clone();
     let samples_played = engine.samples_played.clone();
     let current = engine.current.clone();
 
@@ -209,6 +324,7 @@ pub fn start_device_watcher(engine: &AudioEngine, app: tauri::AppHandle) {
             }
 
             if should_recover_stall {
+                last_stall_recover_at = Some(Instant::now());
                 let pinned = selected_device.lock().unwrap().clone();
                 let samples_now = samples_played.load(Ordering::Relaxed);
                 crate::app_eprintln!(
@@ -217,17 +333,26 @@ pub fn start_device_watcher(engine: &AudioEngine, app: tauri::AppHandle) {
                     samples_now,
                     pinned
                 );
-                if reopen_output_stream(&app, pinned, ReopenNotify::DeviceChanged).await {
-                    last_stall_recover_at = Some(Instant::now());
-                    stalled_since = None;
-                    last_samples_seen = samples_played.load(Ordering::Relaxed);
-                    crate::app_eprintln!(
-                        "[psysonic] device-watcher: stalled-output recovery succeeded"
-                    );
-                } else {
-                    crate::app_eprintln!(
-                        "[psysonic] device-watcher: stalled-output reopen timed out"
-                    );
+                match reopen_output_stream_with_retry(
+                    &app,
+                    pinned,
+                    ReopenNotify::DeviceChanged,
+                )
+                .await
+                {
+                    Ok(ReopenOutcome::Reopened) => {
+                        stalled_since = None;
+                        last_samples_seen = samples_played.load(Ordering::Relaxed);
+                        crate::app_eprintln!(
+                            "[psysonic] device-watcher: stalled-output recovery succeeded"
+                        );
+                    }
+                    Ok(ReopenOutcome::Superseded) => {}
+                    Err(error) => {
+                        crate::app_eprintln!(
+                            "[psysonic] device-watcher: stalled-output reopen failed: {error}"
+                        );
+                    }
                 }
             }
 
@@ -293,16 +418,32 @@ pub fn start_device_watcher(engine: &AudioEngine, app: tauri::AppHandle) {
                     }
                     crate::app_eprintln!("[psysonic] device-watcher: pinned device '{dev_name}' disconnected, falling back to system default");
                     pinned_miss_count = 0;
-                    *selected_device.lock().unwrap() = None;
+                    {
+                        let _stream_guard = stream_open_lock.lock().unwrap();
+                        let mut selected = selected_device.lock().unwrap();
+                        if selected.as_ref() != Some(dev_name) {
+                            continue;
+                        }
+                        *selected = None;
+                    }
 
                     tokio::time::sleep(Duration::from_millis(500)).await;
 
-                    let reopened = reopen_output_stream(&app, None, ReopenNotify::DeviceReset).await;
-                    if !reopened {
-                        crate::app_eprintln!("[psysonic] device-watcher: stream reopen timed out (pinned disconnect)");
+                    match reopen_output_stream_with_retry(
+                        &app,
+                        None,
+                        ReopenNotify::DeviceReset,
+                    )
+                    .await
+                    {
+                        Ok(ReopenOutcome::Reopened) => last_default = current_default,
+                        Ok(ReopenOutcome::Superseded) => {}
+                        Err(error) => {
+                            crate::app_eprintln!(
+                                "[psysonic] device-watcher: stream reopen failed after pinned disconnect: {error}"
+                            );
+                        }
                     }
-
-                    last_default = current_default;
                 } else {
                     pinned_miss_count = 0;
                 }
@@ -346,8 +487,6 @@ pub fn start_device_watcher(engine: &AudioEngine, app: tauri::AppHandle) {
                 }
             }
 
-            last_default = Some(new_name.clone());
-
             // Debounce: give the OS time to finish configuring the new device.
             tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -361,12 +500,19 @@ pub fn start_device_watcher(engine: &AudioEngine, app: tauri::AppHandle) {
                 if stream_on_default {
                     // PipeWire already moved playback — notify frontend (EQ sync) only.
                     app.emit("audio:device-changed", Option::<f64>::None).ok();
+                    last_default = Some(new_name.clone());
                     continue;
                 }
             }
 
-            if !reopen_output_stream(&app, None, ReopenNotify::DeviceChanged).await {
-                crate::app_eprintln!("[psysonic] device-watcher: stream reopen timed out");
+            match reopen_output_stream_with_retry(&app, None, ReopenNotify::DeviceChanged).await {
+                Ok(ReopenOutcome::Reopened) => last_default = Some(new_name),
+                Ok(ReopenOutcome::Superseded) => {}
+                Err(error) => {
+                    crate::app_eprintln!(
+                        "[psysonic] device-watcher: stream reopen failed: {error}"
+                    );
+                }
             }
         }
     });

--- a/src-tauri/crates/psysonic-audio/src/engine.rs
+++ b/src-tauri/crates/psysonic-audio/src/engine.rs
@@ -27,8 +27,11 @@ pub enum StreamThreadMsg {
 
 pub struct AudioEngine {
     pub stream_handle: Arc<std::sync::Mutex<Option<Arc<rodio::MixerDeviceSink>>>>,
-    /// Sample rate the output stream was last opened at (updated on every re-open).
+    /// Actual mixer/device rate selected by the output backend.
     pub stream_sample_rate: Arc<AtomicU32>,
+    /// Last rate requested by playback mode. Kept separate from the negotiated
+    /// rate so ALSA coercion does not trigger another reopen on every track.
+    pub stream_requested_rate: Arc<AtomicU32>,
     /// The rate the device was opened at on cold start — used to restore the
     /// stream when Hi-Res is toggled off while a hi-res rate is active.
     pub device_default_rate: u32,
@@ -205,7 +208,9 @@ fn open_stream_with_verified_rate(
 
     let builder = rodio::DeviceSinkBuilder::from_device(device.clone()).ok()?;
     #[cfg(target_os = "linux")]
-    let builder = builder.with_supported_config(config);
+    let builder = builder
+        .with_channels(std::num::NonZeroU16::new(config.channels())?)
+        .with_sample_format(config.sample_format());
     let handle = builder
         .with_sample_rate(
             std::num::NonZeroU32::new(actual_rate).unwrap_or(std::num::NonZeroU32::MIN),
@@ -213,6 +218,40 @@ fn open_stream_with_verified_rate(
         .open_stream()
         .ok()?;
     Some((finalize_mixer_device_sink(handle), actual_rate))
+}
+
+#[cfg(target_os = "linux")]
+fn open_verified_device_fallback(
+    device: &rodio::cpal::Device,
+) -> Option<(Arc<rodio::MixerDeviceSink>, u32)> {
+    use rodio::cpal::traits::DeviceTrait;
+
+    if let Ok(config) = device.default_output_config() {
+        if let Some(opened) = open_stream_with_verified_rate(device, &config) {
+            return Some(opened);
+        }
+    }
+
+    let mut ranges: Vec<_> = device.supported_output_configs().ok()?.collect();
+    ranges.sort_by(|a, b| b.cmp_default_heuristics(a));
+    for range in ranges {
+        let min_rate = range.min_sample_rate();
+        let max_rate = range.max_sample_rate();
+        let mut rates = vec![max_rate];
+        if (min_rate..=max_rate).contains(&44_100) {
+            rates.push(44_100);
+        }
+        rates.push(min_rate);
+        rates.dedup();
+
+        for rate in rates {
+            let config = range.with_sample_rate(rate);
+            if let Some(opened) = open_stream_with_verified_rate(device, &config) {
+                return Some(opened);
+            }
+        }
+    }
+    None
 }
 
 /// Returns `(stream_handle, actual_sample_rate)`.
@@ -316,7 +355,16 @@ fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32)
             }
         }
 
-        // 3. Device default.
+        // 3. Device fallback configurations.
+        #[cfg(target_os = "linux")]
+        if let Some((handle, rate)) = open_verified_device_fallback(&device) {
+            crate::app_eprintln!(
+                "[psysonic] audio stream opened at {} Hz (verified device fallback)",
+                rate
+            );
+            return (handle, rate);
+        }
+        #[cfg(not(target_os = "linux"))]
         if let Ok(config) = device.default_output_config() {
             if let Some((handle, rate)) = open_stream_with_verified_rate(&device, &config) {
                 crate::app_eprintln!(
@@ -328,16 +376,50 @@ fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32)
         }
     }
 
-    // 4. Last resort: system default.
-    crate::app_eprintln!("[psysonic] audio stream falling back to system default");
-    let handle = rodio::DeviceSinkBuilder::open_default_sink()
-        .expect("cannot open any audio output device");
-    let rate = rodio::cpal::default_host()
-        .default_output_device()
-        .and_then(|d| d.default_output_config().ok())
-        .map(|c| c.sample_rate())
-        .unwrap_or(44100);
-    (finalize_mixer_device_sink(handle), rate)
+    // 4. Verified system-default and alternate-device fallbacks. Do not call
+    // Rodio's broad fallback here: on ALSA it would bypass negotiated-rate
+    // verification and could reintroduce pitch/speed distortion.
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(default_device) = host.default_output_device() {
+            if let Some((handle, rate)) = open_verified_device_fallback(&default_device) {
+                crate::app_eprintln!(
+                    "[psysonic] audio stream opened at {} Hz (verified system default)",
+                    rate
+                );
+                return (handle, rate);
+            }
+        }
+        if let Ok(devices) = host.output_devices() {
+            for fallback_device in devices.filter(|device| {
+                device
+                    .description()
+                    .map(|description| description.driver() != Some("null"))
+                    .unwrap_or(false)
+            }) {
+                if let Some((handle, rate)) = open_verified_device_fallback(&fallback_device) {
+                    crate::app_eprintln!(
+                        "[psysonic] audio stream opened at {} Hz (verified alternate device)",
+                        rate
+                    );
+                    return (handle, rate);
+                }
+            }
+        }
+        panic!("cannot open any verified audio output device")
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        crate::app_eprintln!("[psysonic] audio stream falling back to system default");
+        let handle = rodio::DeviceSinkBuilder::open_default_sink()
+            .expect("cannot open any audio output device");
+        let rate = host
+            .default_output_device()
+            .and_then(|device| device.default_output_config().ok())
+            .map(|config| config.sample_rate())
+            .unwrap_or(44_100);
+        (finalize_mixer_device_sink(handle), rate)
+    }
 }
 
 fn probe_device_default_rate() -> u32 {
@@ -350,7 +432,7 @@ fn probe_device_default_rate() -> u32 {
         .unwrap_or(44_100)
 }
 
-/// Open the output stream (blocking). Updates `stream_handle` and `stream_sample_rate`.
+/// Open the output stream (blocking). Updates requested and negotiated rates.
 pub(crate) fn open_output_stream_blocking(
     engine: &AudioEngine,
     desired_rate: u32,
@@ -378,6 +460,9 @@ pub(crate) fn open_output_stream_blocking(
     engine
         .stream_sample_rate
         .store(actual_rate, std::sync::atomic::Ordering::Relaxed);
+    engine
+        .stream_requested_rate
+        .store(rate, std::sync::atomic::Ordering::Relaxed);
     *engine.stream_handle.lock().unwrap() = Some(handle.clone());
     Ok(handle)
 }
@@ -389,7 +474,9 @@ pub(crate) fn ensure_output_stream_open(
     if let Some(handle) = engine.stream_handle.lock().unwrap().clone() {
         return Ok(handle);
     }
-    let rate = engine.stream_sample_rate.load(std::sync::atomic::Ordering::Relaxed);
+    let rate = engine
+        .stream_requested_rate
+        .load(std::sync::atomic::Ordering::Relaxed);
     let open_rate = if rate > 0 {
         rate
     } else {
@@ -501,6 +588,7 @@ pub fn create_engine() -> (AudioEngine, std::thread::JoinHandle<()>) {
     let engine = AudioEngine {
         stream_handle: Arc::new(std::sync::Mutex::new(None)),
         stream_sample_rate: Arc::new(AtomicU32::new(0)),
+        stream_requested_rate: Arc::new(AtomicU32::new(0)),
         device_default_rate,
         stream_thread_tx,
         selected_device: Arc::new(Mutex::new(None)),
@@ -562,6 +650,26 @@ pub fn create_engine() -> (AudioEngine, std::thread::JoinHandle<()>) {
 
     (engine, thread)
 }
+
+pub(crate) fn stream_rate_needs_switch(target_rate: u32, current_requested_rate: u32) -> bool {
+    target_rate > 0 && target_rate != current_requested_rate
+}
+
+#[cfg(test)]
+mod stream_rate_tests {
+    use super::stream_rate_needs_switch;
+
+    #[test]
+    fn negotiated_rate_difference_does_not_reopen_same_request() {
+        // ALSA may negotiate 48 kHz for a 44.1 kHz request. Reopen decisions
+        // compare the next target with the prior request, not with that 48 kHz
+        // actual rate, so the same mode stays on the existing stream.
+        assert!(!stream_rate_needs_switch(44_100, 44_100));
+        assert!(stream_rate_needs_switch(96_000, 44_100));
+        assert!(!stream_rate_needs_switch(0, 44_100));
+    }
+}
+
 /// `analysis_enqueue_seed_from_url` should bail while this track's HTTP playback
 /// buffer is still filling — playback will seed on completion with the same bytes.
 pub fn playback_analysis_backfill_should_defer(engine: &AudioEngine, track_id: &str) -> bool {

--- a/src-tauri/crates/psysonic-audio/src/engine.rs
+++ b/src-tauri/crates/psysonic-audio/src/engine.rs
@@ -1,6 +1,6 @@
 //! `AudioEngine` / `AudioCurrent`, stream thread, and HTTP client refresh.
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use rodio::Player;
@@ -9,8 +9,8 @@ use tauri::Manager;
 use super::state::{ChainedInfo, CurrentSourceDone, PreloadedTrack, StreamCompletedSpill};
 
 /// Reply channel handed back to the audio-stream thread once an open finishes.
-pub type StreamOpenReply =
-    std::sync::mpsc::SyncSender<(Arc<rodio::MixerDeviceSink>, u32)>;
+pub type StreamOpenResult = Result<(Arc<rodio::MixerDeviceSink>, u32), String>;
+pub type StreamOpenReply = std::sync::mpsc::SyncSender<StreamOpenResult>;
 
 /// Requests handled on the dedicated audio-stream thread (open / idle release).
 pub enum StreamThreadMsg {
@@ -18,6 +18,7 @@ pub enum StreamThreadMsg {
         desired_rate: u32,
         is_hi_res: bool,
         device_name: Option<String>,
+        require_named_device: bool,
         reply: StreamOpenReply,
     },
     Release {
@@ -27,6 +28,12 @@ pub enum StreamThreadMsg {
 
 pub struct AudioEngine {
     pub stream_handle: Arc<std::sync::Mutex<Option<Arc<rodio::MixerDeviceSink>>>>,
+    /// Serializes release/open/state-commit as one output-stream transaction.
+    pub(crate) stream_open_lock: Arc<Mutex<()>>,
+    /// Players connected to the mixer but not yet registered in engine state.
+    pub(crate) stream_attach_pending: Arc<(Mutex<u32>, Condvar)>,
+    /// Serializes playback generation changes with final sink registration.
+    pub(crate) playback_commit_lock: Arc<Mutex<()>>,
     /// Actual mixer/device rate selected by the output backend.
     pub stream_sample_rate: Arc<AtomicU32>,
     /// Last rate requested by playback mode. Kept separate from the negotiated
@@ -171,11 +178,9 @@ impl AudioCurrent {
 /// `device_name`: exact name from `audio_list_devices`. `None` → system default.
 /// Falls back to the system default if the named device is not found.
 ///
-/// Resolution order:
-///   1. Exact rate match in the device's supported config ranges.
-///   2. Highest available rate (for hardware that doesn't support the source rate).
-///   3. Device default.
-///   4. System default (last resort).
+/// Linux resolves one target device, selects its exact/highest/default config,
+/// then performs one ALSA negotiation probe. Other platforms retain Rodio's
+/// broader fallback behavior.
 ///
 /// Rodio prints a stderr line on every intentional stream drop. Keep that only
 /// when runtime logging is in **debug** mode; normal/off silence the noise.
@@ -192,7 +197,7 @@ fn finalize_mixer_device_sink(mut handle: rodio::MixerDeviceSink) -> Arc<rodio::
 fn open_stream_with_verified_rate(
     device: &rodio::cpal::Device,
     config: &rodio::cpal::SupportedStreamConfig,
-) -> Option<(Arc<rodio::MixerDeviceSink>, u32)> {
+) -> StreamOpenResult {
     let requested_rate = config.sample_rate();
     #[cfg(target_os = "linux")]
     let actual_rate = crate::alsa_rate::negotiated_output_rate(device, config)?;
@@ -206,57 +211,74 @@ fn open_stream_with_verified_rate(
         );
     }
 
-    let builder = rodio::DeviceSinkBuilder::from_device(device.clone()).ok()?;
     #[cfg(target_os = "linux")]
-    let builder = builder
-        .with_channels(std::num::NonZeroU16::new(config.channels())?)
+    let builder = rodio::DeviceSinkBuilder::default()
+        .with_device(device.clone())
+        .with_channels(
+            std::num::NonZeroU16::new(config.channels())
+                .ok_or_else(|| "audio output configuration has zero channels".to_string())?,
+        )
         .with_sample_format(config.sample_format());
+    #[cfg(not(target_os = "linux"))]
+    let builder = rodio::DeviceSinkBuilder::from_device(device.clone())
+        .map_err(|error| format!("failed to configure audio output device: {error}"))?;
     let handle = builder
         .with_sample_rate(
             std::num::NonZeroU32::new(actual_rate).unwrap_or(std::num::NonZeroU32::MIN),
         )
         .open_stream()
-        .ok()?;
-    Some((finalize_mixer_device_sink(handle), actual_rate))
+        .map_err(|error| format!("failed to open audio output stream: {error}"))?;
+    Ok((finalize_mixer_device_sink(handle), actual_rate))
 }
 
 #[cfg(target_os = "linux")]
-fn open_verified_device_fallback(
+fn select_verified_stream_config(
     device: &rodio::cpal::Device,
-) -> Option<(Arc<rodio::MixerDeviceSink>, u32)> {
+    desired_rate: u32,
+) -> Result<(rodio::cpal::SupportedStreamConfig, &'static str), String> {
     use rodio::cpal::traits::DeviceTrait;
 
-    if let Ok(config) = device.default_output_config() {
-        if let Some(opened) = open_stream_with_verified_rate(device, &config) {
-            return Some(opened);
+    if desired_rate > 0 {
+        let configs: Vec<_> = device
+            .supported_output_configs()
+            .map_err(|error| format!("failed to query audio output configurations: {error}"))?
+            .collect();
+
+        if let Some(config) = configs
+            .iter()
+            .filter(|config| {
+                config.min_sample_rate() <= desired_rate
+                    && desired_rate <= config.max_sample_rate()
+            })
+            .max_by(|a, b| a.cmp_default_heuristics(b))
+        {
+            return Ok(((*config).with_sample_rate(desired_rate), "requested"));
+        }
+
+        if let Some(config) = configs.iter().max_by(|a, b| {
+            a.max_sample_rate()
+                .cmp(&b.max_sample_rate())
+                .then_with(|| a.cmp_default_heuristics(b))
+        }) {
+            return Ok(((*config).with_max_sample_rate(), "highest supported"));
         }
     }
 
-    let mut ranges: Vec<_> = device.supported_output_configs().ok()?.collect();
-    ranges.sort_by(|a, b| b.cmp_default_heuristics(a));
-    for range in ranges {
-        let min_rate = range.min_sample_rate();
-        let max_rate = range.max_sample_rate();
-        let mut rates = vec![max_rate];
-        if (min_rate..=max_rate).contains(&44_100) {
-            rates.push(44_100);
-        }
-        rates.push(min_rate);
-        rates.dedup();
-
-        for rate in rates {
-            let config = range.with_sample_rate(rate);
-            if let Some(opened) = open_stream_with_verified_rate(device, &config) {
-                return Some(opened);
-            }
-        }
-    }
-    None
+    device
+        .default_output_config()
+        .map(|config| (config, "device default"))
+        .map_err(|error| format!("failed to query default audio output configuration: {error}"))
 }
 
 /// Returns `(stream_handle, actual_sample_rate)`.
-fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32) -> (Arc<rodio::MixerDeviceSink>, u32) {
-    use rodio::cpal::traits::{DeviceTrait, HostTrait};
+fn open_stream_for_device_and_rate(
+    device_name: Option<&str>,
+    desired_rate: u32,
+    require_named_device: bool,
+) -> StreamOpenResult {
+    use rodio::cpal::traits::HostTrait;
+    #[cfg(not(target_os = "linux"))]
+    use rodio::cpal::traits::DeviceTrait;
 
     // Suppress ALSA stderr noise while enumerating devices on Unix.
     #[cfg(unix)]
@@ -283,20 +305,17 @@ fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32)
     // On systems where neither alias exists (pure ALSA, macOS, Windows),
     // `find_by_name` returns None and we drop through to `default_output_device`
     // unchanged — no regression.
-    let find_by_key = |key: &str| -> Option<_> {
-        super::dev_io::resolve_output_device(key).or_else(|| {
-            host.output_devices().ok()?.find(|d| {
-                d.description()
-                    .ok()
-                    .map(|desc| desc.name().to_string())
-                    .as_deref()
-                    == Some(key)
-            })
-        })
-    };
+    let find_by_key = |key: &str| super::dev_io::resolve_output_device(key);
 
-    let device = device_name
-        .and_then(find_by_key)
+    let named_device = device_name.and_then(find_by_key);
+    if require_named_device && device_name.is_some() && named_device.is_none() {
+        return Err(format!(
+            "selected audio output device '{}' is unavailable",
+            device_name.unwrap_or_default()
+        ));
+    }
+
+    let device = named_device
         .or_else(|| {
             #[cfg(target_os = "linux")]
             { find_by_key("pipewire").or_else(|| find_by_key("pulse")) }
@@ -306,6 +325,20 @@ fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32)
         .or_else(|| host.default_output_device());
 
     if let Some(device) = device {
+        #[cfg(target_os = "linux")]
+        {
+            // Probe exactly one chosen configuration on exactly one device.
+            // Failed snd_pcm_open() calls are not guaranteed to clean up on
+            // every ALSA plugin, so broad probe sweeps can poison the backend.
+            let (config, choice) = select_verified_stream_config(&device, desired_rate)?;
+            let (handle, actual_rate) = open_stream_with_verified_rate(&device, &config)?;
+            crate::app_eprintln!(
+                "[psysonic] audio stream opened at {actual_rate} Hz ({choice}, wanted {desired_rate} Hz)"
+            );
+            return Ok((handle, actual_rate));
+        }
+
+        #[cfg(not(target_os = "linux"))]
         if desired_rate > 0 {
             if let Ok(supported) = device.supported_output_configs() {
                 let configs: Vec<_> = supported.collect();
@@ -320,7 +353,7 @@ fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32)
 
                 if let Some(cfg) = exact {
                     let config = (*cfg).with_sample_rate(desired_rate);
-                    if let Some((handle, actual_rate)) =
+                    if let Ok((handle, actual_rate)) =
                         open_stream_with_verified_rate(&device, &config)
                     {
                         crate::app_eprintln!(
@@ -328,7 +361,7 @@ fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32)
                             actual_rate,
                             desired_rate
                         );
-                        return (handle, actual_rate);
+                        return Ok((handle, actual_rate));
                     }
                 }
 
@@ -342,83 +375,49 @@ fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32)
 
                 if let Some(cfg) = best {
                     let config = (*cfg).with_max_sample_rate();
-                    if let Some((handle, actual_rate)) =
+                    if let Ok((handle, actual_rate)) =
                         open_stream_with_verified_rate(&device, &config)
                     {
                         crate::app_eprintln!(
                             "[psysonic] audio stream opened at {} Hz (highest, wanted {})",
                             actual_rate, desired_rate
                         );
-                        return (handle, actual_rate);
+                        return Ok((handle, actual_rate));
                     }
                 }
             }
         }
 
-        // 3. Device fallback configurations.
-        #[cfg(target_os = "linux")]
-        if let Some((handle, rate)) = open_verified_device_fallback(&device) {
-            crate::app_eprintln!(
-                "[psysonic] audio stream opened at {} Hz (verified device fallback)",
-                rate
-            );
-            return (handle, rate);
-        }
+        // 3. Device default.
         #[cfg(not(target_os = "linux"))]
         if let Ok(config) = device.default_output_config() {
-            if let Some((handle, rate)) = open_stream_with_verified_rate(&device, &config) {
+            if let Ok((handle, rate)) = open_stream_with_verified_rate(&device, &config) {
                 crate::app_eprintln!(
                     "[psysonic] audio stream opened at {} Hz (device default)",
                     rate
                 );
-                return (handle, rate);
+                return Ok((handle, rate));
             }
         }
     }
 
-    // 4. Verified system-default and alternate-device fallbacks. Do not call
-    // Rodio's broad fallback here: on ALSA it would bypass negotiated-rate
-    // verification and could reintroduce pitch/speed distortion.
+    // Linux deliberately avoids probing every enumerated device. Apart from
+    // leaking resources on broken ALSA plugins, that can leave all later opens
+    // failing with EBUSY until the process exits.
     #[cfg(target_os = "linux")]
-    {
-        if let Some(default_device) = host.default_output_device() {
-            if let Some((handle, rate)) = open_verified_device_fallback(&default_device) {
-                crate::app_eprintln!(
-                    "[psysonic] audio stream opened at {} Hz (verified system default)",
-                    rate
-                );
-                return (handle, rate);
-            }
-        }
-        if let Ok(devices) = host.output_devices() {
-            for fallback_device in devices.filter(|device| {
-                device
-                    .description()
-                    .map(|description| description.driver() != Some("null"))
-                    .unwrap_or(false)
-            }) {
-                if let Some((handle, rate)) = open_verified_device_fallback(&fallback_device) {
-                    crate::app_eprintln!(
-                        "[psysonic] audio stream opened at {} Hz (verified alternate device)",
-                        rate
-                    );
-                    return (handle, rate);
-                }
-            }
-        }
-        panic!("cannot open any verified audio output device")
-    }
+    return Err("no audio output device is available".to_string());
+
     #[cfg(not(target_os = "linux"))]
     {
         crate::app_eprintln!("[psysonic] audio stream falling back to system default");
         let handle = rodio::DeviceSinkBuilder::open_default_sink()
-            .expect("cannot open any audio output device");
+            .map_err(|error| format!("cannot open any audio output device: {error}"))?;
         let rate = host
             .default_output_device()
             .and_then(|device| device.default_output_config().ok())
             .map(|config| config.sample_rate())
             .unwrap_or(44_100);
-        (finalize_mixer_device_sink(handle), rate)
+        Ok((finalize_mixer_device_sink(handle), rate))
     }
 }
 
@@ -433,42 +432,74 @@ fn probe_device_default_rate() -> u32 {
 }
 
 /// Open the output stream (blocking). Updates requested and negotiated rates.
-pub(crate) fn open_output_stream_blocking(
+pub(crate) fn open_output_stream_blocking_locked(
     engine: &AudioEngine,
     desired_rate: u32,
     is_hi_res: bool,
     device_name: Option<String>,
-) -> Result<Arc<rodio::MixerDeviceSink>, String> {
+    require_named_device: bool,
+) -> Result<(), String> {
+    wait_for_stream_attachments_locked(engine);
     let rate = if desired_rate > 0 {
         desired_rate
     } else {
         engine.device_default_rate
     };
+    // The stream thread owns one Arc and the engine slot owns the other. Drop
+    // the slot before the thread drops its copy so exclusive ALSA devices are
+    // actually released before the verification/open sequence starts.
+    drop(engine.stream_handle.lock().unwrap().take());
+    engine
+        .stream_sample_rate
+        .store(0, std::sync::atomic::Ordering::Relaxed);
     let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel(0);
     engine
         .stream_thread_tx
-        .send(StreamThreadMsg::Open {
+        .try_send(StreamThreadMsg::Open {
             desired_rate: rate,
             is_hi_res,
             device_name,
+            require_named_device,
             reply: reply_tx,
         })
-        .map_err(|e| e.to_string())?;
-    let (handle, actual_rate) = reply_rx
-        .recv_timeout(Duration::from_secs(5))
-        .map_err(|_| "audio stream open timed out".to_string())?;
+        .map_err(|error| match error {
+            std::sync::mpsc::TrySendError::Full(_) => {
+                "audio stream thread request queue is full".to_string()
+            }
+            std::sync::mpsc::TrySendError::Disconnected(_) => {
+                "audio stream thread is unavailable".to_string()
+            }
+        })?;
+    let (handle, actual_rate) = match reply_rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(result) => result?,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            return Err("audio stream open timed out".to_string());
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            return Err("audio stream thread stopped before opening the device".to_string());
+        }
+    };
     engine
         .stream_sample_rate
         .store(actual_rate, std::sync::atomic::Ordering::Relaxed);
     engine
         .stream_requested_rate
         .store(rate, std::sync::atomic::Ordering::Relaxed);
-    *engine.stream_handle.lock().unwrap() = Some(handle.clone());
-    Ok(handle)
+    *engine.stream_handle.lock().unwrap() = Some(handle);
+    Ok(())
 }
 
-/// Ensure a live output stream exists; lazy-opens on first playback.
-pub(crate) fn ensure_output_stream_open(
+pub(crate) fn open_output_stream_blocking(
+    engine: &AudioEngine,
+    desired_rate: u32,
+    is_hi_res: bool,
+    device_name: Option<String>,
+) -> Result<(), String> {
+    let _open_guard = engine.stream_open_lock.lock().unwrap();
+    open_output_stream_blocking_locked(engine, desired_rate, is_hi_res, device_name, false)
+}
+
+fn ensure_output_stream_open_locked(
     engine: &AudioEngine,
 ) -> Result<Arc<rodio::MixerDeviceSink>, String> {
     if let Some(handle) = engine.stream_handle.lock().unwrap().clone() {
@@ -483,15 +514,74 @@ pub(crate) fn ensure_output_stream_open(
         engine.device_default_rate
     };
     let device = engine.selected_device.lock().unwrap().clone();
-    open_output_stream_blocking(engine, open_rate, false, device)
+    open_output_stream_blocking_locked(engine, open_rate, false, device, false)?;
+    engine
+        .stream_handle
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| "audio output stream opened without a handle".to_string())
 }
 
-pub(crate) fn request_stream_release(engine: &AudioEngine) -> Result<(), String> {
+pub(crate) struct StreamAttachGuard {
+    pending: Arc<(Mutex<u32>, Condvar)>,
+}
+
+impl Drop for StreamAttachGuard {
+    fn drop(&mut self) {
+        let (pending, ready) = &*self.pending;
+        let mut count = pending.lock().unwrap();
+        *count = count.saturating_sub(1);
+        ready.notify_all();
+    }
+}
+
+pub(crate) fn wait_for_stream_attachments_locked(engine: &AudioEngine) {
+    let (pending, ready) = &*engine.stream_attach_pending;
+    let mut count = pending.lock().unwrap();
+    while *count > 0 {
+        count = ready.wait(count).unwrap();
+    }
+}
+
+pub(crate) fn stream_attachment_is_pending(engine: &AudioEngine) -> bool {
+    *engine.stream_attach_pending.0.lock().unwrap() > 0
+}
+
+/// Connect a player and mark the stream as needed until the caller registers
+/// that player in `AudioCurrent`, `preview_sink`, or `fading_out_sink`.
+pub(crate) fn connect_new_player(
+    engine: &AudioEngine,
+) -> Result<(Arc<Player>, StreamAttachGuard), String> {
+    let _open_guard = engine.stream_open_lock.lock().unwrap();
+    let stream = ensure_output_stream_open_locked(engine)?;
+    *engine.stream_attach_pending.0.lock().unwrap() += 1;
+    let attach_guard = StreamAttachGuard {
+        pending: engine.stream_attach_pending.clone(),
+    };
+    let player = Arc::new(Player::connect_new(stream.mixer()));
+    drop(stream);
+    Ok((player, attach_guard))
+}
+
+pub(crate) fn request_stream_release_locked(engine: &AudioEngine) -> Result<(), String> {
+    wait_for_stream_attachments_locked(engine);
+    drop(engine.stream_handle.lock().unwrap().take());
+    engine
+        .stream_sample_rate
+        .store(0, std::sync::atomic::Ordering::Relaxed);
     let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel(0);
     engine
         .stream_thread_tx
-        .send(StreamThreadMsg::Release { reply: reply_tx })
-        .map_err(|e| e.to_string())?;
+        .try_send(StreamThreadMsg::Release { reply: reply_tx })
+        .map_err(|error| match error {
+            std::sync::mpsc::TrySendError::Full(_) => {
+                "audio stream thread request queue is full".to_string()
+            }
+            std::sync::mpsc::TrySendError::Disconnected(_) => {
+                "audio stream thread is unavailable".to_string()
+            }
+        })?;
     reply_rx
         .recv_timeout(Duration::from_secs(5))
         .map_err(|_| "audio stream release timed out".to_string())?;
@@ -546,6 +636,7 @@ pub fn create_engine() -> (AudioEngine, std::thread::JoinHandle<()>) {
                         desired_rate,
                         is_hi_res,
                         device_name,
+                        require_named_device,
                         reply,
                     } => {
                         // Escalate to Max for Hi-Res reopens (large PipeWire quanta need
@@ -572,11 +663,27 @@ pub fn create_engine() -> (AudioEngine, std::thread::JoinHandle<()>) {
                             std::env::set_var("PULSE_LATENCY_MSEC", latency_ms.to_string());
                         }
 
-                        let (new_stream, actual_rate) =
-                            open_stream_for_device_and_rate(device_name.as_deref(), desired_rate);
-                        let new_handle = new_stream.clone();
-                        _stream = Some(new_stream);
-                        let _ = reply.send((new_handle, actual_rate));
+                        match open_stream_for_device_and_rate(
+                            device_name.as_deref(),
+                            desired_rate,
+                            require_named_device,
+                        ) {
+                            Ok((new_stream, actual_rate)) => {
+                                let new_handle = new_stream.clone();
+                                // If the caller already timed out, do not retain
+                                // an untracked stream that can hold an exclusive
+                                // device while the engine slot remains empty.
+                                if reply.send(Ok((new_handle, actual_rate))).is_ok() {
+                                    _stream = Some(new_stream);
+                                }
+                            }
+                            Err(error) => {
+                                crate::app_eprintln!(
+                                    "[psysonic] audio stream open failed: {error}"
+                                );
+                                let _ = reply.send(Err(error));
+                            }
+                        }
                     }
                 }
             }
@@ -587,6 +694,9 @@ pub fn create_engine() -> (AudioEngine, std::thread::JoinHandle<()>) {
 
     let engine = AudioEngine {
         stream_handle: Arc::new(std::sync::Mutex::new(None)),
+        stream_open_lock: Arc::new(Mutex::new(())),
+        stream_attach_pending: Arc::new((Mutex::new(0), Condvar::new())),
+        playback_commit_lock: Arc::new(Mutex::new(())),
         stream_sample_rate: Arc::new(AtomicU32::new(0)),
         stream_requested_rate: Arc::new(AtomicU32::new(0)),
         device_default_rate,
@@ -689,6 +799,7 @@ pub fn stop_audio_engine(app: &tauri::AppHandle) {
     use std::sync::atomic::Ordering;
     use tauri::Manager;
     let engine = app.state::<AudioEngine>();
+    let _commit_guard = engine.playback_commit_lock.lock().unwrap();
     engine.generation.fetch_add(1, Ordering::SeqCst);
     *engine.chained_info.lock().unwrap() = None;
     *engine.current_source_done.lock().unwrap() = None;

--- a/src-tauri/crates/psysonic-audio/src/engine.rs
+++ b/src-tauri/crates/psysonic-audio/src/engine.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use rodio::Player;
 use tauri::Manager;
 
-use super::state::{ChainedInfo, PreloadedTrack, StreamCompletedSpill};
+use super::state::{ChainedInfo, CurrentSourceDone, PreloadedTrack, StreamCompletedSpill};
 
 /// Reply channel handed back to the audio-stream thread once an open finishes.
 pub type StreamOpenReply =
@@ -86,6 +86,9 @@ pub struct AudioEngine {
     /// Info about the next-up chained track (gapless mode).
     /// The progress task reads this when `current_source_done` fires.
     pub(crate) chained_info: Arc<Mutex<Option<ChainedInfo>>>,
+    /// Generation-qualified completion flag for the currently active source.
+    /// Replaced when Hi-Res realignment rebuilds a source in-place.
+    pub(crate) current_source_done: CurrentSourceDone,
     /// Atomic sample counter — incremented by CountingSource in the audio thread.
     /// Progress task reads this for drift-free position tracking.
     pub samples_played: Arc<AtomicU64>,
@@ -183,6 +186,35 @@ fn finalize_mixer_device_sink(mut handle: rodio::MixerDeviceSink) -> Arc<rodio::
     handle
 }
 
+fn open_stream_with_verified_rate(
+    device: &rodio::cpal::Device,
+    config: &rodio::cpal::SupportedStreamConfig,
+) -> Option<(Arc<rodio::MixerDeviceSink>, u32)> {
+    let requested_rate = config.sample_rate();
+    #[cfg(target_os = "linux")]
+    let actual_rate = crate::alsa_rate::negotiated_output_rate(device, config)?;
+    #[cfg(not(target_os = "linux"))]
+    let actual_rate = requested_rate;
+
+    #[cfg(target_os = "linux")]
+    if actual_rate != requested_rate {
+        crate::app_eprintln!(
+            "[psysonic] ALSA negotiated {actual_rate} Hz for requested {requested_rate} Hz; using the negotiated mixer rate"
+        );
+    }
+
+    let builder = rodio::DeviceSinkBuilder::from_device(device.clone()).ok()?;
+    #[cfg(target_os = "linux")]
+    let builder = builder.with_supported_config(config);
+    let handle = builder
+        .with_sample_rate(
+            std::num::NonZeroU32::new(actual_rate).unwrap_or(std::num::NonZeroU32::MIN),
+        )
+        .open_stream()
+        .ok()?;
+    Some((finalize_mixer_device_sink(handle), actual_rate))
+}
+
 /// Returns `(stream_handle, actual_sample_rate)`.
 fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32) -> (Arc<rodio::MixerDeviceSink>, u32) {
     use rodio::cpal::traits::{DeviceTrait, HostTrait};
@@ -239,50 +271,60 @@ fn open_stream_for_device_and_rate(device_name: Option<&str>, desired_rate: u32)
             if let Ok(supported) = device.supported_output_configs() {
                 let configs: Vec<_> = supported.collect();
 
-                // 1. Exact rate match — prefer more channels (stereo > mono).
+                // 1. Exact rate match, using CPAL's normal format/channel preference.
                 let exact = configs.iter()
                     .filter(|c| {
                         c.min_sample_rate() <= desired_rate
                             && desired_rate <= c.max_sample_rate()
                     })
-                    .max_by_key(|c| c.channels());
+                    .max_by(|a, b| a.cmp_default_heuristics(b));
 
-                if exact.is_some() {
-                    if let Ok(handle) = rodio::DeviceSinkBuilder::from_device(device.clone())
-                        .and_then(|b| b.with_sample_rate(std::num::NonZeroU32::new(desired_rate).unwrap_or(std::num::NonZeroU32::MIN)).open_stream())
+                if let Some(cfg) = exact {
+                    let config = (*cfg).with_sample_rate(desired_rate);
+                    if let Some((handle, actual_rate)) =
+                        open_stream_with_verified_rate(&device, &config)
                     {
-                        crate::app_eprintln!("[psysonic] audio stream opened at {} Hz (exact)", desired_rate);
-                        return (finalize_mixer_device_sink(handle), desired_rate);
+                        crate::app_eprintln!(
+                            "[psysonic] audio stream opened at {} Hz (wanted {} Hz)",
+                            actual_rate,
+                            desired_rate
+                        );
+                        return (handle, actual_rate);
                     }
                 }
 
                 // 2. No exact match — use the highest supported rate.
                 let best = configs.iter()
-                    .max_by_key(|c| c.max_sample_rate());
+                    .max_by(|a, b| {
+                        a.max_sample_rate()
+                            .cmp(&b.max_sample_rate())
+                            .then_with(|| a.cmp_default_heuristics(b))
+                    });
 
                 if let Some(cfg) = best {
-                    let rate = cfg.max_sample_rate();
-                    if let Ok(handle) = rodio::DeviceSinkBuilder::from_device(device.clone())
-                        .and_then(|b| b.with_sample_rate(std::num::NonZeroU32::new(rate).unwrap_or(std::num::NonZeroU32::MIN)).open_stream())
+                    let config = (*cfg).with_max_sample_rate();
+                    if let Some((handle, actual_rate)) =
+                        open_stream_with_verified_rate(&device, &config)
                     {
                         crate::app_eprintln!(
                             "[psysonic] audio stream opened at {} Hz (highest, wanted {})",
-                            rate, desired_rate
+                            actual_rate, desired_rate
                         );
-                        return (finalize_mixer_device_sink(handle), rate);
+                        return (handle, actual_rate);
                     }
                 }
             }
         }
 
         // 3. Device default.
-        if let Ok(handle) = rodio::DeviceSinkBuilder::from_device(device.clone()).and_then(|b| b.open_stream()) {
-            let rate = device
-                .default_output_config()
-                .map(|c| c.sample_rate())
-                .unwrap_or(44100);
-            crate::app_eprintln!("[psysonic] audio stream opened at {} Hz (device default)", rate);
-            return (finalize_mixer_device_sink(handle), rate);
+        if let Ok(config) = device.default_output_config() {
+            if let Some((handle, rate)) = open_stream_with_verified_rate(&device, &config) {
+                crate::app_eprintln!(
+                    "[psysonic] audio stream opened at {} Hz (device default)",
+                    rate
+                );
+                return (handle, rate);
+            }
         }
     }
 
@@ -502,6 +544,7 @@ pub fn create_engine() -> (AudioEngine, std::thread::JoinHandle<()>) {
         normalization_target_lufs: Arc::new(AtomicU32::new((-16.0f32).to_bits())),
         loudness_pre_analysis_attenuation_db: Arc::new(AtomicU32::new((-4.5f32).to_bits())),
         chained_info: Arc::new(Mutex::new(None)),
+        current_source_done: Arc::new(Mutex::new(None)),
         samples_played: Arc::new(AtomicU64::new(0)),
         current_sample_rate: Arc::new(AtomicU32::new(0)),
         current_channels: Arc::new(AtomicU32::new(2)),
@@ -540,6 +583,7 @@ pub fn stop_audio_engine(app: &tauri::AppHandle) {
     let engine = app.state::<AudioEngine>();
     engine.generation.fetch_add(1, Ordering::SeqCst);
     *engine.chained_info.lock().unwrap() = None;
+    *engine.current_source_done.lock().unwrap() = None;
     drop(engine.radio_state.lock().unwrap().take());
     let mut cur = engine.current.lock().unwrap();
     if let Some(sink) = cur.sink.take() { sink.stop(); }

--- a/src-tauri/crates/psysonic-audio/src/engine.rs
+++ b/src-tauri/crates/psysonic-audio/src/engine.rs
@@ -544,6 +544,18 @@ pub(crate) fn wait_for_stream_attachments_locked(engine: &AudioEngine) {
     }
 }
 
+pub(crate) fn wait_for_stream_attachments_timeout_locked(
+    engine: &AudioEngine,
+    timeout: Duration,
+) -> bool {
+    let (pending, ready) = &*engine.stream_attach_pending;
+    let count = pending.lock().unwrap();
+    let (count, _) = ready
+        .wait_timeout_while(count, timeout, |count| *count > 0)
+        .unwrap();
+    *count == 0
+}
+
 pub(crate) fn stream_attachment_is_pending(engine: &AudioEngine) -> bool {
     *engine.stream_attach_pending.0.lock().unwrap() > 0
 }
@@ -564,8 +576,9 @@ pub(crate) fn connect_new_player(
     Ok((player, attach_guard))
 }
 
-pub(crate) fn request_stream_release_locked(engine: &AudioEngine) -> Result<(), String> {
-    wait_for_stream_attachments_locked(engine);
+pub(crate) fn request_stream_release_after_attachments_locked(
+    engine: &AudioEngine,
+) -> Result<(), String> {
     drop(engine.stream_handle.lock().unwrap().take());
     engine
         .stream_sample_rate
@@ -586,6 +599,11 @@ pub(crate) fn request_stream_release_locked(engine: &AudioEngine) -> Result<(), 
         .recv_timeout(Duration::from_secs(5))
         .map_err(|_| "audio stream release timed out".to_string())?;
     Ok(())
+}
+
+pub(crate) fn request_stream_release_locked(engine: &AudioEngine) -> Result<(), String> {
+    wait_for_stream_attachments_locked(engine);
+    request_stream_release_after_attachments_locked(engine)
 }
 
 pub fn create_engine() -> (AudioEngine, std::thread::JoinHandle<()>) {

--- a/src-tauri/crates/psysonic-audio/src/hi_res_blend.rs
+++ b/src-tauri/crates/psysonic-audio/src/hi_res_blend.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use rodio::Player;
 use tauri::{AppHandle, State};
 
 use super::engine::AudioEngine;
@@ -184,8 +183,10 @@ pub(crate) async fn spawn_outgoing_blend_resample(
         return Ok(());
     }
 
-    let stream = super::engine::ensure_output_stream_open(state)?;
-    let sink = Arc::new(Player::connect_new(stream.mixer()));
+    let (sink, stream_attach) = super::engine::connect_new_player(state)?;
+    if state.generation.load(Ordering::SeqCst) != gen {
+        return Ok(());
+    }
     let effective_volume = (snap.base_volume * snap.gain_linear).clamp(0.0, 1.0);
     sink.set_volume(effective_volume);
     sink.append(ps.built.source);
@@ -207,8 +208,14 @@ pub(crate) async fn spawn_outgoing_blend_resample(
         ps.built.fadeout_trigger.store(true, Ordering::SeqCst);
     }
 
+    let commit_guard = state.playback_commit_lock.lock().unwrap();
+    if state.generation.load(Ordering::SeqCst) != gen {
+        return Ok(());
+    }
     sink.play();
     *state.fading_out_sink.lock().unwrap() = Some(sink);
+    drop(stream_attach);
+    drop(commit_guard);
 
     let fo_arc = state.fading_out_sink.clone();
     let cleanup_secs = snap.actual_fade_secs.max(snap.outgoing_fade_secs) + 0.5;
@@ -288,8 +295,10 @@ pub(crate) async fn rebuild_current_track_at_blend_rate(
         .current_channels
         .store(ps.built.output_channels as u32, Ordering::Relaxed);
 
-    let stream = super::engine::ensure_output_stream_open(state)?;
-    let sink = Arc::new(Player::connect_new(stream.mixer()));
+    let (sink, stream_attach) = super::engine::connect_new_player(state)?;
+    if state.generation.load(Ordering::SeqCst) != gen {
+        return Ok(());
+    }
     let effective_volume = (snap.base_volume * snap.gain_linear).clamp(0.0, 1.0);
     sink.set_volume(effective_volume);
     sink.append(ps.built.source);
@@ -300,6 +309,10 @@ pub(crate) async fn rebuild_current_track_at_blend_rate(
             .map_err(|e| format!("[hi-res-blend] gapless realign seek failed: {e}"))?;
     }
 
+    let commit_guard = state.playback_commit_lock.lock().unwrap();
+    if state.generation.load(Ordering::SeqCst) != gen {
+        return Ok(());
+    }
     sink.play();
 
     {
@@ -314,6 +327,8 @@ pub(crate) async fn rebuild_current_track_at_blend_rate(
         cur.fadeout_trigger = Some(ps.built.fadeout_trigger);
         cur.fadeout_samples = Some(ps.built.fadeout_samples);
     }
+    drop(stream_attach);
+    drop(commit_guard);
 
     state.samples_played.store(
         raw_counter_samples_for_content_position(

--- a/src-tauri/crates/psysonic-audio/src/hi_res_blend.rs
+++ b/src-tauri/crates/psysonic-audio/src/hi_res_blend.rs
@@ -12,6 +12,7 @@ use super::engine::AudioEngine;
 use super::playback_rate::raw_counter_samples_for_content_position;
 use super::play_input::{url_format_hint, PlayInput};
 use super::source_build::{build_playback_source_with_probe_fallback, BuildSourceArgs, PlaybackSource};
+use super::state::install_current_source_done;
 use super::stream::LocalFileSource;
 
 const BLEND_44100: u32 = 44_100;
@@ -323,6 +324,14 @@ pub(crate) async fn rebuild_current_track_at_blend_rate(
         ),
         Ordering::Relaxed,
     );
+    if !install_current_source_done(
+        &state.current_source_done,
+        &state.generation,
+        gen,
+        done_flag,
+    ) {
+        return Ok(());
+    }
 
     crate::app_deprintln!(
         "[hi-res-blend] gapless realigned current track at {blend_rate} Hz from {:.2}s",

--- a/src-tauri/crates/psysonic-audio/src/lib.rs
+++ b/src-tauri/crates/psysonic-audio/src/lib.rs
@@ -8,6 +8,8 @@ pub use psysonic_core::{app_deprintln, app_eprintln, logging};
 
 pub mod autoeq_commands;
 mod analysis_dispatch;
+#[cfg(target_os = "linux")]
+mod alsa_rate;
 mod codec;
 pub mod commands;
 mod decode;

--- a/src-tauri/crates/psysonic-audio/src/power_resume.rs
+++ b/src-tauri/crates/psysonic-audio/src/power_resume.rs
@@ -9,7 +9,10 @@ use tauri::{AppHandle, Emitter, Manager};
 use super::device_watcher::{
     reopen_output_stream_with_retry, ReopenNotify, ReopenOutcome,
 };
-use super::engine::{request_stream_release_locked, AudioEngine};
+use super::engine::{
+    request_stream_release_after_attachments_locked, wait_for_stream_attachments_locked,
+    AudioEngine,
+};
 use super::stream_idle::{output_stream_is_needed, teardown_playback_sinks_for_idle_release};
 
 static RESUME_REOPEN_DEBOUNCE: Mutex<Option<Instant>> = Mutex::new(None);
@@ -39,11 +42,15 @@ pub(crate) async fn reopen_audio_after_system_resume(app: &AppHandle) {
 
     {
         let _stream_guard = engine.stream_open_lock.lock().unwrap();
-        let _commit_guard = engine.playback_commit_lock.lock().unwrap();
         if !output_stream_is_needed(engine) {
+            wait_for_stream_attachments_locked(engine);
+            let _commit_guard = engine.playback_commit_lock.lock().unwrap();
+            if output_stream_is_needed(engine) {
+                return;
+            }
             if engine.stream_handle.lock().unwrap().is_some() {
                 teardown_playback_sinks_for_idle_release(engine);
-                let _ = request_stream_release_locked(engine);
+                let _ = request_stream_release_after_attachments_locked(engine);
                 let _ = app.emit("audio:output-released", ());
             }
             return;

--- a/src-tauri/crates/psysonic-audio/src/power_resume.rs
+++ b/src-tauri/crates/psysonic-audio/src/power_resume.rs
@@ -6,8 +6,10 @@ use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, Emitter, Manager};
 
-use super::device_watcher::{reopen_output_stream, ReopenNotify};
-use super::engine::{request_stream_release, AudioEngine};
+use super::device_watcher::{
+    reopen_output_stream_with_retry, ReopenNotify, ReopenOutcome,
+};
+use super::engine::{request_stream_release_locked, AudioEngine};
 use super::stream_idle::{output_stream_is_needed, teardown_playback_sinks_for_idle_release};
 
 static RESUME_REOPEN_DEBOUNCE: Mutex<Option<Instant>> = Mutex::new(None);
@@ -35,23 +37,28 @@ pub(crate) async fn reopen_audio_after_system_resume(app: &AppHandle) {
     };
     let engine = state.inner();
 
-    if !output_stream_is_needed(engine) {
-        if engine.stream_handle.lock().unwrap().is_some() {
-            teardown_playback_sinks_for_idle_release(engine);
-            let _ = request_stream_release(engine);
-            *engine.stream_handle.lock().unwrap() = None;
-            let _ = app.emit("audio:output-released", ());
+    {
+        let _stream_guard = engine.stream_open_lock.lock().unwrap();
+        let _commit_guard = engine.playback_commit_lock.lock().unwrap();
+        if !output_stream_is_needed(engine) {
+            if engine.stream_handle.lock().unwrap().is_some() {
+                teardown_playback_sinks_for_idle_release(engine);
+                let _ = request_stream_release_locked(engine);
+                let _ = app.emit("audio:output-released", ());
+            }
+            return;
         }
-        return;
     }
 
     let device_name = engine.selected_device.lock().unwrap().clone();
 
-    if reopen_output_stream(app, device_name, ReopenNotify::DeviceChanged).await {
-        crate::app_eprintln!("[psysonic] audio output reopened after system resume");
-    } else {
-        crate::app_eprintln!(
-            "[psysonic] audio: stream reopen failed or timed out after system resume"
-        );
+    match reopen_output_stream_with_retry(app, device_name, ReopenNotify::DeviceChanged).await {
+        Ok(ReopenOutcome::Reopened) => {
+            crate::app_eprintln!("[psysonic] audio output reopened after system resume")
+        }
+        Ok(ReopenOutcome::Superseded) => {}
+        Err(error) => crate::app_eprintln!(
+            "[psysonic] audio: stream reopen failed after system resume: {error}"
+        ),
     }
 }

--- a/src-tauri/crates/psysonic-audio/src/preload_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/preload_commands.rs
@@ -455,6 +455,8 @@ mod tests {
             generation: 8,
             raw_bytes: std::sync::Arc::new(vec![4, 5, 6]),
             resolved_format: None,
+            output_rate: 44_100,
+            output_channels: 2,
             duration_secs: 60.0,
             replay_gain_linear: 1.0,
             base_volume: 1.0,

--- a/src-tauri/crates/psysonic-audio/src/preview.rs
+++ b/src-tauri/crates/psysonic-audio/src/preview.rs
@@ -3,7 +3,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use rodio::Player;
 use rodio::Source;
 use tauri::{AppHandle, Emitter, State};
 
@@ -69,9 +68,14 @@ pub(crate) fn preview_clear_for_new_main_playback(state: &AudioEngine, app: &App
     // so the watchdog — if it wakes between our writes — sees no work to do
     // and bails without resuming main behind our back.
     state.preview_main_resume.store(false, Ordering::Release);
-    state.preview_gen.fetch_add(1, Ordering::SeqCst);
-    let sink = state.preview_sink.lock().unwrap().take();
-    let id = state.preview_song_id.lock().unwrap().take();
+    let (sink, id) = {
+        let _commit_guard = state.playback_commit_lock.lock().unwrap();
+        state.preview_gen.fetch_add(1, Ordering::SeqCst);
+        (
+            state.preview_sink.lock().unwrap().take(),
+            state.preview_song_id.lock().unwrap().take(),
+        )
+    };
     if let Some(s) = sink { s.stop(); }
     if let Some(id) = id {
         app.emit("audio:preview-end", PreviewEndPayload {
@@ -350,12 +354,17 @@ pub async fn audio_preview_play(
     app: AppHandle,
     state: State<'_, AudioEngine>,
 ) -> Result<(), String> {
-    let gen = state.preview_gen.fetch_add(1, Ordering::SeqCst) + 1;
+    let (gen, prev_sink, prev_id) = {
+        let _commit_guard = state.playback_commit_lock.lock().unwrap();
+        (
+            state.preview_gen.fetch_add(1, Ordering::SeqCst) + 1,
+            state.preview_sink.lock().unwrap().take(),
+            state.preview_song_id.lock().unwrap().take(),
+        )
+    };
 
     // Tear down any existing preview before pausing main (so a rapid preview
     // swap doesn't double-pause and double-resume the main sink).
-    let prev_sink = state.preview_sink.lock().unwrap().take();
-    let prev_id = state.preview_song_id.lock().unwrap().take();
     if let Some(s) = prev_sink { s.stop(); }
     if let Some(prev) = prev_id {
         app.emit("audio:preview-end", PreviewEndPayload {
@@ -407,13 +416,21 @@ pub async fn audio_preview_play(
     let source = PriorityBoostSource::new(source);
 
     // ── Build secondary sink on the existing OutputStream ────────────────────
-    let stream = super::engine::ensure_output_stream_open(&state)?;
-    let sink = Arc::new(Player::connect_new(stream.mixer()));
+    let (sink, stream_attach) = super::engine::connect_new_player(&state)?;
+    if state.preview_gen.load(Ordering::SeqCst) != gen {
+        return Ok(());
+    }
     sink.set_volume((volume.clamp(0.0, 1.0) * MASTER_HEADROOM).clamp(0.0, 1.0));
     sink.append(source);
 
+    let commit_guard = state.playback_commit_lock.lock().unwrap();
+    if state.preview_gen.load(Ordering::SeqCst) != gen {
+        return Ok(());
+    }
     *state.preview_sink.lock().unwrap() = Some(sink.clone());
     *state.preview_song_id.lock().unwrap() = Some(id.clone());
+    drop(stream_attach);
+    drop(commit_guard);
 
     app.emit("audio:preview-start", id.clone()).ok();
 
@@ -565,9 +582,14 @@ pub fn audio_preview_set_volume(volume: f32, state: State<'_, AudioEngine>) {
 }
 
 pub(crate) fn preview_stop_inner(app: &AppHandle, state: &AudioEngine, resume_main: bool) {
-    state.preview_gen.fetch_add(1, Ordering::SeqCst);
-    let sink = state.preview_sink.lock().unwrap().take();
-    let id = state.preview_song_id.lock().unwrap().take();
+    let (sink, id) = {
+        let _commit_guard = state.playback_commit_lock.lock().unwrap();
+        state.preview_gen.fetch_add(1, Ordering::SeqCst);
+        (
+            state.preview_sink.lock().unwrap().take(),
+            state.preview_song_id.lock().unwrap().take(),
+        )
+    };
     if let Some(s) = sink { s.stop(); }
 
     if resume_main {

--- a/src-tauri/crates/psysonic-audio/src/progress_task.rs
+++ b/src-tauri/crates/psysonic-audio/src/progress_task.rs
@@ -13,7 +13,7 @@ use tauri::{AppHandle, Emitter, Runtime};
 use super::engine::AudioCurrent;
 use super::helpers::{ramp_sink_volume, ProgressPayload, MASTER_HEADROOM};
 use super::playback_rate::{effective_duration_secs, effective_position_secs, PlaybackRateAtomics};
-use super::state::ChainedInfo;
+use super::state::{install_current_source_done, ChainedInfo, CurrentSourceDone};
 
 /// Sink for the three progress events the task emits. Production wraps an
 /// `AppHandle<R>` (any Tauri runtime) via the blanket impl below; tests pass
@@ -68,7 +68,7 @@ pub(crate) fn spawn_progress_task<E: ProgressEmitter>(
     crossfade_enabled_arc: Arc<AtomicBool>,
     crossfade_secs_arc: Arc<AtomicU32>,
     autodj_suppress_arc: Arc<AtomicBool>,
-    initial_done: Arc<AtomicBool>,
+    current_source_done: CurrentSourceDone,
     emitter: E,
     analysis_app: Option<AppHandle>,
     samples_played: Arc<AtomicU64>,
@@ -109,8 +109,6 @@ pub(crate) fn spawn_progress_task<E: ProgressEmitter>(
 
     tokio::spawn(async move {
         let mut near_end_ticks: u32 = 0;
-        // Local done-flag reference; swapped on gapless transition.
-        let mut current_done = initial_done;
         // Local sample counter; swapped to chained source's counter on transition.
         let mut samples_played = samples_played;
         let mut last_progress_emit_at = Instant::now() - Duration::from_millis(PROGRESS_EMIT_MIN_MS);
@@ -130,7 +128,13 @@ pub(crate) fn spawn_progress_task<E: ProgressEmitter>(
             // If the current source is exhausted AND we have a chained track
             // ready, transition seamlessly: swap tracking state, emit
             // audio:track_switched for the new track, and continue the loop.
-            if current_done.load(Ordering::SeqCst) {
+            let source_done = current_source_done
+                .lock()
+                .unwrap()
+                .as_ref()
+                .filter(|(source_gen, _)| *source_gen == gen)
+                .map(|(_, done)| done.clone());
+            if source_done.is_some_and(|done| done.load(Ordering::SeqCst)) {
                 // Radio (dur == 0): stream exhausted / connection dropped → stop.
                 let cur_dur = current_arc.lock().unwrap().duration_secs;
                 if cur_dur <= 0.0 {
@@ -142,6 +146,14 @@ pub(crate) fn spawn_progress_task<E: ProgressEmitter>(
 
                 let chained = chained_arc.lock().unwrap().take();
                 if let Some(info) = chained {
+                    if !install_current_source_done(
+                        &current_source_done,
+                        &gen_counter,
+                        gen,
+                        info.source_done.clone(),
+                    ) {
+                        break;
+                    }
                     // The successor is now the playing track. Update the
                     // playback URL FIRST: `resolve_analysis_server_id` prefers
                     // the URL-derived server, so spawning the transition
@@ -161,8 +173,8 @@ pub(crate) fn spawn_progress_task<E: ProgressEmitter>(
                         crate::analysis_dispatch::spawn_gapless_transition_analysis(&app, &info);
                     }
 
-                    // Swap to the chained source's done flag.
-                    current_done = info.source_done;
+                    sample_rate_arc.store(info.output_rate, Ordering::Relaxed);
+                    channels_arc.store(info.output_channels as u32, Ordering::Relaxed);
 
                     // Swap to the chained source's sample counter.
                     // The chained CountingSource increments its own Arc,
@@ -380,6 +392,7 @@ mod tests {
         crossfade_secs: Arc<AtomicU32>,
         autodj_suppress: Arc<AtomicBool>,
         done: Arc<AtomicBool>,
+        current_source_done: CurrentSourceDone,
         samples_played: Arc<AtomicU64>,
         sample_rate: Arc<AtomicU32>,
         channels: Arc<AtomicU32>,
@@ -391,6 +404,7 @@ mod tests {
 
     impl TaskHarness {
         fn new(duration_secs: f64) -> Self {
+            let done = Arc::new(AtomicBool::new(false));
             let current = AudioCurrent {
                 sink: None,
                 duration_secs,
@@ -410,7 +424,8 @@ mod tests {
                 crossfade_enabled: Arc::new(AtomicBool::new(false)),
                 crossfade_secs: Arc::new(AtomicU32::new(0f32.to_bits())),
                 autodj_suppress: Arc::new(AtomicBool::new(false)),
-                done: Arc::new(AtomicBool::new(false)),
+                current_source_done: Arc::new(Mutex::new(Some((1, done.clone())))),
+                done,
                 samples_played: Arc::new(AtomicU64::new(0)),
                 sample_rate: Arc::new(AtomicU32::new(44_100)),
                 channels: Arc::new(AtomicU32::new(2)),
@@ -430,7 +445,7 @@ mod tests {
                 self.crossfade_enabled.clone(),
                 self.crossfade_secs.clone(),
                 self.autodj_suppress.clone(),
-                self.done.clone(),
+                self.current_source_done.clone(),
                 emitter,
                 None,
                 self.samples_played.clone(),
@@ -576,15 +591,17 @@ mod tests {
             raw_bytes: Arc::new(Vec::new()),
             resolved_format: Some(crate::decode::ResolvedCodecInfo {
                 codec_name: "flac",
-                sample_rate: Some(44_100),
+                sample_rate: Some(96_000),
                 bits_per_sample: Some(16),
-                channels: Some(2),
+                channels: Some(1),
                 lossless: true,
             }),
+            output_rate: 96_000,
+            output_channels: 1,
             duration_secs: 200.0,
             replay_gain_linear: 1.0,
             base_volume: 1.0,
-            source_done: chained_done,
+            source_done: chained_done.clone(),
             cancel: Arc::new(AtomicBool::new(false)),
             sample_counter: chained_samples,
         });
@@ -616,6 +633,8 @@ mod tests {
             h.gapless_switch_at.load(Ordering::SeqCst) > 0,
             "gapless_switch_at timestamp recorded for ghost-command guard"
         );
+        assert_eq!(h.sample_rate.load(Ordering::Relaxed), 96_000);
+        assert_eq!(h.channels.load(Ordering::Relaxed), 1);
 
         // The successor's resolved format must be emitted at the transition —
         // a gapless advance never re-runs audio_play, so without this the
@@ -628,9 +647,13 @@ mod tests {
             assert_eq!(formats[0].server_id.as_deref(), Some("srv-1"));
         }
 
-        // Stop the task.
-        h.gen_counter.store(99, Ordering::SeqCst);
+        chained_done.store(true, Ordering::SeqCst);
         tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            emitter.ended_count(),
+            1,
+            "the progress task must follow the successor completion flag"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -650,6 +673,29 @@ mod tests {
         assert!(
             h.gen_counter.load(Ordering::SeqCst) > h.gen,
             "generation counter must bump so following commands see the new gen"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn replacement_source_done_flag_drives_end_detection_in_same_generation() {
+        let h = TaskHarness::new(120.0);
+        let replacement_done = Arc::new(AtomicBool::new(false));
+
+        let emitter = Arc::new(MockEmitter::default());
+        h.spawn_with(emitter.clone());
+
+        // Hi-Res gapless realignment rebuilds the current source without
+        // changing the playback generation. The progress task must follow the
+        // replacement source's completion signal instead of waiting forever on
+        // the abandoned source flag captured by audio_play.
+        *h.current_source_done.lock().unwrap() = Some((h.gen, replacement_done.clone()));
+        replacement_done.store(true, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        assert_eq!(
+            emitter.ended_count(),
+            1,
+            "audio:ended must follow the replacement source in the same generation"
         );
     }
 

--- a/src-tauri/crates/psysonic-audio/src/radio_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/radio_commands.rs
@@ -20,6 +20,7 @@ use super::sources::{
     CountingSource, DynSource, EqSource, EqualPowerFadeIn, NotifyingSource,
     PriorityBoostSource, TriggeredFadeOut,
 };
+use super::state::install_current_source_done;
 use super::stream::{
     radio_download_task, AudioStreamReader, RadioLiveState, RadioSharedFlags,
     RADIO_BUF_CAPACITY, RADIO_READ_TIMEOUT_SECS,
@@ -178,6 +179,14 @@ pub async fn audio_play_radio(
     app.emit("audio:playing", 0.0f64).ok();
 
     state.stream_playback_armed.store(true, Ordering::SeqCst);
+    if !install_current_source_done(
+        &state.current_source_done,
+        &state.generation,
+        gen,
+        done_flag,
+    ) {
+        return Ok(());
+    }
     spawn_progress_task(
         gen,
         state.generation.clone(),
@@ -186,7 +195,7 @@ pub async fn audio_play_radio(
         state.crossfade_enabled.clone(),
         state.crossfade_secs.clone(),
         state.autodj_suppress_autocrossfade.clone(),
-        done_flag,
+        state.current_source_done.clone(),
         app,
         None,
         state.samples_played.clone(),

--- a/src-tauri/crates/psysonic-audio/src/radio_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/radio_commands.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use ringbuf::traits::Split;
 use ringbuf::{HeapCons, HeapRb};
-use rodio::{Player, Source};
+use rodio::Source;
 use tauri::{AppHandle, Emitter, State};
 
 use super::decode::SizedDecoder;
@@ -39,7 +39,10 @@ pub async fn audio_play_radio(
     app: AppHandle,
     state: State<'_, AudioEngine>,
 ) -> Result<(), String> {
-    let gen = state.generation.fetch_add(1, Ordering::SeqCst) + 1;
+    let gen = {
+        let _commit_guard = state.playback_commit_lock.lock().unwrap();
+        state.generation.fetch_add(1, Ordering::SeqCst) + 1
+    };
 
     // Cancel any active preview so it doesn't keep playing alongside radio.
     preview_clear_for_new_main_playback(&state, &app);
@@ -152,11 +155,17 @@ pub async fn audio_play_radio(
 
     if state.generation.load(Ordering::SeqCst) != gen { return Ok(()); }
 
-    let stream = super::engine::ensure_output_stream_open(&state)?;
-    let sink = Arc::new(Player::connect_new(stream.mixer()));
+    let (sink, stream_attach) = super::engine::connect_new_player(&state)?;
+    let commit_guard = state.playback_commit_lock.lock().unwrap();
+    if state.generation.load(Ordering::SeqCst) != gen {
+        return Ok(());
+    }
     sink.set_volume((volume.clamp(0.0, 1.0) * MASTER_HEADROOM).clamp(0.0, 1.0));
     sink.append(boosted);
 
+    if state.generation.load(Ordering::SeqCst) != gen {
+        return Ok(());
+    }
     {
         let mut cur = state.current.lock().unwrap();
         if let Some(old) = cur.sink.take() { old.stop(); }
@@ -170,6 +179,8 @@ pub async fn audio_play_radio(
         cur.fadeout_trigger   = Some(fadeout_trigger);
         cur.fadeout_samples   = Some(fadeout_samples);
     }
+    drop(stream_attach);
+    drop(commit_guard);
 
     *state.current_playback_url.lock().unwrap() = Some(url.clone());
 

--- a/src-tauri/crates/psysonic-audio/src/state.rs
+++ b/src-tauri/crates/psysonic-audio/src/state.rs
@@ -1,6 +1,29 @@
 //! Small shared structs for preload / gapless chain metadata.
-use std::sync::atomic::{AtomicBool, AtomicU64};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Completion signal for the source currently owned by a playback generation.
+/// Hi-Res realignment may replace the source without incrementing generation,
+/// so the progress task must resolve this slot dynamically instead of retaining
+/// the flag created by the original `audio_play` call.
+pub(crate) type CurrentSourceDone = Arc<Mutex<Option<(u64, Arc<AtomicBool>)>>>;
+
+/// Publish a source completion flag only while its playback generation remains
+/// current. Holding the slot lock across the generation check prevents a late
+/// resume/rebuild from overwriting a newer play's flag.
+pub(crate) fn install_current_source_done(
+    slot: &CurrentSourceDone,
+    generation: &AtomicU64,
+    expected_generation: u64,
+    done: Arc<AtomicBool>,
+) -> bool {
+    let mut current = slot.lock().unwrap();
+    if generation.load(Ordering::SeqCst) != expected_generation {
+        return false;
+    }
+    *current = Some((expected_generation, done));
+    true
+}
 
 pub(crate) struct PreloadedTrack {
     pub(crate) url: String,
@@ -31,6 +54,9 @@ pub(crate) struct ChainedInfo {
     /// Real decoded format of the chained successor, for the `audio:format`
     /// event emitted at the gapless transition.
     pub(crate) resolved_format: Option<crate::decode::ResolvedCodecInfo>,
+    /// Actual source shape after any blend-rate resampling.
+    pub(crate) output_rate: u32,
+    pub(crate) output_channels: u16,
     pub(crate) duration_secs: f64,
     pub(crate) replay_gain_linear: f32,
     pub(crate) base_volume: f32,
@@ -42,4 +68,28 @@ pub(crate) struct ChainedInfo {
     /// Atomic sample counter for this chained source (swapped into
     /// samples_played on transition).
     pub(crate) sample_counter: Arc<AtomicU64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_generation_cannot_replace_current_source_completion() {
+        let generation = AtomicU64::new(2);
+        let current_done = Arc::new(AtomicBool::new(false));
+        let slot = Arc::new(Mutex::new(Some((2, current_done.clone()))));
+
+        assert!(!install_current_source_done(
+            &slot,
+            &generation,
+            1,
+            Arc::new(AtomicBool::new(false)),
+        ));
+
+        let guard = slot.lock().unwrap();
+        let (slot_generation, slot_done) = guard.as_ref().unwrap();
+        assert_eq!(*slot_generation, 2);
+        assert!(Arc::ptr_eq(slot_done, &current_done));
+    }
 }

--- a/src-tauri/crates/psysonic-audio/src/stream_idle.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream_idle.rs
@@ -177,6 +177,7 @@ mod tests {
         AudioEngine {
             stream_handle: Arc::new(Mutex::new(None)),
             stream_sample_rate: Arc::new(AtomicU32::new(0)),
+            stream_requested_rate: Arc::new(AtomicU32::new(0)),
             device_default_rate: 48_000,
             stream_thread_tx,
             selected_device: Arc::new(Mutex::new(None)),

--- a/src-tauri/crates/psysonic-audio/src/stream_idle.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream_idle.rs
@@ -213,6 +213,7 @@ mod tests {
             normalization_target_lufs: Arc::new(AtomicU32::new(0)),
             loudness_pre_analysis_attenuation_db: Arc::new(AtomicU32::new(0)),
             chained_info: Arc::new(Mutex::new(None)),
+            current_source_done: Arc::new(Mutex::new(None)),
             samples_played: Arc::new(AtomicU64::new(0)),
             current_sample_rate: Arc::new(AtomicU32::new(44_100)),
             current_channels: Arc::new(AtomicU32::new(2)),

--- a/src-tauri/crates/psysonic-audio/src/stream_idle.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream_idle.rs
@@ -114,7 +114,7 @@ pub(crate) fn release_output_stream_on_stop(
     let attachments_ready =
         attachments_ready || !super::engine::stream_attachment_is_pending(engine);
     if !attachments_ready {
-        crate::app_deprintln!(
+        crate::app_eprintln!(
             "[psysonic] audio output release skipped: player attachment still pending"
         );
         return Ok(());
@@ -300,7 +300,7 @@ mod tests {
 
         assert!(super::super::engine::wait_for_stream_attachments_timeout_locked(
             &engine,
-            Duration::from_millis(100),
+            Duration::from_secs(1),
         ));
         attachment.join().unwrap();
     }

--- a/src-tauri/crates/psysonic-audio/src/stream_idle.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream_idle.rs
@@ -15,6 +15,9 @@ const IDLE_POLL_SECS: u64 = 5;
 
 /// Returns true while the app must keep an open output stream (playing, preview, crossfade).
 pub(crate) fn output_stream_is_needed(engine: &AudioEngine) -> bool {
+    if super::engine::stream_attachment_is_pending(engine) {
+        return true;
+    }
     if engine.preview_sink.lock().unwrap().is_some() {
         return true;
     }
@@ -56,9 +59,8 @@ pub(crate) fn teardown_playback_sinks_for_idle_release(engine: &AudioEngine) {
     cur.play_started = None;
 }
 
-fn close_output_device_handle(engine: &AudioEngine, app: &AppHandle) -> Result<(), String> {
-    super::engine::request_stream_release(engine)?;
-    *engine.stream_handle.lock().unwrap() = None;
+fn close_output_device_handle_locked(engine: &AudioEngine, app: &AppHandle) -> Result<(), String> {
+    super::engine::request_stream_release_locked(engine)?;
     let _ = app.emit("audio:output-released", ());
     Ok(())
 }
@@ -68,11 +70,17 @@ pub(crate) fn release_output_stream(
     engine: &AudioEngine,
     app: &AppHandle,
 ) -> Result<(), String> {
+    let _open_guard = engine.stream_open_lock.lock().unwrap();
     if engine.stream_handle.lock().unwrap().is_none() {
         return Ok(());
     }
+    // A player can spend hundreds of milliseconds paused for prefill before it
+    // is visible in `AudioCurrent`; recheck while release/open is serialized.
+    if output_stream_is_needed(engine) {
+        return Ok(());
+    }
     teardown_playback_sinks_for_idle_release(engine);
-    close_output_device_handle(engine, app)?;
+    close_output_device_handle_locked(engine, app)?;
     crate::app_eprintln!(
         "[psysonic] audio output stream released after {}s idle",
         OUTPUT_STREAM_IDLE_RELEASE_SECS
@@ -84,18 +92,21 @@ pub(crate) fn release_output_stream(
 pub(crate) fn release_output_stream_on_stop(
     engine: &AudioEngine,
     app: &AppHandle,
+    expected_generation: u64,
 ) -> Result<(), String> {
+    let _open_guard = engine.stream_open_lock.lock().unwrap();
+    super::engine::wait_for_stream_attachments_locked(engine);
+    let _commit_guard = engine.playback_commit_lock.lock().unwrap();
+    if engine.generation.load(Ordering::SeqCst) != expected_generation {
+        return Ok(());
+    }
     if engine.stream_handle.lock().unwrap().is_none() {
         return Ok(());
     }
-    // `audio_stop` already tore down the main sink; clear any crossfade/preview tail
-    // still tied to the open device before closing the handle.
-    if engine.preview_sink.lock().unwrap().is_some()
-        || engine.fading_out_sink.lock().unwrap().is_some()
-    {
-        teardown_playback_sinks_for_idle_release(engine);
-    }
-    close_output_device_handle(engine, app)?;
+    // A player attachment that was already in flight can finish after
+    // `audio_stop` cleared the main sink. Recheck all sink slots after waiting.
+    teardown_playback_sinks_for_idle_release(engine);
+    close_output_device_handle_locked(engine, app)?;
     crate::app_eprintln!("[psysonic] audio output stream released on stop");
     Ok(())
 }
@@ -176,6 +187,9 @@ mod tests {
         let (stream_thread_tx, _) = std::sync::mpsc::sync_channel(0);
         AudioEngine {
             stream_handle: Arc::new(Mutex::new(None)),
+            stream_open_lock: Arc::new(Mutex::new(())),
+            stream_attach_pending: Arc::new((Mutex::new(0), std::sync::Condvar::new())),
+            playback_commit_lock: Arc::new(Mutex::new(())),
             stream_sample_rate: Arc::new(AtomicU32::new(0)),
             stream_requested_rate: Arc::new(AtomicU32::new(0)),
             device_default_rate: 48_000,
@@ -235,6 +249,13 @@ mod tests {
     fn idle_when_no_sink_and_no_preview() {
         let engine = minimal_engine();
         assert!(!output_stream_is_needed(&engine));
+    }
+
+    #[test]
+    fn needed_while_player_attachment_is_pending() {
+        let engine = minimal_engine();
+        *engine.stream_attach_pending.0.lock().unwrap() = 1;
+        assert!(output_stream_is_needed(&engine));
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-audio/src/stream_idle.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream_idle.rs
@@ -12,6 +12,9 @@ use super::engine::AudioEngine;
 pub(crate) const OUTPUT_STREAM_IDLE_RELEASE_SECS: u64 = 60;
 
 const IDLE_POLL_SECS: u64 = 5;
+// Keep the synchronous stop command responsive. A longer attachment finishes
+// safely and the idle watcher releases the stream afterward.
+const STOP_ATTACHMENT_WAIT_MS: u64 = 50;
 
 /// Returns true while the app must keep an open output stream (playing, preview, crossfade).
 pub(crate) fn output_stream_is_needed(engine: &AudioEngine) -> bool {
@@ -95,18 +98,32 @@ pub(crate) fn release_output_stream_on_stop(
     expected_generation: u64,
 ) -> Result<(), String> {
     let _open_guard = engine.stream_open_lock.lock().unwrap();
-    super::engine::wait_for_stream_attachments_locked(engine);
+    let attachments_ready = super::engine::wait_for_stream_attachments_timeout_locked(
+        engine,
+        Duration::from_millis(STOP_ATTACHMENT_WAIT_MS),
+    );
     let _commit_guard = engine.playback_commit_lock.lock().unwrap();
     if engine.generation.load(Ordering::SeqCst) != expected_generation {
+        return Ok(());
+    }
+    // Stop already-registered preview/crossfade sinks even when a new player is
+    // still attaching. Its stale generation prevents it from committing later.
+    teardown_playback_sinks_for_idle_release(engine);
+    // The attachment may have finished while this command waited for the
+    // commit lock. The stream lock prevents another attachment from starting.
+    let attachments_ready =
+        attachments_ready || !super::engine::stream_attachment_is_pending(engine);
+    if !attachments_ready {
+        crate::app_deprintln!(
+            "[psysonic] audio output release skipped: player attachment still pending"
+        );
         return Ok(());
     }
     if engine.stream_handle.lock().unwrap().is_none() {
         return Ok(());
     }
-    // A player attachment that was already in flight can finish after
-    // `audio_stop` cleared the main sink. Recheck all sink slots after waiting.
-    teardown_playback_sinks_for_idle_release(engine);
-    close_output_device_handle_locked(engine, app)?;
+    super::engine::request_stream_release_after_attachments_locked(engine)?;
+    let _ = app.emit("audio:output-released", ());
     crate::app_eprintln!("[psysonic] audio output stream released on stop");
     Ok(())
 }
@@ -256,6 +273,36 @@ mod tests {
         let engine = minimal_engine();
         *engine.stream_attach_pending.0.lock().unwrap() = 1;
         assert!(output_stream_is_needed(&engine));
+    }
+
+    #[test]
+    fn bounded_attachment_wait_times_out_while_pending() {
+        let engine = minimal_engine();
+        *engine.stream_attach_pending.0.lock().unwrap() = 1;
+
+        assert!(!super::super::engine::wait_for_stream_attachments_timeout_locked(
+            &engine,
+            Duration::from_millis(5),
+        ));
+    }
+
+    #[test]
+    fn bounded_attachment_wait_succeeds_after_notification() {
+        let engine = minimal_engine();
+        *engine.stream_attach_pending.0.lock().unwrap() = 1;
+        let pending = engine.stream_attach_pending.clone();
+        let attachment = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(5));
+            let (count, ready) = &*pending;
+            *count.lock().unwrap() = 0;
+            ready.notify_all();
+        });
+
+        assert!(super::super::engine::wait_for_stream_attachments_timeout_locked(
+            &engine,
+            Duration::from_millis(100),
+        ));
+        attachment.join().unwrap();
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-audio/src/transport_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/transport_commands.rs
@@ -122,6 +122,7 @@ pub fn audio_stop(state: State<'_, AudioEngine>, app: AppHandle) {
     *state.current_analysis_track_id.lock().unwrap() = None;
     *state.current_playback_server_id.lock().unwrap() = None;
     *state.chained_info.lock().unwrap() = None;
+    *state.current_source_done.lock().unwrap() = None;
     // Keep `stream_completed_cache`: natural track end often calls `audio_stop` when the
     // queue is exhausted; clearing here dropped the full ranged buffer and forced a
     // re-download on replay. The slot is only consumed on `take`/overwrite for another URL.

--- a/src-tauri/crates/psysonic-audio/src/transport_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/transport_commands.rs
@@ -117,25 +117,32 @@ pub async fn audio_resume(state: State<'_, AudioEngine>, app: AppHandle) -> Resu
 #[specta::specta]
 pub fn audio_stop(state: State<'_, AudioEngine>, app: AppHandle) {
     preview_clear_for_new_main_playback(&state, &app);
-    state.generation.fetch_add(1, Ordering::SeqCst);
-    *state.current_playback_url.lock().unwrap() = None;
-    *state.current_analysis_track_id.lock().unwrap() = None;
-    *state.current_playback_server_id.lock().unwrap() = None;
-    *state.chained_info.lock().unwrap() = None;
-    *state.current_source_done.lock().unwrap() = None;
-    // Keep `stream_completed_cache`: natural track end often calls `audio_stop` when the
-    // queue is exhausted; clearing here dropped the full ranged buffer and forced a
-    // re-download on replay. The slot is only consumed on `take`/overwrite for another URL.
-    // Drop RadioLiveState → triggers Drop → task.abort() → TCP released.
-    drop(state.radio_state.lock().unwrap().take());
-    let mut cur = state.current.lock().unwrap();
-    if let Some(sink) = cur.sink.take() { sink.stop(); }
-    cur.duration_secs = 0.0;
-    cur.seek_offset   = 0.0;
-    cur.play_started  = None;
-    cur.paused_at     = None;
-    drop(cur);
-    let _ = super::stream_idle::release_output_stream_on_stop(state.inner(), &app);
+    let stop_generation = {
+        let _commit_guard = state.playback_commit_lock.lock().unwrap();
+        let generation = state.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        *state.current_playback_url.lock().unwrap() = None;
+        *state.current_analysis_track_id.lock().unwrap() = None;
+        *state.current_playback_server_id.lock().unwrap() = None;
+        *state.chained_info.lock().unwrap() = None;
+        *state.current_source_done.lock().unwrap() = None;
+        // Keep `stream_completed_cache`: natural track end often calls `audio_stop` when the
+        // queue is exhausted; clearing here dropped the full ranged buffer and forced a
+        // re-download on replay. The slot is only consumed on `take`/overwrite for another URL.
+        // Drop RadioLiveState → triggers Drop → task.abort() → TCP released.
+        drop(state.radio_state.lock().unwrap().take());
+        let mut cur = state.current.lock().unwrap();
+        if let Some(sink) = cur.sink.take() { sink.stop(); }
+        cur.duration_secs = 0.0;
+        cur.seek_offset   = 0.0;
+        cur.play_started  = None;
+        cur.paused_at     = None;
+        generation
+    };
+    let _ = super::stream_idle::release_output_stream_on_stop(
+        state.inner(),
+        &app,
+        stop_generation,
+    );
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- verify the sample rate ALSA actually negotiates before configuring the Rodio mixer, preventing half-speed or double-speed playback
- keep requested and negotiated stream rates separate so Hi-Res and device recovery do not repeatedly reopen coerced streams
- hand off generation-qualified source completion state during Hi-Res and gapless source replacement so playback advances reliably
- preserve verified fallback coverage across Linux output devices and supported configurations

## Verification
- `nix develop -c bash -lc 'cargo test --workspace --all-targets -- --test-threads=1'`
- `nix develop -c bash -lc 'cargo clippy --workspace --all-targets -- -D warnings'`
- all 341 `psysonic-audio` tests pass
- default-parallel workspace runs expose two unrelated library timing-budget tests on this machine; both pass in the single-threaded workspace run and isolated runs
- independent static review found no remaining high/medium issues

## Manual verification
- play adjacent 44.1/48/96 kHz tracks with Native Hi-Res enabled on Linux ALSA/PipeWire
- confirm pitch and playback speed remain correct
- confirm gapless playback and ordinary queue advancement continue to the next track
- switch output devices and resume after an idle stream release

## Tauri boundary
- no invoke commands, events, or payload shapes changed

## Runtime benchmark
- not applicable: the route benchmark harness does not exercise native audio output; this change is limited to ALSA stream negotiation and playback completion correctness