### PR TITLE
fix(ci): avoid unsafe fork checkout in ci-ok

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   push:
     branches: [main]
-  workflow_run:
-    workflows: [frontend-tests, rust-tests, eslint]
-    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -19,9 +16,14 @@ jobs:
   ci-ok:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      # Load only the trusted gate implementation. The PR head is inspected via
+      # read-only API calls below and must never execute in this job.
+      - name: checkout trusted gate code
+        uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts
       - name: aggregate required checks
         uses: actions/github-script@v9
         with:


### PR DESCRIPTION
## Summary
- remove the redundant privileged `workflow_run` invocation of `ci-ok`
- load the gate implementation from the trusted PR base SHA instead of the PR head
- disable persisted checkout credentials and sparse-checkout only `.github/scripts`

The existing `pull_request` aggregate still polls the required frontend, Rust, and ESLint checks on the PR head SHA. This avoids executing fork code with the base repository token and does not enable `allow-unsafe-pr-checkout`.

## Verification
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/ci-main.yml`
- `nix develop -c bash -lc 'node --test .github/scripts/ci-ok-aggregate.test.mjs'` (9 passed)\n- `git diff --check`\n\n## Scope\n- Tauri boundary: not touched\n- Runtime benchmark: not applicable - CI configuration only\n- Changelog: not applicable - no user-visible product behaviour change