### PR TITLE
fix(servers): reject duplicate login profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,6 +385,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Homepage URLs supplied by Navidrome no longer disappear from station cards or the edit form after saving or reloading the station.
 
+### Servers — prevent duplicate account profiles
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1399](https://github.com/Psychotoxical/psysonic/pull/1399)**, reported by zunoz on Discord
+
+* Settings no longer saves a second profile with the same server address and username. The same server can still be saved for a different account.
+
 ## [1.50.0]
 
 ## Added

--- a/src/features/settings/components/ServersTab.test.tsx
+++ b/src/features/settings/components/ServersTab.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   librarySyncClearSession: vi.fn(),
   libraryDeleteServerData: vi.fn(),
   onPersisted: vi.fn(),
+  showToast: vi.fn(),
 }));
 
 vi.mock('@/lib/library/hooks/useLibraryIndexSync', () => ({
@@ -44,6 +45,10 @@ vi.mock('@/lib/server/syncServerHttpContext', () => ({
 vi.mock('@/lib/api/library', () => ({
   librarySyncClearSession: mocks.librarySyncClearSession,
   libraryDeleteServerData: mocks.libraryDeleteServerData,
+}));
+
+vi.mock('@/lib/dom/toast', () => ({
+  showToast: mocks.showToast,
 }));
 
 vi.mock('@/lib/server/serverEndpoint', () => ({
@@ -124,8 +129,35 @@ vi.mock('@/features/settings/components/AddServerForm', () => ({
         save-edit
       </button>
       <button type="button" onClick={onDelete}>delete-edit</button>
+      <button type="button" onClick={() => onSave({
+        name: editingServer.name,
+        url: 'https://a.test/',
+        username: 'user',
+        password: editingServer.password,
+      })}>
+        save-edit-duplicate
+      </button>
     </>
-  ) : null,
+  ) : (
+    <>
+      <button type="button" onClick={() => onSave({
+        name: 'Duplicate',
+        url: 'https://a.test/',
+        username: 'user',
+        password: 'password',
+      })}>
+        save-add-duplicate
+      </button>
+      <button type="button" onClick={() => onSave({
+        name: 'Other user',
+        url: 'https://a.test/',
+        username: 'other',
+        password: 'password',
+      })}>
+        save-add-other-user
+      </button>
+    </>
+  ),
 }));
 
 import { ServersTab } from './ServersTab';
@@ -146,6 +178,7 @@ beforeEach(() => {
   mocks.clearServerHttpContext.mockReset().mockResolvedValue(undefined);
   mocks.invalidateReachableEndpointCache.mockReset();
   mocks.onPersisted.mockReset();
+  mocks.showToast.mockReset();
   mocks.librarySyncClearSession.mockReset().mockResolvedValue(undefined);
   mocks.libraryDeleteServerData.mockReset().mockResolvedValue(undefined);
   useAuthStore.setState({
@@ -154,6 +187,65 @@ beforeEach(() => {
     servers: [{
       id: 'a', name: 'A', url: 'https://a.test', username: 'user', password: 'old-password',
     }],
+  });
+});
+
+describe('ServersTab duplicate server login validation', () => {
+  it('blocks adding an existing URL and username before connecting', async () => {
+    const user = userEvent.setup();
+    const view = renderWithProviders(<ServersTab initialInvite={null} />);
+
+    await user.click(view.container.querySelector('#settings-add-server-btn')!);
+    await user.click(screen.getByRole('button', { name: 'save-add-duplicate' }));
+
+    expect(mocks.pingWithCredentialsForProfile).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().servers).toHaveLength(1);
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      expect.stringMatching(/already exists/i),
+      5000,
+      'error',
+    );
+  });
+
+  it('blocks editing another profile to an existing URL and username', async () => {
+    useAuthStore.setState({
+      servers: [
+        ...useAuthStore.getState().servers,
+        { id: 'b', name: 'B', url: 'https://b.test', username: 'other', password: 'password' },
+      ],
+    });
+    const user = userEvent.setup();
+    const view = renderWithProviders(<ServersTab initialInvite={null} />);
+
+    await user.click(view.container.querySelector('#settings-edit-server-b')!);
+    await user.click(screen.getByRole('button', { name: 'save-edit-duplicate' }));
+
+    expect(useAuthStore.getState().servers.find(server => server.id === 'b')).toMatchObject({
+      url: 'https://b.test',
+      username: 'other',
+    });
+    expect(mocks.ensureConnectUrlResolved).not.toHaveBeenCalled();
+  });
+
+  it('allows the same URL for a different username', async () => {
+    mocks.pingWithCredentialsForProfile.mockResolvedValue({
+      ok: true,
+      type: 'navidrome',
+      serverVersion: '0.56.0',
+      openSubsonic: true,
+    });
+    const user = userEvent.setup();
+    const view = renderWithProviders(<ServersTab initialInvite={null} />);
+
+    await user.click(view.container.querySelector('#settings-add-server-btn')!);
+    await user.click(screen.getByRole('button', { name: 'save-add-other-user' }));
+
+    await waitFor(() => expect(useAuthStore.getState().servers).toHaveLength(2));
+    expect(useAuthStore.getState().servers[1]).toMatchObject({
+      url: 'https://a.test/',
+      username: 'other',
+    });
+    expect(mocks.showToast).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/settings/components/ServersTab.tsx
+++ b/src/features/settings/components/ServersTab.tsx
@@ -39,6 +39,7 @@ import { isFeatureActiveForServer, resolveFeatureForServer } from '@/lib/serverC
 import type { ResolvedCapability } from '@/lib/serverCapabilities/types';
 import { serverIdentityLabel, serverListDisplayLabel, serverSettingsEntryTitle } from '@/lib/server/serverDisplayName';
 import { serverIndexKeyForProfile } from '@/lib/server/serverIndexKey';
+import { serverProfileBaseUrl } from '@/lib/server/serverBaseUrl';
 import { switchActiveServer } from '@/utils/server/switchActiveServer';
 import { AddServerForm } from '@/features/settings/components/AddServerForm';
 import { ServerCapabilityHeaderBadge } from '@/features/settings/components/ServerCapabilityHeaderBadge';
@@ -49,6 +50,18 @@ import { tooltipAttrs } from '@/ui/tooltipAttrs';
 import { publishServerConnectionStatus } from '@/lib/network/serverReachability';
 
 const AUDIOMUSE_NV_PLUGIN_URL = 'https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin';
+
+function hasDuplicateServerLogin(
+  servers: ServerProfile[],
+  candidate: Pick<ServerProfile, 'url' | 'username'>,
+  excludeServerId?: string,
+): boolean {
+  const url = serverProfileBaseUrl({ url: candidate.url.trim() });
+  const username = candidate.username.trim();
+  return servers.some(server => server.id !== excludeServerId
+    && serverProfileBaseUrl({ url: server.url.trim() }) === url
+    && server.username.trim() === username);
+}
 
 /** Row visibility: same as main — hide only when manual strategy proves the feature absent. */
 function showAudiomuseRow(resolved: ResolvedCapability | null): boolean {
@@ -222,6 +235,10 @@ export function ServersTab({
   };
 
   const handleAddServer = async (data: Omit<ServerProfile, 'id'>) => {
+    if (hasDuplicateServerLogin(useAuthStore.getState().servers, data)) {
+      showToast(t('settings.serverDuplicate'), 5000, 'error');
+      return;
+    }
     // Keep the add form open until the connect test actually succeeds — so a
     // failure can point the user at what's wrong (bad credentials, gate header,
     // unreachable) instead of silently closing with a tiny status dot.
@@ -308,6 +325,10 @@ export function ServersTab({
     data: Omit<ServerProfile, 'id'>,
     onPersisted?: () => void,
   ) => {
+    if (hasDuplicateServerLogin(useAuthStore.getState().servers, data, id)) {
+      showToast(t('settings.serverDuplicate'), 5000, 'error');
+      return;
+    }
     const editGeneration = (editGenerationRef.current[id] ?? 0) + 1;
     editGenerationRef.current[id] = editGeneration;
     const previous = auth.servers.find(s => s.id === id);

--- a/src/locales/bg/settings.ts
+++ b/src/locales/bg/settings.ts
@@ -78,6 +78,7 @@ export const settings = {
   serverFailed: 'Връзката се провали.',
   serverUrlRequired: 'Адресът на сървъра е задължителен.',
   serverUsernameRequired: 'Потребителското име е задължително.',
+  serverDuplicate: 'Връзка с този адрес на сървъра и потребителско име вече съществува.',
   serverConnectFailedReason: 'Връзката е неуспешна: {{reason}}',
   testBtn: 'Тествай връзката',
   testingBtn: 'Тестване…',

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -78,6 +78,7 @@ export const settings = {
   serverFailed: 'Verbindung fehlgeschlagen.',
   serverUrlRequired: 'Serveradresse ist erforderlich.',
   serverUsernameRequired: 'Benutzername ist erforderlich.',
+  serverDuplicate: 'Eine Verbindung mit dieser Serveradresse und diesem Benutzernamen ist bereits gespeichert.',
   serverConnectFailedReason: 'Verbindung fehlgeschlagen: {{reason}}',
   testBtn: 'Verbindung testen',
   testingBtn: 'Teste…',

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -78,6 +78,7 @@ export const settings = {
   serverFailed: 'Connection failed.',
   serverUrlRequired: 'Server address is required.',
   serverUsernameRequired: 'Username is required.',
+  serverDuplicate: 'A connection with this server address and username already exists.',
   serverConnectFailedReason: 'Could not connect: {{reason}}',
   testBtn: 'Test Connection',
   testingBtn: 'Testing…',

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -77,6 +77,7 @@ export const settings = {
   serverFailed: 'Conexión fallida.',
   serverUrlRequired: 'La dirección del servidor es obligatoria.',
   serverUsernameRequired: 'El nombre de usuario es obligatorio.',
+  serverDuplicate: 'Ya existe una conexión con esta dirección de servidor y este nombre de usuario.',
   serverConnectFailedReason: 'No se pudo conectar: {{reason}}',
   testBtn: 'Probar Conexión',
   testingBtn: 'Probando…',

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -77,6 +77,7 @@ export const settings = {
   serverFailed: 'Connexion échouée.',
   serverUrlRequired: 'L’adresse du serveur est requise.',
   serverUsernameRequired: 'Le nom d’utilisateur est requis.',
+  serverDuplicate: 'Une connexion avec cette adresse de serveur et ce nom d’utilisateur existe déjà.',
   serverConnectFailedReason: 'Connexion impossible : {{reason}}',
   testBtn: 'Tester la connexion',
   testingBtn: 'Test en cours…',

--- a/src/locales/hu/settings.ts
+++ b/src/locales/hu/settings.ts
@@ -78,6 +78,7 @@ export const settings = {
   serverFailed: 'A kapcsolat sikertelen.',
   serverUrlRequired: 'A szerver címe kötelező.',
   serverUsernameRequired: 'A felhasználónév kötelező.',
+  serverDuplicate: 'Már létezik kapcsolat ezzel a szervercímmel és felhasználónévvel.',
   serverConnectFailedReason: 'Nem sikerült csatlakozni: {{reason}}',
   testBtn: 'Kapcsolat tesztelése',
   testingBtn: 'Tesztelés…',

--- a/src/locales/it/settings.ts
+++ b/src/locales/it/settings.ts
@@ -78,6 +78,7 @@ export const settings = {
   serverFailed: 'Connessione non riuscita.',
   serverUrlRequired: 'L’indirizzo del server è obbligatorio.',
   serverUsernameRequired: 'Il nome utente è obbligatorio.',
+  serverDuplicate: 'Esiste già una connessione con questo indirizzo server e nome utente.',
   serverConnectFailedReason: 'Impossibile connettersi: {{reason}}',
   testBtn: 'Testa connessione',
   testingBtn: 'Test in corso…',

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -78,6 +78,7 @@ export const settings = {
   serverFailed: '接続に失敗しました。',
   serverUrlRequired: 'サーバーアドレスを入力してください。',
   serverUsernameRequired: 'ユーザー名を入力してください。',
+  serverDuplicate: 'このサーバーアドレスとユーザー名の接続は既に存在します。',
   serverConnectFailedReason: '接続できませんでした: {{reason}}',
   testBtn: '接続をテスト',
   testingBtn: 'テスト中…',

--- a/src/locales/nb/settings.ts
+++ b/src/locales/nb/settings.ts
@@ -77,6 +77,7 @@ export const settings = {
   serverFailed: 'Tilkobling mislyktes.',
   serverUrlRequired: 'Serveradresse er påkrevd.',
   serverUsernameRequired: 'Brukernavn er påkrevd.',
+  serverDuplicate: 'En tilkobling med denne serveradressen og dette brukernavnet finnes allerede.',
   serverConnectFailedReason: 'Kunne ikke koble til: {{reason}}',
   testBtn: 'Test tilkobling',
   testingBtn: 'Tester…',

--- a/src/locales/nl/settings.ts
+++ b/src/locales/nl/settings.ts
@@ -77,6 +77,7 @@ export const settings = {
   serverFailed: 'Verbinding mislukt.',
   serverUrlRequired: 'Serveradres is verplicht.',
   serverUsernameRequired: 'Gebruikersnaam is verplicht.',
+  serverDuplicate: 'Er bestaat al een verbinding met dit serveradres en deze gebruikersnaam.',
   serverConnectFailedReason: 'Kan geen verbinding maken: {{reason}}',
   testBtn: 'Verbinding testen',
   testingBtn: 'Testen…',

--- a/src/locales/pl/settings.ts
+++ b/src/locales/pl/settings.ts
@@ -78,6 +78,7 @@ export const settings = {
   serverFailed: 'Połączenie nieudane.',
   serverUrlRequired: 'Adres serwera jest wymagany.',
   serverUsernameRequired: 'Nazwa użytkownika jest wymagana.',
+  serverDuplicate: 'Połączenie z tym adresem serwera i nazwą użytkownika już istnieje.',
   serverConnectFailedReason: 'Nie można połączyć: {{reason}}',
   testBtn: 'Sprawdź połączenie',
   testingBtn: 'Sprawdzanie…',

--- a/src/locales/ro/settings.ts
+++ b/src/locales/ro/settings.ts
@@ -77,6 +77,7 @@ export const settings = {
   serverFailed: 'Conexiune eșuată.',
   serverUrlRequired: 'Adresa serverului este obligatorie.',
   serverUsernameRequired: 'Numele de utilizator este obligatoriu.',
+  serverDuplicate: 'Există deja o conexiune cu această adresă de server și acest nume de utilizator.',
   serverConnectFailedReason: 'Conexiune eșuată: {{reason}}',
   testBtn: 'Testează Conexiunea',
   testingBtn: 'Se testează…',

--- a/src/locales/ru/settings.ts
+++ b/src/locales/ru/settings.ts
@@ -77,6 +77,7 @@ export const settings = {
   serverFailed: 'Ошибка подключения.',
   serverUrlRequired: 'Укажите адрес сервера.',
   serverUsernameRequired: 'Укажите имя пользователя.',
+  serverDuplicate: 'Подключение с этим адресом сервера и именем пользователя уже существует.',
   serverConnectFailedReason: 'Не удалось подключиться: {{reason}}',
   testBtn: 'Проверить',
   testingBtn: 'Проверка…',

--- a/src/locales/zh/settings.ts
+++ b/src/locales/zh/settings.ts
@@ -77,6 +77,7 @@ export const settings = {
   serverFailed: '连接失败。',
   serverUrlRequired: '请填写服务器地址。',
   serverUsernameRequired: '请填写用户名。',
+  serverDuplicate: '已存在使用此服务器地址和用户名的连接。',
   serverConnectFailedReason: '无法连接：{{reason}}',
   testBtn: '测试连接',
   testingBtn: '正在测试…',


### PR DESCRIPTION
## Summary
- reject a saved server profile when its normalized primary URL and username already exist
- apply the same validation to add and edit flows while allowing another username on the same server
- localize the validation message across all shipped languages and cover the behavior with regression tests

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (547 files, 4018 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`

## Runtime benchmark
- Applicability: not applicable - isolated Settings form validation with no measured route, layout, background-work, or performance-path change

## Tauri boundary
- Not changed.