### PR TITLE
fix(tracks): reroll highly rated songs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Settings no longer saves a second profile with the same server address and username. The same server can still be saved for a different account.
 
+### Tracks — reroll the Highly Rated selection
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1400](https://github.com/Psychotoxical/psysonic/pull/1400)**, reported by zunoz on Discord
+
+* **Highly Rated** now reshuffles tracks within each rating tier instead of requesting and redisplaying the same fixed order. Higher ratings stay first, and rerolls reuse the short-lived list cache so the new selection appears without another server roundtrip.
+
 ## [1.50.0]
 
 ## Added

--- a/src/features/search/components/TracksPageChrome.test.tsx
+++ b/src/features/search/components/TracksPageChrome.test.tsx
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '@/test/helpers/renderWithProviders';
+import type { SubsonicSong } from '@/lib/api/subsonicTypes';
+import TracksPageChrome from '@/features/search/components/TracksPageChrome';
+
+const mocks = vi.hoisted(() => ({
+  ndListSongs: vi.fn(),
+  ndInvalidateSongsCache: vi.fn(),
+  shuffleArray: vi.fn(),
+}));
+
+vi.mock('@/lib/api/subsonicLibrary', () => ({
+  getRandomSongs: vi.fn(async () => []),
+}));
+
+vi.mock('@/lib/api/navidromeBrowse', () => ({
+  ndListSongs: mocks.ndListSongs,
+  ndInvalidateSongsCache: mocks.ndInvalidateSongsCache,
+}));
+
+vi.mock('@/lib/util/shuffleArray', () => ({
+  shuffleArray: mocks.shuffleArray,
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: (selector: (state: { activeServerId: string }) => unknown) =>
+    selector({ activeServerId: 'server-1' }),
+}));
+
+vi.mock('@/features/playback/store/playerStore', () => ({
+  usePlayerStore: (selector: (state: { enqueue: () => void }) => unknown) =>
+    selector({ enqueue: vi.fn() }),
+}));
+
+vi.mock('@/lib/perf/perfFlags', () => ({
+  usePerfProbeFlags: () => ({
+    disableMainstageStickyHeader: false,
+    disableMainstageHero: false,
+    disableMainstageRails: false,
+  }),
+}));
+
+vi.mock('@/features/album', () => ({ useNavigateToAlbum: () => vi.fn() }));
+vi.mock('@/features/artist', () => ({ useNavigateToArtist: () => vi.fn() }));
+vi.mock('@/cover/AlbumCoverArtImage', () => ({ AlbumCoverArtImage: () => null }));
+vi.mock('@/ui/ResolvedArtistRefInline', () => ({ ResolvedArtistRefInline: () => null }));
+
+vi.mock('@/features/home', async () => {
+  const React = await import('react');
+  return {
+    SongRail: ({
+      title,
+      songs,
+      onReroll,
+      loading,
+    }: {
+      title: string;
+      songs: SubsonicSong[];
+      onReroll?: () => void | Promise<void>;
+      loading?: boolean;
+    }) => React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, title),
+      onReroll && React.createElement(
+        'button',
+        { 'aria-label': `Reroll ${title}`, disabled: loading, onClick: onReroll },
+        'Reroll',
+      ),
+      React.createElement(
+        'ul',
+        { 'aria-label': `${title} songs` },
+        songs.map(song => React.createElement('li', { key: song.id }, song.id)),
+      ),
+    ),
+  };
+});
+
+function ratedSong(index: number): SubsonicSong {
+  return {
+    id: `song-${index}`,
+    title: `Song ${index}`,
+    artist: 'Artist',
+    album: 'Album',
+    albumId: 'album-1',
+    duration: 180,
+    userRating: index <= 40 ? 5 : 4,
+  };
+}
+
+function visibleSongIds(list: HTMLElement): string[] {
+  return Array.from(list.querySelectorAll('li'), item => item.textContent ?? '');
+}
+
+describe('TracksPageChrome Highly Rated rail', () => {
+  beforeEach(() => {
+    mocks.ndListSongs.mockReset();
+    mocks.ndInvalidateSongsCache.mockReset();
+    mocks.shuffleArray.mockReset();
+  });
+
+  it('rerolls the cached candidates while keeping higher ratings first', async () => {
+    const songs = Array.from({ length: 60 }, (_, index) => ratedSong(index + 1));
+    mocks.ndListSongs.mockResolvedValue(songs);
+    mocks.shuffleArray
+      .mockImplementationOnce((items: SubsonicSong[]) => [...items])
+      .mockImplementationOnce((items: SubsonicSong[]) => [...items].reverse());
+
+    const user = userEvent.setup();
+    renderWithProviders(<TracksPageChrome />);
+
+    const list = await screen.findByRole('list', { name: 'Highly Rated songs' });
+    await waitFor(() => expect(visibleSongIds(list)).toEqual(
+      Array.from({ length: 30 }, (_, index) => `song-${index + 1}`),
+    ));
+
+    await user.click(screen.getByRole('button', { name: 'Reroll Highly Rated' }));
+
+    await waitFor(() => expect(visibleSongIds(list)).toEqual(
+      Array.from({ length: 30 }, (_, index) => `song-${40 - index}`),
+    ));
+    expect(mocks.ndInvalidateSongsCache).not.toHaveBeenCalled();
+    expect(mocks.ndListSongs).toHaveBeenLastCalledWith(0, 60, 'rating', 'DESC', 60_000);
+  });
+});

