### PR TITLE
fix(visualizer): interpolate sub-bin bass bands instead of plateauing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,6 +451,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A 5.1 track played on stereo speakers or headphones now mixes every channel into the two you hear. Previously only the front left and right were played, so anything the recording placed in the centre, the bass channel or the rear — often a large part of the arrangement — was silently dropped.
 * Surround output is unaffected: on a device that can take all the channels, the track still plays with them.
 
+### Visualizer — smooth bass bars without shifting frequencies
+
+**By [@Manwe-777](https://github.com/Manwe-777), PR [#1416](https://github.com/Psychotoxical/psysonic/pull/1416)**
+
+* Narrow bass bands no longer move in flat lockstep plateaus when several bars share one FFT bin. Frequency positions stay correct at standard and Hi-Res sample rates, while bands with real bin coverage keep their peak response.
+
 ## [1.50.0]
 
 ## Added

--- a/src-tauri/crates/psysonic-audio/src/spectrum.rs
+++ b/src-tauri/crates/psysonic-audio/src/spectrum.rs
@@ -1272,6 +1272,34 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn analyzer_hi_res_low_bands_do_not_plateau() {
+        for sample_rate in [96_000u32, 192_000] {
+            let mut analyzer = Analyzer::new();
+            let window: Vec<f32> = tone(60.0, sample_rate as f32, FFT_SIZE)
+                .into_iter()
+                .map(|sample| sample * 0.1)
+                .collect();
+            analyzer
+                .frame((&window, &window), sample_rate, 0.016, true)
+                .unwrap();
+
+            let below_first_bin = analyzer
+                .layout
+                .iter()
+                .take_while(|band| band.centre_bin < 1.0)
+                .count();
+            assert!(below_first_bin > 1, "test rate has no sub-bin low-end group");
+            assert!(
+                analyzer.bands[..below_first_bin]
+                    .windows(2)
+                    .all(|pair| (pair[0] - pair[1]).abs() > 1e-6),
+                "rate {sample_rate}: analyzer low bands still plateau: {:?}",
+                &analyzer.bands[..below_first_bin]
+            );
+        }
+    }
+
+    #[test]
     fn analyzer_falls_back_to_48k_for_an_unknown_rate() {
         let mut a = Analyzer::new();
         let window = tone(1_000.0, 48_000.0, FFT_SIZE);

--- a/src-tauri/crates/psysonic-audio/src/spectrum_dsp.rs
+++ b/src-tauri/crates/psysonic-audio/src/spectrum_dsp.rs
@@ -159,6 +159,9 @@ pub(crate) fn combine_power_magnitudes(left: &[f32], right: &[f32], out: &mut [f
 pub(crate) struct Band {
     pub(crate) lo: usize,
     pub(crate) hi: usize,
+    /// Fractional bin position of the band's centre frequency, for
+    /// interpolating bands narrower than one FFT bin.
+    pub(crate) centre_bin: f32,
     pub(crate) tilt_db: f32,
 }
 
@@ -193,8 +196,9 @@ pub(crate) fn band_layout(sample_rate: u32) -> Vec<Band> {
             (nearest, nearest)
         };
 
+        let centre_bin = (centre / bin_hz).clamp(1.0, max_bin as f32);
         let tilt_db = (TILT_DB_PER_OCTAVE * (centre / TILT_REF_HZ).log2()).clamp(0.0, TILT_MAX_DB);
-        bands.push(Band { lo, hi, tilt_db });
+        bands.push(Band { lo, hi, centre_bin, tilt_db });
     }
     bands
 }
@@ -215,9 +219,31 @@ pub(crate) fn bands_from_magnitudes(mags: &[f32], layout: &[Band], out: &mut [f3
     for (band, slot) in layout.iter().zip(out.iter_mut()) {
         let hi = band.hi.min(mags.len().saturating_sub(1));
         let lo = band.lo.min(hi);
-        let peak = mags[lo..=hi].iter().copied().fold(0.0f32, f32::max);
-        *slot = magnitude_to_level(peak, band.tilt_db);
+        let mag = if lo == hi {
+            // Bands narrower than one FFT bin collapse onto a shared bin, and
+            // taking that bin's value verbatim renders runs of neighbouring
+            // bars as flat lockstep plateaus. Interpolating the spectrum at
+            // each band's own centre frequency keeps adjacent bars distinct
+            // without moving energy away from its true frequency.
+            interpolated_magnitude(mags, band.centre_bin)
+        } else {
+            mags[lo..=hi].iter().copied().fold(0.0f32, f32::max)
+        };
+        *slot = magnitude_to_level(mag, band.tilt_db);
     }
+}
+
+/// Linear interpolation of the magnitude spectrum at a fractional bin position.
+fn interpolated_magnitude(mags: &[f32], centre_bin: f32) -> f32 {
+    let max = mags.len().saturating_sub(1);
+    if max == 0 {
+        return mags.first().copied().unwrap_or(0.0);
+    }
+    let pos = centre_bin.clamp(1.0, max as f32);
+    let i0 = pos.floor() as usize;
+    let i1 = (i0 + 1).min(max);
+    let frac = pos - i0 as f32;
+    mags[i0] * (1.0 - frac) + mags[i1] * frac
 }
 
 // ── Smoothing ────────────────────────────────────────────────────────────────
@@ -624,6 +650,34 @@ mod tests {
                 "rate {rate}: unresolved bass bands were incorrectly forced unique"
             );
         }
+    }
+
+    #[test]
+    fn narrow_bass_bands_interpolate_instead_of_plateauing() {
+        // At 48 kHz, bands 5..=14 all collapse onto FFT bin 2. Reading that
+        // bin verbatim renders them as one flat lockstep plateau — the
+        // "squared" left edge. Interpolating at each band's centre frequency
+        // must keep neighbouring bars visually distinct.
+        let sample_rate = 48_000u32;
+        let layout = band_layout(sample_rate);
+        let plateau = &layout[5..=14];
+        assert!(
+            plateau.iter().all(|b| b.lo == b.hi && b.lo == plateau[0].lo),
+            "test premise broken: bands 5..=14 no longer share one bin: {plateau:?}"
+        );
+
+        let mags = windowed_spectrum(60.0, sample_rate as f32, 1.0);
+        let mut bands = vec![0.0; BAND_COUNT];
+        bands_from_magnitudes(&mags, &layout, &mut bands);
+        let distinct = bands[5..=14]
+            .windows(2)
+            .filter(|pair| (pair[0] - pair[1]).abs() > 1e-6)
+            .count();
+        assert!(
+            distinct >= 5,
+            "bands sharing a bin still move in lockstep: {:?}",
+            &bands[5..=14]
+        );
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-audio/src/spectrum_dsp.rs
+++ b/src-tauri/crates/psysonic-audio/src/spectrum_dsp.rs
@@ -154,7 +154,7 @@ pub(crate) fn combine_power_magnitudes(left: &[f32], right: &[f32], out: &mut [f
 
 // ── Band mapping ─────────────────────────────────────────────────────────────
 
-/// Inclusive bin range and tilt gain for one display band.
+/// Bin range, centre sampling mode, and tilt gain for one display band.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct Band {
     pub(crate) lo: usize,
@@ -162,6 +162,8 @@ pub(crate) struct Band {
     /// Fractional bin position of the band's centre frequency, for
     /// interpolating bands narrower than one FFT bin.
     pub(crate) centre_bin: f32,
+    /// Whether the band's frequency span is narrower than one FFT bin.
+    pub(crate) interpolate_centre: bool,
     pub(crate) tilt_db: f32,
 }
 
@@ -183,10 +185,11 @@ pub(crate) fn band_layout(sample_rate: u32) -> Vec<Band> {
 
         let centre = (f_lo * f_hi).sqrt().max(1.0);
         // Select FFT-bin centres that actually lie in this half-open frequency
-        // interval. If the interval is narrower than one bin, use the nearest
-        // real bin and let adjacent display bands share it. Assigning each such
-        // band a unique higher bin invents resolution and relabels midrange
-        // energy as bass, especially at high sample rates.
+        // interval. If none do, keep the nearest real bin as the band's range
+        // fallback. Assigning each such band a unique higher bin invents
+        // resolution and relabels midrange energy as bass, especially at high
+        // sample rates. Narrow bands are sampled at their fractional centre
+        // below, independently of whether a bin centre falls inside the range.
         let first = (f_lo / bin_hz).ceil() as usize;
         let last = ((f_hi / bin_hz).ceil() as usize).saturating_sub(1);
         let (lo, hi) = if first <= last && first <= max_bin {
@@ -196,9 +199,16 @@ pub(crate) fn band_layout(sample_rate: u32) -> Vec<Band> {
             (nearest, nearest)
         };
 
-        let centre_bin = (centre / bin_hz).clamp(1.0, max_bin as f32);
+        let centre_bin = (centre / bin_hz).clamp(0.0, max_bin as f32);
+        let interpolate_centre = f_hi - f_lo < bin_hz;
         let tilt_db = (TILT_DB_PER_OCTAVE * (centre / TILT_REF_HZ).log2()).clamp(0.0, TILT_MAX_DB);
-        bands.push(Band { lo, hi, centre_bin, tilt_db });
+        bands.push(Band {
+            lo,
+            hi,
+            centre_bin,
+            interpolate_centre,
+            tilt_db,
+        });
     }
     bands
 }
@@ -219,12 +229,12 @@ pub(crate) fn bands_from_magnitudes(mags: &[f32], layout: &[Band], out: &mut [f3
     for (band, slot) in layout.iter().zip(out.iter_mut()) {
         let hi = band.hi.min(mags.len().saturating_sub(1));
         let lo = band.lo.min(hi);
-        let mag = if lo == hi {
-            // Bands narrower than one FFT bin collapse onto a shared bin, and
-            // taking that bin's value verbatim renders runs of neighbouring
-            // bars as flat lockstep plateaus. Interpolating the spectrum at
-            // each band's own centre frequency keeps adjacent bars distinct
-            // without moving energy away from its true frequency.
+        let mag = if band.interpolate_centre {
+            // Bands narrower than one FFT bin can collapse onto a shared bin.
+            // Taking that bin's value verbatim renders runs of neighbouring
+            // bars as flat lockstep plateaus. Sampling the spectrum at each
+            // band's own centre keeps adjacent bars distinct without moving
+            // the band's frequency range.
             interpolated_magnitude(mags, band.centre_bin)
         } else {
             mags[lo..=hi].iter().copied().fold(0.0f32, f32::max)
@@ -239,7 +249,9 @@ fn interpolated_magnitude(mags: &[f32], centre_bin: f32) -> f32 {
     if max == 0 {
         return mags.first().copied().unwrap_or(0.0);
     }
-    let pos = centre_bin.clamp(1.0, max as f32);
+    // Bin zero is never a display band, but its windowed magnitude is a useful
+    // interpolation endpoint for real frequencies below the first positive bin.
+    let pos = centre_bin.clamp(0.0, max as f32);
     let i0 = pos.floor() as usize;
     let i1 = (i0 + 1).min(max);
     let frac = pos - i0 as f32;
@@ -678,6 +690,69 @@ mod tests {
             "bands sharing a bin still move in lockstep: {:?}",
             &bands[5..=14]
         );
+    }
+
+    #[test]
+    fn wide_single_bin_band_keeps_its_peak() {
+        let sample_rate = 48_000u32;
+        let layout = band_layout(sample_rate);
+        let band_index = 57usize;
+        let band = layout[band_index];
+        let bin_hz = sample_rate as f32 / FFT_SIZE as f32;
+        let ratio = (BAND_MAX_HZ / BAND_MIN_HZ).ln() / BAND_COUNT as f32;
+        let f_lo = BAND_MIN_HZ * (ratio * band_index as f32).exp();
+        let f_hi = BAND_MIN_HZ * (ratio * (band_index + 1) as f32).exp();
+
+        assert!(
+            f_hi - f_lo >= bin_hz,
+            "test band is no longer at least one bin wide"
+        );
+        assert_eq!(
+            band.lo, band.hi,
+            "test band no longer contains exactly one bin"
+        );
+
+        let mut mags = vec![0.0; FFT_SIZE / 2];
+        mags[band.lo] = 0.1;
+        let mut bands = vec![0.0; BAND_COUNT];
+        bands_from_magnitudes(&mags, &layout, &mut bands);
+
+        let expected = magnitude_to_level(0.1, band.tilt_db);
+        assert!(
+            (bands[band_index] - expected).abs() < 1e-6,
+            "wide one-bin band blended away from its owned peak: {} vs {expected}",
+            bands[band_index]
+        );
+    }
+
+    #[test]
+    fn hi_res_bands_below_bin_one_do_not_plateau() {
+        for sample_rate in [96_000u32, 192_000] {
+            let layout = band_layout(sample_rate);
+            let bin_hz = sample_rate as f32 / FFT_SIZE as f32;
+            let ratio = (BAND_MAX_HZ / BAND_MIN_HZ).ln() / BAND_COUNT as f32;
+            let below_first_bin = (0..BAND_COUNT)
+                .take_while(|band| {
+                    let centre = BAND_MIN_HZ * (ratio * (*band as f32 + 0.5)).exp();
+                    centre < bin_hz
+                })
+                .count();
+            assert!(below_first_bin > 1, "test rate has no sub-bin low-end group");
+
+            let mut mags = vec![0.0; FFT_SIZE / 2];
+            mags[0] = 0.2;
+            mags[1] = 0.8;
+            let mut bands = vec![0.0; BAND_COUNT];
+            bands_from_magnitudes(&mags, &layout, &mut bands);
+
+            assert!(
+                bands[..below_first_bin]
+                    .windows(2)
+                    .all(|pair| (pair[0] - pair[1]).abs() > 1e-6),
+                "rate {sample_rate}: bands below bin one still plateau: {:?}",
+                &bands[..below_first_bin]
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Since the band-layout correction in 03aa18ca, display bands narrower than one FFT bin all collapse onto the same nearest bin and read its value verbatim. At 48 kHz that means runs of 5–10 neighbouring bars (everything below ~460 Hz) move in perfect lockstep, rendering the left side of the spectrum as flat, squared plateaus:

The old forced-unique mapping hid this by giving every bar its own bin, but at the cost of mislabeling frequencies (the bug that correction rightly fixed).

Before:
<img width="520" height="311" alt="Screenshot 2026-08-14 at 8 50 29 AM" src="https://github.com/user-attachments/assets/87753788-d8a2-4dd6-b973-8be734d42b55" />
After:
<img width="563" height="296" alt="Screenshot 2026-08-14 at 9 21 34 AM" src="https://github.com/user-attachments/assets/9640daa8-dbb9-448e-9453-a935ae341ab6" />


## Fix

Keep the corrected frequency mapping. For bands narrower than one bin, linearly interpolate the magnitude spectrum at the band's own centre frequency (new fractional `centre_bin` on `Band`) instead of reading the shared bin verbatim. Neighbouring bars become smooth, distinct gradients while energy stays at its true frequency; bands wide enough to own real bins keep the existing per-band peak.

## Testing

- New regression test `narrow_bass_bands_interpolate_instead_of_plateauing` pins the shared-bin premise (bands 5..=14 share one bin at 48 kHz) and asserts the rendered bars diverge.
- Full `psysonic-audio` suite passes (366 tests), including the frequency-position tests from the earlier correction.
- Verified visually in the running app: the squared left edge is gone, tone positions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
