### PR TITLE
ci(release): pin Xcode 26.4.1 for macOS app bundling

### DIFF
--- a/.github/workflows/reusable-channel-publish.yml
+++ b/.github/workflows/reusable-channel-publish.yml
@@ -301,6 +301,26 @@ jobs:
           mkdir -p ~/private_keys
           echo "${{ secrets.APPLE_API_KEY_B64 }}" | base64 --decode > ~/private_keys/AuthKey.p8
           echo "APPLE_API_KEY_PATH=$HOME/private_keys/AuthKey.p8" >> "$GITHUB_ENV"
+      # actool from Xcode 26.5 and later crashes on Icon Composer .icon bundles
+      # ("attempt to insert nil object from objects[0]", raised before it reads
+      # the bundle), so Assets.car is never produced and app bundling fails.
+      # 26.4.1 is the last release that compiles them. Apple feedback FB20183399.
+      # Remove this step once the regression is fixed upstream; fail loudly if
+      # the pinned version disappears from the runner image rather than silently
+      # falling back to a broken default.
+      - name: pin Xcode for app bundling (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          PINNED="/Applications/Xcode_26.4.1.app/Contents/Developer"
+          if [ ! -d "$PINNED" ]; then
+            echo "::error::pinned Xcode not present: $PINNED"
+            exit 1
+          fi
+          echo "DEVELOPER_DIR=$PINNED" >> "$GITHUB_ENV"
+          export DEVELOPER_DIR="$PINNED"
+          xcodebuild -version
+          xcrun --find actool
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- macOS bundling fails on the current runner image: `Failed to create app Assets.car: failed to run actool`, on both arm64 and x64, after a green Rust build.
- `actool` from Xcode 26.5 onwards crashes on Icon Composer `.icon` bundles before it reads them (Apple feedback FB20183399). 26.4.1 is the last release that compiles them and is present on the image.
- Pins `DEVELOPER_DIR` to Xcode 26.4.1 for the macOS matrix entries only; the Windows entry is untouched.
- Fails the job when the pinned version is absent instead of silently falling back to a broken default.

## Test plan

- Workflow YAML parses; the new step sits between the Apple key setup and `tauri-action`, gated on `runner.os == 'macOS'`.
- Confirmed this is the only macOS build path under `.github/workflows/`.
- Real verification is the next channel run: the step logs `xcodebuild -version` and the resolved `actool` path, and the macOS bundles plus the updater manifest must appear on the draft release.

Runtime benchmark: not applicable - CI workflow metadata only.
