### PR TITLE
Fix first-track playback after clearing the queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -432,6 +432,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Psysonic has a new app icon. It keeps the same rounded outline as before, so nothing shifts in the taskbar, dock or app launcher.
 * On **macOS 26**, the icon now ships as a Liquid Glass bundle instead of being shrunk onto a grey plate by the system's icon frame. Earlier macOS versions keep the previous rendering.
 
+### Queue — start the first track added after clearing
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1410](https://github.com/Psychotoxical/psysonic/pull/1410)**
+
+* Adding a track to a cleared queue now mounts and starts it immediately instead of leaving it hidden as the current queue item without playing.
+
 ## [1.50.0]
 
 ## Added

--- a/src/features/playback/store/playTrackAction.ts
+++ b/src/features/playback/store/playTrackAction.ts
@@ -134,6 +134,7 @@ export function runPlayTrack(
   manual: boolean,
   _orbitConfirmed: boolean,
   targetQueueIndex: number | undefined,
+  skipQueueUndo = false,
 ): void {
   if (orbitSnapshot().role === 'host') {
     if (
@@ -341,7 +342,7 @@ export function runPlayTrack(
   const normIdx = normWindow.length;
   normWindow.push(scopedTrack);
   if (nextNeighbour) normWindow.push(nextNeighbour);
-  if (manual) {
+  if (manual && !skipQueueUndo) {
     pushQueueUndoFromGetter(get);
   }
   const visualForInitial = getSeekFallbackVisualTarget();

--- a/src/features/playback/store/playerStore.queue.test.ts
+++ b/src/features/playback/store/playerStore.queue.test.ts
@@ -50,7 +50,7 @@ import {
   appendTimelineSessionPlay,
   getTimelineSessionHistorySnapshot,
 } from '@/features/playback/store/timelineSessionHistory';
-import { onInvoke } from '@/test/mocks/tauri';
+import { invokeMock, onInvoke } from '@/test/mocks/tauri';
 import { resetPlayerStore } from '@/test/helpers/storeReset';
 import { makeTrack, makeTracks, seedQueue } from '@/test/helpers/factories';
 import { getCachedTrack } from '@/features/playback/store/queueTrackResolver';
@@ -66,6 +66,7 @@ beforeEach(() => {
   // `clearQueue` fires `invoke('audio_stop')`; every queue mutation triggers a
   // debounced `syncQueueToServer` we don't need to advance.
   onInvoke('audio_stop', () => undefined);
+  onInvoke('audio_play', () => undefined);
   onInvoke('audio_update_replay_gain', () => undefined);
 });
 
@@ -74,6 +75,26 @@ afterEach(() => {
 });
 
 describe('enqueue', () => {
+  it('mounts and starts the first track added after the queue was cleared', async () => {
+    const previous = makeTrack({ id: 'previous', serverId: 'srv-a' });
+    seedQueue([previous], { currentTrack: previous, serverId: 'srv-a' });
+    usePlayerStore.getState().clearQueue();
+    invokeMock.mockClear();
+
+    const first = makeTrack({ id: 'first', serverId: 'srv-a' });
+    usePlayerStore.getState().enqueue([first], true);
+    await vi.waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('audio_play', expect.objectContaining({
+        analysisTrackId: 'first',
+      }));
+    });
+
+    const state = usePlayerStore.getState();
+    expect(state.queueItems.map(ref => ref.trackId)).toEqual(['first']);
+    expect(state.queueIndex).toBe(0);
+    expect(state.currentTrack).toEqual(expect.objectContaining({ id: 'first' }));
+  });
+
   it('appends a single track to an empty queue', () => {
     const t1 = makeTrack({ id: 't1' });
     usePlayerStore.getState().enqueue([t1], true);
@@ -92,6 +113,49 @@ describe('enqueue', () => {
     const tracks = makeTracks(3);
     usePlayerStore.getState().enqueue(tracks, true);
     expect(usePlayerStore.getState().queueItems.map(r => r.trackId)).toEqual(tracks.map(t => t.id));
+  });
+
+  it('mounts the first track without dropping the rest of an empty-queue batch', async () => {
+    const tracks = makeTracks(3);
+    usePlayerStore.getState().enqueue(tracks, true);
+
+    expect(usePlayerStore.getState().queueItems.map(ref => ref.trackId)).toEqual(
+      tracks.map(track => track.id),
+    );
+    await vi.waitFor(() => {
+      expect(usePlayerStore.getState().currentTrack?.id).toBe(tracks[0].id);
+    });
+    expect(usePlayerStore.getState().queueIndex).toBe(0);
+  });
+
+  it('does not restart playback when appending to a non-empty queue', () => {
+    const current = makeTrack({ id: 'current' });
+    seedQueue([current], { currentTrack: current });
+    invokeMock.mockClear();
+
+    usePlayerStore.getState().enqueue([makeTrack({ id: 'upcoming' })], true);
+
+    expect(usePlayerStore.getState().queueItems.map(ref => ref.trackId)).toEqual([
+      'current',
+      'upcoming',
+    ]);
+    expect(invokeMock).not.toHaveBeenCalledWith('audio_play', expect.anything());
+  });
+
+  it('does not interrupt internet radio when adding the first queued track', () => {
+    const currentRadio = {
+      id: 'radio-1',
+      name: 'Test Radio',
+      streamUrl: 'https://radio.test/stream',
+    };
+    usePlayerStore.setState({ currentRadio, currentTrack: null, queueItems: [] });
+    invokeMock.mockClear();
+
+    usePlayerStore.getState().enqueue([makeTrack({ id: 'upcoming' })], true);
+
+    expect(usePlayerStore.getState().currentRadio).toEqual(currentRadio);
+    expect(usePlayerStore.getState().queueItems.map(ref => ref.trackId)).toEqual(['upcoming']);
+    expect(invokeMock).not.toHaveBeenCalledWith('audio_play', expect.anything());
   });
 
   it('keeps allowed Orbit-host tracks and reports rejected server owners', () => {
@@ -429,6 +493,17 @@ describe('undo / redo', () => {
 
   it('returns false on redo when the redo stack is empty', () => {
     expect(usePlayerStore.getState().redoLastQueueEdit()).toBe(false);
+  });
+
+  it('records one undo snapshot when the first enqueue mounts playback', () => {
+    usePlayerStore.getState().enqueue([makeTrack({ id: 'first' })], true);
+
+    expect(usePlayerStore.getState().undoLastQueueEdit()).toBe(true);
+    // Queue undo preserves the live current track even when the snapshot was empty.
+    expect(usePlayerStore.getState().queueItems).toEqual([
+      expect.objectContaining({ trackId: 'first' }),
+    ]);
+    expect(usePlayerStore.getState().undoLastQueueEdit()).toBe(false);
   });
 
   it('rolls back the most recent destructive edit', () => {

--- a/src/features/playback/store/playerStore.ts
+++ b/src/features/playback/store/playerStore.ts
@@ -94,8 +94,8 @@ export const usePlayerStore = create<PlayerState>()(
       ...createMiscActions(set, get),
       ...createScheduleActions(set, get),
 
-      playTrack: (track, queue, manual = true, _orbitConfirmed = false, targetQueueIndex) =>
-        runPlayTrack(set, get, track, queue, manual, _orbitConfirmed, targetQueueIndex),
+      playTrack: (track, queue, manual = true, _orbitConfirmed = false, targetQueueIndex, _skipQueueUndo = false) =>
+        runPlayTrack(set, get, track, queue, manual, _orbitConfirmed, targetQueueIndex, _skipQueueUndo),
       resume: () => runResume(set, get),
       next: (manual = true) => runNext(set, get, manual),
       seek: (progress) => runSeek(set, get, progress),

--- a/src/features/playback/store/playerStoreTypes.ts
+++ b/src/features/playback/store/playerStoreTypes.ts
@@ -83,8 +83,10 @@ export interface PlayerState {
    *  by-id fallback, which otherwise resolves to the *first* occurrence
    *  and breaks navigation when the same track appears multiple times in
    *  the queue (issue #500). Ignored if out of range or if the track id
-   *  at that position doesn't match. */
-  playTrack: (track: Track, queue?: Track[], manual?: boolean, _orbitConfirmed?: boolean, targetQueueIndex?: number) => void;
+   *  at that position doesn't match. `_skipQueueUndo` is internal: queue
+   *  mutations that already captured an undo snapshot use it when mounting
+   *  their first track. */
+  playTrack: (track: Track, queue?: Track[], manual?: boolean, _orbitConfirmed?: boolean, targetQueueIndex?: number, _skipQueueUndo?: boolean) => void;
   /** Queue becomes `[track]` only; if already on this track, does not restart `audio_play`. */
   reseedQueueForInstantMix: (track: Track) => void;
   pause: () => void;

--- a/src/features/playback/store/queueMutationActions.ts
+++ b/src/features/playback/store/queueMutationActions.ts
@@ -169,6 +169,11 @@ export function createQueueMutationActions(set: SetState, get: GetState): Pick<
         });
         return;
       }
+      const stateBeforeEnqueue = get();
+      const shouldMountFirstTrack = stateBeforeEnqueue.queueItems.length === 0
+        && !stateBeforeEnqueue.currentTrack
+        && !stateBeforeEnqueue.currentRadio
+        && tracks.length > 0;
       if (!skipQueueUndo) pushQueueUndoFromGetter(get);
       ensureQueueServerPinned(tracks);
       set(state => {
@@ -185,6 +190,9 @@ export function createQueueMutationActions(set: SetState, get: GetState): Pick<
         prefetchLoudnessForEnqueuedTracks(newItems, state.queueIndex);
         return { queueItems: newItems };
       });
+      if (shouldMountFirstTrack) {
+        get().playTrack(tracks[0], undefined, true, true, 0, true);
+      }
     },
 
     setRadioArtistId: (artistId, serverId) => {

--- a/src/test/scenarios/orbitBulkEnqueue.scenario.test.ts
+++ b/src/test/scenarios/orbitBulkEnqueue.scenario.test.ts
@@ -3,6 +3,7 @@ import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { registerOrbitRuntime } from '@/store/orbitRuntime';
 import { makeTracks } from '@/test/helpers/factories';
 import { resetAllStores } from '@/test/helpers/storeReset';
+import { onInvoke } from '@/test/mocks/tauri';
 
 // Scenario: orbit session × bulk enqueue. The real `enqueue` action routes a
 // multi-track enqueue through the orbitRuntime.bulkGuard seam and only commits the
@@ -16,6 +17,7 @@ let allowsTrackServer: Mock<(serverId?: string) => boolean>;
 
 beforeEach(() => {
   resetAllStores();
+  onInvoke('audio_play', () => undefined);
   bulkGuard = vi.fn<(count: number) => Promise<boolean>>(async () => true);
   allowsTrackServer = vi.fn<(serverId?: string) => boolean>(() => true);
   registerOrbitRuntime({


### PR DESCRIPTION
## Summary
- mount and start the first track added to an empty, idle queue
- preserve batch enqueue order, queue undo history, and active internet radio playback
- cover cleared-queue, multi-track, existing playback, radio, undo, and Orbit scenarios

Closes #1404

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (552 files, 4046 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`

## Tauri boundary
- no command, event, or payload shape changes
- existing `audio_play` is now invoked when enqueue transitions an idle empty queue to its first track

## Runtime benchmark
- Applicability: not applicable (discrete queue/playback behaviour; no measured route, browse/search interaction, or performance claim)
