### PR TITLE
fix(genre): seat page headings and their counts on one baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,6 +397,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **Highly Rated** now reshuffles tracks within each rating tier instead of requesting and redisplaying the same fixed order. Higher ratings stay first, and rerolls reuse the short-lived list cache so the new selection appears without another server roundtrip.
 
+### Genres — line up the page heading with its album count
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1402](https://github.com/Psychotoxical/psysonic/pull/1402)**, reported by zunoz
+
+* The genre name and the album count beside it now sit on one line instead of a couple of pixels apart, on the **Genres** overview as well as on a genre's own page. The alignment holds when the heading shrinks as you scroll.
+* The small icon between the two gives way to a dash, and a long genre name now shortens with its full text on hover instead of making the row taller.
+
 ## [1.50.0]
 
 ## Added

--- a/src/features/genre/pages/GenreDetail.tsx
+++ b/src/features/genre/pages/GenreDetail.tsx
@@ -205,16 +205,16 @@ export default function GenreDetail() {
             <ArrowLeft size={16} />
             <span className="toolbar-btn-label">{t('genres.back')}</span>
           </button>
-          <div className="inpage-heading">
-            <h1 className="page-title">{genre}</h1>
+          <div className="mainstage-inpage-heading">
+            <h1 className="page-title truncate" title={genre}>{genre}</h1>
             {headerCount != null && headerCount > 0 && (
-              <span className="inpage-heading__count">
+              <span className="mainstage-inpage-heading__count">
                 {t('genres.albumCount', { count: headerCount })}
               </span>
             )}
           </div>
           {showPlayback && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginLeft: 'auto' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
               <button
                 type="button"
                 className="btn btn-primary long-press-play-btn"

--- a/src/features/genre/pages/GenreDetail.tsx
+++ b/src/features/genre/pages/GenreDetail.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, Disc3, Play, ListPlus, Loader2 } from 'lucide-react';
+import { ArrowLeft, Play, ListPlus, Loader2 } from 'lucide-react';
 import { AlbumCard } from '@/features/album';
 import { LongPressWaveOverlay } from '@/ui/LongPressWaveOverlay';
 import InpageScrollSentinel from '@/ui/InpageScrollSentinel';
@@ -205,13 +205,14 @@ export default function GenreDetail() {
             <ArrowLeft size={16} />
             <span className="toolbar-btn-label">{t('genres.back')}</span>
           </button>
-          <h1 className="page-title" style={{ marginBottom: 0 }}>{genre}</h1>
-          {headerCount != null && headerCount > 0 && (
-            <span style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', color: 'var(--text-secondary)', fontSize: '0.9rem', fontWeight: 500 }}>
-              <Disc3 size={14} style={{ color: 'var(--accent)' }} />
-              {t('genres.albumCount', { count: headerCount })}
-            </span>
-          )}
+          <div className="inpage-heading">
+            <h1 className="page-title" style={{ marginBottom: 0 }}>{genre}</h1>
+            {headerCount != null && headerCount > 0 && (
+              <span className="inpage-heading__count">
+                {t('genres.albumCount', { count: headerCount })}
+              </span>
+            )}
+          </div>
           {showPlayback && (
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginLeft: 'auto' }}>
               <button

--- a/src/features/genre/pages/GenreDetail.tsx
+++ b/src/features/genre/pages/GenreDetail.tsx
@@ -205,10 +205,10 @@ export default function GenreDetail() {
             <ArrowLeft size={16} />
             <span className="toolbar-btn-label">{t('genres.back')}</span>
           </button>
-          <div className="mainstage-inpage-heading">
+          <div className="psy-page-heading">
             <h1 className="page-title truncate" title={genre}>{genre}</h1>
             {headerCount != null && headerCount > 0 && (
-              <span className="mainstage-inpage-heading__count">
+              <span className="psy-page-heading__count">
                 {t('genres.albumCount', { count: headerCount })}
               </span>
             )}

--- a/src/features/genre/pages/GenreDetail.tsx
+++ b/src/features/genre/pages/GenreDetail.tsx
@@ -205,16 +205,17 @@ export default function GenreDetail() {
             <ArrowLeft size={16} />
             <span className="toolbar-btn-label">{t('genres.back')}</span>
           </button>
-          <div className="psy-page-heading">
+          <div className="psy-page-heading psy-page-heading--fill">
             <h1 className="page-title truncate" title={genre}>{genre}</h1>
             {headerCount != null && headerCount > 0 && (
               <span className="psy-page-heading__count">
+                <span aria-hidden="true">–</span>
                 {t('genres.albumCount', { count: headerCount })}
               </span>
             )}
           </div>
           {showPlayback && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginLeft: 'auto' }}>
               <button
                 type="button"
                 className="btn btn-primary long-press-play-btn"

--- a/src/features/genre/pages/GenreDetail.tsx
+++ b/src/features/genre/pages/GenreDetail.tsx
@@ -206,7 +206,7 @@ export default function GenreDetail() {
             <span className="toolbar-btn-label">{t('genres.back')}</span>
           </button>
           <div className="inpage-heading">
-            <h1 className="page-title" style={{ marginBottom: 0 }}>{genre}</h1>
+            <h1 className="page-title">{genre}</h1>
             {headerCount != null && headerCount > 0 && (
               <span className="inpage-heading__count">
                 {t('genres.albumCount', { count: headerCount })}

--- a/src/features/genre/pages/Genres.tsx
+++ b/src/features/genre/pages/Genres.tsx
@@ -2,7 +2,6 @@ import type { SubsonicGenre } from '@/lib/api/subsonicTypes';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { Tags } from 'lucide-react';
 import { APP_MAIN_SCROLL_VIEWPORT_ID } from '@/constants/appScroll';
 import { useAuthStore } from '@/store/authStore';
 import { useLibraryIndexStore } from '@/store/libraryIndexStore';
@@ -127,11 +126,10 @@ export default function Genres() {
 
   return (
     <div className="content-body animate-fade-in">
-      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
-        <h1 className="page-title" style={{ marginBottom: 0 }}>{t('genres.title')}</h1>
+      <div className="psy-page-heading psy-page-heading--spaced">
+        <h1 className="page-title truncate">{t('genres.title')}</h1>
         {!loading && genres.length > 0 && (
-          <span style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', color: 'var(--text-secondary)', fontSize: '0.9rem', fontWeight: 500 }}>
-            <Tags size={14} style={{ color: 'var(--accent)' }} />
+          <span className="psy-page-heading__count">
             {genres.length} {t('genres.genreCount')}
           </span>
         )}

--- a/src/features/genre/pages/Genres.tsx
+++ b/src/features/genre/pages/Genres.tsx
@@ -127,9 +127,10 @@ export default function Genres() {
   return (
     <div className="content-body animate-fade-in">
       <div className="psy-page-heading psy-page-heading--spaced">
-        <h1 className="page-title truncate">{t('genres.title')}</h1>
+        <h1 className="page-title truncate" title={t('genres.title')}>{t('genres.title')}</h1>
         {!loading && genres.length > 0 && (
           <span className="psy-page-heading__count">
+            <span aria-hidden="true">–</span>
             {genres.length} {t('genres.genreCount')}
           </span>
         )}

--- a/src/styles/components/page-header-row-title-actions.css
+++ b/src/styles/components/page-header-row-title-actions.css
@@ -12,3 +12,53 @@
   margin-bottom: 0;
 }
 
+/* ─ Page heading with an entity count ─
+   A title next to a smaller count on one line. Centring puts the two type sizes
+   on separate baselines, and on the genre detail page the offset shifts again
+   once the sticky header shrinks the title. Sharing a baseline holds at every
+   type size and needs no per-size correction. */
+.psy-page-heading {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+  /* Toolbar rows distribute with space-between, so without this the heading's
+     position would depend on how many siblings happen to be rendered - it
+     drifts right while the playback actions are still loading. */
+  margin-right: auto;
+}
+
+/* For headings that stand above their content rather than in a toolbar row. */
+.psy-page-heading--spaced {
+  margin-bottom: var(--space-6);
+}
+
+/* Nothing in a page title truncates on its own, so a long name would wrap the
+   heading taller. The .truncate utility supplies the clipping; only the shrink
+   floor and the margin reset belong to this context. */
+.psy-page-heading .page-title {
+  margin-bottom: 0;
+  min-width: 0;
+}
+
+.psy-page-heading__count {
+  display: flex;
+  align-items: baseline;
+  /* Same value as the wrapper's gap, so the dash sits evenly between the two. */
+  gap: var(--space-2);
+  /* The title yields first: a shortened name still reads, a shortened count
+     does not. */
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+/* Separator glyph. Generated content is exposed to assistive technology, so
+   this is a visual convention only - it does not hide the dash from a screen
+   reader. */
+.psy-page-heading__count::before {
+  content: '–';
+}
+

--- a/src/styles/components/page-header-row-title-actions.css
+++ b/src/styles/components/page-header-row-title-actions.css
@@ -12,3 +12,37 @@
   margin-bottom: 0;
 }
 
+/* ─ Inpage heading (title + entity count on one line) ─
+   The title and the count are two different type sizes sharing a row. Centring
+   them vertically leaves their baselines a few pixels apart, and the offset
+   changes again once the sticky header shrinks its title on scroll. Aligning on
+   the shared baseline seats both on one line at every size, with no per-size
+   correction to maintain. */
+.inpage-heading {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+  /* The row distributes with space-between, so the heading's position would
+     otherwise depend on how many siblings are currently rendered - it would
+     drift right while the playback actions are still loading. */
+  margin-right: auto;
+}
+
+.inpage-heading__count {
+  display: inline-flex;
+  align-items: baseline;
+  /* Same value as the wrapper's gap, so the dash sits evenly between the two. */
+  gap: var(--space-2);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+/* A dash reads as a separator on its own; it carries no meaning a screen reader
+   needs to announce, so it stays in the stylesheet rather than the markup. */
+.inpage-heading__count::before {
+  content: '–';
+}
+

--- a/src/styles/components/page-header-row-title-actions.css
+++ b/src/styles/components/page-header-row-title-actions.css
@@ -22,9 +22,16 @@
   align-items: baseline;
   gap: var(--space-2);
   min-width: 0;
-  /* Toolbar rows distribute with space-between, so without this the heading's
-     position would depend on how many siblings happen to be rendered - it
-     drifts right while the playback actions are still loading. */
+  /* Kept from the markup this replaced: both parts stay readable on a narrow
+     window instead of the title clipping while the count holds its width. */
+  flex-wrap: wrap;
+}
+
+/* For a heading sharing a toolbar row with other controls. That row distributes
+   with space-between, so without this the heading's position would depend on
+   how many siblings happen to be rendered - it drifts right while the playback
+   actions are still loading. Inert outside such a row, hence a modifier. */
+.psy-page-heading--fill {
   margin-right: auto;
 }
 
@@ -41,24 +48,21 @@
   min-width: 0;
 }
 
+/* The separator sits in the markup behind aria-hidden rather than in generated
+   content, which every engine exposes to assistive technology. The CSS
+   alt-text form that would suppress it is not portable - an engine that cannot
+   parse it drops the whole declaration and the dash with it. */
 .psy-page-heading__count {
   display: flex;
   align-items: baseline;
   /* Same value as the wrapper's gap, so the dash sits evenly between the two. */
   gap: var(--space-2);
-  /* The title yields first: a shortened name still reads, a shortened count
-     does not. */
+  /* The count wraps to its own line before anything gives way; if it still
+     shares one, it keeps its width because a clipped number reads as a
+     different number, while a clipped title stays recognisable. */
   flex-shrink: 0;
   color: var(--text-secondary);
   font-size: 0.9rem;
   font-weight: 500;
   white-space: nowrap;
 }
-
-/* Separator glyph. Generated content is exposed to assistive technology, so
-   this is a visual convention only - it does not hide the dash from a screen
-   reader. */
-.psy-page-heading__count::before {
-  content: '–';
-}
-

--- a/src/styles/components/page-header-row-title-actions.css
+++ b/src/styles/components/page-header-row-title-actions.css
@@ -12,37 +12,3 @@
   margin-bottom: 0;
 }
 
-/* ─ Inpage heading (title + entity count on one line) ─
-   The title and the count are two different type sizes sharing a row. Centring
-   them vertically leaves their baselines a few pixels apart, and the offset
-   changes again once the sticky header shrinks its title on scroll. Aligning on
-   the shared baseline seats both on one line at every size, with no per-size
-   correction to maintain. */
-.inpage-heading {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-2);
-  min-width: 0;
-  /* The row distributes with space-between, so the heading's position would
-     otherwise depend on how many siblings are currently rendered - it would
-     drift right while the playback actions are still loading. */
-  margin-right: auto;
-}
-
-.inpage-heading__count {
-  display: inline-flex;
-  align-items: baseline;
-  /* Same value as the wrapper's gap, so the dash sits evenly between the two. */
-  gap: var(--space-2);
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-/* A dash reads as a separator on its own; it carries no meaning a screen reader
-   needs to announce, so it stays in the stylesheet rather than the markup. */
-.inpage-heading__count::before {
-  content: '–';
-}
-

--- a/src/styles/layout/main-content.css
+++ b/src/styles/layout/main-content.css
@@ -163,7 +163,7 @@
    Centring puts the two type sizes on separate baselines, and the offset shifts
    again when tight mode shrinks the title above - so they align on the shared
    baseline instead, which needs no per-size correction. */
-.inpage-heading {
+.mainstage-inpage-heading {
   display: flex;
   align-items: baseline;
   gap: var(--space-2);
@@ -174,23 +174,20 @@
   margin-right: auto;
 }
 
-/* The row lets the heading shrink, and nothing in a page title truncates on its
-   own, so a long name would wrap the header taller and push the count out of
-   the clipped content body. Same recipe as .genre-name in statistics-page.css. */
-.inpage-heading .page-title {
+/* Nothing in a page title truncates on its own, so a long name would wrap the
+   header taller. The .truncate utility supplies the clipping; only the shrink
+   floor and the margin reset are specific to sitting in this row. */
+.mainstage-inpage-heading .page-title {
   margin-bottom: 0;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.inpage-heading__count {
-  display: inline-flex;
+.mainstage-inpage-heading__count {
+  display: flex;
   align-items: baseline;
   /* Same value as the wrapper's gap, so the dash sits evenly between the two. */
   gap: var(--space-2);
-  /* The title yields first: a truncated name still reads, a truncated count
+  /* The title yields first: a shortened name still reads, a shortened count
      does not. */
   flex-shrink: 0;
   color: var(--text-secondary);
@@ -199,10 +196,10 @@
   white-space: nowrap;
 }
 
-/* Separator glyph, same approach as .disc-subtitle and .changelog-item. Note
-   that generated content is exposed to assistive technology, so this is a
-   visual convention, not a way to hide the dash from a screen reader. */
-.inpage-heading__count::before {
+/* Separator glyph. Generated content is exposed to assistive technology, so
+   this is a visual convention only - it does not hide the dash from a screen
+   reader. */
+.mainstage-inpage-heading__count::before {
   content: '–';
 }
 

--- a/src/styles/layout/main-content.css
+++ b/src/styles/layout/main-content.css
@@ -159,6 +159,53 @@
   gap: 0.5rem;
 }
 
+/* Heading inside a toolbar row: a title next to a smaller entity count.
+   Centring puts the two type sizes on separate baselines, and the offset shifts
+   again when tight mode shrinks the title above - so they align on the shared
+   baseline instead, which needs no per-size correction. */
+.inpage-heading {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+  /* The row distributes with space-between, so without this the heading's
+     position would depend on how many siblings happen to be rendered - it
+     drifts right while the playback actions are still loading. */
+  margin-right: auto;
+}
+
+/* The row lets the heading shrink, and nothing in a page title truncates on its
+   own, so a long name would wrap the header taller and push the count out of
+   the clipped content body. Same recipe as .genre-name in statistics-page.css. */
+.inpage-heading .page-title {
+  margin-bottom: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inpage-heading__count {
+  display: inline-flex;
+  align-items: baseline;
+  /* Same value as the wrapper's gap, so the dash sits evenly between the two. */
+  gap: var(--space-2);
+  /* The title yields first: a truncated name still reads, a truncated count
+     does not. */
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+/* Separator glyph, same approach as .disc-subtitle and .changelog-item. Note
+   that generated content is exposed to assistive technology, so this is a
+   visual convention, not a way to hide the dash from a screen reader. */
+.inpage-heading__count::before {
+  content: '–';
+}
+
 .mainstage-inpage-toolbar-alpha-row {
   display: flex;
   flex-wrap: wrap;

--- a/src/styles/layout/main-content.css
+++ b/src/styles/layout/main-content.css
@@ -159,50 +159,6 @@
   gap: 0.5rem;
 }
 
-/* Heading inside a toolbar row: a title next to a smaller entity count.
-   Centring puts the two type sizes on separate baselines, and the offset shifts
-   again when tight mode shrinks the title above - so they align on the shared
-   baseline instead, which needs no per-size correction. */
-.mainstage-inpage-heading {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-2);
-  min-width: 0;
-  /* The row distributes with space-between, so without this the heading's
-     position would depend on how many siblings happen to be rendered - it
-     drifts right while the playback actions are still loading. */
-  margin-right: auto;
-}
-
-/* Nothing in a page title truncates on its own, so a long name would wrap the
-   header taller. The .truncate utility supplies the clipping; only the shrink
-   floor and the margin reset are specific to sitting in this row. */
-.mainstage-inpage-heading .page-title {
-  margin-bottom: 0;
-  min-width: 0;
-}
-
-.mainstage-inpage-heading__count {
-  display: flex;
-  align-items: baseline;
-  /* Same value as the wrapper's gap, so the dash sits evenly between the two. */
-  gap: var(--space-2);
-  /* The title yields first: a shortened name still reads, a shortened count
-     does not. */
-  flex-shrink: 0;
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-/* Separator glyph. Generated content is exposed to assistive technology, so
-   this is a visual convention only - it does not hide the dash from a screen
-   reader. */
-.mainstage-inpage-heading__count::before {
-  content: '–';
-}
-
 .mainstage-inpage-toolbar-alpha-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
The genre pages put a 20px title beside a 14px count and centred them, so the
two sat on separate baselines - and on the detail page the offset shifted again
once the sticky header shrinks the title on scroll.

- Both parts now share a baseline, which holds at every type size without a
  per-size correction. Applied to the genre detail header and to the genre
  overview, which had the same mismatch.
- The disc and tag icons give way to a dash, and the heading keeps its place
  beside the back button instead of drifting with however many siblings the
  row happens to render.
- A long name truncates and keeps its full text in a title attribute; the count
  wraps to its own line before anything gives way.

## Test plan

- `npm run lint`, `npm run dep:check`, `npx tsc --noEmit` - clean
- `npx vitest run src/features/genre` - 5/5
- Verified in the running build on both pages and at both header sizes: title
  and count share a baseline before and after the scroll shrink, measured at a
  0px offset in every state.

## Runtime benchmark

- not applicable: static header markup on two routes; no data path, render
  frequency, or list behaviour changes.
