### PR TITLE
fix(deps): resolve npm security advisories

### DIFF
--- a/nix/upstream-sources.json
+++ b/nix/upstream-sources.json
@@ -1,3 +1,3 @@
 {
-  "npmDepsHash": "sha256-HSg7n/gxQ7NOJIUqfwreVGv9Z0XbjGcguS1AA1yzSfE="
+  "npmDepsHash": "sha256-p0x8Xk0HPhnR/c68wgg/0Cxg/I15G6Bjq8q09agy6CQ="
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2896,9 +2896,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4759,9 +4759,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -5566,9 +5566,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "vitest": "^4.1.8"
   },
   "overrides": {
-    "undici": "^7.28.0"
+    "undici": "^7.29.0"
   }
 }


### PR DESCRIPTION
## Summary
- raise the `undici` override to `7.29.0`, resolving the five open Dependabot alerts
- refresh transitive `brace-expansion` to `5.0.9` and `nanoid` to `3.3.18`
- synchronize the Nix `npmDepsHash` with the updated lockfile
- leave `npm audit` with zero known vulnerabilities

## Verification
- `npm ci`
- `npm audit`
- `npm run lint`
- `npm run dep:check`
- `npm test` (548 files, 4019 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- `Sync Nix npmDepsHash` workflow

## Scope
- Runtime benchmark: not applicable - dependency metadata and development/test dependencies only; no application runtime behavior changed.
- Tauri boundary: unchanged.
- Changelog: not applicable - security maintenance only.