--- a/src/features/search/components/TracksPageChrome.tsx
+++ b/src/features/search/components/TracksPageChrome.tsx
@@ -9,12 +9,13 @@ import { useAuthStore } from '@/store/authStore';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { SongRail } from '@/features/home';
 import { playSongNow } from '@/features/playback/utils/playback/playSong';
-import { ndListSongs, ndInvalidateSongsCache } from '@/lib/api/navidromeBrowse';
+import { ndListSongs } from '@/lib/api/navidromeBrowse';
 import { usePerfProbeFlags } from '@/lib/perf/perfFlags';
 import { useNavigateToAlbum } from '@/features/album';
 import { useNavigateToArtist } from '@/features/artist';
 import { ResolvedArtistRefInline } from '@/ui/ResolvedArtistRefInline';
 import { resolveTrackArtistRefs } from '@/features/playback/utils/playback/trackArtistRefs';
+import { shuffleArray } from '@/lib/util/shuffleArray';
 
 const RANDOM_RAIL_SIZE = 18;
 const RATED_RAIL_FETCH = 60;
@@ -72,7 +73,10 @@ export default function TracksPageChrome({
     setRatedLoading(true);
     try {
       const songs = await ndListSongs(0, RATED_RAIL_FETCH, 'rating', 'DESC', RATED_RAIL_CACHE_MS);
-      const filtered = songs.filter(s => (s.userRating ?? 0) > 0).slice(0, RATED_RAIL_DISPLAY);
+      // Stable rating sort keeps higher tiers first while shuffle randomises ties.
+      const filtered = shuffleArray(songs.filter(s => (s.userRating ?? 0) > 0))
+        .sort((a, b) => (b.userRating ?? 0) - (a.userRating ?? 0))
+        .slice(0, RATED_RAIL_DISPLAY);
       setRated(filtered);
       setRatedSupported(true);
     } catch {
@@ -196,7 +200,7 @@ export default function TracksPageChrome({
           title={t('tracks.railHighlyRated')}
           songs={rated}
           loading={ratedLoading}
-          onReroll={() => { ndInvalidateSongsCache(); return reloadRated(); }}
+          onReroll={reloadRated}
           windowArtworkByViewport={TRACKS_SONG_RAIL_WINDOWING}
           initialArtworkBudget={TRACKS_SONG_RAIL_INITIAL_ARTWORK_BUDGET}
         />


### PR DESCRIPTION
### Summary
- randomise songs within each rating tier before selecting the Highly Rated rail
- reuse the short-lived song-list cache so reroll responds without another network roundtrip
- add a regression test covering changed results, rating priority and cache preservation
- document the Discord report in `CHANGELOG.md`

Reported by **zunoz** on Discord.

### Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (548 files, 4019 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`

### Runtime benchmark
- Applicability: final smoke required; Tracks is a measured route
- Final head: `429205e7`; measured code SHA: `8536a641` (the later commit is changelog-only)
- Command: `psysonic benchmark run --scenario core-pages --runs 2 --profile realistic --json`
- Reports: `2026-08-07T22-09-13-694Z`, `2026-08-07T22-09-57-149Z`
- Environment: one selected server; stable scope fingerprint; same viewport and user agent
- Tracks: `1576 ms` first smoke, `1124 ms` repeat; no errors, timeouts, skipped routes or wrong-route results
- Note: no performance improvement is claimed; the repeat was run because the first automatic comparison used an older, unverified baseline

### Tauri boundary
- No commands, events or payloads changed.