### PR TITLE
Improve analysis backfill reuse and scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Home, Albums, Artists, New Releases, Lossless Albums and Search reuse bounded local results instead of repeating large scoped reads while routes mount, paginate or restore their session.
 * Browse pages coordinate cover traffic and background catalogue work more carefully, so the first useful content appears before non-visible enrichment and prefetch work.
 
+### Analysis — reuse downloaded audio and prioritise playback
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1419](https://github.com/Psychotoxical/psysonic/pull/1419)**
+
+* Waveform, loudness and enrichment reuse audio already loaded for playback, preload, cache and local files, including large completed streams held on disk, instead of downloading the original again.
+* Background analysis stays within bounded memory and disk limits while active playback takes priority over library backfill. Range-stripping servers and unavailable source files also stop cleanly without repeated work.
+
 ## Fixed
 
 ### Cross-server ownership — IDs no longer collide or drift to the active server

--- a/src-tauri/crates/psysonic-analysis/src/analysis_cache/compute.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_cache/compute.rs
@@ -42,6 +42,7 @@ pub enum SeedFromBytesOutcome {
 
 /// Full Symphonia + (optional) EBU decode for waveform + loudness. Call only from the
 /// single CPU-seed worker in `lib.rs` (`spawn_blocking`) so at most one heavy decode runs.
+#[allow(clippy::too_many_arguments)]
 pub fn seed_from_bytes_execute<R: Runtime>(
     app: &tauri::AppHandle<R>,
     server_id: &str,
@@ -49,6 +50,7 @@ pub fn seed_from_bytes_execute<R: Runtime>(
     bytes: &[u8],
     format_hint: Option<&str>,
     trusted_md5_16kb: Option<&str>,
+    trusted_generation: Option<u64>,
     notify_ui: bool,
 ) -> Result<(SeedFromBytesOutcome, AnalysisSeedTimings), String> {
     seed_from_bytes_execute_with_policy(
@@ -58,6 +60,7 @@ pub fn seed_from_bytes_execute<R: Runtime>(
         bytes,
         format_hint,
         trusted_md5_16kb,
+        trusted_generation,
         true,
         notify_ui,
     )
@@ -65,6 +68,7 @@ pub fn seed_from_bytes_execute<R: Runtime>(
 
 /// Analyse a server-generated transcode while storing the result under a
 /// separately verified fingerprint of the original file.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn seed_transcoded_bytes_execute<R: Runtime>(
     app: &tauri::AppHandle<R>,
     server_id: &str,
@@ -72,6 +76,7 @@ pub(crate) fn seed_transcoded_bytes_execute<R: Runtime>(
     bytes: &[u8],
     format_hint: Option<&str>,
     trusted_md5_16kb: &str,
+    trusted_generation: u64,
     notify_ui: bool,
 ) -> Result<(SeedFromBytesOutcome, AnalysisSeedTimings), String> {
     seed_from_bytes_execute_with_policy(
@@ -81,6 +86,7 @@ pub(crate) fn seed_transcoded_bytes_execute<R: Runtime>(
         bytes,
         format_hint,
         Some(trusted_md5_16kb),
+        Some(trusted_generation),
         false,
         notify_ui,
     )
@@ -94,6 +100,7 @@ fn seed_from_bytes_execute_with_policy<R: Runtime>(
     bytes: &[u8],
     format_hint: Option<&str>,
     trusted_md5_16kb: Option<&str>,
+    trusted_generation: Option<u64>,
     verify_trusted_prefix: bool,
     notify_ui: bool,
 ) -> Result<(SeedFromBytesOutcome, AnalysisSeedTimings), String> {
@@ -142,6 +149,7 @@ fn seed_from_bytes_execute_with_policy<R: Runtime>(
             track_id,
             bytes,
             trusted_md5_16kb,
+            trusted_generation.map(|generation| (server_id, generation)),
             notify_ui,
         );
         if matches!(enrichment_outcome, TrackEnrichmentOutcome::Failed) {
@@ -1579,8 +1587,9 @@ mod tests {
         let app = tauri::test::mock_app();
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 0.25), 44_100);
         let handle = app.handle().clone();
-        let (outcome, timings) = seed_from_bytes_execute(&handle, "s", "t", &wav, None, None, true)
-            .expect("seed execute should return a graceful skip");
+        let (outcome, timings) =
+            seed_from_bytes_execute(&handle, "s", "t", &wav, None, None, None, true)
+                .expect("seed execute should return a graceful skip");
         assert_eq!(outcome, SeedFromBytesOutcome::SkippedNoAnalysisCache);
         assert_eq!(timings.seed_ms, 0);
         assert_eq!(timings.bpm_ms, 0);
@@ -1594,14 +1603,32 @@ mod tests {
         let handle = app.handle().clone();
 
         let (first, timings_first) =
-            seed_from_bytes_execute(&handle, "server-a", "track-exec", &wav, None, None, true)
-                .unwrap();
+            seed_from_bytes_execute(
+                &handle,
+                "server-a",
+                "track-exec",
+                &wav,
+                None,
+                None,
+                None,
+                true,
+            )
+            .unwrap();
         assert_eq!(first, SeedFromBytesOutcome::Upserted);
         assert!(timings_first.seed_ms <= 30_000);
 
         let (second, timings_second) =
-            seed_from_bytes_execute(&handle, "server-a", "track-exec", &wav, None, None, true)
-                .unwrap();
+            seed_from_bytes_execute(
+                &handle,
+                "server-a",
+                "track-exec",
+                &wav,
+                None,
+                None,
+                None,
+                true,
+            )
+            .unwrap();
         assert_eq!(second, SeedFromBytesOutcome::SkippedWaveformCacheHit);
         assert!(timings_second.seed_ms <= 30_000);
     }

--- a/src-tauri/crates/psysonic-analysis/src/analysis_cache/compute.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_cache/compute.rs
@@ -2,6 +2,7 @@ use std::io::Cursor;
 use std::time::Instant;
 
 use ebur128::{EbuR128, Mode as Ebur128Mode};
+use psysonic_core::track_enrichment::TrackEnrichmentOutcome;
 use symphonia::core::codecs::audio::{AudioDecoder, AudioDecoderOptions};
 use symphonia::core::errors::Error as SymphoniaError;
 use symphonia::core::formats::probe::Hint;
@@ -10,7 +11,6 @@ use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::units::Time;
 use tauri::{Manager, Runtime};
-use psysonic_core::track_enrichment::TrackEnrichmentOutcome;
 
 use crate::analysis_perf::AnalysisSeedTimings;
 use crate::codec::make_decoder;
@@ -51,6 +51,52 @@ pub fn seed_from_bytes_execute<R: Runtime>(
     trusted_md5_16kb: Option<&str>,
     notify_ui: bool,
 ) -> Result<(SeedFromBytesOutcome, AnalysisSeedTimings), String> {
+    seed_from_bytes_execute_with_policy(
+        app,
+        server_id,
+        track_id,
+        bytes,
+        format_hint,
+        trusted_md5_16kb,
+        true,
+        notify_ui,
+    )
+}
+
+/// Analyse a server-generated transcode while storing the result under a
+/// separately verified fingerprint of the original file.
+pub(crate) fn seed_transcoded_bytes_execute<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    server_id: &str,
+    track_id: &str,
+    bytes: &[u8],
+    format_hint: Option<&str>,
+    trusted_md5_16kb: &str,
+    notify_ui: bool,
+) -> Result<(SeedFromBytesOutcome, AnalysisSeedTimings), String> {
+    seed_from_bytes_execute_with_policy(
+        app,
+        server_id,
+        track_id,
+        bytes,
+        format_hint,
+        Some(trusted_md5_16kb),
+        false,
+        notify_ui,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn seed_from_bytes_execute_with_policy<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    server_id: &str,
+    track_id: &str,
+    bytes: &[u8],
+    format_hint: Option<&str>,
+    trusted_md5_16kb: Option<&str>,
+    verify_trusted_prefix: bool,
+    notify_ui: bool,
+) -> Result<(SeedFromBytesOutcome, AnalysisSeedTimings), String> {
     let seed_started = Instant::now();
     let Some(cache) = app.try_state::<AnalysisCache>() else {
         crate::app_deprintln!(
@@ -63,8 +109,15 @@ pub fn seed_from_bytes_execute<R: Runtime>(
             AnalysisSeedTimings::default(),
         ));
     };
-    let (outcome, md5_16kb) =
-        seed_from_bytes_into_cache(&cache, server_id, track_id, bytes, format_hint, trusted_md5_16kb)?;
+    let (outcome, md5_16kb) = seed_from_bytes_into_cache_with_policy(
+        &cache,
+        server_id,
+        track_id,
+        bytes,
+        format_hint,
+        trusted_md5_16kb,
+        verify_trusted_prefix,
+    )?;
     let seed_ms = seed_started.elapsed().as_millis() as u64;
     // E2 bridge for byte-owned originals (local/offline paths). Trusted HTTP
     // revisions activate in `analysis_runtime` after its per-track generation
@@ -115,10 +168,7 @@ pub fn seed_from_bytes_execute<R: Runtime>(
     } else {
         0
     };
-    Ok((
-        outcome,
-        AnalysisSeedTimings { seed_ms, bpm_ms },
-    ))
+    Ok((outcome, AnalysisSeedTimings { seed_ms, bpm_ms }))
 }
 
 /// AppHandle-free entry point for [`seed_from_bytes_execute`]: takes the cache
@@ -136,14 +186,36 @@ pub fn seed_from_bytes_into_cache(
     format_hint: Option<&str>,
     trusted_md5_16kb: Option<&str>,
 ) -> Result<(SeedFromBytesOutcome, String), String> {
+    seed_from_bytes_into_cache_with_policy(
+        cache,
+        server_id,
+        track_id,
+        bytes,
+        format_hint,
+        trusted_md5_16kb,
+        true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn seed_from_bytes_into_cache_with_policy(
+    cache: &AnalysisCache,
+    server_id: &str,
+    track_id: &str,
+    bytes: &[u8],
+    format_hint: Option<&str>,
+    trusted_md5_16kb: Option<&str>,
+    verify_trusted_prefix: bool,
+) -> Result<(SeedFromBytesOutcome, String), String> {
     let started = Instant::now();
-    if let Some(trusted) = trusted_md5_16kb {
+    if let Some(trusted) = trusted_md5_16kb.filter(|_| verify_trusted_prefix) {
         if md5_first_16kb(bytes) != trusted {
             return Err("trusted original fingerprint does not match analysis bytes".to_string());
         }
     }
-    // Write under the playback server's scope. A trusted identity is accepted
-    // only when the analysed bytes carry that exact original prefix.
+    // Write under the playback server's scope. Ordinary trusted callers must
+    // carry the original prefix; the narrow transcode entry point establishes
+    // that identity separately with a raw-original probe.
     let key = TrackKey {
         server_id: server_id.to_string(),
         track_id: track_id.to_string(),
@@ -159,7 +231,10 @@ pub fn seed_from_bytes_into_cache(
             key.md5_16kb,
             started.elapsed().as_millis()
         );
-        return Ok((SeedFromBytesOutcome::SkippedWaveformCacheHit, key.md5_16kb.clone()));
+        return Ok((
+            SeedFromBytesOutcome::SkippedWaveformCacheHit,
+            key.md5_16kb.clone(),
+        ));
     }
     if coverage.has_waveform && !coverage.has_loudness {
         crate::app_deprintln!(
@@ -184,15 +259,13 @@ pub fn seed_from_bytes_into_cache(
 
         let (wf_bins, loudness_opt, used_pcm_decode) =
             match analyze_loudness_and_waveform(bytes, -16.0, 500, format_hint) {
-            Some((integrated_lufs, true_peak, recommended_gain_db, target_lufs, bins)) => {
-                (
+                Some((integrated_lufs, true_peak, recommended_gain_db, target_lufs, bins)) => (
                     bins,
                     Some((integrated_lufs, true_peak, recommended_gain_db, target_lufs)),
                     true,
-                )
-            }
-            None => (derive_waveform_bins(bytes, 500), None, false),
-        };
+                ),
+                None => (derive_waveform_bins(bytes, 500), None, false),
+            };
         let bins_len = wf_bins.len();
         let waveform = WaveformEntry {
             bins: wf_bins,
@@ -265,7 +338,9 @@ fn derive_waveform_bins(bytes: &[u8], bin_count: usize) -> Vec<u8> {
     let mut peak_half = vec![0u8; bin_count];
     for (i, slot) in peak_half.iter_mut().enumerate() {
         let start = i * bytes.len() / bin_count;
-        let end = ((i + 1) * bytes.len() / bin_count).max(start + 1).min(bytes.len());
+        let end = ((i + 1) * bytes.len() / bin_count)
+            .max(start + 1)
+            .min(bytes.len());
         let mut peak: u8 = 0;
         for &b in &bytes[start..end] {
             let centered = b.abs_diff(128);
@@ -299,7 +374,14 @@ fn analyze_loudness_and_waveform(
     if decoded_frames == 0 {
         return None;
     }
-    let scanned = decode_scan_pcm(bytes, bin_count, decoded_frames, timeline_hint, Some(target_lufs), format_hint)?;
+    let scanned = decode_scan_pcm(
+        bytes,
+        bin_count,
+        decoded_frames,
+        timeline_hint,
+        Some(target_lufs),
+        format_hint,
+    )?;
     let (i, t, r, tgt) = scanned.loudness?;
     Some((i, t, r, tgt, scanned.bins))
 }
@@ -351,7 +433,12 @@ fn open_decode_session(bytes: &[u8], format_hint: Option<&str>) -> Option<Decode
         hint.with_extension(ext);
     }
     let format = symphonia::default::get_probe()
-        .probe(&hint, mss, FormatOptions::default(), MetadataOptions::default())
+        .probe(
+            &hint,
+            mss,
+            FormatOptions::default(),
+            MetadataOptions::default(),
+        )
         .ok()?;
     // Prefer an audio track that reports both sample rate and channels; fall back to
     // the first audio track with a known codec (skips e.g. MJPEG cover-art tracks).
@@ -368,23 +455,38 @@ fn open_decode_session(bytes: &[u8], format_hint: Option<&str>) -> Option<Decode
     let track_id = track.id;
     let timeline_hint = track.num_frames.filter(|&n| n > 0);
     let audio_params = track.codec_params.as_ref()?.audio()?.clone();
-    let decoder = match make_decoder(&audio_params, &AudioDecoderOptions::default().gapless(false)) {
+    let decoder = match make_decoder(
+        &audio_params,
+        &AudioDecoderOptions::default().gapless(false),
+    ) {
         Ok(v) => v,
         Err(e) => {
             crate::app_deprintln!("[analysis] decoder make failed: {}", e);
             return None;
         }
     };
-    Some(DecodeSession { format, decoder, track_id, timeline_hint })
+    Some(DecodeSession {
+        format,
+        decoder,
+        track_id,
+        timeline_hint,
+    })
 }
 
 /// Returns `(decoded_mono_frames, container_timeline_frames)` where the second is
 /// `codec_params.n_frames` when the container reports total track length — used
 /// as a **fixed** waveform time axis so partial decodes do not remap every bin
 /// when the buffer grows.
-fn count_mono_frames_from_audio_bytes(bytes: &[u8], format_hint: Option<&str>) -> Option<(u64, Option<u64>)> {
-    let DecodeSession { mut format, mut decoder, track_id, timeline_hint } =
-        open_decode_session(bytes, format_hint)?;
+fn count_mono_frames_from_audio_bytes(
+    bytes: &[u8],
+    format_hint: Option<&str>,
+) -> Option<(u64, Option<u64>)> {
+    let DecodeSession {
+        mut format,
+        mut decoder,
+        track_id,
+        timeline_hint,
+    } = open_decode_session(bytes, format_hint)?;
 
     let mut total: u64 = 0;
     let mut loop_i: u32 = 0;
@@ -448,7 +550,12 @@ fn decode_scan_pcm(
     loudness_target_lufs: Option<f64>,
     format_hint: Option<&str>,
 ) -> Option<PcmScanResult> {
-    let DecodeSession { mut format, mut decoder, track_id, .. } = open_decode_session(bytes, format_hint)?;
+    let DecodeSession {
+        mut format,
+        mut decoder,
+        track_id,
+        ..
+    } = open_decode_session(bytes, format_hint)?;
 
     let mut bin_max = vec![0.0f32; bin_count];
     let mut bin_sum = vec![0.0f32; bin_count];
@@ -672,7 +779,8 @@ pub fn decode_mono_pcm_window(
         mut decoder,
         track_id,
         ..
-    } = open_decode_session(bytes, None).ok_or_else(|| "failed to open audio decode session".to_string())?;
+    } = open_decode_session(bytes, None)
+        .ok_or_else(|| "failed to open audio decode session".to_string())?;
 
     if start_sec.is_finite() && start_sec > 0.0 {
         let time = Time::try_from_secs_f64(start_sec.max(0.0))
@@ -704,7 +812,8 @@ pub fn decode_mono_pcm_limited(
         mut decoder,
         track_id,
         ..
-    } = open_decode_session(bytes, None).ok_or_else(|| "failed to open audio decode session".to_string())?;
+    } = open_decode_session(bytes, None)
+        .ok_or_else(|| "failed to open audio decode session".to_string())?;
     decode_mono_pcm_from_session(&mut format, &mut decoder, track_id, max_seconds)
 }
 
@@ -871,7 +980,10 @@ mod tests {
         // 128 is the unsigned-PCM midpoint: abs_diff(128) == 0 for every sample.
         let silence = vec![128u8; 64];
         let out = derive_waveform_bins(&silence, 8);
-        assert!(out.iter().all(|&b| b == 0), "silence must produce all-zero bins, got {out:?}");
+        assert!(
+            out.iter().all(|&b| b == 0),
+            "silence must produce all-zero bins, got {out:?}"
+        );
     }
 
     #[test]
@@ -889,7 +1001,10 @@ mod tests {
         // (127/127)^0.5 = 1.0 → 255 in u8.
         let bytes = vec![0u8; 16];
         let out = derive_waveform_bins(&bytes, 4);
-        assert!(out.iter().all(|&b| b == 255), "max amplitude must yield 255 bins");
+        assert!(
+            out.iter().all(|&b| b == 255),
+            "max amplitude must yield 255 bins"
+        );
     }
 
     // ── normalize_peak_bins ───────────────────────────────────────────────────
@@ -998,8 +1113,8 @@ mod tests {
     #[test]
     fn count_mono_frames_returns_decoded_length_for_synthetic_wav() {
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
-        let (frames, _hint) = count_mono_frames_from_audio_bytes(&wav, None)
-            .expect("WAV decode must succeed");
+        let (frames, _hint) =
+            count_mono_frames_from_audio_bytes(&wav, None).expect("WAV decode must succeed");
         // 1 second × 44.1 kHz mono = 44 100 frames; allow ±1 packet tolerance.
         assert!(
             (43_900..=44_300).contains(&frames),
@@ -1013,7 +1128,10 @@ mod tests {
         assert_eq!(format_hint_from_bytes(&aiff), Some("aiff".into()));
         let (frames, hint) =
             count_mono_frames_from_audio_bytes(&aiff, None).expect("AIFF decode must succeed");
-        assert!((43_900..=44_300).contains(&frames), "expected ~44100 frames, got {frames}");
+        assert!(
+            (43_900..=44_300).contains(&frames),
+            "expected ~44100 frames, got {frames}"
+        );
         assert_eq!(hint, Some(44_100));
     }
 
@@ -1030,10 +1148,14 @@ mod tests {
     #[test]
     fn analyze_loudness_and_waveform_returns_loudness_for_synthetic_sine() {
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.5), 44_100);
-        let result = analyze_loudness_and_waveform(&wav, -14.0, 100, None)
-            .expect("WAV decode must succeed");
+        let result =
+            analyze_loudness_and_waveform(&wav, -14.0, 100, None).expect("WAV decode must succeed");
         let (integrated_lufs, true_peak, recommended_gain_db, target_lufs, bins) = result;
-        assert_eq!(bins.len(), 200, "bins layout is peak_u8 + mean_u8 = 2 * bin_count");
+        assert_eq!(
+            bins.len(),
+            200,
+            "bins layout is peak_u8 + mean_u8 = 2 * bin_count"
+        );
         assert_eq!(target_lufs, -14.0);
         // -6 dBFS sine ≈ -9 LUFS integrated for 1.5 s. EBU R128 needs >=400 ms
         // of audio; we have 1.5 s so the measurement is valid.
@@ -1070,11 +1192,19 @@ mod tests {
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
         let original_md5 = md5_first_16kb(&wav);
         let (outcome, md5) = seed_from_bytes_into_cache(
-            &cache, "server-a", "original-track", &wav, None, Some(&original_md5),
+            &cache,
+            "server-a",
+            "original-track",
+            &wav,
+            None,
+            Some(&original_md5),
         )
         .unwrap();
         assert_eq!(outcome, SeedFromBytesOutcome::Upserted);
-        assert_eq!(md5, original_md5, "row keyed under the trusted original fingerprint");
+        assert_eq!(
+            md5, original_md5,
+            "row keyed under the trusted original fingerprint"
+        );
     }
 
     #[test]
@@ -1083,7 +1213,12 @@ mod tests {
         let original = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
         let original_md5 = md5_first_16kb(&original);
         let (first, _) = seed_from_bytes_into_cache(
-            &cache, "server-a", "track-x", &original, None, Some(&original_md5),
+            &cache,
+            "server-a",
+            "track-x",
+            &original,
+            None,
+            Some(&original_md5),
         )
         .unwrap();
         assert_eq!(first, SeedFromBytesOutcome::Upserted);
@@ -1102,6 +1237,33 @@ mod tests {
     }
 
     #[test]
+    fn explicitly_trusted_transcode_is_keyed_under_original_fingerprint() {
+        let cache = AnalysisCache::open_in_memory();
+        let original = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
+        let trusted = md5_first_16kb(&original);
+        let transcode = build_mono_pcm16_wav(&sine_440_at_minus_6db(48_000, 1.5), 48_000);
+        assert_ne!(md5_first_16kb(&transcode), trusted);
+
+        let (outcome, stored_md5) = seed_from_bytes_into_cache_with_policy(
+            &cache,
+            "server-a",
+            "track-transcode",
+            &transcode,
+            None,
+            Some(&trusted),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(outcome, SeedFromBytesOutcome::Upserted);
+        assert_eq!(stored_md5, trusted);
+        assert!(cache
+            .content_cache_coverage("server-a", "track-transcode", &stored_md5)
+            .unwrap()
+            .complete());
+    }
+
+    #[test]
     fn verified_row_purges_stale_fingerprint_variants() {
         // A pre-existing row under a stale (e.g. transcode-derived) fingerprint
         // must disappear once a verified trusted row is active, so latest-row
@@ -1116,7 +1278,8 @@ mod tests {
         let original = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
         let trusted = md5_first_16kb(&original);
         let (second, _) =
-            seed_from_bytes_into_cache(&cache, "srv", "t1", &original, None, Some(&trusted)).unwrap();
+            seed_from_bytes_into_cache(&cache, "srv", "t1", &original, None, Some(&trusted))
+                .unwrap();
         assert_eq!(second, SeedFromBytesOutcome::Upserted);
         let key = TrackKey {
             server_id: "srv".into(),
@@ -1130,7 +1293,9 @@ mod tests {
             track_id: "t1".into(),
             md5_16kb: stale_md5,
         };
-        assert!(!cache.loudness_row_exists_for_key(&stale_key).unwrap_or(true));
+        assert!(!cache
+            .loudness_row_exists_for_key(&stale_key)
+            .unwrap_or(true));
         // The trusted row survives.
         let cov = cache.content_cache_coverage("srv", "t1", &trusted).unwrap();
         assert!(cov.has_waveform);
@@ -1140,9 +1305,14 @@ mod tests {
     fn seed_from_bytes_into_cache_upserts_waveform_and_loudness_for_wav() {
         let cache = AnalysisCache::open_in_memory();
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.5), 44_100);
-        let (outcome, md5) = seed_from_bytes_into_cache(&cache, "server-a", "wav-track", &wav, None, None).unwrap();
+        let (outcome, md5) =
+            seed_from_bytes_into_cache(&cache, "server-a", "wav-track", &wav, None, None).unwrap();
         assert_eq!(outcome, SeedFromBytesOutcome::Upserted);
-        assert_eq!(md5, md5_first_16kb(&wav), "outcome carries the content fingerprint");
+        assert_eq!(
+            md5,
+            md5_first_16kb(&wav),
+            "outcome carries the content fingerprint"
+        );
 
         // Both a waveform AND a loudness row must exist after a successful
         // PCM decode + EBU R128 analysis.
@@ -1169,22 +1339,32 @@ mod tests {
             track_id: "scoped-track".to_string(),
             md5_16kb: md5.clone(),
         };
-        assert!(cache.get_waveform(&scoped).unwrap().is_some(), "row lands under server scope");
+        assert!(
+            cache.get_waveform(&scoped).unwrap().is_some(),
+            "row lands under server scope"
+        );
         let other = TrackKey {
             server_id: "server-y".to_string(),
             track_id: "scoped-track".to_string(),
             md5_16kb: md5,
         };
-        assert!(cache.get_waveform(&other).unwrap().is_none(), "row stays under the exact server");
+        assert!(
+            cache.get_waveform(&other).unwrap().is_none(),
+            "row stays under the exact server"
+        );
     }
 
     #[test]
     fn seed_from_bytes_into_cache_returns_skipped_on_second_call() {
         let cache = AnalysisCache::open_in_memory();
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
-        let (first, _) = seed_from_bytes_into_cache(&cache, "server-a", "wav-track-2", &wav, None, None).unwrap();
+        let (first, _) =
+            seed_from_bytes_into_cache(&cache, "server-a", "wav-track-2", &wav, None, None)
+                .unwrap();
         assert_eq!(first, SeedFromBytesOutcome::Upserted);
-        let (second, _) = seed_from_bytes_into_cache(&cache, "server-a", "wav-track-2", &wav, None, None).unwrap();
+        let (second, _) =
+            seed_from_bytes_into_cache(&cache, "server-a", "wav-track-2", &wav, None, None)
+                .unwrap();
         assert_eq!(
             second,
             SeedFromBytesOutcome::SkippedWaveformCacheHit,
@@ -1198,7 +1378,8 @@ mod tests {
         // Garbage bytes — Symphonia probe fails, the pipeline falls back to
         // `derive_waveform_bins` (no loudness row gets cached).
         let bytes = vec![0xAAu8; 8 * 1024];
-        let (outcome, _) = seed_from_bytes_into_cache(&cache, "server-a", "garbage", &bytes, None, None).unwrap();
+        let (outcome, _) =
+            seed_from_bytes_into_cache(&cache, "server-a", "garbage", &bytes, None, None).unwrap();
         assert_eq!(outcome, SeedFromBytesOutcome::Upserted);
 
         let key = TrackKey {
@@ -1206,7 +1387,10 @@ mod tests {
             track_id: "garbage".to_string(),
             md5_16kb: md5_first_16kb(&bytes),
         };
-        let waveform = cache.get_waveform(&key).unwrap().expect("byte-envelope waveform cached");
+        let waveform = cache
+            .get_waveform(&key)
+            .unwrap()
+            .expect("byte-envelope waveform cached");
         assert_eq!(waveform.bin_count, 500);
         assert!(
             !cache.loudness_row_exists_for_key(&key).unwrap(),
@@ -1280,8 +1464,10 @@ mod tests {
     #[test]
     fn decode_scan_pcm_supports_waveform_only_mode_without_loudness() {
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
-        let (frames, hint) = count_mono_frames_from_audio_bytes(&wav, None).expect("frame counting");
-        let scanned = decode_scan_pcm(&wav, 64, frames, hint, None, None).expect("scan must succeed");
+        let (frames, hint) =
+            count_mono_frames_from_audio_bytes(&wav, None).expect("frame counting");
+        let scanned =
+            decode_scan_pcm(&wav, 64, frames, hint, None, None).expect("scan must succeed");
         assert_eq!(scanned.bins.len(), 128);
         assert!(scanned.loudness.is_none());
     }
@@ -1289,8 +1475,10 @@ mod tests {
     #[test]
     fn decode_scan_pcm_with_loudness_target_returns_loudness_tuple() {
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
-        let (frames, hint) = count_mono_frames_from_audio_bytes(&wav, None).expect("frame counting");
-        let scanned = decode_scan_pcm(&wav, 64, frames, hint, Some(-14.0), None).expect("scan must succeed");
+        let (frames, hint) =
+            count_mono_frames_from_audio_bytes(&wav, None).expect("frame counting");
+        let scanned =
+            decode_scan_pcm(&wav, 64, frames, hint, Some(-14.0), None).expect("scan must succeed");
         assert_eq!(scanned.bins.len(), 128);
         let (integrated_lufs, true_peak, recommended_gain_db, target_lufs) =
             scanned.loudness.expect("loudness tuple must be present");
@@ -1332,7 +1520,8 @@ mod tests {
         assert!(!cache.loudness_row_exists_for_key(&key).unwrap());
 
         let (outcome, _) =
-            seed_from_bytes_into_cache(&cache, "server-a", "track-reseed", &wav, None, None).unwrap();
+            seed_from_bytes_into_cache(&cache, "server-a", "track-reseed", &wav, None, None)
+                .unwrap();
         assert_eq!(outcome, SeedFromBytesOutcome::Upserted);
         assert!(cache.loudness_row_exists_for_key(&key).unwrap());
     }
@@ -1379,7 +1568,8 @@ mod tests {
     #[test]
     fn decode_scan_pcm_ignores_oversized_timeline_hint() {
         let wav = build_mono_pcm16_wav(&sine_440_at_minus_6db(44_100, 1.0), 44_100);
-        let (frames, _hint) = count_mono_frames_from_audio_bytes(&wav, None).expect("frame counting");
+        let (frames, _hint) =
+            count_mono_frames_from_audio_bytes(&wav, None).expect("frame counting");
         let scanned = decode_scan_pcm(&wav, 64, frames, Some(frames * 10), None, None).unwrap();
         assert_eq!(scanned.bins.len(), 128);
     }
@@ -1404,12 +1594,14 @@ mod tests {
         let handle = app.handle().clone();
 
         let (first, timings_first) =
-            seed_from_bytes_execute(&handle, "server-a", "track-exec", &wav, None, None, true).unwrap();
+            seed_from_bytes_execute(&handle, "server-a", "track-exec", &wav, None, None, true)
+                .unwrap();
         assert_eq!(first, SeedFromBytesOutcome::Upserted);
         assert!(timings_first.seed_ms <= 30_000);
 
         let (second, timings_second) =
-            seed_from_bytes_execute(&handle, "server-a", "track-exec", &wav, None, None, true).unwrap();
+            seed_from_bytes_execute(&handle, "server-a", "track-exec", &wav, None, None, true)
+                .unwrap();
         assert_eq!(second, SeedFromBytesOutcome::SkippedWaveformCacheHit);
         assert!(timings_second.seed_ms <= 30_000);
     }

--- a/src-tauri/crates/psysonic-analysis/src/analysis_cache/mod.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_cache/mod.rs
@@ -1,6 +1,7 @@
 mod compute;
 mod store;
 
+pub(crate) use compute::seed_transcoded_bytes_execute;
 pub use compute::{
     analysis_pcm_window, audio_duration_from_bytes, decode_mono_pcm_limited,
     decode_mono_pcm_window, md5_first_16kb, recommended_gain_for_target, seed_from_bytes_execute,

--- a/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
@@ -113,7 +113,7 @@ pub enum AnalysisBackfillEnqueueKind {
     RunningSkipped,
     /// Automatic backfill recently failed before CPU admission.
     RetryDeferred,
-    /// Automatic backfill hit a permanent HTTP failure in this app session.
+    /// Automatic backfill is cooling down after a terminal failure.
     TerminalSkipped,
 }
 
@@ -133,6 +133,9 @@ type BackfillJob = (String, String, String);
 
 const ANALYSIS_BACKFILL_RETRY_BASE_SECS: u64 = 30;
 const ANALYSIS_BACKFILL_RETRY_MAX_SECS: u64 = 30 * 60;
+// A track id can later point at new content, so even terminal HTTP/size
+// failures must not suppress automatic analysis for the whole app session.
+const ANALYSIS_BACKFILL_TERMINAL_RETRY_SECS: u64 = 60 * 60;
 
 #[derive(Debug, Clone, Copy)]
 struct AnalysisBackfillRetryState {
@@ -158,7 +161,7 @@ pub struct AnalysisBackfillQueueState {
     /// This reservation prevents a second download without consuming an HTTP slot.
     awaiting_cpu: HashSet<String>,
     retry_state: HashMap<String, AnalysisBackfillRetryState>,
-    terminal_failures: HashSet<String>,
+    terminal_failures: HashMap<String, std::time::Instant>,
 }
 
 impl AnalysisBackfillQueueState {
@@ -299,7 +302,11 @@ impl AnalysisBackfillQueueState {
             }
             AnalysisBackfillFinish::TerminalFailure => {
                 self.retry_state.remove(key);
-                self.terminal_failures.insert(key.to_string());
+                self.terminal_failures.insert(
+                    key.to_string(),
+                    std::time::Instant::now()
+                        + std::time::Duration::from_secs(ANALYSIS_BACKFILL_TERMINAL_RETRY_SECS),
+                );
             }
         }
     }
@@ -313,6 +320,12 @@ impl AnalysisBackfillQueueState {
         self.retry_state
             .get(key)
             .is_some_and(|state| state.retry_after > std::time::Instant::now())
+    }
+
+    fn terminal_deferred(&self, key: &str) -> bool {
+        self.terminal_failures
+            .get(key)
+            .is_some_and(|retry_after| *retry_after > std::time::Instant::now())
     }
 
     pub fn enqueue(
@@ -349,8 +362,11 @@ impl AnalysisBackfillQueueState {
         if priority == AnalysisBackfillPriority::Low && self.retry_deferred(tref) {
             return AnalysisBackfillEnqueueKind::RetryDeferred;
         }
-        if priority == AnalysisBackfillPriority::Low && self.terminal_failures.contains(tref) {
+        if priority == AnalysisBackfillPriority::Low && self.terminal_deferred(tref) {
             return AnalysisBackfillEnqueueKind::TerminalSkipped;
+        }
+        if !self.terminal_deferred(tref) {
+            self.terminal_failures.remove(tref);
         }
         let kind = match priority {
             AnalysisBackfillPriority::High => AnalysisBackfillEnqueueKind::NewHigh,
@@ -1649,6 +1665,22 @@ pub fn analysis_track_in_cpu_pipeline(server_id: &str, track_id: &str) -> bool {
     false
 }
 
+pub fn analysis_revision_in_cpu_pipeline(
+    server_id: &str,
+    track_id: &str,
+    revision: &str,
+) -> bool {
+    let tid = track_id.trim();
+    if tid.is_empty() || revision.is_empty() {
+        return false;
+    }
+    let Some(shared) = ANALYSIS_CPU_SEED.get() else {
+        return false;
+    };
+    let st = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    st.contains_revision(server_id, tid, revision)
+}
+
 pub fn analysis_pipeline_queue_stats() -> AnalysisPipelineQueueStatsDto {
     let pipeline_workers = ANALYSIS_BACKFILL
         .get()
@@ -1853,7 +1885,7 @@ pub fn enqueue_seed_from_url(
         }
         AnalysisBackfillEnqueueKind::TerminalSkipped => {
             crate::app_deprintln!(
-                "[analysis] backfill suppressed after permanent HTTP failure: track_id={}",
+                "[analysis] backfill deferred during terminal-failure cooldown: track_id={}",
                 tid_log,
             );
             Ok(EnqueueSeedFromUrlOutcome::Skipped)
@@ -1982,6 +2014,11 @@ impl AnalysisCpuSeedQueueState {
             }
         }
         None
+    }
+
+    fn contains_revision(&self, server_id: &str, track_id: &str, revision: &str) -> bool {
+        let key = seed_revision_key(server_id, track_id, revision);
+        self.running.contains_key(&key) || self.locate_queued(&key).is_some()
     }
 
     fn push_new(&mut self, priority: AnalysisBackfillPriority, job: AnalysisCpuSeedJob) {
@@ -3292,6 +3329,31 @@ mod tests {
     }
 
     #[test]
+    fn terminal_failure_cooldown_allows_a_later_low_priority_retry() {
+        let mut state = AnalysisBackfillQueueState::default();
+        let key = seed_key("server-1", "changed-after-terminal");
+        state
+            .in_progress
+            .insert(key.clone(), AnalysisBackfillPriority::Low);
+        state.finish_job(&key, AnalysisBackfillFinish::TerminalFailure);
+        state.terminal_failures.insert(
+            key,
+            std::time::Instant::now() - std::time::Duration::from_secs(1),
+        );
+
+        assert_eq!(
+            state.enqueue(
+                "server-1".into(),
+                "changed-after-terminal".into(),
+                "url".into(),
+                AnalysisBackfillPriority::Low,
+            ),
+            AnalysisBackfillEnqueueKind::NewLow
+        );
+        assert!(state.terminal_failures.is_empty());
+    }
+
+    #[test]
     fn late_registration_cannot_replace_a_newer_trusted_revision() {
         let app = tauri::test::mock_app();
         let older_generation = next_trusted_generation();
@@ -3499,6 +3561,8 @@ mod tests {
             seed_revision_key(&job_a.server_id, &job_a.track_id, &job_a.revision),
             Arc::new(Mutex::new(Vec::new())),
         );
+        assert!(s.contains_revision("srv", "t1", "revision-a"));
+        assert!(!s.contains_revision("srv", "t1", "revision-b"));
 
         let (kind, _r2) = s.enqueue(
             "srv".into(),

--- a/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
@@ -328,6 +328,24 @@ impl AnalysisBackfillQueueState {
             .is_some_and(|retry_after| *retry_after > std::time::Instant::now())
     }
 
+    fn clear_failure_state(&mut self, server_id: &str, track_ids: &[String]) {
+        if track_ids.is_empty() {
+            let prefix = format!("{server_id}\u{1f}");
+            self.retry_state.retain(|key, _| !key.starts_with(&prefix));
+            self.terminal_failures
+                .retain(|key, _| !key.starts_with(&prefix));
+            return;
+        }
+        for track_id in track_ids {
+            let bare_track_id = track_id.strip_prefix("stream:").unwrap_or(track_id);
+            for variant in [bare_track_id.to_string(), format!("stream:{bare_track_id}")] {
+                let key = seed_key(server_id, &variant);
+                self.retry_state.remove(&key);
+                self.terminal_failures.remove(&key);
+            }
+        }
+    }
+
     pub fn enqueue(
         &mut self,
         server_id: String,
@@ -1151,6 +1169,7 @@ fn analysis_http_client() -> &'static reqwest::Client {
 }
 
 const ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES: usize = 64 * 1024 * 1024;
+const ANALYSIS_SOURCE_UNAVAILABLE_REVISION: &str = "source-unavailable";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum AnalysisBackfillJobError {
@@ -1169,6 +1188,83 @@ impl std::fmt::Display for AnalysisBackfillJobError {
 impl AnalysisBackfillJobError {
     fn is_retryable(&self) -> bool {
         matches!(self, Self::Retryable(_))
+    }
+}
+
+fn source_unavailable_failure<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    server_id: &str,
+    track_id: &str,
+    error: &crate::raw_probe::SubsonicStreamError,
+    generation: u64,
+) -> AnalysisBackfillJobError {
+    let message = error.message.lines().collect::<Vec<_>>().join(" ");
+    crate::app_deprintln!(
+        "[analysis][backfill] source unavailable track_id={track_id} code={} message={message}",
+        error.code
+    );
+    register_trusted_revision_generation(
+        server_id,
+        track_id,
+        ANALYSIS_SOURCE_UNAVAILABLE_REVISION,
+        generation,
+    );
+    let Some(cache) = app.try_state::<analysis_cache::AnalysisCache>() else {
+        return AnalysisBackfillJobError::Retryable(format!(
+            "analysis source unavailable (Subsonic code {}), but analysis cache is unavailable",
+            error.code
+        ));
+    };
+    let key = analysis_cache::TrackKey {
+        server_id: server_id.to_string(),
+        track_id: track_id.to_string(),
+        md5_16kb: ANALYSIS_SOURCE_UNAVAILABLE_REVISION.to_string(),
+    };
+    match cache.touch_track_status(&key, "failed") {
+        Ok(()) => AnalysisBackfillJobError::Terminal(format!(
+            "analysis source unavailable (Subsonic code {}): {message}",
+            error.code
+        )),
+        Err(cache_error) => AnalysisBackfillJobError::Retryable(format!(
+            "analysis source unavailable (Subsonic code {}), but failed to record it: {cache_error}",
+            error.code
+        )),
+    }
+}
+
+async fn probe_backfill_trusted_identity<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    registry: Option<&ServerHttpRegistry>,
+    server_id: &str,
+    track_id: &str,
+    url: &str,
+    generation: u64,
+) -> Result<Option<String>, AnalysisBackfillJobError> {
+    match crate::raw_probe::probe_trusted_original_md5(
+        analysis_http_client(),
+        registry,
+        Some(server_id),
+        url,
+    )
+    .await
+    {
+        crate::raw_probe::TrustedOriginalProbeResult::Trusted(hash) => Ok(Some(hash)),
+        crate::raw_probe::TrustedOriginalProbeResult::SubsonicError(error)
+            if error.is_source_unavailable() =>
+        {
+            Err(source_unavailable_failure(
+                app, server_id, track_id, &error, generation,
+            ))
+        }
+        crate::raw_probe::TrustedOriginalProbeResult::SubsonicError(error) => {
+            let message = error.message.lines().collect::<Vec<_>>().join(" ");
+            crate::app_deprintln!(
+                "[analysis][backfill] raw identity probe rejected track_id={track_id} code={} message={message}",
+                error.code
+            );
+            Ok(None)
+        }
+        crate::raw_probe::TrustedOriginalProbeResult::Unavailable => Ok(None),
     }
 }
 
@@ -1241,15 +1337,17 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
     let raw_supported =
         crate::raw_probe::raw_stream_supported(registry.as_deref(), Some(server_id), url);
     let mut trusted = if raw_supported {
-        match crate::raw_probe::resolve_trusted_identity(
-            analysis_http_client(),
+        match probe_backfill_trusted_identity(
+            app,
             registry.as_deref(),
-            Some(server_id),
+            server_id,
+            track_id,
             url,
+            operation_generation,
         )
         .await
         {
-            crate::raw_probe::TrustedProbeVerdict::Trusted(hash) => {
+            Ok(Some(hash)) => {
                 register_trusted_revision_generation(
                     server_id,
                     track_id,
@@ -1258,12 +1356,13 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
                 );
                 Some(hash)
             }
-            crate::raw_probe::TrustedProbeVerdict::SkipCanonicalWrites => {
+            Ok(None) => {
                 crate::app_deprintln!(
                     "[analysis] raw identity probe unavailable track_id={track_id}; falling back to original download"
                 );
                 None
             }
+            Err(error) => return Err(error),
         }
     } else {
         None
@@ -1279,15 +1378,17 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
             max_bytes,
         )
         .await;
-        let revalidated = crate::raw_probe::resolve_trusted_identity(
-            analysis_http_client(),
+        let revalidated = probe_backfill_trusted_identity(
+            app,
             registry.as_deref(),
-            Some(server_id),
+            server_id,
+            track_id,
             url,
+            operation_generation,
         )
         .await;
         match revalidated {
-            crate::raw_probe::TrustedProbeVerdict::Trusted(hash) => {
+            Ok(Some(hash)) => {
                 register_trusted_revision_generation(
                     server_id,
                     track_id,
@@ -1323,6 +1424,17 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
                                 "analysis transcode exceeds cap of {max_bytes} bytes"
                             )));
                         }
+                        Err(crate::raw_probe::BoundedStreamFetchError::SubsonicApi(error))
+                            if error.is_source_unavailable() =>
+                        {
+                            return Err(source_unavailable_failure(
+                                app,
+                                server_id,
+                                track_id,
+                                &error,
+                                operation_generation,
+                            ));
+                        }
                         Err(error) => {
                             crate::app_deprintln!(
                                 "[analysis] transcode unavailable track_id={track_id}: {error}; falling back to original download"
@@ -1335,12 +1447,13 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
                     );
                 }
             }
-            crate::raw_probe::TrustedProbeVerdict::SkipCanonicalWrites => {
+            Ok(None) => {
                 trusted = None;
                 crate::app_deprintln!(
                     "[analysis] raw identity revalidation unavailable track_id={track_id}; falling back to original download"
                 );
             }
+            Err(error) => return Err(error),
         }
     }
 
@@ -1387,6 +1500,17 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
             return Err(AnalysisBackfillJobError::Terminal(format!(
                 "original download exceeds analysis cap of {max_bytes} bytes"
             )));
+        }
+        Err(crate::raw_probe::BoundedStreamFetchError::SubsonicApi(error))
+            if error.is_source_unavailable() =>
+        {
+            return Err(source_unavailable_failure(
+                app,
+                server_id,
+                track_id,
+                &error,
+                operation_generation,
+            ));
         }
         Err(error) => {
             let message = format!("original download unavailable: {error}");
@@ -1632,6 +1756,17 @@ pub fn analysis_backfill_queue_stats() -> (usize, usize, Option<String>) {
     } else {
         (0, 0, None)
     }
+}
+
+pub fn clear_analysis_backfill_failure_state(server_id: &str, track_ids: &[String]) {
+    let Some(shared) = ANALYSIS_BACKFILL.get() else {
+        return;
+    };
+    let mut state = shared
+        .state
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    state.clear_failure_state(server_id, track_ids);
 }
 
 pub fn analysis_track_in_cpu_pipeline(server_id: &str, track_id: &str) -> bool {
@@ -2990,6 +3125,54 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn missing_source_is_recorded_without_original_download_fallback() {
+        use tauri::Manager;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let response = br#"{"subsonic-response":{"status":"failed","error":{"code":0,"message":"open /music/missing.flac: no such file or directory"}}}"#.to_vec();
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "raw"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(response))
+            .mount(&server)
+            .await;
+
+        let app = tauri::test::mock_app();
+        app.handle()
+            .manage(Arc::new(analysis_registry(&server.uri(), true)));
+        app.handle()
+            .manage(analysis_cache::AnalysisCache::open_in_memory());
+        let stream_url = format!("{}/rest/stream.view?id=missing&format=mp3", server.uri());
+
+        let result = analysis_backfill_download(
+            app.handle(),
+            "canonical-server",
+            "missing",
+            &stream_url,
+            ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES,
+        )
+        .await;
+
+        let Err(AnalysisBackfillJobError::Terminal(message)) = result else {
+            panic!("missing source should be a recoverable terminal backfill failure");
+        };
+        assert!(message.contains("Subsonic code 0"));
+        assert!(message.contains("no such file or directory"));
+        let cache = app.handle().state::<analysis_cache::AnalysisCache>();
+        let failed = cache
+            .list_failed_tracks("canonical-server", None)
+            .unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].track_id, "missing");
+        assert_eq!(failed[0].md5_16kb, ANALYSIS_SOURCE_UNAVAILABLE_REVISION);
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].url.path(), "/rest/stream.view");
+    }
+
     #[test]
     fn explicit_backfill_server_hint_beats_url_transport_scope() {
         assert_eq!(
@@ -3351,6 +3534,29 @@ mod tests {
             AnalysisBackfillEnqueueKind::NewLow
         );
         assert!(state.terminal_failures.is_empty());
+    }
+
+    #[test]
+    fn clearing_failed_tracks_removes_matching_backfill_cooldowns() {
+        let mut state = AnalysisBackfillQueueState::default();
+        let bare_key = seed_key("server-1", "missing");
+        let stream_key = seed_key("server-1", "stream:missing");
+        let other_server_key = seed_key("server-2", "missing");
+        state.record_retryable_failure(&bare_key);
+        state.terminal_failures.insert(
+            stream_key.clone(),
+            std::time::Instant::now() + std::time::Duration::from_secs(60),
+        );
+        state.terminal_failures.insert(
+            other_server_key.clone(),
+            std::time::Instant::now() + std::time::Duration::from_secs(60),
+        );
+
+        state.clear_failure_state("server-1", &["missing".to_string()]);
+
+        assert!(!state.retry_state.contains_key(&bare_key));
+        assert!(!state.terminal_failures.contains_key(&stream_key));
+        assert!(state.terminal_failures.contains_key(&other_server_key));
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
@@ -353,6 +353,17 @@ impl AnalysisBackfillQueueState {
         url: String,
         priority: AnalysisBackfillPriority,
     ) -> AnalysisBackfillEnqueueKind {
+        self.enqueue_with_force(server_id, tid, url, priority, false)
+    }
+
+    fn enqueue_with_force(
+        &mut self,
+        server_id: String,
+        tid: String,
+        url: String,
+        priority: AnalysisBackfillPriority,
+        force: bool,
+    ) -> AnalysisBackfillEnqueueKind {
         // Reservation/merge scope is (server, track): the same Subsonic id on
         // two servers is two different files and must not collide.
         let key = seed_key(&server_id, &tid);
@@ -377,10 +388,10 @@ impl AnalysisBackfillQueueState {
             self.push_new(priority, (tid, url, server_id));
             return AnalysisBackfillEnqueueKind::ReorderedHigher;
         }
-        if priority == AnalysisBackfillPriority::Low && self.retry_deferred(tref) {
+        if !force && priority == AnalysisBackfillPriority::Low && self.retry_deferred(tref) {
             return AnalysisBackfillEnqueueKind::RetryDeferred;
         }
-        if priority == AnalysisBackfillPriority::Low && self.terminal_deferred(tref) {
+        if !force && priority == AnalysisBackfillPriority::Low && self.terminal_deferred(tref) {
             return AnalysisBackfillEnqueueKind::TerminalSkipped;
         }
         if !self.terminal_deferred(tref) {
@@ -519,6 +530,27 @@ struct TrustedActivationState {
     current_by_track: HashMap<String, TrustedRevisionGeneration>,
 }
 
+impl TrustedActivationState {
+    fn register(&mut self, key: String, revision: &str, generation: u64) -> u64 {
+        if let Some(current) = self.current_by_track.get(&key) {
+            if current.revision == revision {
+                return current.generation;
+            }
+            if current.generation > generation {
+                return generation;
+            }
+        }
+        self.current_by_track.insert(
+            key,
+            TrustedRevisionGeneration {
+                revision: revision.to_string(),
+                generation,
+            },
+        );
+        generation
+    }
+}
+
 static TRUSTED_ACTIVATION_GENERATION: AtomicU64 = AtomicU64::new(0);
 static TRUSTED_ACTIVATIONS: OnceLock<Mutex<TrustedActivationState>> = OnceLock::new();
 
@@ -536,26 +568,32 @@ fn register_trusted_revision_generation(
     track_id: &str,
     revision: &str,
     generation: u64,
-) {
+) -> u64 {
     let key = canonical_activation_key(server_id, track_id);
     let mut state = TRUSTED_ACTIVATIONS
         .get_or_init(|| Mutex::new(TrustedActivationState::default()))
         .lock()
         .unwrap_or_else(|e| e.into_inner());
-    if state
+    state.register(key, revision, generation)
+}
+
+#[cfg(test)]
+fn trusted_revision_generation_is_current(
+    server_id: &str,
+    track_id: &str,
+    revision: &str,
+    generation: u64,
+) -> bool {
+    let key = canonical_activation_key(server_id, track_id);
+    TRUSTED_ACTIVATIONS
+        .get_or_init(|| Mutex::new(TrustedActivationState::default()))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
         .current_by_track
         .get(&key)
-        .is_some_and(|current| current.generation > generation)
-    {
-        return;
-    }
-    state.current_by_track.insert(
-        key,
-        TrustedRevisionGeneration {
-            revision: revision.to_string(),
-            generation,
-        },
-    );
+        .is_some_and(|current| {
+            current.revision == revision && current.generation == generation
+        })
 }
 
 pub fn begin_trusted_revision(server_id: &str, track_id: &str, revision: &str) -> u64 {
@@ -1175,12 +1213,14 @@ const ANALYSIS_SOURCE_UNAVAILABLE_REVISION: &str = "source-unavailable";
 enum AnalysisBackfillJobError {
     Terminal(String),
     Retryable(String),
+    Superseded,
 }
 
 impl std::fmt::Display for AnalysisBackfillJobError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Terminal(message) | Self::Retryable(message) => formatter.write_str(message),
+            Self::Superseded => formatter.write_str("superseded by newer analysis work"),
         }
     }
 }
@@ -1188,6 +1228,10 @@ impl std::fmt::Display for AnalysisBackfillJobError {
 impl AnalysisBackfillJobError {
     fn is_retryable(&self) -> bool {
         matches!(self, Self::Retryable(_))
+    }
+
+    fn is_superseded(&self) -> bool {
+        matches!(self, Self::Superseded)
     }
 }
 
@@ -1198,17 +1242,31 @@ fn source_unavailable_failure<R: tauri::Runtime>(
     error: &crate::raw_probe::SubsonicStreamError,
     generation: u64,
 ) -> AnalysisBackfillJobError {
-    let message = error.message.lines().collect::<Vec<_>>().join(" ");
     crate::app_deprintln!(
-        "[analysis][backfill] source unavailable track_id={track_id} code={} message={message}",
-        error.code
+        "[analysis][backfill] source unavailable track_id={track_id} code={} reason={}",
+        error.code,
+        error.diagnostic_reason(),
     );
-    register_trusted_revision_generation(
-        server_id,
-        track_id,
+    let activation_key = canonical_activation_key(server_id, track_id);
+    let mut activation_state = TRUSTED_ACTIVATIONS
+        .get_or_init(|| Mutex::new(TrustedActivationState::default()))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let effective_generation = activation_state.register(
+        activation_key.clone(),
         ANALYSIS_SOURCE_UNAVAILABLE_REVISION,
         generation,
     );
+    let is_current = activation_state
+        .current_by_track
+        .get(&activation_key)
+        .is_some_and(|current| {
+            current.revision == ANALYSIS_SOURCE_UNAVAILABLE_REVISION
+                && current.generation == effective_generation
+        });
+    if !is_current {
+        return AnalysisBackfillJobError::Superseded;
+    }
     let Some(cache) = app.try_state::<analysis_cache::AnalysisCache>() else {
         return AnalysisBackfillJobError::Retryable(format!(
             "analysis source unavailable (Subsonic code {}), but analysis cache is unavailable",
@@ -1222,8 +1280,9 @@ fn source_unavailable_failure<R: tauri::Runtime>(
     };
     match cache.touch_track_status(&key, "failed") {
         Ok(()) => AnalysisBackfillJobError::Terminal(format!(
-            "analysis source unavailable (Subsonic code {}): {message}",
-            error.code
+            "analysis source unavailable (Subsonic code {}, reason={})",
+            error.code,
+            error.diagnostic_reason(),
         )),
         Err(cache_error) => AnalysisBackfillJobError::Retryable(format!(
             "analysis source unavailable (Subsonic code {}), but failed to record it: {cache_error}",
@@ -1257,10 +1316,10 @@ async fn probe_backfill_trusted_identity<R: tauri::Runtime>(
             ))
         }
         crate::raw_probe::TrustedOriginalProbeResult::SubsonicError(error) => {
-            let message = error.message.lines().collect::<Vec<_>>().join(" ");
             crate::app_deprintln!(
-                "[analysis][backfill] raw identity probe rejected track_id={track_id} code={} message={message}",
-                error.code
+                "[analysis][backfill] raw identity probe rejected track_id={track_id} code={} reason={}",
+                error.code,
+                error.diagnostic_reason(),
             );
             Ok(None)
         }
@@ -1331,6 +1390,7 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
     max_bytes: usize,
 ) -> Result<AnalysisBackfillDownload, AnalysisBackfillJobError> {
     let operation_generation = next_trusted_generation();
+    let mut effective_generation = operation_generation;
     let registry = app
         .try_state::<Arc<ServerHttpRegistry>>()
         .map(|s| Arc::clone(&*s));
@@ -1348,7 +1408,7 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
         .await
         {
             Ok(Some(hash)) => {
-                register_trusted_revision_generation(
+                effective_generation = register_trusted_revision_generation(
                     server_id,
                     track_id,
                     &hash,
@@ -1389,7 +1449,7 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
         .await;
         match revalidated {
             Ok(Some(hash)) => {
-                register_trusted_revision_generation(
+                effective_generation = register_trusted_revision_generation(
                     server_id,
                     track_id,
                     &hash,
@@ -1406,7 +1466,7 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
                                 format_hint: analysis_stream_format_hint(url),
                                 trusted_revision: Some(TrustedAnalysisRevision {
                                     md5_16kb: hash,
-                                    generation: operation_generation,
+                                    generation: effective_generation,
                                     analysis_bytes_transcoded: true,
                                     content_hash_server_id: None,
                                 }),
@@ -1418,22 +1478,11 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
                                 server_id,
                                 track_id,
                                 &hash,
-                                operation_generation,
+                                effective_generation,
                             )?;
                             return Err(AnalysisBackfillJobError::Terminal(format!(
                                 "analysis transcode exceeds cap of {max_bytes} bytes"
                             )));
-                        }
-                        Err(crate::raw_probe::BoundedStreamFetchError::SubsonicApi(error))
-                            if error.is_source_unavailable() =>
-                        {
-                            return Err(source_unavailable_failure(
-                                app,
-                                server_id,
-                                track_id,
-                                &error,
-                                operation_generation,
-                            ));
                         }
                         Err(error) => {
                             crate::app_deprintln!(
@@ -1483,7 +1532,7 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
             }
             let original_md5_16kb = trusted.as_deref().unwrap_or(&md5_16kb);
             if trusted.is_none() {
-                register_trusted_revision_generation(
+                effective_generation = register_trusted_revision_generation(
                     server_id,
                     track_id,
                     original_md5_16kb,
@@ -1495,7 +1544,7 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
                 server_id,
                 track_id,
                 original_md5_16kb,
-                operation_generation,
+                effective_generation,
             )?;
             return Err(AnalysisBackfillJobError::Terminal(format!(
                 "original download exceeds analysis cap of {max_bytes} bytes"
@@ -1529,9 +1578,14 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
         }
     }
     let md5_16kb = trusted.unwrap_or_else(|| analysis_cache::md5_first_16kb(&bytes));
-    register_trusted_revision_generation(server_id, track_id, &md5_16kb, operation_generation);
+    effective_generation = register_trusted_revision_generation(
+        server_id,
+        track_id,
+        &md5_16kb,
+        operation_generation,
+    );
     let trusted_revision = Some(TrustedAnalysisRevision {
-        generation: operation_generation,
+        generation: effective_generation,
         md5_16kb,
         analysis_bytes_transcoded: false,
         content_hash_server_id: None,
@@ -1707,6 +1761,7 @@ async fn spawn_backfill_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisBackf
                 &track_id,
                 match &result {
                     Ok(_) => AnalysisBackfillFinish::Success,
+                    Err(error) if error.is_superseded() => AnalysisBackfillFinish::Success,
                     Err(error) if error.is_retryable() => {
                         AnalysisBackfillFinish::RetryableFailure
                     }
@@ -1721,6 +1776,12 @@ async fn spawn_backfill_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisBackf
                     max,
                     track_id,
                     has_loudness
+                ),
+                Err(error) if error.is_superseded() => crate::app_deprintln!(
+                    "[analysis] backfill worker={}/{}: skipped stale track_id={}",
+                    worker_slot,
+                    max,
+                    track_id,
                 ),
                 Err(e) => crate::app_eprintln!(
                     "[analysis] backfill worker={}/{}: failed track_id={}: {}",
@@ -1986,7 +2047,13 @@ pub fn enqueue_seed_from_url(
             .state
             .lock()
             .map_err(|_| "analysis backfill lock poisoned".to_string())?;
-        st.enqueue(server_id, track_id.to_string(), url.to_string(), resolved)
+        st.enqueue_with_force(
+            server_id,
+            track_id.to_string(),
+            url.to_string(),
+            resolved,
+            force,
+        )
     };
     match kind {
         AnalysisBackfillEnqueueKind::NewLow
@@ -2817,7 +2884,7 @@ mod tests {
         let oversized = analysis_backfill_download(
             app.handle(),
             "canonical-server",
-            "oversized",
+            "oversized-transcode",
             &stream_url,
             8 * 1024,
         )
@@ -2831,7 +2898,7 @@ mod tests {
         let cache = app.handle().state::<analysis_cache::AnalysisCache>();
         assert_eq!(
             cache
-                .get_latest_status_for_track("canonical-server", "oversized")
+                .get_latest_status_for_track("canonical-server", "oversized-transcode")
                 .unwrap()
                 .map(|(status, _)| status),
             Some("failed".to_string())
@@ -2892,6 +2959,67 @@ mod tests {
         assert_eq!(
             trusted.md5_16kb,
             analysis_cache::md5_first_16kb(&download.bytes)
+        );
+        assert_eq!(server.received_requests().await.unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn successful_raw_revalidation_wins_over_transcode_source_error() {
+        use tauri::Manager;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let mut original = vec![0x45; 24 * 1024];
+        original[..4].copy_from_slice(b"fLaC");
+        let source_error = br#"{"subsonic-response":{"status":"failed","error":{"code":0,"message":"open /private/music.flac: no such file or directory"}}}"#.to_vec();
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "raw"))
+            .respond_with(RawOriginalResponder {
+                body: original.clone(),
+            })
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "mp3"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(source_error))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/download.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(original.clone()))
+            .mount(&server)
+            .await;
+
+        let app = tauri::test::mock_app();
+        app.handle()
+            .manage(Arc::new(analysis_registry(&server.uri(), true)));
+        app.handle()
+            .manage(analysis_cache::AnalysisCache::open_in_memory());
+        let stream_url = format!(
+            "{}/rest/stream.view?id=transcode-error&format=mp3",
+            server.uri()
+        );
+
+        let download = analysis_backfill_download(
+            app.handle(),
+            "canonical-server",
+            "transcode-source-error",
+            &stream_url,
+            ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(download.bytes, original);
+        let cache = app.handle().state::<analysis_cache::AnalysisCache>();
+        assert_eq!(
+            cache
+                .get_latest_status_for_track("canonical-server", "transcode-source-error")
+                .unwrap(),
+            None
         );
         assert_eq!(server.received_requests().await.unwrap().len(), 4);
     }
@@ -3071,7 +3199,7 @@ mod tests {
         let oversized = analysis_backfill_download(
             app.handle(),
             "canonical-server",
-            "oversized",
+            "oversized-original",
             &stream_url,
             8 * 1024,
         )
@@ -3085,7 +3213,7 @@ mod tests {
         let cache = app.handle().state::<analysis_cache::AnalysisCache>();
         assert_eq!(
             cache
-                .get_latest_status_for_track("canonical-server", "oversized")
+                .get_latest_status_for_track("canonical-server", "oversized-original")
                 .unwrap()
                 .map(|(status, _)| status),
             Some("failed".to_string())
@@ -3160,7 +3288,8 @@ mod tests {
             panic!("missing source should be a recoverable terminal backfill failure");
         };
         assert!(message.contains("Subsonic code 0"));
-        assert!(message.contains("no such file or directory"));
+        assert!(message.contains("reason=no_such_file_or_directory"));
+        assert!(!message.contains("/music/"));
         let cache = app.handle().state::<analysis_cache::AnalysisCache>();
         let failed = cache
             .list_failed_tracks("canonical-server", None)
@@ -3537,6 +3666,27 @@ mod tests {
     }
 
     #[test]
+    fn forced_low_priority_retry_bypasses_terminal_cooldown() {
+        let mut state = AnalysisBackfillQueueState::default();
+        let key = seed_key("server-1", "manual-retry");
+        state
+            .in_progress
+            .insert(key.clone(), AnalysisBackfillPriority::Low);
+        state.finish_job(&key, AnalysisBackfillFinish::TerminalFailure);
+
+        assert_eq!(
+            state.enqueue_with_force(
+                "server-1".into(),
+                "manual-retry".into(),
+                "url".into(),
+                AnalysisBackfillPriority::Low,
+                true,
+            ),
+            AnalysisBackfillEnqueueKind::NewLow
+        );
+    }
+
+    #[test]
     fn clearing_failed_tracks_removes_matching_backfill_cooldowns() {
         let mut state = AnalysisBackfillQueueState::default();
         let bare_key = seed_key("server-1", "missing");
@@ -3594,6 +3744,75 @@ mod tests {
             "newer-fingerprint",
             newer_generation,
         ));
+    }
+
+    #[test]
+    fn same_revision_reuses_the_current_generation() {
+        let first_generation = next_trusted_generation();
+        let second_generation = next_trusted_generation();
+        let server_id = "same-revision-generation-server";
+        let track_id = "same-revision-track";
+
+        let first = register_trusted_revision_generation(
+            server_id,
+            track_id,
+            "same-fingerprint",
+            first_generation,
+        );
+        let second = register_trusted_revision_generation(
+            server_id,
+            track_id,
+            "same-fingerprint",
+            second_generation,
+        );
+
+        assert_eq!(first, first_generation);
+        assert_eq!(second, first_generation);
+        assert!(trusted_revision_generation_is_current(
+            server_id,
+            track_id,
+            "same-fingerprint",
+            first_generation,
+        ));
+    }
+
+    #[test]
+    fn stale_source_unavailable_response_does_not_write_failed_status() {
+        use tauri::Manager;
+
+        let app = tauri::test::mock_app();
+        app.handle()
+            .manage(analysis_cache::AnalysisCache::open_in_memory());
+        let server_id = "stale-unavailable-server";
+        let track_id = "stale-unavailable-track";
+        let stale_generation = next_trusted_generation();
+        let current_generation = next_trusted_generation();
+        register_trusted_revision_generation(
+            server_id,
+            track_id,
+            "current-fingerprint",
+            current_generation,
+        );
+
+        let outcome = source_unavailable_failure(
+            app.handle(),
+            server_id,
+            track_id,
+            &crate::raw_probe::SubsonicStreamError {
+                code: 0,
+                message: "open /private/music.flac: no such file or directory".to_string(),
+            },
+            stale_generation,
+        );
+
+        assert_eq!(outcome, AnalysisBackfillJobError::Superseded);
+        let cache = app.handle().state::<analysis_cache::AnalysisCache>();
+        assert_eq!(
+            cache
+                .get_latest_status_for_track(server_id, track_id)
+                .unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
@@ -113,6 +113,8 @@ pub enum AnalysisBackfillEnqueueKind {
     RunningSkipped,
     /// Automatic backfill recently failed before CPU admission.
     RetryDeferred,
+    /// Automatic backfill hit a permanent HTTP failure in this app session.
+    TerminalSkipped,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, specta::Type)]
@@ -138,6 +140,13 @@ struct AnalysisBackfillRetryState {
     retry_after: std::time::Instant,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnalysisBackfillFinish {
+    Success,
+    RetryableFailure,
+    TerminalFailure,
+}
+
 #[derive(Default)]
 pub struct AnalysisBackfillQueueState {
     high: VecDeque<BackfillJob>,
@@ -149,6 +158,7 @@ pub struct AnalysisBackfillQueueState {
     /// This reservation prevents a second download without consuming an HTTP slot.
     awaiting_cpu: HashSet<String>,
     retry_state: HashMap<String, AnalysisBackfillRetryState>,
+    terminal_failures: HashSet<String>,
 }
 
 impl AnalysisBackfillQueueState {
@@ -275,13 +285,22 @@ impl AnalysisBackfillQueueState {
         }
     }
 
-    fn finish_job(&mut self, key: &str, retryable_failure: bool) {
+    fn finish_job(&mut self, key: &str, finish: AnalysisBackfillFinish) {
         self.in_progress.remove(key);
         self.awaiting_cpu.remove(key);
-        if retryable_failure {
-            self.record_retryable_failure(key);
-        } else {
-            self.retry_state.remove(key);
+        match finish {
+            AnalysisBackfillFinish::Success => {
+                self.retry_state.remove(key);
+                self.terminal_failures.remove(key);
+            }
+            AnalysisBackfillFinish::RetryableFailure => {
+                self.terminal_failures.remove(key);
+                self.record_retryable_failure(key);
+            }
+            AnalysisBackfillFinish::TerminalFailure => {
+                self.retry_state.remove(key);
+                self.terminal_failures.insert(key.to_string());
+            }
         }
     }
 
@@ -329,6 +348,9 @@ impl AnalysisBackfillQueueState {
         }
         if priority == AnalysisBackfillPriority::Low && self.retry_deferred(tref) {
             return AnalysisBackfillEnqueueKind::RetryDeferred;
+        }
+        if priority == AnalysisBackfillPriority::Low && self.terminal_failures.contains(tref) {
+            return AnalysisBackfillEnqueueKind::TerminalSkipped;
         }
         let kind = match priority {
             AnalysisBackfillPriority::High => AnalysisBackfillEnqueueKind::NewHigh,
@@ -1285,9 +1307,9 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
                                 "analysis transcode exceeds cap of {max_bytes} bytes"
                             )));
                         }
-                        Err(crate::raw_probe::BoundedStreamFetchError::Unavailable) => {
+                        Err(error) => {
                             crate::app_deprintln!(
-                                "[analysis] transcode unavailable track_id={track_id}; falling back to original download"
+                                "[analysis] transcode unavailable track_id={track_id}: {error}; falling back to original download"
                             );
                         }
                     }
@@ -1350,10 +1372,13 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
                 "original download exceeds analysis cap of {max_bytes} bytes"
             )));
         }
-        Err(crate::raw_probe::BoundedStreamFetchError::Unavailable) => {
-            return Err(AnalysisBackfillJobError::Retryable(
-                "original download unavailable".to_string(),
-            ));
+        Err(error) => {
+            let message = format!("original download unavailable: {error}");
+            return Err(if error.is_permanent_http() {
+                AnalysisBackfillJobError::Terminal(message)
+            } else {
+                AnalysisBackfillJobError::Retryable(message)
+            });
         }
     };
     if let Some(trusted_md5_16kb) = trusted.as_deref() {
@@ -1421,14 +1446,14 @@ fn release_backfill_reservation(
     shared: &AnalysisBackfillShared,
     server_id: &str,
     track_id: &str,
-    retryable_failure: bool,
+    finish: AnalysisBackfillFinish,
 ) {
     {
         let mut state = shared
             .state
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        state.finish_job(&seed_key(server_id, track_id), retryable_failure);
+        state.finish_job(&seed_key(server_id, track_id), finish);
     }
     shared.ping_worker();
 }
@@ -1540,9 +1565,13 @@ async fn spawn_backfill_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisBackf
                 &shared,
                 &server_id,
                 &track_id,
-                result
-                    .as_ref()
-                    .is_err_and(AnalysisBackfillJobError::is_retryable),
+                match &result {
+                    Ok(_) => AnalysisBackfillFinish::Success,
+                    Err(error) if error.is_retryable() => {
+                        AnalysisBackfillFinish::RetryableFailure
+                    }
+                    Err(_) => AnalysisBackfillFinish::TerminalFailure,
+                },
             );
 
             match &result {
@@ -1818,6 +1847,13 @@ pub fn enqueue_seed_from_url(
         AnalysisBackfillEnqueueKind::RetryDeferred => {
             crate::app_deprintln!(
                 "[analysis] backfill retry deferred after transient failure: track_id={}",
+                tid_log,
+            );
+            Ok(EnqueueSeedFromUrlOutcome::Skipped)
+        }
+        AnalysisBackfillEnqueueKind::TerminalSkipped => {
+            crate::app_deprintln!(
+                "[analysis] backfill suppressed after permanent HTTP failure: track_id={}",
                 tid_log,
             );
             Ok(EnqueueSeedFromUrlOutcome::Skipped)
@@ -2557,7 +2593,7 @@ mod tests {
         app.handle()
             .manage(analysis_cache::AnalysisCache::open_in_memory());
         let stream_url = format!(
-            "{}/rest/stream.view?id=t1&format=mp3&maxBitRate=64&estimateContentLength=true",
+            "{}/rest/stream.view?id=t1&format=mp3&maxBitRate=64",
             server.uri()
         );
         assert_eq!(
@@ -2601,6 +2637,10 @@ mod tests {
                 .count(),
             1
         );
+        assert!(requests.iter().all(|request| !request
+            .url
+            .query_pairs()
+            .any(|(key, _)| key == "estimateContentLength")));
 
         let oversized = analysis_backfill_download(
             app.handle(),
@@ -2880,6 +2920,39 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn permanent_original_download_http_failure_is_terminal() {
+        use tauri::Manager;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/download.view"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let app = tauri::test::mock_app();
+        app.handle()
+            .manage(Arc::new(analysis_registry(&server.uri(), false)));
+        let stream_url = format!("{}/rest/stream.view?id=missing", server.uri());
+
+        assert_eq!(
+            analysis_backfill_download(
+                app.handle(),
+                "canonical-server",
+                "missing",
+                &stream_url,
+                ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES,
+            )
+            .await,
+            Err(AnalysisBackfillJobError::Terminal(
+                "original download unavailable: HTTP 404".to_string()
+            ))
+        );
+    }
+
     #[test]
     fn explicit_backfill_server_hint_beats_url_transport_scope() {
         assert_eq!(
@@ -3094,7 +3167,7 @@ mod tests {
         let key = seed_key("server-1", "retry");
         s.in_progress
             .insert(key.clone(), AnalysisBackfillPriority::Low);
-        s.finish_job(&key, true);
+        s.finish_job(&key, AnalysisBackfillFinish::RetryableFailure);
 
         let kind = s.enqueue(
             "server-1".into(),
@@ -3113,7 +3186,7 @@ mod tests {
         let key = seed_key("server-1", "retry");
         s.in_progress
             .insert(key.clone(), AnalysisBackfillPriority::Low);
-        s.finish_job(&key, true);
+        s.finish_job(&key, AnalysisBackfillFinish::RetryableFailure);
 
         assert_eq!(
             s.enqueue(
@@ -3125,7 +3198,10 @@ mod tests {
             AnalysisBackfillEnqueueKind::NewHigh
         );
         let job = s.try_pop_next(1).unwrap();
-        s.finish_job(&seed_key(&job.2, &job.0), false);
+        s.finish_job(
+            &seed_key(&job.2, &job.0),
+            AnalysisBackfillFinish::Success,
+        );
 
         assert_eq!(
             s.enqueue(
@@ -3145,7 +3221,7 @@ mod tests {
         state
             .in_progress
             .insert(key.clone(), AnalysisBackfillPriority::Low);
-        state.finish_job(&key, true);
+        state.finish_job(&key, AnalysisBackfillFinish::RetryableFailure);
         assert_eq!(
             state.retry_state.get(&key).map(|retry| retry.failures),
             Some(1)
@@ -3174,12 +3250,44 @@ mod tests {
             AnalysisBackfillEnqueueKind::RunningSkipped
         );
 
-        state.finish_job(&seed_key(&job.2, &job.0), true);
+        state.finish_job(
+            &seed_key(&job.2, &job.0),
+            AnalysisBackfillFinish::RetryableFailure,
+        );
 
         assert!(state.retry_deferred(&key));
         assert_eq!(
             state.retry_state.get(&key).map(|retry| retry.failures),
             Some(2)
+        );
+    }
+
+    #[test]
+    fn permanent_http_failure_suppresses_low_priority_until_high_priority_retries() {
+        let mut state = AnalysisBackfillQueueState::default();
+        let key = seed_key("server-1", "permanent");
+        state
+            .in_progress
+            .insert(key.clone(), AnalysisBackfillPriority::Low);
+        state.finish_job(&key, AnalysisBackfillFinish::TerminalFailure);
+
+        assert_eq!(
+            state.enqueue(
+                "server-1".into(),
+                "permanent".into(),
+                "url".into(),
+                AnalysisBackfillPriority::Low,
+            ),
+            AnalysisBackfillEnqueueKind::TerminalSkipped
+        );
+        assert_eq!(
+            state.enqueue(
+                "server-1".into(),
+                "permanent".into(),
+                "url".into(),
+                AnalysisBackfillPriority::High,
+            ),
+            AnalysisBackfillEnqueueKind::NewHigh
         );
     }
 

--- a/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -110,6 +111,8 @@ pub enum AnalysisBackfillEnqueueKind {
     DuplicateSkipped,
     /// High-priority request but that track is already being downloaded+seeded.
     RunningSkipped,
+    /// Automatic backfill recently failed before CPU admission.
+    RetryDeferred,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, specta::Type)]
@@ -122,9 +125,18 @@ pub enum EnqueueSeedFromUrlOutcome {
 }
 
 /// One queued HTTP-backfill job: `(track_id, url, server_id)`. Dedup is by
-/// `track_id` (a track is backfilled at most once at a time); `server_id` rides
-/// along to scope the eventual cache write and follows the latest enqueue.
+/// `(server_id, track_id)` so identical Subsonic ids on different servers do
+/// not share downloads or cache writes.
 type BackfillJob = (String, String, String);
+
+const ANALYSIS_BACKFILL_RETRY_BASE_SECS: u64 = 30;
+const ANALYSIS_BACKFILL_RETRY_MAX_SECS: u64 = 30 * 60;
+
+#[derive(Debug, Clone, Copy)]
+struct AnalysisBackfillRetryState {
+    failures: u32,
+    retry_after: std::time::Instant,
+}
 
 #[derive(Default)]
 pub struct AnalysisBackfillQueueState {
@@ -133,6 +145,10 @@ pub struct AnalysisBackfillQueueState {
     low: VecDeque<BackfillJob>,
     /// Active HTTP downloads keyed by track id (tier kept for pipeline stats).
     pub in_progress: HashMap<String, AnalysisBackfillPriority>,
+    /// HTTP download completed and the corresponding CPU seed is still pending.
+    /// This reservation prevents a second download without consuming an HTTP slot.
+    awaiting_cpu: HashSet<String>,
+    retry_state: HashMap<String, AnalysisBackfillRetryState>,
 }
 
 impl AnalysisBackfillQueueState {
@@ -184,8 +200,7 @@ impl AnalysisBackfillQueueState {
         ]
         .into_iter()
         .find(|&tier| {
-            self
-                .tier_deque(tier)
+            self.tier_deque(tier)
                 .iter()
                 .any(|(t, _, sid)| seed_key(sid, t) == key)
         })
@@ -217,7 +232,9 @@ impl AnalysisBackfillQueueState {
     }
 
     fn is_reserved(&self, key: &str) -> bool {
-        self.in_progress.contains_key(key) || self.locate_queued(key).is_some()
+        self.in_progress.contains_key(key)
+            || self.awaiting_cpu.contains(key)
+            || self.locate_queued(key).is_some()
     }
 
     fn try_pop_next(&mut self, max_concurrent: usize) -> Option<BackfillJob> {
@@ -237,8 +254,46 @@ impl AnalysisBackfillQueueState {
         None
     }
 
-    fn finish_job(&mut self, key: &str) {
+    fn record_retryable_failure(&mut self, key: &str) {
+        let failures = self
+            .retry_state
+            .get(key)
+            .map_or(1, |state| state.failures.saturating_add(1));
+        let exponent = failures.saturating_sub(1).min(6);
+        let delay_secs = ANALYSIS_BACKFILL_RETRY_BASE_SECS
+            .saturating_mul(1_u64 << exponent)
+            .min(ANALYSIS_BACKFILL_RETRY_MAX_SECS);
+        self.retry_state.insert(
+            key.to_string(),
+            AnalysisBackfillRetryState {
+                failures,
+                retry_after: std::time::Instant::now() + std::time::Duration::from_secs(delay_secs),
+            },
+        );
+        if self.locate_queued(key) == Some(AnalysisBackfillPriority::Low) {
+            self.remove_queued(key);
+        }
+    }
+
+    fn finish_job(&mut self, key: &str, retryable_failure: bool) {
         self.in_progress.remove(key);
+        self.awaiting_cpu.remove(key);
+        if retryable_failure {
+            self.record_retryable_failure(key);
+        } else {
+            self.retry_state.remove(key);
+        }
+    }
+
+    fn mark_cpu_admitted(&mut self, key: &str) {
+        self.in_progress.remove(key);
+        self.awaiting_cpu.insert(key.to_string());
+    }
+
+    fn retry_deferred(&self, key: &str) -> bool {
+        self.retry_state
+            .get(key)
+            .is_some_and(|state| state.retry_after > std::time::Instant::now())
     }
 
     pub fn enqueue(
@@ -256,19 +311,24 @@ impl AnalysisBackfillQueueState {
             return AnalysisBackfillEnqueueKind::DuplicateSkipped;
         }
         if self.is_reserved(tref) {
-            if self.in_progress.contains_key(tref) {
+            if self.in_progress.contains_key(tref) || self.awaiting_cpu.contains(tref) {
                 if priority == AnalysisBackfillPriority::High {
                     return AnalysisBackfillEnqueueKind::RunningSkipped;
                 }
                 return AnalysisBackfillEnqueueKind::DuplicateSkipped;
             }
-            let existing = self.locate_queued(tref).unwrap_or(AnalysisBackfillPriority::Low);
+            let existing = self
+                .locate_queued(tref)
+                .unwrap_or(AnalysisBackfillPriority::Low);
             if priority <= existing {
                 return AnalysisBackfillEnqueueKind::DuplicateSkipped;
             }
             self.remove_queued(tref);
             self.push_new(priority, (tid, url, server_id));
             return AnalysisBackfillEnqueueKind::ReorderedHigher;
+        }
+        if priority == AnalysisBackfillPriority::Low && self.retry_deferred(tref) {
+            return AnalysisBackfillEnqueueKind::RetryDeferred;
         }
         let kind = match priority {
             AnalysisBackfillPriority::High => AnalysisBackfillEnqueueKind::NewHigh,
@@ -292,9 +352,8 @@ impl AnalysisBackfillQueueState {
         ] {
             self.tier_deque_mut(tier)
                 .retain(|(track_id, _, job_server_id)| {
-                    let scoped = server_id.is_some_and(|sid| {
-                        job_server_id.is_empty() || job_server_id == sid
-                    });
+                    let scoped = server_id
+                        .is_some_and(|sid| job_server_id.is_empty() || job_server_id == sid);
                     if server_id.is_some() && !scoped {
                         return true;
                     }
@@ -312,10 +371,7 @@ pub struct PlaybackPriorityHints {
 }
 
 impl PlaybackPriorityHints {
-    pub fn set_middle_track_ids(
-        &self,
-        ids: impl IntoIterator<Item = (String, String)>,
-    ) {
+    pub fn set_middle_track_ids(&self, ids: impl IntoIterator<Item = (String, String)>) {
         let mut set = HashSet::new();
         for (server_id, track_id) in ids {
             let sid = server_id.trim();
@@ -324,7 +380,10 @@ impl PlaybackPriorityHints {
                 set.insert(priority_hint_key(sid, tid));
             }
         }
-        *self.middle_track_ids.lock().unwrap_or_else(|e| e.into_inner()) = set;
+        *self
+            .middle_track_ids
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = set;
     }
 
     pub fn is_middle_priority(&self, server_id: &str, track_id: &str) -> bool {
@@ -368,7 +427,11 @@ pub fn analysis_backfill_shared(app: &tauri::AppHandle) -> Arc<AnalysisBackfillS
                 max_parallel: AtomicUsize::new(requested_pipeline_parallelism()),
             });
             let app = app.clone();
-            tauri::async_runtime::spawn(analysis_backfill_worker_loop(app, shared.clone(), wake_rx));
+            tauri::async_runtime::spawn(analysis_backfill_worker_loop(
+                app,
+                shared.clone(),
+                wake_rx,
+            ));
             shared.ping_worker();
             shared
         })
@@ -387,6 +450,9 @@ struct TrustedRevisionGeneration {
 pub struct TrustedAnalysisRevision {
     pub md5_16kb: String,
     pub generation: u64,
+    /// The analysis bytes are a server transcode whose original identity was
+    /// established independently through the raw-prefix probe.
+    pub analysis_bytes_transcoded: bool,
     /// Library `track.server_id` scope for `content_hash` repair when it differs
     /// from the analysis-cache scope (offline dual-address/library paths).
     pub content_hash_server_id: Option<String>,
@@ -405,6 +471,37 @@ fn canonical_activation_key(server_id: &str, track_id: &str) -> String {
     seed_key(server_id, canonical_track_id)
 }
 
+fn next_trusted_generation() -> u64 {
+    TRUSTED_ACTIVATION_GENERATION.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+fn register_trusted_revision_generation(
+    server_id: &str,
+    track_id: &str,
+    revision: &str,
+    generation: u64,
+) {
+    let key = canonical_activation_key(server_id, track_id);
+    let mut state = TRUSTED_ACTIVATIONS
+        .get_or_init(|| Mutex::new(TrustedActivationState::default()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    if state
+        .current_by_track
+        .get(&key)
+        .is_some_and(|current| current.generation > generation)
+    {
+        return;
+    }
+    state.current_by_track.insert(
+        key,
+        TrustedRevisionGeneration {
+            revision: revision.to_string(),
+            generation,
+        },
+    );
+}
+
 pub fn begin_trusted_revision(server_id: &str, track_id: &str, revision: &str) -> u64 {
     let key = canonical_activation_key(server_id, track_id);
     let mut state = TRUSTED_ACTIVATIONS
@@ -416,7 +513,7 @@ pub fn begin_trusted_revision(server_id: &str, track_id: &str, revision: &str) -
             return current.generation;
         }
     }
-    let generation = TRUSTED_ACTIVATION_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
+    let generation = next_trusted_generation();
     state.current_by_track.insert(
         key,
         TrustedRevisionGeneration {
@@ -455,7 +552,7 @@ pub async fn enqueue_track_analysis(
         app,
         server_id,
         track_id,
-        bytes,
+        Cow::Borrowed(bytes),
         format_hint,
         None,
         priority,
@@ -464,7 +561,6 @@ pub async fn enqueue_track_analysis(
     )
     .await
 }
-
 
 /// Activate a trusted revision only while it is still the latest registered
 /// revision for the canonical `(server, track)`. The guard remains locked
@@ -497,8 +593,8 @@ fn activate_trusted_identity<R: tauri::Runtime>(
         md5_16kb: content_hash.to_string(),
     };
     if !is_current {
-        let superseded_by_other_revision = current
-            .is_some_and(|current| current.revision != content_hash);
+        let superseded_by_other_revision =
+            current.is_some_and(|current| current.revision != content_hash);
         if superseded_by_other_revision {
             if let Some(cache) = app.try_state::<analysis_cache::AnalysisCache>() {
                 match cache.delete_fingerprint(&key) {
@@ -556,8 +652,8 @@ fn activate_trusted_enrichment<R: tauri::Runtime>(
 }
 
 /// Like [`enqueue_track_analysis`] but with a verified original fingerprint.
-/// `bytes` must be that original representation; a mismatched capture is
-/// rejected rather than stored under another revision's identity.
+/// Original bytes are prefix-verified; an explicitly marked server transcode
+/// is analysed under the separately verified original identity.
 pub async fn enqueue_track_analysis_trusted(
     app: &tauri::AppHandle,
     server_id: &str,
@@ -571,7 +667,32 @@ pub async fn enqueue_track_analysis_trusted(
         app,
         server_id,
         track_id,
-        bytes,
+        Cow::Borrowed(bytes),
+        format_hint,
+        Some(trusted_revision),
+        priority,
+        0,
+        None,
+    )
+    .await
+}
+
+/// Owned-byte variant for completed playback captures. Large spill files can
+/// enter the CPU queue without cloning the complete track a second time.
+pub async fn enqueue_track_analysis_trusted_owned(
+    app: &tauri::AppHandle,
+    server_id: &str,
+    track_id: &str,
+    bytes: Vec<u8>,
+    format_hint: Option<&str>,
+    trusted_revision: TrustedAnalysisRevision,
+    priority: AnalysisBackfillPriority,
+) -> Result<EnqueueTrackAnalysisOutcome, String> {
+    enqueue_track_analysis_with_fetch(
+        app,
+        server_id,
+        track_id,
+        Cow::Owned(bytes),
         format_hint,
         Some(trusted_revision),
         priority,
@@ -586,7 +707,7 @@ async fn enqueue_track_analysis_with_fetch(
     app: &tauri::AppHandle,
     server_id: &str,
     track_id: &str,
-    bytes: &[u8],
+    bytes: Cow<'_, [u8]>,
     format_hint: Option<&str>,
     trusted_revision: Option<TrustedAnalysisRevision>,
     priority: AnalysisBackfillPriority,
@@ -596,8 +717,11 @@ async fn enqueue_track_analysis_with_fetch(
     if bytes.is_empty() {
         return Ok(EnqueueTrackAnalysisOutcome::Complete);
     }
-    if let Some(trusted) = trusted_revision.as_ref() {
-        if !crate::raw_probe::bytes_match_trusted(bytes, &trusted.md5_16kb) {
+    if let Some(trusted) = trusted_revision
+        .as_ref()
+        .filter(|trusted| !trusted.analysis_bytes_transcoded)
+    {
+        if !crate::raw_probe::bytes_match_trusted(bytes.as_ref(), &trusted.md5_16kb) {
             return Err("trusted original fingerprint does not match analysis bytes".to_string());
         }
     }
@@ -606,7 +730,7 @@ async fn enqueue_track_analysis_with_fetch(
     let content_hash = trusted_revision
         .as_ref()
         .map(|trusted| trusted.md5_16kb.clone())
-        .unwrap_or_else(|| analysis_cache::md5_first_16kb(bytes));
+        .unwrap_or_else(|| analysis_cache::md5_first_16kb(bytes.as_ref()));
     let plan = plan_track_analysis(app, server_id, track_id, &content_hash);
     if !plan.any() {
         crate::app_deprintln!(
@@ -643,7 +767,7 @@ async fn enqueue_track_analysis_with_fetch(
             app.clone(),
             server_id.to_string(),
             track_id.to_string(),
-            bytes.to_vec(),
+            bytes.into_owned(),
             format_hint.map(str::to_string),
             trusted_revision,
             priority,
@@ -660,11 +784,11 @@ async fn enqueue_track_analysis_with_fetch(
             content_hash
         );
         let bpm_started = std::time::Instant::now();
-        let outcome = run_track_enrichment_from_bytes(
+        let outcome = run_track_enrichment_from_owned_bytes(
             app,
             server_id,
             track_id,
-            bytes,
+            bytes.into_owned(),
             Some(content_hash.clone()),
             analysis_emits_ui_events(priority),
         )
@@ -714,16 +838,39 @@ pub async fn run_track_enrichment_from_bytes(
     trusted_md5_16kb: Option<String>,
     notify_ui: bool,
 ) -> TrackEnrichmentOutcome {
+    run_track_enrichment_from_owned_bytes(
+        app,
+        server_id,
+        track_id,
+        bytes.to_vec(),
+        trusted_md5_16kb,
+        notify_ui,
+    )
+    .await
+}
+
+async fn run_track_enrichment_from_owned_bytes(
+    app: &tauri::AppHandle,
+    server_id: &str,
+    track_id: &str,
+    data: Vec<u8>,
+    trusted_md5_16kb: Option<String>,
+    notify_ui: bool,
+) -> TrackEnrichmentOutcome {
     if server_id.is_empty() {
         return TrackEnrichmentOutcome::SkippedNoServer;
     }
     let app = app.clone();
     let sid = server_id.to_string();
     let tid = track_id.to_string();
-    let data = bytes.to_vec();
     match tokio::task::spawn_blocking(move || {
         crate::track_enrichment::run_track_enrichment_if_needed(
-            &app, &sid, &tid, &data, trusted_md5_16kb.as_deref(), notify_ui,
+            &app,
+            &sid,
+            &tid,
+            &data,
+            trusted_md5_16kb.as_deref(),
+            notify_ui,
         )
     })
     .await
@@ -752,7 +899,15 @@ pub async fn enqueue_track_analysis_from_file(
         .and_then(|e| e.to_str())
         .map(|e| e.to_ascii_lowercase())
         .filter(|e| !e.is_empty());
-    enqueue_track_analysis(app, server_id, track_id, &bytes, format_hint.as_deref(), priority).await
+    enqueue_track_analysis(
+        app,
+        server_id,
+        track_id,
+        &bytes,
+        format_hint.as_deref(),
+        priority,
+    )
+    .await
 }
 
 /// Library-tier offline pin: reuse waveform/LUFS cached under the playback index key,
@@ -783,6 +938,7 @@ pub async fn enqueue_offline_library_analysis_from_file(
     let trusted_revision = verified_original.then(|| TrustedAnalysisRevision {
         md5_16kb: content_hash.clone(),
         generation: begin_trusted_revision(server_index_key, track_id, &content_hash),
+        analysis_bytes_transcoded: false,
         content_hash_server_id: Some(library_server_id.to_string()),
     });
     let plan = plan_track_analysis_offline_library(
@@ -958,51 +1114,269 @@ fn analysis_http_client() -> &'static reqwest::Client {
 
 const ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES: usize = 64 * 1024 * 1024;
 
-async fn analysis_backfill_download_trusted_original<R: tauri::Runtime>(
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AnalysisBackfillJobError {
+    Terminal(String),
+    Retryable(String),
+}
+
+impl std::fmt::Display for AnalysisBackfillJobError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Terminal(message) | Self::Retryable(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl AnalysisBackfillJobError {
+    fn is_retryable(&self) -> bool {
+        matches!(self, Self::Retryable(_))
+    }
+}
+
+fn analysis_stream_format_hint(url: &str) -> Option<String> {
+    reqwest::Url::parse(url)
+        .ok()?
+        .query_pairs()
+        .find_map(|(key, value)| (key == "format" && value != "raw").then(|| value.into_owned()))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AnalysisBackfillDownload {
+    bytes: Vec<u8>,
+    fetch_ms: u64,
+    format_hint: Option<String>,
+    trusted_revision: Option<TrustedAnalysisRevision>,
+}
+
+fn record_oversized_trusted_analysis<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    server_id: &str,
+    track_id: &str,
+    trusted_md5_16kb: &str,
+    generation: u64,
+) -> Result<(), AnalysisBackfillJobError> {
+    let activation_key = canonical_activation_key(server_id, track_id);
+    let state = TRUSTED_ACTIVATIONS
+        .get_or_init(|| Mutex::new(TrustedActivationState::default()))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    if !state
+        .current_by_track
+        .get(&activation_key)
+        .is_some_and(|current| {
+            current.revision == trusted_md5_16kb && current.generation == generation
+        })
+    {
+        return Ok(());
+    }
+    let cache = app
+        .try_state::<analysis_cache::AnalysisCache>()
+        .ok_or_else(|| {
+            AnalysisBackfillJobError::Retryable(
+                "analysis cache unavailable while recording oversized analysis input".to_string(),
+            )
+        })?;
+    let key = analysis_cache::TrackKey {
+        server_id: server_id.to_string(),
+        track_id: track_id.to_string(),
+        md5_16kb: trusted_md5_16kb.to_string(),
+    };
+    cache.touch_track_status(&key, "failed").map_err(|error| {
+        AnalysisBackfillJobError::Retryable(format!(
+            "failed to record oversized analysis input: {error}"
+        ))
+    })
+}
+
+async fn analysis_backfill_download<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     server_id: &str,
     track_id: &str,
     url: &str,
-) -> Result<(Vec<u8>, u64, TrustedAnalysisRevision), String> {
+    max_bytes: usize,
+) -> Result<AnalysisBackfillDownload, AnalysisBackfillJobError> {
+    let operation_generation = next_trusted_generation();
     let registry = app
         .try_state::<Arc<ServerHttpRegistry>>()
         .map(|s| Arc::clone(&*s));
-    let trusted = match crate::raw_probe::resolve_trusted_identity(
+    let raw_supported =
+        crate::raw_probe::raw_stream_supported(registry.as_deref(), Some(server_id), url);
+    let mut trusted = if raw_supported {
+        match crate::raw_probe::resolve_trusted_identity(
+            analysis_http_client(),
+            registry.as_deref(),
+            Some(server_id),
+            url,
+        )
+        .await
+        {
+            crate::raw_probe::TrustedProbeVerdict::Trusted(hash) => {
+                register_trusted_revision_generation(
+                    server_id,
+                    track_id,
+                    &hash,
+                    operation_generation,
+                );
+                Some(hash)
+            }
+            crate::raw_probe::TrustedProbeVerdict::SkipCanonicalWrites => {
+                crate::app_deprintln!(
+                    "[analysis] raw identity probe unavailable track_id={track_id}; falling back to original download"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let fetch_started = std::time::Instant::now();
+    if let Some(initial_trusted_md5_16kb) = trusted.clone() {
+        let transcode_result = crate::raw_probe::fetch_bounded_stream_bytes(
+            analysis_http_client(),
+            registry.as_deref(),
+            Some(server_id),
+            url,
+            max_bytes,
+        )
+        .await;
+        let revalidated = crate::raw_probe::resolve_trusted_identity(
+            analysis_http_client(),
+            registry.as_deref(),
+            Some(server_id),
+            url,
+        )
+        .await;
+        match revalidated {
+            crate::raw_probe::TrustedProbeVerdict::Trusted(hash) => {
+                register_trusted_revision_generation(
+                    server_id,
+                    track_id,
+                    &hash,
+                    operation_generation,
+                );
+                let unchanged = hash == initial_trusted_md5_16kb;
+                trusted = Some(hash.clone());
+                if unchanged {
+                    match transcode_result {
+                        Ok(bytes) => {
+                            return Ok(AnalysisBackfillDownload {
+                                bytes,
+                                fetch_ms: fetch_started.elapsed().as_millis() as u64,
+                                format_hint: analysis_stream_format_hint(url),
+                                trusted_revision: Some(TrustedAnalysisRevision {
+                                    md5_16kb: hash,
+                                    generation: operation_generation,
+                                    analysis_bytes_transcoded: true,
+                                    content_hash_server_id: None,
+                                }),
+                            });
+                        }
+                        Err(crate::raw_probe::BoundedStreamFetchError::TooLarge { .. }) => {
+                            record_oversized_trusted_analysis(
+                                app,
+                                server_id,
+                                track_id,
+                                &hash,
+                                operation_generation,
+                            )?;
+                            return Err(AnalysisBackfillJobError::Terminal(format!(
+                                "analysis transcode exceeds cap of {max_bytes} bytes"
+                            )));
+                        }
+                        Err(crate::raw_probe::BoundedStreamFetchError::Unavailable) => {
+                            crate::app_deprintln!(
+                                "[analysis] transcode unavailable track_id={track_id}; falling back to original download"
+                            );
+                        }
+                    }
+                } else {
+                    crate::app_deprintln!(
+                        "[analysis] original changed during transcode fetch track_id={track_id}; falling back to original download"
+                    );
+                }
+            }
+            crate::raw_probe::TrustedProbeVerdict::SkipCanonicalWrites => {
+                trusted = None;
+                crate::app_deprintln!(
+                    "[analysis] raw identity revalidation unavailable track_id={track_id}; falling back to original download"
+                );
+            }
+        }
+    }
+
+    let download_url = crate::raw_probe::build_original_download_url(url).ok_or_else(|| {
+        AnalysisBackfillJobError::Retryable(
+            "original download endpoint unavailable for analysis fallback".to_string(),
+        )
+    })?;
+    let bytes = match crate::raw_probe::fetch_bounded_stream_bytes(
         analysis_http_client(),
         registry.as_deref(),
         Some(server_id),
-        url,
+        &download_url,
+        max_bytes,
     )
     .await
     {
-        crate::raw_probe::TrustedProbeVerdict::Trusted(hash) => hash,
-        crate::raw_probe::TrustedProbeVerdict::SkipCanonicalWrites => {
-            return Err("raw original identity unavailable".to_string());
+        Ok(bytes) => bytes,
+        Err(crate::raw_probe::BoundedStreamFetchError::TooLarge { md5_16kb }) => {
+            if trusted
+                .as_deref()
+                .is_some_and(|trusted_md5_16kb| trusted_md5_16kb != md5_16kb)
+            {
+                return Err(AnalysisBackfillJobError::Retryable(
+                    "oversized original download does not match raw-probed identity".to_string(),
+                ));
+            }
+            let original_md5_16kb = trusted.as_deref().unwrap_or(&md5_16kb);
+            if trusted.is_none() {
+                register_trusted_revision_generation(
+                    server_id,
+                    track_id,
+                    original_md5_16kb,
+                    operation_generation,
+                );
+            }
+            record_oversized_trusted_analysis(
+                app,
+                server_id,
+                track_id,
+                original_md5_16kb,
+                operation_generation,
+            )?;
+            return Err(AnalysisBackfillJobError::Terminal(format!(
+                "original download exceeds analysis cap of {max_bytes} bytes"
+            )));
+        }
+        Err(crate::raw_probe::BoundedStreamFetchError::Unavailable) => {
+            return Err(AnalysisBackfillJobError::Retryable(
+                "original download unavailable".to_string(),
+            ));
         }
     };
-    let generation = begin_trusted_revision(server_id, track_id, &trusted);
-
-    let fetch_started = std::time::Instant::now();
-    let bytes = crate::raw_probe::fetch_trusted_original_bytes(
-        analysis_http_client(),
-        registry.as_deref(),
-        Some(server_id),
-        url,
-        &trusted,
-        ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES,
-    )
-    .await
-    .ok_or_else(|| "raw original unavailable or exceeds analysis cap".to_string())?;
-    let fetch_ms = fetch_started.elapsed().as_millis() as u64;
-    Ok((
+    if let Some(trusted_md5_16kb) = trusted.as_deref() {
+        if !crate::raw_probe::bytes_match_trusted(&bytes, trusted_md5_16kb) {
+            return Err(AnalysisBackfillJobError::Retryable(
+                "original download does not match raw-probed identity".to_string(),
+            ));
+        }
+    }
+    let md5_16kb = trusted.unwrap_or_else(|| analysis_cache::md5_first_16kb(&bytes));
+    register_trusted_revision_generation(server_id, track_id, &md5_16kb, operation_generation);
+    let trusted_revision = Some(TrustedAnalysisRevision {
+        generation: operation_generation,
+        md5_16kb,
+        analysis_bytes_transcoded: false,
+        content_hash_server_id: None,
+    });
+    Ok(AnalysisBackfillDownload {
         bytes,
-        fetch_ms,
-        TrustedAnalysisRevision {
-            md5_16kb: trusted,
-            generation,
-            content_hash_server_id: None,
-        },
-    ))
+        fetch_ms: fetch_started.elapsed().as_millis() as u64,
+        format_hint: None,
+        trusted_revision,
+    })
 }
 
 async fn process_analysis_backfill_job(
@@ -1011,22 +1385,35 @@ async fn process_analysis_backfill_job(
     track_id: &str,
     url: &str,
     cpu_admitted: tokio::sync::oneshot::Sender<()>,
-) -> Result<bool, String> {
-    let (bytes, fetch_ms, trusted) =
-        analysis_backfill_download_trusted_original(app, server_id, track_id, url).await?;
+) -> Result<bool, AnalysisBackfillJobError> {
+    let download = analysis_backfill_download(
+        app,
+        server_id,
+        track_id,
+        url,
+        ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES,
+    )
+    .await?;
     let priority = analysis_backfill_resolve_priority(app, server_id, track_id, None);
+    let AnalysisBackfillDownload {
+        bytes,
+        fetch_ms,
+        format_hint,
+        trusted_revision,
+    } = download;
     let outcome = enqueue_track_analysis_with_fetch(
         app,
         server_id,
         track_id,
-        &bytes,
-        None,
-        Some(trusted),
+        Cow::Owned(bytes),
+        format_hint.as_deref(),
+        trusted_revision,
         priority,
         fetch_ms,
         Some(cpu_admitted),
     )
-    .await?;
+    .await
+    .map_err(AnalysisBackfillJobError::Retryable)?;
     Ok(!matches!(outcome, EnqueueTrackAnalysisOutcome::Complete))
 }
 
@@ -1034,13 +1421,25 @@ fn release_backfill_reservation(
     shared: &AnalysisBackfillShared,
     server_id: &str,
     track_id: &str,
+    retryable_failure: bool,
 ) {
     {
         let mut state = shared
             .state
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        state.finish_job(&seed_key(server_id, track_id));
+        state.finish_job(&seed_key(server_id, track_id), retryable_failure);
+    }
+    shared.ping_worker();
+}
+
+fn mark_backfill_cpu_admitted(shared: &AnalysisBackfillShared, server_id: &str, track_id: &str) {
+    {
+        let mut state = shared
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        state.mark_cpu_admitted(&seed_key(server_id, track_id));
     }
     shared.ping_worker();
 }
@@ -1077,11 +1476,7 @@ fn cpu_seed_pipeline_cap(max_parallel: usize) -> usize {
 
 /// Decide whether the HTTP backfill worker should idle right now. High-tier
 /// (now-playing) jobs always bypass the cap so playback is never starved.
-fn should_idle_for_cpu_backpressure(
-    cpu_load: usize,
-    cpu_cap: usize,
-    high_pending: bool,
-) -> bool {
+fn should_idle_for_cpu_backpressure(cpu_load: usize, cpu_cap: usize, high_pending: bool) -> bool {
     !high_pending && cpu_load >= cpu_cap
 }
 
@@ -1096,10 +1491,7 @@ async fn spawn_backfill_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisBackf
         let cpu_load = cpu_seed_pipeline_load();
         let cpu_cap = cpu_seed_pipeline_cap(max);
         let job_bundle = {
-            let mut st = shared
-                .state
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+            let mut st = shared.state.lock().unwrap_or_else(|e| e.into_inner());
             let high_pending = !st.high.is_empty();
             if should_idle_for_cpu_backpressure(cpu_load, cpu_cap, high_pending) {
                 None
@@ -1133,27 +1525,25 @@ async fn spawn_backfill_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisBackf
             // the full raw fetch, and CPU queue admission. Releasing it earlier
             // allows a duplicate full download before the CPU queue sees the job.
             let (cpu_admitted_tx, cpu_admitted_rx) = tokio::sync::oneshot::channel();
-            let process = process_analysis_backfill_job(
-                &app,
-                &server_id,
-                &track_id,
-                &url,
-                cpu_admitted_tx,
-            );
+            let process =
+                process_analysis_backfill_job(&app, &server_id, &track_id, &url, cpu_admitted_tx);
             tokio::pin!(process);
-            let mut released = false;
             let result = tokio::select! {
                 biased;
                 result = &mut process => result,
                 Ok(()) = cpu_admitted_rx => {
-                    release_backfill_reservation(&shared, &server_id, &track_id);
-                    released = true;
+                    mark_backfill_cpu_admitted(&shared, &server_id, &track_id);
                     process.await
                 }
             };
-            if !released {
-                release_backfill_reservation(&shared, &server_id, &track_id);
-            }
+            release_backfill_reservation(
+                &shared,
+                &server_id,
+                &track_id,
+                result
+                    .as_ref()
+                    .is_err_and(AnalysisBackfillJobError::is_retryable),
+            );
 
             match &result {
                 Ok(has_loudness) => crate::app_deprintln!(
@@ -1179,15 +1569,11 @@ pub fn analysis_set_pipeline_parallelism(workers: usize) {
     let workers = clamp_pipeline_parallelism(workers);
     REQUESTED_PIPELINE_PARALLELISM.store(workers, Ordering::Relaxed);
     if let Some(shared) = ANALYSIS_BACKFILL.get() {
-        shared
-            .max_parallel
-            .store(workers, Ordering::Relaxed);
+        shared.max_parallel.store(workers, Ordering::Relaxed);
         shared.ping_worker();
     }
     if let Some(shared) = ANALYSIS_CPU_SEED.get() {
-        shared
-            .max_parallel
-            .store(workers, Ordering::Relaxed);
+        shared.max_parallel.store(workers, Ordering::Relaxed);
         shared.ping_worker();
     }
 }
@@ -1309,7 +1695,10 @@ pub fn analysis_emits_ui_events(priority: AnalysisBackfillPriority) -> bool {
 
 /// Enqueue HTTP download + analysis seed (native coordinator + optional UI invoke).
 fn resolve_backfill_server_id(url: &str, server_id_hint: Option<&str>) -> String {
-    if let Some(hint) = server_id_hint.map(str::trim).filter(|hint| !hint.is_empty()) {
+    if let Some(hint) = server_id_hint
+        .map(str::trim)
+        .filter(|hint| !hint.is_empty())
+    {
         return hint.to_string();
     }
     let Ok(parsed) = reqwest::Url::parse(url) else {
@@ -1352,20 +1741,11 @@ pub fn enqueue_seed_from_url(
     }
     let server_id = resolve_backfill_server_id(url, server_id_hint);
     let is_http = url.starts_with("http://") || url.starts_with("https://");
-    if is_http {
-        let registry = app
-            .try_state::<Arc<ServerHttpRegistry>>()
-            .map(|s| Arc::clone(&*s));
-        if !crate::raw_probe::raw_stream_supported(
-            registry.as_deref(),
-            Some(server_id.as_str()).filter(|s| !s.is_empty()),
-            url,
-        ) {
-            crate::app_deprintln!(
-                "[analysis] backfill unsupported track_id={track_id}: endpoint has no trusted raw-stream capability"
-            );
-            return Ok(EnqueueSeedFromUrlOutcome::Unsupported);
-        }
+    if is_http && crate::raw_probe::build_original_download_url(url).is_none() {
+        crate::app_deprintln!(
+            "[analysis] backfill unsupported track_id={track_id}: no original-download endpoint"
+        );
+        return Ok(EnqueueSeedFromUrlOutcome::Unsupported);
     }
     if !force {
         if let Some(playback) = app.try_state::<PlaybackQueryHandle>() {
@@ -1431,8 +1811,16 @@ pub fn enqueue_seed_from_url(
             );
             Ok(EnqueueSeedFromUrlOutcome::Enqueued)
         }
-        AnalysisBackfillEnqueueKind::DuplicateSkipped | AnalysisBackfillEnqueueKind::RunningSkipped => {
+        AnalysisBackfillEnqueueKind::DuplicateSkipped
+        | AnalysisBackfillEnqueueKind::RunningSkipped => {
             Ok(EnqueueSeedFromUrlOutcome::AlreadyReserved)
+        }
+        AnalysisBackfillEnqueueKind::RetryDeferred => {
+            crate::app_deprintln!(
+                "[analysis] backfill retry deferred after transient failure: track_id={}",
+                tid_log,
+            );
+            Ok(EnqueueSeedFromUrlOutcome::Skipped)
         }
     }
 }
@@ -1463,8 +1851,9 @@ struct AnalysisCpuSeedJob {
     track_id: String,
     bytes: Vec<u8>,
     format_hint: Option<String>,
-    /// Verified fingerprint of the ORIGINAL file represented by `bytes`.
-    /// `None` means the bytes own their identity (local/offline paths).
+    /// Verified fingerprint of the ORIGINAL file associated with `bytes`.
+    /// Advanced backfill may decode its explicit server transcode; `None`
+    /// means the bytes own their identity (local/offline paths).
     trusted_revision: Option<TrustedAnalysisRevision>,
     /// Content revision this job represents: the trusted fingerprint when
     /// present, else the bytes' own fingerprint. Part of the dedup identity —
@@ -1531,7 +1920,10 @@ impl AnalysisCpuSeedQueueState {
         }
     }
 
-    fn tier_deque_mut(&mut self, tier: AnalysisBackfillPriority) -> &mut VecDeque<AnalysisCpuSeedJob> {
+    fn tier_deque_mut(
+        &mut self,
+        tier: AnalysisBackfillPriority,
+    ) -> &mut VecDeque<AnalysisCpuSeedJob> {
         match tier {
             AnalysisBackfillPriority::High => &mut self.high,
             AnalysisBackfillPriority::Middle => &mut self.middle,
@@ -1574,10 +1966,7 @@ impl AnalysisCpuSeedQueueState {
         trusted_revision: Option<TrustedAnalysisRevision>,
         priority: AnalysisBackfillPriority,
         fetch_ms: u64,
-    ) -> (
-        AnalysisCpuSeedEnqueueKind,
-        SeedDoneReceiver,
-    ) {
+    ) -> (AnalysisCpuSeedEnqueueKind, SeedDoneReceiver) {
         let (done_tx, done_rx) = tokio::sync::oneshot::channel();
         // Dedup/merge scope is (server, track, content revision): the same
         // Subsonic id on two servers is two different files, and a different
@@ -1599,12 +1988,22 @@ impl AnalysisCpuSeedQueueState {
 
         if let Some((existing_tier, pos)) = self.locate_queued(&key) {
             let mut job = self.tier_deque_mut(existing_tier).remove(pos).unwrap();
-            job.server_id = server_id;
-            job.bytes = bytes;
-            job.format_hint = format_hint;
-            job.trusted_revision = trusted_revision;
-            job.revision = revision;
-            job.fetch_ms = fetch_ms;
+            let existing_transcode = job
+                .trusted_revision
+                .as_ref()
+                .is_some_and(|trusted| trusted.analysis_bytes_transcoded);
+            let incoming_transcode = trusted_revision
+                .as_ref()
+                .is_some_and(|trusted| trusted.analysis_bytes_transcoded);
+            let replace_bytes = existing_transcode || !incoming_transcode;
+            if replace_bytes {
+                job.server_id = server_id;
+                job.bytes = bytes;
+                job.format_hint = format_hint;
+                job.trusted_revision = trusted_revision;
+                job.revision = revision;
+                job.fetch_ms = fetch_ms;
+            }
             job.waiters.push(done_tx);
             if priority > existing_tier {
                 job.priority = priority;
@@ -1650,9 +2049,8 @@ impl AnalysisCpuSeedQueueState {
         ] {
             let mut kept = VecDeque::with_capacity(self.tier_deque(tier).len());
             while let Some(job) = self.tier_deque_mut(tier).pop_front() {
-                let scoped = server_id.is_some_and(|sid| {
-                    job.server_id.is_empty() || job.server_id == sid
-                });
+                let scoped =
+                    server_id.is_some_and(|sid| job.server_id.is_empty() || job.server_id == sid);
                 if server_id.is_some() && !scoped {
                     kept.push_back(job);
                     continue;
@@ -1665,7 +2063,7 @@ impl AnalysisCpuSeedQueueState {
                 removed_waiters += job.waiters.len();
                 for tx in job.waiters {
                     let _ = tx.send(Err(
-                        "cpu-seed pruned: track no longer in playback queue".to_string(),
+                        "cpu-seed pruned: track no longer in playback queue".to_string()
                     ));
                 }
             }
@@ -1710,7 +2108,11 @@ fn analysis_cpu_seed_shared(app: &tauri::AppHandle) -> Arc<AnalysisCpuSeedShared
                 max_parallel: AtomicUsize::new(requested_pipeline_parallelism()),
             });
             let app = app.clone();
-            tauri::async_runtime::spawn(analysis_cpu_seed_worker_loop(app, shared.clone(), wake_rx));
+            tauri::async_runtime::spawn(analysis_cpu_seed_worker_loop(
+                app,
+                shared.clone(),
+                wake_rx,
+            ));
             shared.ping_worker();
             shared
         })
@@ -1740,11 +2142,7 @@ fn emit_analysis_queue_snapshot_line() {
         let tiers = st.queued_tier_counts();
         format!(
             "cpu_seed={{queued_jobs:{} tiers=({},{},{}) decoding_active:{}}}",
-            queued_jobs,
-            tiers.high,
-            tiers.middle,
-            tiers.low,
-            decoding_count,
+            queued_jobs, tiers.high, tiers.middle, tiers.low, decoding_count,
         )
     } else {
         "cpu_seed={{not_started}}".to_string()
@@ -1819,20 +2217,39 @@ async fn spawn_cpu_seed_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisCpuSe
             let bytes = job.bytes;
             let format_hint = job.format_hint;
             let trusted_for_activation = job.trusted_revision.clone();
+            let analysis_bytes_transcoded = job
+                .trusted_revision
+                .as_ref()
+                .is_some_and(|trusted| trusted.analysis_bytes_transcoded);
             let trusted_md5_16kb = job
                 .trusted_revision
                 .as_ref()
                 .map(|trusted| trusted.md5_16kb.clone());
             let seed_result = tokio::task::spawn_blocking(move || {
-                analysis_cache::seed_from_bytes_execute(
-                    &app_for_decode,
-                    &sid,
-                    &tid_for_decode,
-                    &bytes,
-                    format_hint.as_deref(),
-                    trusted_md5_16kb.as_deref(),
-                    notify_ui,
-                )
+                if analysis_bytes_transcoded {
+                    let trusted = trusted_md5_16kb.as_deref().ok_or_else(|| {
+                        "trusted analysis transcode missing original fingerprint".to_string()
+                    })?;
+                    analysis_cache::seed_transcoded_bytes_execute(
+                        &app_for_decode,
+                        &sid,
+                        &tid_for_decode,
+                        &bytes,
+                        format_hint.as_deref(),
+                        trusted,
+                        notify_ui,
+                    )
+                } else {
+                    analysis_cache::seed_from_bytes_execute(
+                        &app_for_decode,
+                        &sid,
+                        &tid_for_decode,
+                        &bytes,
+                        format_hint.as_deref(),
+                        trusted_md5_16kb.as_deref(),
+                        notify_ui,
+                    )
+                }
             })
             .await
             .unwrap_or_else(|e| Err(format!("cpu-seed spawn_blocking: {e}")));
@@ -2011,6 +2428,19 @@ mod tests {
         Some(TrustedAnalysisRevision {
             md5_16kb: md5_16kb.to_string(),
             generation,
+            analysis_bytes_transcoded: false,
+            content_hash_server_id: None,
+        })
+    }
+
+    fn trusted_transcode_revision(
+        md5_16kb: &str,
+        generation: u64,
+    ) -> Option<TrustedAnalysisRevision> {
+        Some(TrustedAnalysisRevision {
+            md5_16kb: md5_16kb.to_string(),
+            generation,
+            analysis_bytes_transcoded: true,
             content_hash_server_id: None,
         })
     }
@@ -2042,17 +2472,168 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn backfill_probes_then_downloads_only_the_raw_original() {
+    struct ChangingRawOriginalResponder {
+        first: Vec<u8>,
+        later: Vec<u8>,
+        requests: Arc<AtomicUsize>,
+    }
+
+    impl wiremock::Respond for ChangingRawOriginalResponder {
+        fn respond(&self, request: &wiremock::Request) -> wiremock::ResponseTemplate {
+            let body = if self.requests.fetch_add(1, Ordering::Relaxed) == 0 {
+                &self.first
+            } else {
+                &self.later
+            };
+            if request
+                .headers
+                .get(reqwest::header::RANGE.as_str())
+                .is_some()
+            {
+                let end = body
+                    .len()
+                    .saturating_sub(1)
+                    .min(crate::raw_probe::RAW_PROBE_RANGE_END as usize);
+                return wiremock::ResponseTemplate::new(206)
+                    .insert_header(
+                        "Content-Range",
+                        format!("bytes 0-{end}/{}", body.len()).as_str(),
+                    )
+                    .set_body_bytes(body[..=end].to_vec());
+            }
+            wiremock::ResponseTemplate::new(200).set_body_bytes(body.clone())
+        }
+    }
+
+    fn analysis_registry(endpoint: &str, supports_raw_stream: bool) -> ServerHttpRegistry {
         use psysonic_core::server_http::{
             EndpointKind, ServerHttpContextSyncWire, ServerHttpEndpointWire,
         };
+
+        let registry = ServerHttpRegistry::new();
+        registry.sync(ServerHttpContextSyncWire {
+            server_id: "canonical-server".into(),
+            app_server_id: "profile-id".into(),
+            endpoints: vec![ServerHttpEndpointWire {
+                url: endpoint.into(),
+                kind: EndpointKind::Public,
+            }],
+            custom_headers: Vec::new(),
+            custom_headers_apply_to: None,
+            supports_raw_stream,
+        });
+        registry
+    }
+
+    #[tokio::test]
+    async fn backfill_probes_original_then_downloads_bounded_transcode() {
         use tauri::Manager;
         use wiremock::matchers::{method, path, query_param};
         use wiremock::{Mock, MockServer};
 
         let server = MockServer::start().await;
         let mut original = vec![0x66; 24 * 1024];
+        original[..4].copy_from_slice(b"fLaC");
+        let transcode = vec![0x55; 12 * 1024];
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "raw"))
+            .respond_with(RawOriginalResponder {
+                body: original.clone(),
+            })
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "mp3"))
+            .and(query_param("maxBitRate", "64"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_bytes(transcode.clone()))
+            .mount(&server)
+            .await;
+
+        let registry = analysis_registry(&server.uri(), true);
+        let app = tauri::test::mock_app();
+        app.handle().manage(Arc::new(registry));
+        app.handle()
+            .manage(analysis_cache::AnalysisCache::open_in_memory());
+        let stream_url = format!(
+            "{}/rest/stream.view?id=t1&format=mp3&maxBitRate=64&estimateContentLength=true",
+            server.uri()
+        );
+        assert_eq!(
+            analysis_stream_format_hint(&stream_url).as_deref(),
+            Some("mp3")
+        );
+
+        let download = analysis_backfill_download(
+            app.handle(),
+            "canonical-server",
+            "t1",
+            &stream_url,
+            ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(download.bytes, transcode);
+        let trusted = download.trusted_revision.unwrap();
+        assert_eq!(trusted.md5_16kb, analysis_cache::md5_first_16kb(&original));
+        assert!(trusted.analysis_bytes_transcoded);
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 3, "raw probe before and after transcode");
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request
+                    .url
+                    .query_pairs()
+                    .any(|(key, value)| { key == "format" && value == "raw" }))
+                .count(),
+            2
+        );
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request
+                    .url
+                    .query_pairs()
+                    .any(|(key, value)| { key == "format" && value == "mp3" }))
+                .count(),
+            1
+        );
+
+        let oversized = analysis_backfill_download(
+            app.handle(),
+            "canonical-server",
+            "oversized",
+            &stream_url,
+            8 * 1024,
+        )
+        .await;
+        assert_eq!(
+            oversized,
+            Err(AnalysisBackfillJobError::Terminal(
+                "analysis transcode exceeds cap of 8192 bytes".to_string()
+            ))
+        );
+        let cache = app.handle().state::<analysis_cache::AnalysisCache>();
+        assert_eq!(
+            cache
+                .get_latest_status_for_track("canonical-server", "oversized")
+                .unwrap()
+                .map(|(status, _)| status),
+            Some("failed".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn backfill_falls_back_to_original_download_when_transcode_fails() {
+        use tauri::Manager;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let mut original = vec![0x44; 24 * 1024];
         original[..4].copy_from_slice(b"fLaC");
         Mock::given(method("GET"))
             .and(path("/rest/stream.view"))
@@ -2062,42 +2643,241 @@ mod tests {
             })
             .mount(&server)
             .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "mp3"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/download.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(original.clone()))
+            .mount(&server)
+            .await;
 
-        let registry = ServerHttpRegistry::new();
-        registry.sync(ServerHttpContextSyncWire {
-            server_id: "canonical-server".into(),
-            app_server_id: "profile-id".into(),
-            endpoints: vec![ServerHttpEndpointWire {
-                url: server.uri(),
-                kind: EndpointKind::Public,
-            }],
-            custom_headers: Vec::new(),
-            custom_headers_apply_to: None,
-            supports_raw_stream: true,
-        });
         let app = tauri::test::mock_app();
-        app.handle().manage(Arc::new(registry));
+        app.handle()
+            .manage(Arc::new(analysis_registry(&server.uri(), true)));
         let stream_url = format!(
-            "{}/rest/stream.view?id=t1&maxBitRate=128",
+            "{}/rest/stream.view?id=t1&format=mp3&maxBitRate=64",
             server.uri()
         );
 
-        let (bytes, _, trusted) = analysis_backfill_download_trusted_original(
+        let download = analysis_backfill_download(
             app.handle(),
             "canonical-server",
             "t1",
             &stream_url,
+            ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES,
         )
         .await
         .unwrap();
 
-        assert_eq!(bytes, original);
-        assert_eq!(trusted.md5_16kb, analysis_cache::md5_first_16kb(&bytes));
+        assert_eq!(download.bytes, original);
+        assert_eq!(download.format_hint, None);
+        let trusted = download.trusted_revision.unwrap();
+        assert!(!trusted.analysis_bytes_transcoded);
+        assert_eq!(
+            trusted.md5_16kb,
+            analysis_cache::md5_first_16kb(&download.bytes)
+        );
+        assert_eq!(server.received_requests().await.unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn backfill_discards_transcode_when_original_changes_during_fetch() {
+        use tauri::Manager;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let mut original_a = vec![0x41; 24 * 1024];
+        original_a[..4].copy_from_slice(b"fLaC");
+        let mut original_b = vec![0x42; 24 * 1024];
+        original_b[..4].copy_from_slice(b"fLaC");
+        let raw_requests = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "raw"))
+            .respond_with(ChangingRawOriginalResponder {
+                first: original_a,
+                later: original_b.clone(),
+                requests: raw_requests,
+            })
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "mp3"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![0x55; 12 * 1024]))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/download.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(original_b.clone()))
+            .mount(&server)
+            .await;
+
+        let app = tauri::test::mock_app();
+        app.handle()
+            .manage(Arc::new(analysis_registry(&server.uri(), true)));
+        let stream_url = format!(
+            "{}/rest/stream.view?id=t1&format=mp3&maxBitRate=64",
+            server.uri()
+        );
+
+        let download = analysis_backfill_download(
+            app.handle(),
+            "canonical-server",
+            "t1",
+            &stream_url,
+            ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(download.bytes, original_b);
+        let trusted = download.trusted_revision.unwrap();
+        assert!(!trusted.analysis_bytes_transcoded);
+        assert_eq!(
+            trusted.md5_16kb,
+            analysis_cache::md5_first_16kb(&download.bytes)
+        );
+        assert_eq!(server.received_requests().await.unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn oversized_download_does_not_fail_a_stale_raw_fingerprint() {
+        use tauri::Manager;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let mut probed_original = vec![0x41; 24 * 1024];
+        probed_original[..4].copy_from_slice(b"fLaC");
+        let mut downloaded_original = vec![0x42; 24 * 1024];
+        downloaded_original[..4].copy_from_slice(b"fLaC");
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "raw"))
+            .respond_with(RawOriginalResponder {
+                body: probed_original,
+            })
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "mp3"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/download.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(downloaded_original))
+            .mount(&server)
+            .await;
+
+        let app = tauri::test::mock_app();
+        app.handle()
+            .manage(Arc::new(analysis_registry(&server.uri(), true)));
+        app.handle()
+            .manage(analysis_cache::AnalysisCache::open_in_memory());
+        let stream_url = format!(
+            "{}/rest/stream.view?id=t1&format=mp3&maxBitRate=64",
+            server.uri()
+        );
+
+        let result = analysis_backfill_download(
+            app.handle(),
+            "canonical-server",
+            "t1",
+            &stream_url,
+            8 * 1024,
+        )
+        .await;
+
+        assert_eq!(
+            result,
+            Err(AnalysisBackfillJobError::Retryable(
+                "oversized original download does not match raw-probed identity".to_string()
+            ))
+        );
+        let cache = app.handle().state::<analysis_cache::AnalysisCache>();
+        assert_eq!(
+            cache
+                .get_latest_status_for_track("canonical-server", "t1")
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn non_navidrome_backfill_uses_standard_original_download() {
+        use tauri::Manager;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let original = vec![0x33; 12 * 1024];
+        Mock::given(method("GET"))
+            .and(path("/rest/download.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(original.clone()))
+            .mount(&server)
+            .await;
+
+        let app = tauri::test::mock_app();
+        app.handle()
+            .manage(Arc::new(analysis_registry(&server.uri(), false)));
+        app.handle()
+            .manage(analysis_cache::AnalysisCache::open_in_memory());
+        let stream_url = format!(
+            "{}/rest/stream.view?id=t1&format=mp3&maxBitRate=64",
+            server.uri()
+        );
+
+        let download = analysis_backfill_download(
+            app.handle(),
+            "canonical-server",
+            "t1",
+            &stream_url,
+            ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(download.bytes, original);
+        let trusted = download.trusted_revision.unwrap();
+        assert_eq!(
+            trusted.md5_16kb,
+            analysis_cache::md5_first_16kb(&download.bytes)
+        );
+        assert!(!trusted.analysis_bytes_transcoded);
         let requests = server.received_requests().await.unwrap();
-        assert_eq!(requests.len(), 2, "one prefix probe plus one full raw fetch");
-        assert!(requests.iter().all(|request| {
-            request.url.query_pairs().any(|(key, value)| key == "format" && value == "raw")
-        }));
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].url.path(), "/rest/download.view");
+
+        let oversized = analysis_backfill_download(
+            app.handle(),
+            "canonical-server",
+            "oversized",
+            &stream_url,
+            8 * 1024,
+        )
+        .await;
+        assert_eq!(
+            oversized,
+            Err(AnalysisBackfillJobError::Terminal(
+                "original download exceeds analysis cap of 8192 bytes".to_string()
+            ))
+        );
+        let cache = app.handle().state::<analysis_cache::AnalysisCache>();
+        assert_eq!(
+            cache
+                .get_latest_status_for_track("canonical-server", "oversized")
+                .unwrap()
+                .map(|(status, _)| status),
+            Some("failed".to_string())
+        );
     }
 
     #[test]
@@ -2110,10 +2890,7 @@ mod tests {
             "canonical.example/nav"
         );
         assert_eq!(
-            resolve_backfill_server_id(
-                "https://lan.example:4533/nav/rest/stream.view?id=t1",
-                None,
-            ),
+            resolve_backfill_server_id("https://lan.example:4533/nav/rest/stream.view?id=t1", None,),
             "lan.example:4533/nav"
         );
     }
@@ -2136,7 +2913,8 @@ mod tests {
             "u".into(),
             AnalysisBackfillPriority::Middle,
         );
-        s.in_progress.insert(seed_key("", "active"), AnalysisBackfillPriority::Low);
+        s.in_progress
+            .insert(seed_key("", "active"), AnalysisBackfillPriority::Low);
         assert!(s.is_reserved(&seed_key("", "queued")));
         assert!(s.is_reserved(&seed_key("", "active")));
         assert!(!s.is_reserved(&seed_key("", "other")));
@@ -2145,9 +2923,24 @@ mod tests {
     #[test]
     fn backfill_try_pop_next_drains_high_then_middle_then_low() {
         let mut s = AnalysisBackfillQueueState::default();
-        s.enqueue(String::new(), "low".into(), "u".into(), AnalysisBackfillPriority::Low);
-        s.enqueue(String::new(), "mid".into(), "u".into(), AnalysisBackfillPriority::Middle);
-        s.enqueue(String::new(), "hi".into(), "u".into(), AnalysisBackfillPriority::High);
+        s.enqueue(
+            String::new(),
+            "low".into(),
+            "u".into(),
+            AnalysisBackfillPriority::Low,
+        );
+        s.enqueue(
+            String::new(),
+            "mid".into(),
+            "u".into(),
+            AnalysisBackfillPriority::Middle,
+        );
+        s.enqueue(
+            String::new(),
+            "hi".into(),
+            "u".into(),
+            AnalysisBackfillPriority::High,
+        );
         assert_eq!(s.try_pop_next(4).unwrap().0, "hi");
         assert_eq!(s.try_pop_next(4).unwrap().0, "mid");
         assert_eq!(s.try_pop_next(4).unwrap().0, "low");
@@ -2283,10 +3076,7 @@ mod tests {
     #[test]
     fn backfill_enqueue_returns_running_skipped_for_high_prio_active_track() {
         let mut s = AnalysisBackfillQueueState {
-            in_progress: HashMap::from([(
-                seed_key("", "active"),
-                AnalysisBackfillPriority::Low,
-            )]),
+            in_progress: HashMap::from([(seed_key("", "active"), AnalysisBackfillPriority::Low)]),
             ..Default::default()
         };
         let kind = s.enqueue(
@@ -2299,11 +3089,154 @@ mod tests {
     }
 
     #[test]
+    fn backfill_transient_failure_defers_low_priority_retry() {
+        let mut s = AnalysisBackfillQueueState::default();
+        let key = seed_key("server-1", "retry");
+        s.in_progress
+            .insert(key.clone(), AnalysisBackfillPriority::Low);
+        s.finish_job(&key, true);
+
+        let kind = s.enqueue(
+            "server-1".into(),
+            "retry".into(),
+            "url".into(),
+            AnalysisBackfillPriority::Low,
+        );
+
+        assert_eq!(kind, AnalysisBackfillEnqueueKind::RetryDeferred);
+        assert_eq!(s.queued_len(), 0);
+    }
+
+    #[test]
+    fn backfill_high_priority_retry_bypasses_and_clears_cooldown() {
+        let mut s = AnalysisBackfillQueueState::default();
+        let key = seed_key("server-1", "retry");
+        s.in_progress
+            .insert(key.clone(), AnalysisBackfillPriority::Low);
+        s.finish_job(&key, true);
+
+        assert_eq!(
+            s.enqueue(
+                "server-1".into(),
+                "retry".into(),
+                "url".into(),
+                AnalysisBackfillPriority::High,
+            ),
+            AnalysisBackfillEnqueueKind::NewHigh
+        );
+        let job = s.try_pop_next(1).unwrap();
+        s.finish_job(&seed_key(&job.2, &job.0), false);
+
+        assert_eq!(
+            s.enqueue(
+                "server-1".into(),
+                "retry".into(),
+                "url".into(),
+                AnalysisBackfillPriority::Low,
+            ),
+            AnalysisBackfillEnqueueKind::NewLow
+        );
+    }
+
+    #[test]
+    fn post_admission_failure_preserves_reservation_and_increments_backoff() {
+        let mut state = AnalysisBackfillQueueState::default();
+        let key = seed_key("server-1", "retry");
+        state
+            .in_progress
+            .insert(key.clone(), AnalysisBackfillPriority::Low);
+        state.finish_job(&key, true);
+        assert_eq!(
+            state.retry_state.get(&key).map(|retry| retry.failures),
+            Some(1)
+        );
+
+        assert_eq!(
+            state.enqueue(
+                "server-1".into(),
+                "retry".into(),
+                "url".into(),
+                AnalysisBackfillPriority::High,
+            ),
+            AnalysisBackfillEnqueueKind::NewHigh
+        );
+        let job = state.try_pop_next(1).unwrap();
+        state.mark_cpu_admitted(&key);
+
+        assert!(state.awaiting_cpu.contains(&key));
+        assert_eq!(
+            state.enqueue(
+                "server-1".into(),
+                "retry".into(),
+                "url".into(),
+                AnalysisBackfillPriority::High,
+            ),
+            AnalysisBackfillEnqueueKind::RunningSkipped
+        );
+
+        state.finish_job(&seed_key(&job.2, &job.0), true);
+
+        assert!(state.retry_deferred(&key));
+        assert_eq!(
+            state.retry_state.get(&key).map(|retry| retry.failures),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn late_registration_cannot_replace_a_newer_trusted_revision() {
+        let app = tauri::test::mock_app();
+        let older_generation = next_trusted_generation();
+        let newer_generation = next_trusted_generation();
+
+        register_trusted_revision_generation(
+            "generation-order-server",
+            "t1",
+            "newer-fingerprint",
+            newer_generation,
+        );
+        register_trusted_revision_generation(
+            "generation-order-server",
+            "t1",
+            "older-fingerprint",
+            older_generation,
+        );
+
+        assert!(!activate_trusted_identity(
+            app.handle(),
+            "generation-order-server",
+            "generation-order-server",
+            "t1",
+            "older-fingerprint",
+            older_generation,
+        ));
+        assert!(activate_trusted_identity(
+            app.handle(),
+            "generation-order-server",
+            "generation-order-server",
+            "t1",
+            "newer-fingerprint",
+            newer_generation,
+        ));
+    }
+
+    #[test]
     fn backfill_try_pop_next_respects_max_concurrent() {
         let mut s = AnalysisBackfillQueueState::default();
-        s.enqueue(String::new(), "a".into(), "u".into(), AnalysisBackfillPriority::Low);
-        s.enqueue(String::new(), "b".into(), "u".into(), AnalysisBackfillPriority::Low);
-        s.in_progress.insert("active".into(), AnalysisBackfillPriority::Low);
+        s.enqueue(
+            String::new(),
+            "a".into(),
+            "u".into(),
+            AnalysisBackfillPriority::Low,
+        );
+        s.enqueue(
+            String::new(),
+            "b".into(),
+            "u".into(),
+            AnalysisBackfillPriority::Low,
+        );
+        s.in_progress
+            .insert("active".into(), AnalysisBackfillPriority::Low);
         assert!(s.try_pop_next(1).is_none());
         assert_eq!(s.try_pop_next(2).unwrap().0, "a");
     }
@@ -2312,7 +3245,12 @@ mod tests {
     fn backfill_prune_queued_not_in_drops_unkept_entries() {
         let mut s = AnalysisBackfillQueueState::default();
         for tid in ["a", "b", "c", "d"] {
-            s.enqueue(String::new(), tid.into(), "u".into(), AnalysisBackfillPriority::Low);
+            s.enqueue(
+                String::new(),
+                tid.into(),
+                "u".into(),
+                AnalysisBackfillPriority::Low,
+            );
         }
         let keep: HashSet<&str> = ["a", "c"].iter().copied().collect();
         let removed = s.prune_queued_not_in(&keep, None);
@@ -2393,6 +3331,35 @@ mod tests {
         let job = s.try_pop_next().unwrap();
         assert_eq!(job.bytes, vec![4, 5, 6], "fresh bytes overwrite");
         assert_eq!(job.waiters.len(), 2, "both waiters attached");
+    }
+
+    #[test]
+    fn cpu_seed_merge_never_replaces_original_bytes_with_transcode() {
+        let mut s = AnalysisCpuSeedQueueState::default();
+        let (_, _original_rx) = s.enqueue(
+            "server-a".into(),
+            "track".into(),
+            vec![1, 2, 3],
+            None,
+            trusted_revision("revision", 1),
+            AnalysisBackfillPriority::High,
+            0,
+        );
+        let (kind, _transcode_rx) = s.enqueue(
+            "server-a".into(),
+            "track".into(),
+            vec![9, 9, 9],
+            Some("mp3".into()),
+            trusted_transcode_revision("revision", 1),
+            AnalysisBackfillPriority::Low,
+            0,
+        );
+
+        assert_eq!(kind, AnalysisCpuSeedEnqueueKind::MergedQueued);
+        let job = s.try_pop_next().unwrap();
+        assert_eq!(job.bytes, vec![1, 2, 3]);
+        assert!(!job.trusted_revision.unwrap().analysis_bytes_transcoded);
+        assert_eq!(job.waiters.len(), 2);
     }
 
     #[test]
@@ -2533,7 +3500,11 @@ mod tests {
             0,
         );
         assert_eq!(kind, AnalysisCpuSeedEnqueueKind::RunningFollower);
-        assert_eq!(followers.lock().unwrap().len(), 1, "follower channel attached");
+        assert_eq!(
+            followers.lock().unwrap().len(),
+            1,
+            "follower channel attached"
+        );
         assert_eq!(s.queued_len(), 0, "follower does not occupy a queue slot");
     }
 
@@ -2598,7 +3569,9 @@ mod tests {
         );
         let keep: HashSet<&str> = HashSet::new();
         let _ = s.prune_queued_not_in(&keep, None);
-        let result = rx.blocking_recv().expect("sender side should have closed cleanly");
+        let result = rx
+            .blocking_recv()
+            .expect("sender side should have closed cleanly");
         assert!(result.is_err(), "pruned job must yield Err, got {result:?}");
     }
 
@@ -2659,23 +3632,29 @@ mod complete_repair_tests {
         let key = key_for(server_id, track_id, md5);
         cache.touch_track_status(&key, "ready").unwrap();
         cache
-            .upsert_waveform(&key, &WaveformEntry {
-                bins: vec![1, 2, 3, 4, 5, 6],
-                bin_count: 3,
-                is_partial: false,
-                known_until_sec: 100.0,
-                duration_sec: 100.0,
-                updated_at,
-            })
+            .upsert_waveform(
+                &key,
+                &WaveformEntry {
+                    bins: vec![1, 2, 3, 4, 5, 6],
+                    bin_count: 3,
+                    is_partial: false,
+                    known_until_sec: 100.0,
+                    duration_sec: 100.0,
+                    updated_at,
+                },
+            )
             .unwrap();
         cache
-            .upsert_loudness(&key, &LoudnessEntry {
-                integrated_lufs: -14.0,
-                true_peak: 0.5,
-                recommended_gain_db: 0.0,
-                target_lufs: -14.0,
-                updated_at,
-            })
+            .upsert_loudness(
+                &key,
+                &LoudnessEntry {
+                    integrated_lufs: -14.0,
+                    true_peak: 0.5,
+                    recommended_gain_db: 0.0,
+                    target_lufs: -14.0,
+                    updated_at,
+                },
+            )
             .unwrap();
     }
 
@@ -2695,7 +3674,10 @@ mod complete_repair_tests {
         seed_complete_row_for(&cache, server_id, "t1", "stale-transcode-fp", 200); // newer wins reads today
 
         assert_eq!(
-            cache.get_latest_md5_16kb_for_track(server_id, "t1").unwrap().as_deref(),
+            cache
+                .get_latest_md5_16kb_for_track(server_id, "t1")
+                .unwrap()
+                .as_deref(),
             Some("stale-transcode-fp"),
             "precondition: the stale variant is what reads currently select"
         );
@@ -2711,7 +3693,10 @@ mod complete_repair_tests {
         );
 
         assert_eq!(
-            cache.get_latest_md5_16kb_for_track(server_id, "t1").unwrap().as_deref(),
+            cache
+                .get_latest_md5_16kb_for_track(server_id, "t1")
+                .unwrap()
+                .as_deref(),
             Some("trusted-fp"),
             "the stale variant must be purged on the complete-repair path"
         );
@@ -2723,13 +3708,13 @@ mod complete_repair_tests {
         app.handle().manage(AnalysisCache::open_in_memory());
         let recorded = Arc::new(Mutex::new(Vec::<String>::new()));
         let recorded_for_sink = recorded.clone();
-        app.handle().manage(psysonic_core::ports::ContentHashSink::new(
-            move |_, _, hash| recorded_for_sink.lock().unwrap().push(hash.to_string()),
-        ));
+        app.handle()
+            .manage(psysonic_core::ports::ContentHashSink::new(
+                move |_, _, hash| recorded_for_sink.lock().unwrap().push(hash.to_string()),
+            ));
         let cache = app.handle().state::<AnalysisCache>();
 
-        let older_generation =
-            begin_trusted_revision("srv-reverse", "stream:t1", "older-fp");
+        let older_generation = begin_trusted_revision("srv-reverse", "stream:t1", "older-fp");
         let newer_generation = begin_trusted_revision("srv-reverse", "t1", "newer-fp");
         seed_complete_row_for(&cache, "srv-reverse", "t1", "newer-fp", 200);
         assert!(activate_trusted_identity(
@@ -2755,10 +3740,12 @@ mod complete_repair_tests {
             .content_cache_coverage("srv-reverse", "t1", "newer-fp")
             .unwrap()
             .complete());
-        assert!(!cache
-            .content_cache_coverage("srv-reverse", "t1", "older-fp")
-            .unwrap()
-            .has_waveform);
+        assert!(
+            !cache
+                .content_cache_coverage("srv-reverse", "t1", "older-fp")
+                .unwrap()
+                .has_waveform
+        );
         assert_eq!(&*recorded.lock().unwrap(), &["newer-fp".to_string()]);
     }
 
@@ -2768,14 +3755,15 @@ mod complete_repair_tests {
         app.handle().manage(AnalysisCache::open_in_memory());
         let recorded = Arc::new(Mutex::new(Vec::<(String, String)>::new()));
         let recorded_for_sink = recorded.clone();
-        app.handle().manage(psysonic_core::ports::ContentHashSink::new(
-            move |server_id, _, hash| {
-                recorded_for_sink
-                    .lock()
-                    .unwrap()
-                    .push((server_id.to_string(), hash.to_string()))
-            },
-        ));
+        app.handle()
+            .manage(psysonic_core::ports::ContentHashSink::new(
+                move |server_id, _, hash| {
+                    recorded_for_sink
+                        .lock()
+                        .unwrap()
+                        .push((server_id.to_string(), hash.to_string()))
+                },
+            ));
         let cache = app.handle().state::<AnalysisCache>();
         let server_id = "srv-enrichment-repair";
         seed_complete_row_for(&cache, server_id, "t1", "trusted-enrichment", 100);
@@ -2800,7 +3788,10 @@ mod complete_repair_tests {
         );
         assert_eq!(
             &*recorded.lock().unwrap(),
-            &[("library-scope".to_string(), "trusted-enrichment".to_string())]
+            &[(
+                "library-scope".to_string(),
+                "trusted-enrichment".to_string()
+            )]
         );
     }
 }

--- a/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
+++ b/src-tauri/crates/psysonic-analysis/src/analysis_runtime.rs
@@ -267,6 +267,24 @@ impl AnalysisBackfillQueueState {
         None
     }
 
+    fn try_pop_next_with_cpu_backpressure(
+        &mut self,
+        max_concurrent: usize,
+        cpu_load: usize,
+        cpu_cap: usize,
+    ) -> Option<BackfillJob> {
+        let high_pending = !self.high.is_empty();
+        if should_idle_for_cpu_backpressure(
+            cpu_load,
+            self.in_progress.len(),
+            cpu_cap,
+            high_pending,
+        ) {
+            return None;
+        }
+        self.try_pop_next(max_concurrent)
+    }
+
     fn record_retryable_failure(&mut self, key: &str) {
         let failures = self
             .retry_state
@@ -553,6 +571,64 @@ impl TrustedActivationState {
 
 static TRUSTED_ACTIVATION_GENERATION: AtomicU64 = AtomicU64::new(0);
 static TRUSTED_ACTIVATIONS: OnceLock<Mutex<TrustedActivationState>> = OnceLock::new();
+type TrustedAnalysisFetchWaiter = tokio::sync::oneshot::Sender<()>;
+static TRUSTED_ANALYSIS_FETCHES: OnceLock<
+    Mutex<HashMap<String, Vec<TrustedAnalysisFetchWaiter>>>,
+> = OnceLock::new();
+
+#[derive(Debug)]
+pub struct TrustedAnalysisFetchPermit {
+    key: String,
+    waited: bool,
+}
+
+impl TrustedAnalysisFetchPermit {
+    pub fn waited(&self) -> bool {
+        self.waited
+    }
+}
+
+impl Drop for TrustedAnalysisFetchPermit {
+    fn drop(&mut self) {
+        let waiters = TRUSTED_ANALYSIS_FETCHES
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(&self.key)
+            .unwrap_or_default();
+        for waiter in waiters {
+            let _ = waiter.send(());
+        }
+    }
+}
+
+pub async fn reserve_trusted_analysis_fetch(
+    server_id: &str,
+    track_id: &str,
+    revision: &str,
+) -> TrustedAnalysisFetchPermit {
+    let canonical_track_id = track_id.strip_prefix("stream:").unwrap_or(track_id);
+    let key = seed_revision_key(server_id, canonical_track_id, revision);
+    let mut waited = false;
+    loop {
+        let receiver = {
+            let mut reservations = TRUSTED_ANALYSIS_FETCHES
+                .get_or_init(|| Mutex::new(HashMap::new()))
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            if let Some(waiters) = reservations.get_mut(&key) {
+                let (sender, receiver) = tokio::sync::oneshot::channel();
+                waiters.push(sender);
+                Some(receiver)
+            } else {
+                reservations.insert(key.clone(), Vec::new());
+                return TrustedAnalysisFetchPermit { key, waited };
+            }
+        };
+        let _ = receiver.expect("occupied fetch must provide a waiter").await;
+        waited = true;
+    }
+}
 
 fn canonical_activation_key(server_id: &str, track_id: &str) -> String {
     let canonical_track_id = track_id.strip_prefix("stream:").unwrap_or(track_id);
@@ -732,7 +808,10 @@ fn activate_trusted_enrichment<R: tauri::Runtime>(
     generation: u64,
     outcome: TrackEnrichmentOutcome,
 ) -> bool {
-    if matches!(outcome, TrackEnrichmentOutcome::Failed) {
+    if matches!(
+        outcome,
+        TrackEnrichmentOutcome::Failed | TrackEnrichmentOutcome::SkippedSuperseded
+    ) {
         return false;
     }
     activate_trusted_identity(
@@ -743,6 +822,27 @@ fn activate_trusted_enrichment<R: tauri::Runtime>(
         content_hash,
         generation,
     )
+}
+
+pub(crate) fn commit_trusted_enrichment_if_current<T>(
+    server_id: &str,
+    track_id: &str,
+    content_hash: &str,
+    generation: u64,
+    commit: impl FnOnce() -> T,
+) -> Option<T> {
+    let activation_key = canonical_activation_key(server_id, track_id);
+    let state = TRUSTED_ACTIVATIONS
+        .get_or_init(|| Mutex::new(TrustedActivationState::default()))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let is_current = state
+        .current_by_track
+        .get(&activation_key)
+        .is_some_and(|current| {
+            current.revision == content_hash && current.generation == generation
+        });
+    is_current.then(commit)
 }
 
 /// Like [`enqueue_track_analysis`] but with a verified original fingerprint.
@@ -878,12 +978,16 @@ async fn enqueue_track_analysis_with_fetch(
             content_hash
         );
         let bpm_started = std::time::Instant::now();
+        let trusted_guard = trusted_revision
+            .as_ref()
+            .map(|trusted| (server_id.to_string(), trusted.generation));
         let outcome = run_track_enrichment_from_owned_bytes(
             app,
             server_id,
             track_id,
             bytes.into_owned(),
             Some(content_hash.clone()),
+            trusted_guard,
             analysis_emits_ui_events(priority),
         )
         .await;
@@ -938,6 +1042,7 @@ pub async fn run_track_enrichment_from_bytes(
         track_id,
         bytes.to_vec(),
         trusted_md5_16kb,
+        None,
         notify_ui,
     )
     .await
@@ -949,6 +1054,7 @@ async fn run_track_enrichment_from_owned_bytes(
     track_id: &str,
     data: Vec<u8>,
     trusted_md5_16kb: Option<String>,
+    trusted_guard: Option<(String, u64)>,
     notify_ui: bool,
 ) -> TrackEnrichmentOutcome {
     if server_id.is_empty() {
@@ -964,6 +1070,9 @@ async fn run_track_enrichment_from_owned_bytes(
             &tid,
             &data,
             trusted_md5_16kb.as_deref(),
+            trusted_guard
+                .as_ref()
+                .map(|(server_id, generation)| (server_id.as_str(), *generation)),
             notify_ui,
         )
     })
@@ -1141,12 +1250,17 @@ async fn enqueue_track_analysis_offline_library_with_plan(
             content_hash
         );
         let bpm_started = std::time::Instant::now();
-        let outcome = run_track_enrichment_from_bytes(
+        let trusted_guard = args
+            .trusted_revision
+            .as_ref()
+            .map(|trusted| (args.cache_server_id.to_string(), trusted.generation));
+        let outcome = run_track_enrichment_from_owned_bytes(
             args.app,
             args.enrichment_server_id,
             args.track_id,
-            args.bytes,
+            args.bytes.to_vec(),
             Some(content_hash.clone()),
+            trusted_guard,
             analysis_emits_ui_events(args.priority),
         )
         .await;
@@ -1334,12 +1448,13 @@ fn analysis_stream_format_hint(url: &str) -> Option<String> {
         .find_map(|(key, value)| (key == "format" && value != "raw").then(|| value.into_owned()))
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 struct AnalysisBackfillDownload {
     bytes: Vec<u8>,
     fetch_ms: u64,
     format_hint: Option<String>,
     trusted_revision: Option<TrustedAnalysisRevision>,
+    trusted_fetch_permit: Option<TrustedAnalysisFetchPermit>,
 }
 
 fn record_oversized_trusted_analysis<R: tauri::Runtime>(
@@ -1470,6 +1585,7 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
                                     analysis_bytes_transcoded: true,
                                     content_hash_server_id: None,
                                 }),
+                                trusted_fetch_permit: None,
                             });
                         }
                         Err(crate::raw_probe::BoundedStreamFetchError::TooLarge { .. }) => {
@@ -1511,6 +1627,21 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
             "original download endpoint unavailable for analysis fallback".to_string(),
         )
     })?;
+    let trusted_fetch_permit = if let Some(revision) = trusted.as_deref() {
+        let permit = reserve_trusted_analysis_fetch(server_id, track_id, revision).await;
+        if permit.waited()
+            && (analysis_revision_in_cpu_pipeline(server_id, track_id, revision)
+                || !crate::track_analysis_plan::plan_track_analysis(
+                    app, server_id, track_id, revision,
+                )
+                .any())
+        {
+            return Err(AnalysisBackfillJobError::Superseded);
+        }
+        Some(permit)
+    } else {
+        None
+    };
     let bytes = match crate::raw_probe::fetch_bounded_stream_bytes(
         analysis_http_client(),
         registry.as_deref(),
@@ -1595,6 +1726,7 @@ async fn analysis_backfill_download<R: tauri::Runtime>(
         fetch_ms: fetch_started.elapsed().as_millis() as u64,
         format_hint: None,
         trusted_revision,
+        trusted_fetch_permit,
     })
 }
 
@@ -1619,6 +1751,7 @@ async fn process_analysis_backfill_job(
         fetch_ms,
         format_hint,
         trusted_revision,
+        trusted_fetch_permit,
     } = download;
     let outcome = enqueue_track_analysis_with_fetch(
         app,
@@ -1632,7 +1765,9 @@ async fn process_analysis_backfill_job(
         Some(cpu_admitted),
     )
     .await
-    .map_err(AnalysisBackfillJobError::Retryable)?;
+    .map_err(AnalysisBackfillJobError::Retryable);
+    drop(trusted_fetch_permit);
+    let outcome = outcome?;
     Ok(!matches!(outcome, EnqueueTrackAnalysisOutcome::Complete))
 }
 
@@ -1693,10 +1828,17 @@ fn cpu_seed_pipeline_cap(max_parallel: usize) -> usize {
     max_parallel.saturating_mul(2).max(2)
 }
 
-/// Decide whether the HTTP backfill worker should idle right now. High-tier
-/// (now-playing) jobs always bypass the cap so playback is never starved.
-fn should_idle_for_cpu_backpressure(cpu_load: usize, cpu_cap: usize, high_pending: bool) -> bool {
-    !high_pending && cpu_load >= cpu_cap
+/// Decide whether the HTTP backfill worker should idle right now. Active HTTP
+/// downloads reserve their prospective CPU-buffer slots before another job is
+/// popped. High-tier work gets one slot beyond the ordinary cap.
+fn should_idle_for_cpu_backpressure(
+    cpu_load: usize,
+    http_active: usize,
+    cpu_cap: usize,
+    high_pending: bool,
+) -> bool {
+    let admission_cap = cpu_cap.saturating_add(usize::from(high_pending));
+    cpu_load.saturating_add(http_active) >= admission_cap
 }
 
 async fn spawn_backfill_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisBackfillShared>) {
@@ -1706,20 +1848,17 @@ async fn spawn_backfill_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisBackf
         // (Vec<u8>, tens of MB for FLAC) sit in `AnalysisCpuSeedJob.bytes` until
         // Symphonia decode + R128 finish — much slower than HTTP. Without a cap,
         // aggressive library backfill on large libraries grows RAM unbounded.
-        // High-tier (now-playing) jobs always proceed.
+        // High-tier (now-playing) jobs get one reserved slot beyond the normal
+        // cap, but cannot grow an unbounded backlog during rapid track skips.
         let cpu_load = cpu_seed_pipeline_load();
         let cpu_cap = cpu_seed_pipeline_cap(max);
         let job_bundle = {
             let mut st = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-            let high_pending = !st.high.is_empty();
-            if should_idle_for_cpu_backpressure(cpu_load, cpu_cap, high_pending) {
-                None
-            } else {
-                st.try_pop_next(max).map(|job| {
+            st.try_pop_next_with_cpu_backpressure(max, cpu_load, cpu_cap)
+                .map(|job| {
                     let worker_slot = st.in_progress.len();
                     (job, worker_slot)
                 })
-            }
         };
         let Some(((track_id, url, server_id), worker_slot)) = job_bundle else {
             if cpu_load >= cpu_cap {
@@ -2353,6 +2492,20 @@ impl AnalysisCpuSeedQueueState {
             .or_else(|| self.middle.pop_front())
             .or_else(|| self.low.pop_front())
     }
+
+    fn finish_running(&mut self, key: &str) -> Vec<SeedDoneSender> {
+        self.running_tiers.remove(key);
+        self.running
+            .remove(key)
+            .map(|followers| {
+                followers
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .drain(..)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
 }
 
 struct AnalysisCpuSeedShared {
@@ -2464,11 +2617,11 @@ async fn spawn_cpu_seed_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisCpuSe
                     st.running.insert(run_key.clone(), followers.clone());
                     st.running_tiers.insert(run_key, job_priority);
                     let worker_slot = st.running.len();
-                    (j, followers, worker_slot)
+                    (j, worker_slot)
                 })
             }
         };
-        let Some((job, followers, worker_slot)) = job_bundle else {
+        let Some((job, worker_slot)) = job_bundle else {
             break;
         };
         let tid_log = job.track_id.clone();
@@ -2500,6 +2653,10 @@ async fn spawn_cpu_seed_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisCpuSe
                 .trusted_revision
                 .as_ref()
                 .map(|trusted| trusted.md5_16kb.clone());
+            let trusted_generation = job
+                .trusted_revision
+                .as_ref()
+                .map(|trusted| trusted.generation);
             let seed_result = tokio::task::spawn_blocking(move || {
                 if analysis_bytes_transcoded {
                     let trusted = trusted_md5_16kb.as_deref().ok_or_else(|| {
@@ -2512,6 +2669,9 @@ async fn spawn_cpu_seed_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisCpuSe
                         &bytes,
                         format_hint.as_deref(),
                         trusted,
+                        trusted_generation.ok_or_else(|| {
+                            "trusted analysis transcode missing generation".to_string()
+                        })?,
                         notify_ui,
                     )
                 } else {
@@ -2522,6 +2682,7 @@ async fn spawn_cpu_seed_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisCpuSe
                         &bytes,
                         format_hint.as_deref(),
                         trusted_md5_16kb.as_deref(),
+                        trusted_generation,
                         notify_ui,
                     )
                 }
@@ -2551,22 +2712,15 @@ async fn spawn_cpu_seed_slots(app: &tauri::AppHandle, shared: &Arc<AnalysisCpuSe
                 }
             }
 
-            let mut extra = followers
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .drain(..)
-                .collect::<Vec<_>>();
+            let mut extra = {
+                let mut st = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+                st.finish_running(&run_key_log)
+            };
             for tx in job.waiters {
                 let _ = tx.send(seed_result.clone());
             }
             for tx in extra.drain(..) {
                 let _ = tx.send(seed_result.clone());
-            }
-
-            {
-                let mut st = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-                st.running.remove(&run_key_log);
-                st.running_tiers.remove(&run_key_log);
             }
             // Decode slot freed → wake HTTP backfill in case it was idling on
             // the `cpu_seed_pipeline_cap` backpressure check.
@@ -2890,10 +3044,10 @@ mod tests {
         )
         .await;
         assert_eq!(
-            oversized,
-            Err(AnalysisBackfillJobError::Terminal(
+            oversized.unwrap_err(),
+            AnalysisBackfillJobError::Terminal(
                 "analysis transcode exceeds cap of 8192 bytes".to_string()
-            ))
+            )
         );
         let cache = app.handle().state::<analysis_cache::AnalysisCache>();
         assert_eq!(
@@ -3137,10 +3291,10 @@ mod tests {
         .await;
 
         assert_eq!(
-            result,
-            Err(AnalysisBackfillJobError::Retryable(
+            result.unwrap_err(),
+            AnalysisBackfillJobError::Retryable(
                 "oversized original download does not match raw-probed identity".to_string()
-            ))
+            )
         );
         let cache = app.handle().state::<analysis_cache::AnalysisCache>();
         assert_eq!(
@@ -3205,10 +3359,10 @@ mod tests {
         )
         .await;
         assert_eq!(
-            oversized,
-            Err(AnalysisBackfillJobError::Terminal(
+            oversized.unwrap_err(),
+            AnalysisBackfillJobError::Terminal(
                 "original download exceeds analysis cap of 8192 bytes".to_string()
-            ))
+            )
         );
         let cache = app.handle().state::<analysis_cache::AnalysisCache>();
         assert_eq!(
@@ -3246,10 +3400,11 @@ mod tests {
                 &stream_url,
                 ANALYSIS_BACKFILL_DOWNLOAD_MAX_BYTES,
             )
-            .await,
-            Err(AnalysisBackfillJobError::Terminal(
+            .await
+            .unwrap_err(),
+            AnalysisBackfillJobError::Terminal(
                 "original download unavailable: HTTP 404".to_string()
-            ))
+            )
         );
     }
 
@@ -4106,6 +4261,35 @@ mod tests {
     }
 
     #[test]
+    fn cpu_seed_finish_running_closes_follower_registration_before_drain() {
+        let mut s = AnalysisCpuSeedQueueState::default();
+        let revision = analysis_cache::md5_first_16kb(&[]);
+        let key = seed_revision_key("", "active", &revision);
+        let followers = Arc::new(Mutex::new(Vec::new()));
+        let (existing_tx, _existing_rx) = tokio::sync::oneshot::channel();
+        followers.lock().unwrap().push(existing_tx);
+        s.running.insert(key.clone(), followers);
+        s.running_tiers
+            .insert(key.clone(), AnalysisBackfillPriority::Low);
+
+        let drained = s.finish_running(&key);
+        assert_eq!(drained.len(), 1);
+        assert!(!s.running.contains_key(&key));
+        assert!(!s.running_tiers.contains_key(&key));
+
+        let (kind, _rx) = s.enqueue(
+            String::new(),
+            "active".into(),
+            vec![],
+            None,
+            None,
+            AnalysisBackfillPriority::Low,
+            0,
+        );
+        assert_eq!(kind, AnalysisCpuSeedEnqueueKind::NewLow);
+    }
+
+    #[test]
     fn cpu_seed_prune_returns_removed_jobs_and_waiter_count() {
         let mut s = AnalysisCpuSeedQueueState::default();
         let (_, _r1) = s.enqueue(
@@ -4189,19 +4373,96 @@ mod tests {
 
     #[test]
     fn backpressure_idles_when_cpu_load_meets_cap_and_no_high() {
-        assert!(should_idle_for_cpu_backpressure(12, 12, false));
-        assert!(should_idle_for_cpu_backpressure(20, 12, false));
+        assert!(should_idle_for_cpu_backpressure(12, 0, 12, false));
+        assert!(should_idle_for_cpu_backpressure(20, 0, 12, false));
     }
 
     #[test]
     fn backpressure_allows_pop_when_cpu_load_below_cap() {
-        assert!(!should_idle_for_cpu_backpressure(11, 12, false));
-        assert!(!should_idle_for_cpu_backpressure(0, 12, false));
+        assert!(!should_idle_for_cpu_backpressure(11, 0, 12, false));
+        assert!(!should_idle_for_cpu_backpressure(0, 0, 12, false));
+        assert!(should_idle_for_cpu_backpressure(11, 1, 12, false));
     }
 
     #[test]
-    fn backpressure_bypassed_for_high_priority_jobs() {
-        assert!(!should_idle_for_cpu_backpressure(100, 12, true));
+    fn backpressure_reserves_one_extra_slot_for_high_priority_jobs() {
+        assert!(!should_idle_for_cpu_backpressure(12, 0, 12, true));
+        assert!(should_idle_for_cpu_backpressure(12, 1, 12, true));
+        assert!(should_idle_for_cpu_backpressure(13, 0, 12, true));
+        assert!(should_idle_for_cpu_backpressure(100, 0, 12, true));
+    }
+
+    #[test]
+    fn backpressure_admits_only_one_high_download_beyond_cpu_cap() {
+        let mut state = AnalysisBackfillQueueState::default();
+        state.enqueue(
+            "backpressure-server".into(),
+            "first".into(),
+            "u1".into(),
+            AnalysisBackfillPriority::High,
+        );
+        state.enqueue(
+            "backpressure-server".into(),
+            "second".into(),
+            "u2".into(),
+            AnalysisBackfillPriority::High,
+        );
+
+        assert!(state
+            .try_pop_next_with_cpu_backpressure(20, 12, 12)
+            .is_some());
+        assert!(state
+            .try_pop_next_with_cpu_backpressure(20, 12, 12)
+            .is_none());
+        assert_eq!(state.in_progress.len(), 1);
+        assert_eq!(state.queued_len(), 1);
+    }
+
+    #[tokio::test]
+    async fn trusted_fetch_reservation_waits_for_stream_track_alias_owner() {
+        let first = reserve_trusted_analysis_fetch(
+            "fetch-reservation-server",
+            "stream:fetch-reservation-track",
+            "fetch-reservation-revision",
+        )
+        .await;
+        assert!(!first.waited());
+
+        let mut waiter = tokio::spawn(async {
+            reserve_trusted_analysis_fetch(
+                "fetch-reservation-server",
+                "fetch-reservation-track",
+                "fetch-reservation-revision",
+            )
+            .await
+        });
+        let key = seed_revision_key(
+            "fetch-reservation-server",
+            "fetch-reservation-track",
+            "fetch-reservation-revision",
+        );
+        loop {
+            let registered = TRUSTED_ANALYSIS_FETCHES
+                .get_or_init(|| Mutex::new(HashMap::new()))
+                .lock()
+                .unwrap()
+                .get(&key)
+                .is_some_and(|waiters| !waiters.is_empty());
+            if registered {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(tokio::time::timeout(std::time::Duration::from_millis(10), &mut waiter)
+            .await
+            .is_err());
+
+        drop(first);
+        let second = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter should wake when the owner releases")
+            .expect("waiter task should complete");
+        assert!(second.waited());
     }
 }
 
@@ -4344,6 +4605,35 @@ mod complete_repair_tests {
                 .has_waveform
         );
         assert_eq!(&*recorded.lock().unwrap(), &["newer-fp".to_string()]);
+    }
+
+    #[test]
+    fn trusted_enrichment_commit_rejects_superseded_generation() {
+        let server_id = "srv-enrichment-generation-guard";
+        let track_id = "t1";
+        let older_generation = begin_trusted_revision(server_id, track_id, "older-fp");
+        let newer_generation = begin_trusted_revision(server_id, track_id, "newer-fp");
+        let committed = std::sync::atomic::AtomicBool::new(false);
+
+        assert!(commit_trusted_enrichment_if_current(
+            server_id,
+            track_id,
+            "older-fp",
+            older_generation,
+            || committed.store(true, Ordering::Relaxed),
+        )
+        .is_none());
+        assert!(!committed.load(Ordering::Relaxed));
+
+        assert!(commit_trusted_enrichment_if_current(
+            server_id,
+            track_id,
+            "newer-fp",
+            newer_generation,
+            || committed.store(true, Ordering::Relaxed),
+        )
+        .is_some());
+        assert!(committed.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-analysis/src/commands.rs
+++ b/src-tauri/crates/psysonic-analysis/src/commands.rs
@@ -7,9 +7,9 @@ use std::collections::HashSet;
 
 use crate::analysis_cache;
 use crate::analysis_runtime::{
-    analysis_backfill_queue_stats, analysis_pipeline_queue_stats, enqueue_seed_from_url,
-    prune_analysis_queues, AnalysisBackfillPriority, EnqueueSeedFromUrlOutcome,
-    PlaybackPriorityHints,
+    analysis_backfill_queue_stats, analysis_pipeline_queue_stats,
+    clear_analysis_backfill_failure_state, enqueue_seed_from_url, prune_analysis_queues,
+    AnalysisBackfillPriority, EnqueueSeedFromUrlOutcome, PlaybackPriorityHints,
 };
 
 #[derive(serde::Serialize, specta::Type)]
@@ -295,7 +295,9 @@ pub fn analysis_clear_failed_tracks(
         .map(|id| id.trim().to_string())
         .filter(|id| !id.is_empty())
         .collect::<Vec<_>>();
-    cache.clear_failed_tracks(&server_id, &track_ids)
+    let cleared = cache.clear_failed_tracks(&server_id, &track_ids)?;
+    clear_analysis_backfill_failure_state(&server_id, &track_ids);
+    Ok(cleared)
 }
 
 #[tauri::command]

--- a/src-tauri/crates/psysonic-analysis/src/raw_probe.rs
+++ b/src-tauri/crates/psysonic-analysis/src/raw_probe.rs
@@ -54,10 +54,9 @@ pub fn build_original_download_url(stream_url: &str) -> Option<String> {
     let (base, query) = stream_url.split_once('?')?;
     let download_base = if let Some(prefix) = base.strip_suffix("/stream.view") {
         format!("{prefix}/download.view")
-    } else if let Some(prefix) = base.strip_suffix("/stream") {
-        format!("{prefix}/download")
     } else {
-        return None;
+        let prefix = base.strip_suffix("/stream")?;
+        format!("{prefix}/download")
     };
     let params: Vec<&str> = query
         .split('&')

--- a/src-tauri/crates/psysonic-analysis/src/raw_probe.rs
+++ b/src-tauri/crates/psysonic-analysis/src/raw_probe.rs
@@ -8,11 +8,10 @@
 //! yields the same `md5_16kb` fingerprint the untranscoded playback path would
 //! compute, so all bitrate representations resolve to one analysis identity.
 //!
-//! Probe contract: accept the prefix only when the
-//! response is `206 Partial Content`, its `Content-Range` starts at byte zero
-//! and matches the body length, and the body is not a Subsonic JSON/XML error
-//! envelope. On any failure the caller must treat the stream as having NO
-//! trusted identity — playback continues, canonical writes are skipped.
+//! Probe contract: prefer a strict `206 Partial Content` whose `Content-Range`
+//! starts at byte zero. Some reverse proxies strip `Range`; for a verified
+//! Navidrome raw endpoint, a `200 OK` response is consumed only through the
+//! first 16 KiB and then dropped. Error envelopes are never trusted.
 
 use std::time::Duration;
 
@@ -178,40 +177,50 @@ pub async fn fetch_trusted_original_md5(
         .send()
         .await
         .ok()?;
-    // Validate status + Content-Range BEFORE touching the body: a server that
-    // ignored the Range request would otherwise make us buffer the whole file.
     let status = resp.status().as_u16();
     let content_range = resp
         .headers()
         .get("Content-Range")
         .and_then(|v| v.to_str().ok())
         .map(str::to_string);
-    let Some(expected_len) = expected_prefix_len(status, content_range.as_deref()) else {
+    let content_length = resp.content_length();
+    let full_response = status == 200 && content_range.is_none();
+    let target_len = if full_response {
+        content_length
+            .unwrap_or(RAW_PROBE_RANGE_END + 1)
+            .min(RAW_PROBE_RANGE_END + 1) as usize
+    } else if let Some(expected_len) = expected_prefix_len(status, content_range.as_deref()) {
+        expected_len
+    } else {
         crate::app_deprintln!(
-            "[analysis][raw-probe] rejected pre-body status={status} content_range={content_range:?}"
+            "[analysis][raw-probe] rejected pre-body status={status} content_range={content_range:?} content_length={content_length:?}"
         );
         return None;
     };
-    // Stream the body with a hard cap — never trust the headers alone.
-    let mut body: Vec<u8> = Vec::with_capacity(expected_len);
+    if target_len == 0 {
+        return None;
+    }
+    // Never buffer beyond the fingerprint window, including when a proxy
+    // ignored Range and returned the complete original as 200 OK.
+    let mut body: Vec<u8> = Vec::with_capacity(target_len);
     loop {
         match resp.chunk().await {
             Ok(Some(chunk)) => {
-                if body.len() + chunk.len() > expected_len {
-                    crate::app_deprintln!(
-                        "[analysis][raw-probe] rejected: body exceeds advertised range"
-                    );
-                    return None;
+                let remaining = target_len.saturating_sub(body.len());
+                body.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+                if body.len() == target_len {
+                    break;
                 }
-                body.extend_from_slice(&chunk);
             }
             Ok(None) => break,
             Err(_) => return None,
         }
     }
-    if !validate_prefix_body(&body, expected_len) {
+    let valid_len = body.len() == target_len
+        || (full_response && content_length.is_none() && !body.is_empty());
+    if !valid_len || looks_like_subsonic_error(&body) {
         crate::app_deprintln!(
-            "[analysis][raw-probe] rejected body_len={} expected={expected_len}",
+            "[analysis][raw-probe] rejected body_len={} target={target_len}",
             body.len()
         );
         return None;
@@ -245,7 +254,28 @@ pub async fn fetch_trusted_original_bytes(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BoundedStreamFetchError {
     TooLarge { md5_16kb: String },
-    Unavailable,
+    HttpStatus(u16),
+    RequestFailed(String),
+    BodyReadFailed(String),
+    InvalidResponse,
+}
+
+impl BoundedStreamFetchError {
+    pub fn is_permanent_http(&self) -> bool {
+        matches!(self, Self::HttpStatus(status) if (400..500).contains(status) && !matches!(status, 408 | 425 | 429))
+    }
+}
+
+impl std::fmt::Display for BoundedStreamFetchError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooLarge { .. } => formatter.write_str("response exceeds analysis cap"),
+            Self::HttpStatus(status) => write!(formatter, "HTTP {status}"),
+            Self::RequestFailed(message) => write!(formatter, "request failed: {message}"),
+            Self::BodyReadFailed(message) => write!(formatter, "body read failed: {message}"),
+            Self::InvalidResponse => formatter.write_str("invalid or empty response"),
+        }
+    }
 }
 
 /// Fetch one already-constructed stream URL into a bounded buffer. This does
@@ -258,7 +288,7 @@ pub async fn fetch_bounded_stream_bytes(
     max_bytes: usize,
 ) -> Result<Vec<u8>, BoundedStreamFetchError> {
     if max_bytes == 0 {
-        return Err(BoundedStreamFetchError::Unavailable);
+        return Err(BoundedStreamFetchError::InvalidResponse);
     }
     let request =
         apply_optional_registry_headers(registry, server_id, stream_url, client.get(stream_url));
@@ -266,9 +296,13 @@ pub async fn fetch_bounded_stream_bytes(
         .timeout(RAW_FULL_FETCH_TIMEOUT)
         .send()
         .await
-        .map_err(|_| BoundedStreamFetchError::Unavailable)?;
+        .map_err(|error| {
+            BoundedStreamFetchError::RequestFailed(error.without_url().to_string())
+        })?;
     if response.status() != reqwest::StatusCode::OK {
-        return Err(BoundedStreamFetchError::Unavailable);
+        return Err(BoundedStreamFetchError::HttpStatus(
+            response.status().as_u16(),
+        ));
     }
     let content_length = response.content_length();
     let mut too_large = content_length.is_some_and(|length| length > max_bytes as u64);
@@ -296,11 +330,15 @@ pub async fn fetch_bounded_stream_bytes(
                 }
             }
             Ok(None) => break,
-            Err(_) => return Err(BoundedStreamFetchError::Unavailable),
+            Err(error) => {
+                return Err(BoundedStreamFetchError::BodyReadFailed(
+                    error.without_url().to_string(),
+                ));
+            }
         }
     }
     if body.is_empty() || looks_like_subsonic_error(&body) {
-        return Err(BoundedStreamFetchError::Unavailable);
+        return Err(BoundedStreamFetchError::InvalidResponse);
     }
     if too_large {
         return Err(BoundedStreamFetchError::TooLarge {
@@ -321,13 +359,13 @@ pub async fn fetch_trusted_original_bytes_result(
     max_bytes: usize,
 ) -> Result<Vec<u8>, BoundedStreamFetchError> {
     if max_bytes == 0 || trusted_md5_16kb.is_empty() {
-        return Err(BoundedStreamFetchError::Unavailable);
+        return Err(BoundedStreamFetchError::InvalidResponse);
     }
     let raw_url = capability_gated_raw_url(registry, server_id, stream_url)
-        .ok_or(BoundedStreamFetchError::Unavailable)?;
+        .ok_or(BoundedStreamFetchError::InvalidResponse)?;
     let body = fetch_bounded_stream_bytes(client, registry, server_id, &raw_url, max_bytes).await?;
     if !bytes_match_trusted(&body, trusted_md5_16kb) {
-        return Err(BoundedStreamFetchError::Unavailable);
+        return Err(BoundedStreamFetchError::InvalidResponse);
     }
     Ok(body)
 }
@@ -550,7 +588,8 @@ mod tests {
             expected_prefix_len(206, Some("bytes 0-16383/9999999")),
             Some(16384)
         );
-        // 200 = Range ignored → reject BEFORE reading any body.
+        // The strict 206 parser still rejects 200; the HTTP probe handles a
+        // verified raw 200 separately with a hard 16 KiB read cap.
         assert_eq!(
             expected_prefix_len(200, Some("bytes 0-16383/9999999")),
             None
@@ -568,6 +607,15 @@ mod tests {
         assert_eq!(expected_prefix_len(206, Some("bytes 0-16383/*")), None);
         // Missing header entirely.
         assert_eq!(expected_prefix_len(206, None), None);
+    }
+
+    #[test]
+    fn permanent_http_status_classification_excludes_retryable_responses() {
+        assert!(BoundedStreamFetchError::HttpStatus(404).is_permanent_http());
+        assert!(BoundedStreamFetchError::HttpStatus(401).is_permanent_http());
+        assert!(!BoundedStreamFetchError::HttpStatus(408).is_permanent_http());
+        assert!(!BoundedStreamFetchError::HttpStatus(429).is_permanent_http());
+        assert!(!BoundedStreamFetchError::HttpStatus(503).is_permanent_http());
     }
 
     #[test]
@@ -651,12 +699,13 @@ mod http_tests {
     }
 
     #[tokio::test]
-    async fn probe_rejects_a_200_that_ignored_the_range_request() {
-        // Range ignored → whole-file 200. Must be rejected on headers alone.
+    async fn probe_bounds_a_200_that_ignored_the_range_request_to_the_fingerprint_window() {
         let server = MockServer::start().await;
+        let body = prefix(64 * 1024);
         Mock::given(method("GET"))
             .and(path("/rest/stream.view"))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(prefix(64 * 1024)))
+            .and(header("Range", "bytes=0-16383"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
             .mount(&server)
             .await;
         let url = format!("{}/rest/stream.view?id=t1&maxBitRate=128", server.uri());
@@ -668,7 +717,10 @@ mod http_tests {
             &url,
         )
         .await;
-        assert_eq!(got, None);
+        assert_eq!(
+            got,
+            Some(crate::analysis_cache::md5_first_16kb(&body))
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/crates/psysonic-analysis/src/raw_probe.rs
+++ b/src-tauri/crates/psysonic-analysis/src/raw_probe.rs
@@ -133,6 +133,20 @@ impl SubsonicStreamError {
         let message = self.message.to_ascii_lowercase();
         self.code == 70 || message.contains("no such file or directory")
     }
+
+    pub fn diagnostic_reason(&self) -> &'static str {
+        if self
+            .message
+            .to_ascii_lowercase()
+            .contains("no such file or directory")
+        {
+            "no_such_file_or_directory"
+        } else if self.code == 70 {
+            "requested_data_not_found"
+        } else {
+            "subsonic_api_error"
+        }
+    }
 }
 
 fn parse_subsonic_stream_error(body: &[u8]) -> Option<SubsonicStreamError> {
@@ -317,7 +331,7 @@ pub enum BoundedStreamFetchError {
 
 impl BoundedStreamFetchError {
     pub fn is_permanent_http(&self) -> bool {
-        matches!(self, Self::HttpStatus(status) if (400..500).contains(status) && !matches!(status, 408 | 425 | 429))
+        matches!(self, Self::HttpStatus(status) if (400..500).contains(status) && !matches!(status, 401 | 403 | 408 | 425 | 429))
     }
 }
 
@@ -329,8 +343,9 @@ impl std::fmt::Display for BoundedStreamFetchError {
             Self::SubsonicApi(error) => {
                 write!(
                     formatter,
-                    "Subsonic API error {}: {}",
-                    error.code, error.message
+                    "Subsonic API error {} ({})",
+                    error.code,
+                    error.diagnostic_reason(),
                 )
             }
             Self::RequestFailed(message) => write!(formatter, "request failed: {message}"),
@@ -677,7 +692,8 @@ mod tests {
     #[test]
     fn permanent_http_status_classification_excludes_retryable_responses() {
         assert!(BoundedStreamFetchError::HttpStatus(404).is_permanent_http());
-        assert!(BoundedStreamFetchError::HttpStatus(401).is_permanent_http());
+        assert!(!BoundedStreamFetchError::HttpStatus(401).is_permanent_http());
+        assert!(!BoundedStreamFetchError::HttpStatus(403).is_permanent_http());
         assert!(!BoundedStreamFetchError::HttpStatus(408).is_permanent_http());
         assert!(!BoundedStreamFetchError::HttpStatus(429).is_permanent_http());
         assert!(!BoundedStreamFetchError::HttpStatus(503).is_permanent_http());
@@ -694,6 +710,7 @@ mod tests {
             "open /music/a.flac: no such file or directory"
         );
         assert!(error.is_source_unavailable());
+        assert_eq!(error.diagnostic_reason(), "no_such_file_or_directory");
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-analysis/src/raw_probe.rs
+++ b/src-tauri/crates/psysonic-analysis/src/raw_probe.rs
@@ -122,6 +122,40 @@ fn looks_like_subsonic_error(body: &[u8]) -> bool {
     trimmed.starts_with(b"{") || trimmed.starts_with(b"<?xml") || trimmed.starts_with(b"<subsonic")
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubsonicStreamError {
+    pub code: i64,
+    pub message: String,
+}
+
+impl SubsonicStreamError {
+    pub fn is_source_unavailable(&self) -> bool {
+        let message = self.message.to_ascii_lowercase();
+        self.code == 70 || message.contains("no such file or directory")
+    }
+}
+
+fn parse_subsonic_stream_error(body: &[u8]) -> Option<SubsonicStreamError> {
+    let envelope: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let response = envelope.get("subsonic-response")?;
+    let error = response.get("error")?;
+    Some(SubsonicStreamError {
+        code: error.get("code").and_then(|value| value.as_i64()).unwrap_or(-1),
+        message: error
+            .get("message")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string(),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustedOriginalProbeResult {
+    Trusted(String),
+    SubsonicError(SubsonicStreamError),
+    Unavailable,
+}
+
 /// Header-phase validation — runs BEFORE any body bytes are read, so a server
 /// that ignored the Range request (200 with the whole file) is rejected
 /// without buffering it. Returns the exact prefix length the body must have.
@@ -158,25 +192,29 @@ pub fn validate_prefix_body(body: &[u8], expected_len: usize) -> bool {
     body.len() == expected_len && !looks_like_subsonic_error(body)
 }
 
-/// Fetch the original file's first 16 KiB via `format=raw` and fingerprint it.
-/// `None` on any failure — the caller must then skip canonical analysis writes.
-pub async fn fetch_trusted_original_md5(
+/// Fetch the original file's first 16 KiB via `format=raw` and fingerprint it,
+/// preserving structured Subsonic errors for background analysis handling.
+pub async fn probe_trusted_original_md5(
     client: &reqwest::Client,
     registry: Option<&ServerHttpRegistry>,
     server_id: Option<&str>,
     stream_url: &str,
-) -> Option<String> {
-    let probe_url = capability_gated_raw_url(registry, server_id, stream_url)?;
+) -> TrustedOriginalProbeResult {
+    let Some(probe_url) = capability_gated_raw_url(registry, server_id, stream_url) else {
+        return TrustedOriginalProbeResult::Unavailable;
+    };
     // Same reverse-proxy gate headers as playback itself — a probe through
     // Pangolin/Cloudflare Access must not 403 while the stream succeeds.
     let req =
         apply_optional_registry_headers(registry, server_id, &probe_url, client.get(&probe_url));
-    let mut resp = req
+    let Ok(mut resp) = req
         .header("Range", format!("bytes=0-{RAW_PROBE_RANGE_END}"))
         .timeout(RAW_PROBE_TIMEOUT)
         .send()
         .await
-        .ok()?;
+    else {
+        return TrustedOriginalProbeResult::Unavailable;
+    };
     let status = resp.status().as_u16();
     let content_range = resp
         .headers()
@@ -195,10 +233,10 @@ pub async fn fetch_trusted_original_md5(
         crate::app_deprintln!(
             "[analysis][raw-probe] rejected pre-body status={status} content_range={content_range:?} content_length={content_length:?}"
         );
-        return None;
+        return TrustedOriginalProbeResult::Unavailable;
     };
     if target_len == 0 {
-        return None;
+        return TrustedOriginalProbeResult::Unavailable;
     }
     // Never buffer beyond the fingerprint window, including when a proxy
     // ignored Range and returned the complete original as 200 OK.
@@ -213,19 +251,35 @@ pub async fn fetch_trusted_original_md5(
                 }
             }
             Ok(None) => break,
-            Err(_) => return None,
+            Err(_) => return TrustedOriginalProbeResult::Unavailable,
         }
     }
     let valid_len = body.len() == target_len
         || (full_response && content_length.is_none() && !body.is_empty());
+    if let Some(error) = parse_subsonic_stream_error(&body) {
+        return TrustedOriginalProbeResult::SubsonicError(error);
+    }
     if !valid_len || looks_like_subsonic_error(&body) {
         crate::app_deprintln!(
             "[analysis][raw-probe] rejected body_len={} target={target_len}",
             body.len()
         );
-        return None;
+        return TrustedOriginalProbeResult::Unavailable;
     }
-    Some(crate::analysis_cache::md5_first_16kb(&body))
+    TrustedOriginalProbeResult::Trusted(crate::analysis_cache::md5_first_16kb(&body))
+}
+
+pub async fn fetch_trusted_original_md5(
+    client: &reqwest::Client,
+    registry: Option<&ServerHttpRegistry>,
+    server_id: Option<&str>,
+    stream_url: &str,
+) -> Option<String> {
+    match probe_trusted_original_md5(client, registry, server_id, stream_url).await {
+        TrustedOriginalProbeResult::Trusted(hash) => Some(hash),
+        TrustedOriginalProbeResult::SubsonicError(_)
+        | TrustedOriginalProbeResult::Unavailable => None,
+    }
 }
 
 /// Fetch the complete verified original through `format=raw`, bounded by the
@@ -255,6 +309,7 @@ pub async fn fetch_trusted_original_bytes(
 pub enum BoundedStreamFetchError {
     TooLarge { md5_16kb: String },
     HttpStatus(u16),
+    SubsonicApi(SubsonicStreamError),
     RequestFailed(String),
     BodyReadFailed(String),
     InvalidResponse,
@@ -271,6 +326,13 @@ impl std::fmt::Display for BoundedStreamFetchError {
         match self {
             Self::TooLarge { .. } => formatter.write_str("response exceeds analysis cap"),
             Self::HttpStatus(status) => write!(formatter, "HTTP {status}"),
+            Self::SubsonicApi(error) => {
+                write!(
+                    formatter,
+                    "Subsonic API error {}: {}",
+                    error.code, error.message
+                )
+            }
             Self::RequestFailed(message) => write!(formatter, "request failed: {message}"),
             Self::BodyReadFailed(message) => write!(formatter, "body read failed: {message}"),
             Self::InvalidResponse => formatter.write_str("invalid or empty response"),
@@ -336,6 +398,9 @@ pub async fn fetch_bounded_stream_bytes(
                 ));
             }
         }
+    }
+    if let Some(error) = parse_subsonic_stream_error(&body) {
+        return Err(BoundedStreamFetchError::SubsonicApi(error));
     }
     if body.is_empty() || looks_like_subsonic_error(&body) {
         return Err(BoundedStreamFetchError::InvalidResponse);
@@ -619,6 +684,19 @@ mod tests {
     }
 
     #[test]
+    fn subsonic_missing_source_error_preserves_code_and_reason() {
+        let body = br#"{"subsonic-response":{"status":"failed","error":{"code":0,"message":"open /music/a.flac: no such file or directory"}}}"#;
+        let error = parse_subsonic_stream_error(body).unwrap();
+
+        assert_eq!(error.code, 0);
+        assert_eq!(
+            error.message,
+            "open /music/a.flac: no such file or directory"
+        );
+        assert!(error.is_source_unavailable());
+    }
+
+    #[test]
     fn short_files_use_their_full_size_and_bodies_must_match_exactly() {
         // File smaller than the probe window: exact "0-(size-1)/size" accepted.
         assert_eq!(expected_prefix_len(206, Some("bytes 0-511/512")), Some(512));
@@ -749,6 +827,36 @@ mod http_tests {
         )
         .await;
         assert_eq!(got, None);
+    }
+
+    #[tokio::test]
+    async fn detailed_probe_returns_the_subsonic_error_reason() {
+        let server = MockServer::start().await;
+        let err = br#"{"subsonic-response":{"status":"failed","error":{"code":0,"message":"open /music/a.flac: no such file or directory"}}}"#.to_vec();
+        Mock::given(method("GET"))
+            .and(path("/rest/stream.view"))
+            .and(query_param("format", "raw"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(err))
+            .mount(&server)
+            .await;
+        let url = format!("{}/rest/stream.view?id=missing", server.uri());
+        let registry = registry_for(&server.uri());
+
+        let result = probe_trusted_original_md5(
+            &reqwest::Client::new(),
+            Some(&registry),
+            Some("server-key"),
+            &url,
+        )
+        .await;
+
+        assert_eq!(
+            result,
+            TrustedOriginalProbeResult::SubsonicError(SubsonicStreamError {
+                code: 0,
+                message: "open /music/a.flac: no such file or directory".to_string(),
+            })
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/crates/psysonic-analysis/src/raw_probe.rs
+++ b/src-tauri/crates/psysonic-analysis/src/raw_probe.rs
@@ -46,6 +46,30 @@ pub fn build_raw_probe_url(stream_url: &str) -> Option<String> {
     Some(format!("{base}?{}", params.join("&")))
 }
 
+/// Rebuild a `stream.view` URL as the standard Subsonic original-download
+/// endpoint, retaining track/auth parameters but removing transcode controls.
+pub fn build_original_download_url(stream_url: &str) -> Option<String> {
+    if !stream_url.starts_with("http://") && !stream_url.starts_with("https://") {
+        return None;
+    }
+    let (base, query) = stream_url.split_once('?')?;
+    let download_base = if let Some(prefix) = base.strip_suffix("/stream.view") {
+        format!("{prefix}/download.view")
+    } else if let Some(prefix) = base.strip_suffix("/stream") {
+        format!("{prefix}/download")
+    } else {
+        return None;
+    };
+    let params: Vec<&str> = query
+        .split('&')
+        .filter(|kv| {
+            let key = kv.split('=').next().unwrap_or("");
+            !matches!(key, "maxBitRate" | "format" | "estimateContentLength")
+        })
+        .collect();
+    Some(format!("{download_base}?{}", params.join("&")))
+}
+
 /// Whether the request endpoint belongs to a registered profile whose current
 /// saved identity explicitly supports Navidrome's `format=raw` contract.
 pub fn raw_stream_supported(
@@ -53,9 +77,7 @@ pub fn raw_stream_supported(
     server_id: Option<&str>,
     stream_url: &str,
 ) -> bool {
-    registry.is_some_and(|registry| {
-        registry.supports_raw_stream_for_request(server_id, stream_url)
-    })
+    registry.is_some_and(|registry| registry.supports_raw_stream_for_request(server_id, stream_url))
 }
 
 /// Whether this exact request is the capability-bound Navidrome raw-original
@@ -148,12 +170,8 @@ pub async fn fetch_trusted_original_md5(
     let probe_url = capability_gated_raw_url(registry, server_id, stream_url)?;
     // Same reverse-proxy gate headers as playback itself — a probe through
     // Pangolin/Cloudflare Access must not 403 while the stream succeeds.
-    let req = apply_optional_registry_headers(
-        registry,
-        server_id,
-        &probe_url,
-        client.get(&probe_url),
-    );
+    let req =
+        apply_optional_registry_headers(registry, server_id, &probe_url, client.get(&probe_url));
     let mut resp = req
         .header("Range", format!("bytes=0-{RAW_PROBE_RANGE_END}"))
         .timeout(RAW_PROBE_TIMEOUT)
@@ -212,56 +230,107 @@ pub async fn fetch_trusted_original_bytes(
     trusted_md5_16kb: &str,
     max_bytes: usize,
 ) -> Option<Vec<u8>> {
-    if max_bytes == 0 || trusted_md5_16kb.is_empty() {
-        return None;
-    }
-    let raw_url = capability_gated_raw_url(registry, server_id, stream_url)?;
-    let request = apply_optional_registry_headers(
+    fetch_trusted_original_bytes_result(
+        client,
         registry,
         server_id,
-        &raw_url,
-        client.get(&raw_url),
-    );
+        stream_url,
+        trusted_md5_16kb,
+        max_bytes,
+    )
+    .await
+    .ok()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoundedStreamFetchError {
+    TooLarge { md5_16kb: String },
+    Unavailable,
+}
+
+/// Fetch one already-constructed stream URL into a bounded buffer. This does
+/// not establish content identity; callers must do that independently.
+pub async fn fetch_bounded_stream_bytes(
+    client: &reqwest::Client,
+    registry: Option<&ServerHttpRegistry>,
+    server_id: Option<&str>,
+    stream_url: &str,
+    max_bytes: usize,
+) -> Result<Vec<u8>, BoundedStreamFetchError> {
+    if max_bytes == 0 {
+        return Err(BoundedStreamFetchError::Unavailable);
+    }
+    let request =
+        apply_optional_registry_headers(registry, server_id, stream_url, client.get(stream_url));
     let mut response = request
         .timeout(RAW_FULL_FETCH_TIMEOUT)
         .send()
         .await
-        .ok()?;
-    if response.status() != reqwest::StatusCode::OK
-        || response
-            .content_length()
-            .is_some_and(|length| length > max_bytes as u64)
-    {
-        return None;
+        .map_err(|_| BoundedStreamFetchError::Unavailable)?;
+    if response.status() != reqwest::StatusCode::OK {
+        return Err(BoundedStreamFetchError::Unavailable);
     }
-
-    let mut body = Vec::with_capacity(
-        response
-            .content_length()
-            .unwrap_or(0)
-            .min(max_bytes as u64) as usize,
-    );
+    let content_length = response.content_length();
+    let mut too_large = content_length.is_some_and(|length| length > max_bytes as u64);
+    let fingerprint_len = RAW_PROBE_RANGE_END as usize + 1;
+    let initial_capacity = if too_large {
+        fingerprint_len
+    } else {
+        content_length.unwrap_or(0).min(max_bytes as u64) as usize
+    };
+    let mut body = Vec::with_capacity(initial_capacity);
     loop {
         match response.chunk().await {
             Ok(Some(chunk)) => {
-                if body.len().saturating_add(chunk.len()) > max_bytes {
-                    return None;
+                if !too_large && body.len().saturating_add(chunk.len()) > max_bytes {
+                    too_large = true;
                 }
-                body.extend_from_slice(&chunk);
+                if too_large {
+                    let remaining = fingerprint_len.saturating_sub(body.len());
+                    body.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+                    if body.len() >= fingerprint_len {
+                        break;
+                    }
+                } else {
+                    body.extend_from_slice(&chunk);
+                }
             }
             Ok(None) => break,
-            Err(_) => return None,
+            Err(_) => return Err(BoundedStreamFetchError::Unavailable),
         }
     }
-    if body.is_empty()
-        || looks_like_subsonic_error(&body)
-        || !bytes_match_trusted(&body, trusted_md5_16kb)
-    {
-        return None;
+    if body.is_empty() || looks_like_subsonic_error(&body) {
+        return Err(BoundedStreamFetchError::Unavailable);
     }
-    Some(body)
+    if too_large {
+        return Err(BoundedStreamFetchError::TooLarge {
+            md5_16kb: crate::analysis_cache::md5_first_16kb(&body),
+        });
+    }
+    Ok(body)
 }
 
+/// Detailed variant for background jobs that must distinguish a permanent
+/// full-buffer size rejection from a transient HTTP/provenance failure.
+pub async fn fetch_trusted_original_bytes_result(
+    client: &reqwest::Client,
+    registry: Option<&ServerHttpRegistry>,
+    server_id: Option<&str>,
+    stream_url: &str,
+    trusted_md5_16kb: &str,
+    max_bytes: usize,
+) -> Result<Vec<u8>, BoundedStreamFetchError> {
+    if max_bytes == 0 || trusted_md5_16kb.is_empty() {
+        return Err(BoundedStreamFetchError::Unavailable);
+    }
+    let raw_url = capability_gated_raw_url(registry, server_id, stream_url)
+        .ok_or(BoundedStreamFetchError::Unavailable)?;
+    let body = fetch_bounded_stream_bytes(client, registry, server_id, &raw_url, max_bytes).await?;
+    if !bytes_match_trusted(&body, trusted_md5_16kb) {
+        return Err(BoundedStreamFetchError::Unavailable);
+    }
+    Ok(body)
+}
 
 /// Whether captured stream bytes ARE the verified original: their own 16 KiB
 /// fingerprint equals the trusted one. Used to gate stream-to-local promotion
@@ -318,8 +387,8 @@ mod byte_match_tests {
 mod capability_tests {
     use super::*;
     use psysonic_core::server_http::{
-        CustomHeaderEntryWire, CustomHeadersApplyTo, EndpointKind,
-        ServerHttpContextSyncWire, ServerHttpEndpointWire,
+        CustomHeaderEntryWire, CustomHeadersApplyTo, EndpointKind, ServerHttpContextSyncWire,
+        ServerHttpEndpointWire,
     };
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -356,7 +425,10 @@ mod capability_tests {
         let url = format!("{}/rest/stream.view?id=t1", server.uri());
         let registry = registry_for(&server.uri(), true);
         let got = resolve_trusted_identity(
-            &reqwest::Client::new(), Some(&registry), Some("server-key"), &url,
+            &reqwest::Client::new(),
+            Some(&registry),
+            Some("server-key"),
+            &url,
         )
         .await;
         assert_eq!(got, TrustedProbeVerdict::SkipCanonicalWrites);
@@ -372,10 +444,8 @@ mod capability_tests {
             .await;
         let url = format!("{}/rest/stream.view?id=t1", server.uri());
 
-        let unknown = resolve_trusted_identity(
-            &reqwest::Client::new(), None, Some("server-key"), &url,
-        )
-        .await;
+        let unknown =
+            resolve_trusted_identity(&reqwest::Client::new(), None, Some("server-key"), &url).await;
         let unsupported_registry = registry_for(&server.uri(), false);
         let unsupported = resolve_trusted_identity(
             &reqwest::Client::new(),
@@ -414,8 +484,27 @@ mod tests {
 
     #[test]
     fn probe_url_rejects_local_and_non_stream_urls() {
-        assert_eq!(build_raw_probe_url("psysonic-local:///library/t.flac"), None);
-        assert_eq!(build_raw_probe_url("https://s.example/rest/getCoverArt.view?id=c"), None);
+        assert_eq!(
+            build_raw_probe_url("psysonic-local:///library/t.flac"),
+            None
+        );
+        assert_eq!(
+            build_raw_probe_url("https://s.example/rest/getCoverArt.view?id=c"),
+            None
+        );
+    }
+
+    #[test]
+    fn original_download_url_replaces_endpoint_and_strips_transcode_params() {
+        let url = "https://s.example/rest/stream.view?id=t1&u=a&t=tok&format=mp3&maxBitRate=64&estimateContentLength=true";
+        let download = build_original_download_url(url).unwrap();
+        assert!(download.starts_with("https://s.example/rest/download.view?"));
+        assert!(download.contains("id=t1"));
+        assert!(download.contains("u=a"));
+        assert!(download.contains("t=tok"));
+        assert!(!download.contains("format="));
+        assert!(!download.contains("maxBitRate="));
+        assert!(!download.contains("estimateContentLength="));
     }
 
     #[test]
@@ -457,11 +546,20 @@ mod tests {
     #[test]
     fn header_validation_requires_206_zero_start_and_exact_window() {
         // Full window on a large file.
-        assert_eq!(expected_prefix_len(206, Some("bytes 0-16383/9999999")), Some(16384));
+        assert_eq!(
+            expected_prefix_len(206, Some("bytes 0-16383/9999999")),
+            Some(16384)
+        );
         // 200 = Range ignored → reject BEFORE reading any body.
-        assert_eq!(expected_prefix_len(200, Some("bytes 0-16383/9999999")), None);
+        assert_eq!(
+            expected_prefix_len(200, Some("bytes 0-16383/9999999")),
+            None
+        );
         // Range not starting at zero.
-        assert_eq!(expected_prefix_len(206, Some("bytes 100-16483/9999999")), None);
+        assert_eq!(
+            expected_prefix_len(206, Some("bytes 100-16483/9999999")),
+            None
+        );
         // Truncated prefix of a large file — wrong fingerprint window.
         assert_eq!(expected_prefix_len(206, Some("bytes 0-999/9999999")), None);
         // Range end past the advertised total (inconsistent).
@@ -492,8 +590,8 @@ mod tests {
 mod http_tests {
     use super::*;
     use psysonic_core::server_http::{
-        CustomHeaderEntryWire, CustomHeadersApplyTo, EndpointKind,
-        ServerHttpContextSyncWire, ServerHttpEndpointWire,
+        CustomHeaderEntryWire, CustomHeadersApplyTo, EndpointKind, ServerHttpContextSyncWire,
+        ServerHttpEndpointWire,
     };
     use wiremock::matchers::{header, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -628,7 +726,7 @@ mod http_tests {
         .await;
         assert_eq!(fetched.as_deref(), Some(original.as_slice()));
 
-        let oversized = fetch_trusted_original_bytes(
+        let oversized = fetch_trusted_original_bytes_result(
             &reqwest::Client::new(),
             Some(&registry),
             Some("server-key"),
@@ -637,7 +735,12 @@ mod http_tests {
             original.len() - 1,
         )
         .await;
-        assert_eq!(oversized, None);
+        assert_eq!(
+            oversized,
+            Err(BoundedStreamFetchError::TooLarge {
+                md5_16kb: trusted.clone(),
+            })
+        );
 
         let wrong_prefix = fetch_trusted_original_bytes(
             &reqwest::Client::new(),
@@ -671,6 +774,9 @@ mod http_tests {
             original.len(),
         )
         .await;
-        assert_eq!(partial, None, "partial responses are not complete originals");
+        assert_eq!(
+            partial, None,
+            "partial responses are not complete originals"
+        );
     }
 }

--- a/src-tauri/crates/psysonic-analysis/src/track_analysis_plan.rs
+++ b/src-tauri/crates/psysonic-analysis/src/track_analysis_plan.rs
@@ -5,12 +5,12 @@
 
 use psysonic_core::track_analysis::TrackAnalysisPlan;
 use psysonic_core::track_enrichment::TrackEnrichmentPort;
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Manager, Runtime};
 
 use crate::analysis_cache::{AnalysisCache, TrackKey};
 
-pub fn plan_track_analysis(
-    app: &AppHandle,
+pub fn plan_track_analysis<R: Runtime>(
+    app: &AppHandle<R>,
     server_id: &str,
     track_id: &str,
     content_hash: &str,
@@ -20,8 +20,8 @@ pub fn plan_track_analysis(
 
 /// Offline/library download: waveform cache and enrichment facts may live under the
 /// playback index key while library rows use the UUID — try every scope before seeding.
-pub fn plan_track_analysis_offline_library(
-    app: &AppHandle,
+pub fn plan_track_analysis_offline_library<R: Runtime>(
+    app: &AppHandle<R>,
     cache_server_ids: &[&str],
     _enrichment_server_id: &str,
     track_id: &str,
@@ -38,8 +38,8 @@ pub fn plan_track_analysis_offline_library(
 }
 
 /// Plan from the latest cached fingerprint when bytes are not available yet (HTTP backfill gate).
-pub fn plan_track_analysis_from_cache(
-    app: &AppHandle,
+pub fn plan_track_analysis_from_cache<R: Runtime>(
+    app: &AppHandle<R>,
     server_id: &str,
     track_id: &str,
 ) -> Result<TrackAnalysisPlan, String> {
@@ -60,8 +60,8 @@ pub fn plan_track_analysis_from_cache(
     Ok(plan_track_analysis(app, server_id, track_id, &md5))
 }
 
-pub fn track_analysis_needs_work(
-    app: &AppHandle,
+pub fn track_analysis_needs_work<R: Runtime>(
+    app: &AppHandle<R>,
     server_id: &str,
     track_id: &str,
 ) -> Result<bool, String> {
@@ -102,8 +102,8 @@ pub fn track_analysis_needs_work(
     Ok(plan_track_analysis_from_cache(app, server_id, track_id)?.any())
 }
 
-fn cache_gaps(
-    app: &AppHandle,
+fn cache_gaps<R: Runtime>(
+    app: &AppHandle<R>,
     server_id: &str,
     track_id: &str,
     content_hash: &str,
@@ -116,8 +116,8 @@ fn cache_gaps(
     )
 }
 
-fn cache_gaps_multi(
-    app: &AppHandle,
+fn cache_gaps_multi<R: Runtime>(
+    app: &AppHandle<R>,
     server_ids: &[&str],
     track_id: &str,
     content_hash: &str,
@@ -142,8 +142,8 @@ fn cache_gaps_multi(
     (need_waveform, need_loudness)
 }
 
-fn enrichment_plan(
-    app: &AppHandle,
+fn enrichment_plan<R: Runtime>(
+    app: &AppHandle<R>,
     server_id: &str,
     track_id: &str,
     content_hash: &str,
@@ -156,8 +156,8 @@ fn enrichment_plan(
         .unwrap_or_default()
 }
 
-fn enrichment_plan_multi(
-    app: &AppHandle,
+fn enrichment_plan_multi<R: Runtime>(
+    app: &AppHandle<R>,
     server_ids: &[&str],
     track_id: &str,
     content_hash: &str,

--- a/src-tauri/crates/psysonic-analysis/src/track_enrichment.rs
+++ b/src-tauri/crates/psysonic-analysis/src/track_enrichment.rs
@@ -2,8 +2,8 @@
 
 use oximedia_mir::{mood, tempo, MirConfig};
 use psysonic_core::track_enrichment::{
-    TrackEnrichmentFacts, TrackEnrichmentIntFact, TrackEnrichmentOutcome, TrackEnrichmentPort,
-    TrackEnrichmentPlan, TrackEnrichmentRealFact,
+    TrackEnrichmentFacts, TrackEnrichmentIntFact, TrackEnrichmentOutcome, TrackEnrichmentPlan,
+    TrackEnrichmentPort, TrackEnrichmentRealFact,
 };
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 
@@ -44,8 +44,8 @@ pub fn run_track_enrichment_if_needed<R: Runtime>(
     let Some(port) = app.try_state::<TrackEnrichmentPort>() else {
         return TrackEnrichmentOutcome::SkippedNoPort;
     };
-    // Trusted original bytes carry their verified fingerprint so facts stay
-    // keyed/current against the same canonical file revision.
+    // A trusted identity comes from the original bytes or the separate raw
+    // prefix probe used by bounded background transcodes.
     let content_hash = trusted_md5_16kb
         .map(str::to_string)
         .unwrap_or_else(|| md5_first_16kb(bytes));
@@ -89,8 +89,7 @@ fn analyze_and_store(
 ) -> Result<(), String> {
     let total_duration = audio_duration_from_bytes(bytes).unwrap_or(0.0);
     let window = analysis_pcm_window(total_duration, ENRICHMENT_WINDOW_SEC);
-    let (mono, sample_rate) =
-        decode_mono_pcm_window(bytes, window.start_sec, window.duration_sec)?;
+    let (mono, sample_rate) = decode_mono_pcm_window(bytes, window.start_sec, window.duration_sec)?;
     if mono.is_empty() || sample_rate <= 0.0 {
         return Err("empty PCM window".to_string());
     }
@@ -125,9 +124,8 @@ fn analyze_and_store(
             });
         }
         if plan.need_moods && !mood.moods.is_empty() {
-            facts.moods = Some(
-                serde_json::to_string(&mood.moods).map_err(|e| format!("moods json: {e}"))?,
-            );
+            facts.moods =
+                Some(serde_json::to_string(&mood.moods).map_err(|e| format!("moods json: {e}"))?);
         }
     }
 

--- a/src-tauri/crates/psysonic-analysis/src/track_enrichment.rs
+++ b/src-tauri/crates/psysonic-analysis/src/track_enrichment.rs
@@ -36,6 +36,7 @@ pub fn run_track_enrichment_if_needed<R: Runtime>(
     track_id: &str,
     bytes: &[u8],
     trusted_md5_16kb: Option<&str>,
+    trusted_guard: Option<(&str, u64)>,
     notify_ui: bool,
 ) -> TrackEnrichmentOutcome {
     if server_id.is_empty() {
@@ -54,8 +55,16 @@ pub fn run_track_enrichment_if_needed<R: Runtime>(
         return TrackEnrichmentOutcome::SkippedComplete;
     }
 
-    match analyze_and_store(&port, server_id, track_id, &content_hash, bytes, plan) {
-        Ok(()) => {
+    match analyze_and_store(
+        &port,
+        server_id,
+        track_id,
+        &content_hash,
+        bytes,
+        plan,
+        trusted_guard,
+    ) {
+        Ok(true) => {
             crate::app_deprintln!(
                 "[analysis][enrichment] applied track_id={} server_id={} hash={}",
                 track_id,
@@ -66,6 +75,15 @@ pub fn run_track_enrichment_if_needed<R: Runtime>(
                 emit_enrichment_updated(app, server_id, track_id);
             }
             TrackEnrichmentOutcome::Applied
+        }
+        Ok(false) => {
+            crate::app_deprintln!(
+                "[analysis][enrichment] skipped stale track_id={} server_id={} hash={}",
+                track_id,
+                server_id,
+                content_hash
+            );
+            TrackEnrichmentOutcome::SkippedSuperseded
         }
         Err(e) => {
             crate::app_eprintln!(
@@ -86,7 +104,8 @@ fn analyze_and_store(
     content_hash: &str,
     bytes: &[u8],
     plan: TrackEnrichmentPlan,
-) -> Result<(), String> {
+    trusted_guard: Option<(&str, u64)>,
+) -> Result<bool, String> {
     let total_duration = audio_duration_from_bytes(bytes).unwrap_or(0.0);
     let window = analysis_pcm_window(total_duration, ENRICHMENT_WINDOW_SEC);
     let (mono, sample_rate) = decode_mono_pcm_window(bytes, window.start_sec, window.duration_sec)?;
@@ -129,5 +148,19 @@ fn analyze_and_store(
         }
     }
 
-    port.store(server_id, track_id, content_hash, &facts)
+    if let Some((guard_server_id, generation)) = trusted_guard {
+        let Some(result) = crate::analysis_runtime::commit_trusted_enrichment_if_current(
+            guard_server_id,
+            track_id,
+            content_hash,
+            generation,
+            || port.store(server_id, track_id, content_hash, &facts),
+        ) else {
+            return Ok(false);
+        };
+        result?;
+        return Ok(true);
+    }
+    port.store(server_id, track_id, content_hash, &facts)?;
+    Ok(true)
 }

--- a/src-tauri/crates/psysonic-audio/src/analysis_dispatch.rs
+++ b/src-tauri/crates/psysonic-audio/src/analysis_dispatch.rs
@@ -3,6 +3,7 @@
 //! Stream completion, hot/offline files, gapless chain, preload, and in-memory
 //! replay all funnel through here before [`psysonic_analysis::analysis_runtime::enqueue_track_analysis`].
 
+use std::io::Read;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -16,7 +17,9 @@ use psysonic_analysis::analysis_runtime::AnalysisBackfillPriority;
 use crate::engine::{analysis_track_id_is_current_playback, AudioEngine};
 use crate::helpers::{analysis_cache_track_id, current_playback_server_id_str};
 use crate::state::ChainedInfo;
-use crate::stream::{LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES, TRACK_STREAM_PROMOTE_MAX_BYTES};
+use crate::stream::{
+    AnalysisSeedHoldGuard, LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES, TRACK_STREAM_PROMOTE_MAX_BYTES,
+};
 
 /// Where playback obtained the bytes — used for logging and size caps only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,6 +54,11 @@ struct StreamProvenanceEvent {
 
 pub(crate) type GenerationGuard = (u64, Arc<AtomicU64>);
 
+pub(crate) struct PreparedTrackAnalysisFile {
+    file: std::fs::File,
+    file_len: u64,
+}
+
 pub(crate) struct TrackAnalysisDispatchOptions<'a> {
     pub(crate) priority: AnalysisBackfillPriority,
     pub(crate) generation_guard: Option<&'a GenerationGuard>,
@@ -72,6 +80,14 @@ fn live_capture_origin(origin: TrackAnalysisOrigin) -> bool {
 
 fn generation_guard_is_current(guard: &GenerationGuard) -> bool {
     guard.1.load(Ordering::SeqCst) == guard.0
+}
+
+fn generation_guard_allows_analysis(
+    origin: TrackAnalysisOrigin,
+    generation_guard: Option<&GenerationGuard>,
+) -> bool {
+    matches!(origin, TrackAnalysisOrigin::StreamSpillFile)
+        || generation_guard.is_none_or(generation_guard_is_current)
 }
 
 fn provenance_event_generation(
@@ -111,9 +127,15 @@ pub(crate) fn emit_stream_provenance_if_current(
 
 fn max_bytes_for_dispatch(origin: TrackAnalysisOrigin) -> usize {
     match origin {
-        TrackAnalysisOrigin::LocalFilePlayback => LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES,
+        TrackAnalysisOrigin::LocalFilePlayback | TrackAnalysisOrigin::StreamSpillFile => {
+            LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES
+        }
         _ => TRACK_STREAM_PROMOTE_MAX_BYTES,
     }
+}
+
+fn max_http_fetch_bytes_for_dispatch() -> usize {
+    TRACK_STREAM_PROMOTE_MAX_BYTES
 }
 
 /// Playback server scope: explicit IPC value, else pinned engine scope.
@@ -249,6 +271,7 @@ pub(crate) fn spawn_gapless_transition_analysis(app: &AppHandle, info: &ChainedI
         Some(info.url.clone()),
         priority,
         Some((info.generation, engine.generation.clone())),
+        None,
     );
 }
 
@@ -349,9 +372,7 @@ pub(crate) async fn dispatch_track_analysis_bytes(
         match verdict {
             TrustedProbeVerdict::Trusted(trusted) => {
                 let provenance = provenance_from_trusted_bytes(&bytes, &trusted);
-                if generation_guard
-                    .is_some_and(|guard| !generation_guard_is_current(guard))
-                {
+                if !generation_guard_allows_analysis(origin, generation_guard) {
                     return Ok(provenance);
                 }
                 let trusted_generation =
@@ -425,23 +446,31 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                         return Ok(provenance);
                     }
                     trusted_fetch_permit = Some(permit);
-                    let Some(original) =
-                        psysonic_analysis::raw_probe::fetch_trusted_original_bytes(
+                    match psysonic_analysis::raw_probe::fetch_trusted_original_bytes(
                             &client,
                             registry.as_deref(),
                             Some(server_id).filter(|s| !s.is_empty()),
                             stream_url.unwrap_or_default(),
                             &trusted,
-                            max,
+                            max_http_fetch_bytes_for_dispatch(),
                         )
                         .await
-                    else {
-                        crate::app_deprintln!(
-                            "[analysis][dispatch] skip origin={origin:?} track_id={track_id}: raw original unavailable or exceeds cap"
-                        );
-                        return Ok(provenance);
-                    };
-                    (original, false)
+                    {
+                        Some(original) => (original, false),
+                        None => {
+                            if bytes.len() > max {
+                                crate::app_deprintln!(
+                                    "[analysis][dispatch] skip captured transcode origin={origin:?} track_id={track_id} bytes={} max={max}",
+                                    bytes.len(),
+                                );
+                                return Ok(provenance);
+                            }
+                            crate::app_deprintln!(
+                                "[analysis][dispatch] raw original unavailable or exceeds HTTP cap; analyzing captured transcode track_id={track_id}"
+                            );
+                            (bytes, true)
+                        }
+                    }
                 };
                 let result = psysonic_analysis::analysis_runtime::enqueue_track_analysis_trusted_owned(
                     app,
@@ -508,15 +537,14 @@ pub(crate) fn spawn_track_analysis_bytes(
     stream_url: Option<String>,
     priority: AnalysisBackfillPriority,
     generation_guard: Option<GenerationGuard>,
+    analysis_seed_hold: Option<AnalysisSeedHoldGuard>,
 ) {
     if track_id.trim().is_empty() || bytes.is_empty() {
         return;
     }
     tokio::spawn(async move {
-        if generation_guard
-            .as_ref()
-            .is_some_and(|guard| !generation_guard_is_current(guard))
-        {
+        let _analysis_seed_hold = analysis_seed_hold;
+        if !generation_guard_allows_analysis(origin, generation_guard.as_ref()) {
             return;
         }
         match dispatch_track_analysis_bytes(
@@ -556,36 +584,106 @@ pub(crate) fn spawn_track_analysis_file(
     stream_url: Option<String>,
     priority: AnalysisBackfillPriority,
     generation_guard: Option<GenerationGuard>,
+    analysis_seed_hold: Option<AnalysisSeedHoldGuard>,
 ) {
     if track_id.trim().is_empty() {
         return;
     }
-    tokio::spawn(async move {
-        if generation_guard
-            .as_ref()
-            .is_some_and(|guard| !generation_guard_is_current(guard))
-        {
-            return;
-        }
-        let max = max_bytes_for_dispatch(origin);
-        let file_len = match tokio::fs::metadata(&file_path).await {
-            Ok(metadata) => metadata.len(),
-            Err(_) => return,
-        };
-        if file_len > max as u64 {
-            crate::app_deprintln!(
-                "[analysis][dispatch] skip file origin={origin:?} track_id={track_id} bytes={file_len} max={max}"
+    if !generation_guard_allows_analysis(origin, generation_guard.as_ref()) {
+        return;
+    }
+    let Some(prepared_file) = prepare_track_analysis_file(origin, &track_id, &file_path) else {
+        return;
+    };
+    spawn_track_analysis_prepared_file(
+        app,
+        origin,
+        server_id,
+        track_id,
+        prepared_file,
+        stream_url,
+        priority,
+        generation_guard,
+        analysis_seed_hold,
+    );
+}
+
+pub(crate) fn prepare_track_analysis_file(
+    origin: TrackAnalysisOrigin,
+    track_id: &str,
+    file_path: &std::path::Path,
+) -> Option<PreparedTrackAnalysisFile> {
+    let max = max_bytes_for_dispatch(origin);
+    let file = match std::fs::File::open(file_path) {
+        Ok(file) => file,
+        Err(error) => {
+            crate::app_eprintln!(
+                "[analysis][dispatch] open file failed origin={origin:?} track_id={track_id}: {error}"
             );
+            return None;
+        }
+    };
+    let file_len = match file.metadata() {
+        Ok(metadata) => metadata.len(),
+        Err(error) => {
+            crate::app_eprintln!(
+                "[analysis][dispatch] file metadata failed origin={origin:?} track_id={track_id}: {error}"
+            );
+            return None;
+        }
+    };
+    if file_len > max as u64 {
+        crate::app_deprintln!(
+            "[analysis][dispatch] skip file origin={origin:?} track_id={track_id} bytes={file_len} max={max}"
+        );
+        return None;
+    }
+    Some(PreparedTrackAnalysisFile { file, file_len })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn spawn_track_analysis_prepared_file(
+    app: AppHandle,
+    origin: TrackAnalysisOrigin,
+    server_id: String,
+    track_id: String,
+    prepared_file: PreparedTrackAnalysisFile,
+    stream_url: Option<String>,
+    priority: AnalysisBackfillPriority,
+    generation_guard: Option<GenerationGuard>,
+    analysis_seed_hold: Option<AnalysisSeedHoldGuard>,
+) {
+    let PreparedTrackAnalysisFile { file, file_len } = prepared_file;
+    tokio::spawn(async move {
+        let _analysis_seed_hold = analysis_seed_hold;
+        if !generation_guard_allows_analysis(origin, generation_guard.as_ref()) {
             return;
         }
-        let bytes = match tokio::fs::read(&file_path).await {
-            Ok(b) if !b.is_empty() => b,
-            _ => return,
-        };
-        if generation_guard
-            .as_ref()
-            .is_some_and(|guard| !generation_guard_is_current(guard))
+        let bytes = match tokio::task::spawn_blocking(move || {
+            let mut file = file;
+            let mut bytes = Vec::with_capacity(file_len as usize);
+            file.read_to_end(&mut bytes)
+                .map(|_| bytes)
+                .map_err(|error| error.to_string())
+        })
+        .await
         {
+            Ok(Ok(bytes)) if !bytes.is_empty() => bytes,
+            Ok(Ok(_)) => return,
+            Ok(Err(error)) => {
+                crate::app_eprintln!(
+                    "[analysis][dispatch] file read failed origin={origin:?} track_id={track_id}: {error}"
+                );
+                return;
+            }
+            Err(error) => {
+                crate::app_eprintln!(
+                    "[analysis][dispatch] file read task failed origin={origin:?} track_id={track_id}: {error}"
+                );
+                return;
+            }
+        };
+        if !generation_guard_allows_analysis(origin, generation_guard.as_ref()) {
             return;
         }
         match dispatch_track_analysis_bytes(
@@ -652,6 +750,8 @@ mod scope_tests {
 mod provenance_tests {
     use super::*;
 
+    static TEST_FILE_ID: AtomicU64 = AtomicU64::new(0);
+
     #[test]
     fn trusted_prefix_distinguishes_original_from_transcoded_capture() {
         let original = vec![7u8; 20 * 1024];
@@ -674,10 +774,10 @@ mod provenance_tests {
     }
 
     #[test]
-    fn stream_spills_keep_the_background_size_cap_even_when_active() {
+    fn disk_backed_stream_spills_use_the_local_file_analysis_cap() {
         assert_eq!(
             max_bytes_for_dispatch(TrackAnalysisOrigin::StreamSpillFile),
-            TRACK_STREAM_PROMOTE_MAX_BYTES,
+            LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES,
         );
         assert_eq!(
             max_bytes_for_dispatch(TrackAnalysisOrigin::PrefetchOrCacheFile),
@@ -686,9 +786,63 @@ mod provenance_tests {
     }
 
     #[test]
-    fn oversized_active_spill_is_rejected_before_the_file_is_read() {
-        assert!(TRACK_STREAM_PROMOTE_MAX_BYTES + 1
-            > max_bytes_for_dispatch(TrackAnalysisOrigin::StreamSpillFile));
+    fn stream_spill_above_the_ram_capture_cap_remains_eligible_for_analysis() {
+        let spill_cap = max_bytes_for_dispatch(TrackAnalysisOrigin::StreamSpillFile);
+        assert!(TRACK_STREAM_PROMOTE_MAX_BYTES < spill_cap);
+        assert_eq!(spill_cap, LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES);
+    }
+
+    #[test]
+    fn spill_analysis_keeps_raw_http_refetch_at_the_ram_cap() {
+        assert_eq!(
+            max_http_fetch_bytes_for_dispatch(),
+            TRACK_STREAM_PROMOTE_MAX_BYTES
+        );
+        assert!(
+            max_http_fetch_bytes_for_dispatch()
+                < max_bytes_for_dispatch(TrackAnalysisOrigin::StreamSpillFile)
+        );
+    }
+
+    #[test]
+    fn completed_spill_analysis_survives_a_stale_playback_generation() {
+        let generation = Arc::new(AtomicU64::new(8));
+        let stale_guard = (7, generation);
+        assert!(generation_guard_allows_analysis(
+            TrackAnalysisOrigin::StreamSpillFile,
+            Some(&stale_guard),
+        ));
+        assert!(!generation_guard_allows_analysis(
+            TrackAnalysisOrigin::StreamDownloadComplete,
+            Some(&stale_guard),
+        ));
+    }
+
+    #[test]
+    fn prepared_spill_handle_survives_path_removal_when_supported() {
+        let path = std::env::temp_dir().join(format!(
+            "psysonic-analysis-spill-{}-{}",
+            std::process::id(),
+            TEST_FILE_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        let expected = b"stable spill bytes";
+        std::fs::write(&path, expected).unwrap();
+        let prepared = prepare_track_analysis_file(
+            TrackAnalysisOrigin::StreamSpillFile,
+            "track-1",
+            &path,
+        )
+        .unwrap();
+        let removed = std::fs::remove_file(&path).is_ok();
+
+        let PreparedTrackAnalysisFile { mut file, .. } = prepared;
+        let mut actual = Vec::new();
+        file.read_to_end(&mut actual).unwrap();
+        assert_eq!(actual, expected);
+        drop(file);
+        if !removed {
+            std::fs::remove_file(path).unwrap();
+        }
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-audio/src/analysis_dispatch.rs
+++ b/src-tauri/crates/psysonic-audio/src/analysis_dispatch.rs
@@ -109,11 +109,30 @@ pub(crate) fn emit_stream_provenance_if_current(
     );
 }
 
-fn max_bytes_for_origin(origin: TrackAnalysisOrigin) -> usize {
+fn max_bytes_for_dispatch(
+    origin: TrackAnalysisOrigin,
+    priority: AnalysisBackfillPriority,
+) -> usize {
     match origin {
         TrackAnalysisOrigin::LocalFilePlayback => LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES,
+        // A completed spill at high priority is the track that is still being
+        // listened to. Analyse that capture regardless of file size; preload,
+        // cache, and no-longer-current work keep the bounded background cap.
+        TrackAnalysisOrigin::StreamSpillFile if priority == AnalysisBackfillPriority::High => {
+            usize::MAX
+        }
         _ => TRACK_STREAM_PROMOTE_MAX_BYTES,
     }
+}
+
+fn use_oversized_active_transcode(
+    origin: TrackAnalysisOrigin,
+    priority: AnalysisBackfillPriority,
+    byte_len: usize,
+) -> bool {
+    origin == TrackAnalysisOrigin::StreamSpillFile
+        && priority == AnalysisBackfillPriority::High
+        && byte_len > TRACK_STREAM_PROMOTE_MAX_BYTES
 }
 
 /// Playback server scope: explicit IPC value, else pinned engine scope.
@@ -154,7 +173,6 @@ fn resolve_analysis_scope(
         .to_string()
 }
 
-
 fn server_id_from_playback_url(url_raw: &str) -> Option<String> {
     if url_raw.starts_with("psysonic-local://") {
         return None;
@@ -194,10 +212,7 @@ fn resolve_analysis_priority(
         return AnalysisBackfillPriority::High;
     }
     psysonic_analysis::analysis_runtime::analysis_backfill_resolve_priority(
-        app,
-        server_id,
-        track_id,
-        None,
+        app, server_id, track_id, None,
     )
 }
 
@@ -214,10 +229,7 @@ pub(crate) fn prepare_playback_analysis(
     (sid, resolved)
 }
 
-pub(crate) fn resolve_server_id_for_app(
-    app: &AppHandle,
-    explicit: Option<&str>,
-) -> String {
+pub(crate) fn resolve_server_id_for_app(app: &AppHandle, explicit: Option<&str>) -> String {
     let engine = app.try_state::<AudioEngine>();
     resolve_analysis_server_id(explicit, engine.as_deref())
 }
@@ -327,7 +339,7 @@ pub(crate) async fn dispatch_track_analysis_bytes(
             StreamProvenance::Original
         });
     }
-    let max = max_bytes_for_origin(origin);
+    let max = max_bytes_for_dispatch(origin, priority);
     crate::app_deprintln!(
         "[analysis][dispatch] origin={origin:?} track_id={track_id} server_id={} size_mib={:.2} priority={priority:?}",
         if server_id.is_empty() { "''" } else { server_id },
@@ -361,7 +373,9 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                     provenance,
                     generation_guard,
                 );
-                let analysis_bytes = if provenance == StreamProvenance::Original {
+                let (analysis_bytes, analysis_bytes_transcoded) = if provenance
+                    == StreamProvenance::Original
+                {
                     if bytes.len() > max {
                         crate::app_deprintln!(
                             "[analysis][dispatch] skip origin={origin:?} track_id={track_id} bytes={} max={max}",
@@ -369,7 +383,18 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                         );
                         return Ok(provenance);
                     }
-                    bytes
+                    (bytes, false)
+                } else if use_oversized_active_transcode(origin, priority, bytes.len()) {
+                    if !trusted_original_fetch_needed(app, server_id, track_id, &trusted) {
+                        crate::app_deprintln!(
+                            "[analysis][dispatch] skip active spill track_id={track_id}: analysis complete or already queued"
+                        );
+                        return Ok(provenance);
+                    }
+                    crate::app_deprintln!(
+                        "[analysis][dispatch] active spill exceeds background cap track_id={track_id}; analysing played transcode under trusted original identity"
+                    );
+                    (bytes, true)
                 } else {
                     if !trusted_original_fetch_needed(app, server_id, track_id, &trusted) {
                         crate::app_deprintln!(
@@ -380,38 +405,38 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                     crate::app_deprintln!(
                         "[analysis][dispatch] captured bytes differ from trusted original track_id={track_id}; fetching bounded raw original"
                     );
-                    let Some(original) = psysonic_analysis::raw_probe::fetch_trusted_original_bytes(
-                        &client,
-                        registry.as_deref(),
-                        Some(server_id).filter(|s| !s.is_empty()),
-                        stream_url.unwrap_or_default(),
-                        &trusted,
-                        max,
-                    )
-                    .await
+                    let Some(original) =
+                        psysonic_analysis::raw_probe::fetch_trusted_original_bytes(
+                            &client,
+                            registry.as_deref(),
+                            Some(server_id).filter(|s| !s.is_empty()),
+                            stream_url.unwrap_or_default(),
+                            &trusted,
+                            max,
+                        )
+                        .await
                     else {
                         crate::app_deprintln!(
                             "[analysis][dispatch] skip origin={origin:?} track_id={track_id}: raw original unavailable or exceeds cap"
                         );
                         return Ok(provenance);
                     };
-                    original
+                    (original, false)
                 };
                 let trusted_generation =
                     psysonic_analysis::analysis_runtime::begin_trusted_revision(
-                        server_id,
-                        track_id,
-                        &trusted,
+                        server_id, track_id, &trusted,
                     );
-                psysonic_analysis::analysis_runtime::enqueue_track_analysis_trusted(
+                psysonic_analysis::analysis_runtime::enqueue_track_analysis_trusted_owned(
                     app,
                     server_id,
                     track_id,
-                    &analysis_bytes,
+                    analysis_bytes,
                     None,
                     psysonic_analysis::analysis_runtime::TrustedAnalysisRevision {
                         md5_16kb: trusted,
                         generation: trusted_generation,
+                        analysis_bytes_transcoded,
                         content_hash_server_id: None,
                     },
                     priority,
@@ -447,12 +472,7 @@ pub(crate) async fn dispatch_track_analysis_bytes(
             return Ok(StreamProvenance::Original);
         }
         psysonic_analysis::analysis_runtime::enqueue_track_analysis(
-            app,
-            server_id,
-            track_id,
-            &bytes,
-            None,
-            priority,
+            app, server_id, track_id, &bytes, None, priority,
         )
         .await
         .map(|_| StreamProvenance::Original)
@@ -529,6 +549,17 @@ pub(crate) fn spawn_track_analysis_file(
         {
             return;
         }
+        let max = max_bytes_for_dispatch(origin, priority);
+        let file_len = match tokio::fs::metadata(&file_path).await {
+            Ok(metadata) => metadata.len(),
+            Err(_) => return,
+        };
+        if file_len > max as u64 {
+            crate::app_deprintln!(
+                "[analysis][dispatch] skip file origin={origin:?} track_id={track_id} bytes={file_len} max={max}"
+            );
+            return;
+        }
         let bytes = match tokio::fs::read(&file_path).await {
             Ok(b) if !b.is_empty() => b,
             _ => return,
@@ -572,7 +603,11 @@ mod scope_tests {
         // Primary vs alternate address must share one analysis scope: the
         // explicit canonical key wins over the URL-derived transport host.
         assert_eq!(
-            resolve_analysis_scope(Some("canonical.example"), Some("canonical.example"), Some("lan.local:4533")),
+            resolve_analysis_scope(
+                Some("canonical.example"),
+                Some("canonical.example"),
+                Some("lan.local:4533")
+            ),
             "canonical.example"
         );
         assert_eq!(
@@ -587,7 +622,10 @@ mod scope_tests {
             resolve_analysis_scope(None, Some("pinned.example"), Some("lan.local")),
             "pinned.example"
         );
-        assert_eq!(resolve_analysis_scope(None, None, Some("lan.local")), "lan.local");
+        assert_eq!(
+            resolve_analysis_scope(None, None, Some("lan.local")),
+            "lan.local"
+        );
         assert_eq!(resolve_analysis_scope(Some("  "), None, None), "");
     }
 }
@@ -615,6 +653,50 @@ mod provenance_tests {
         assert!(should_fetch_trusted_original(false, true));
         assert!(!should_fetch_trusted_original(true, true));
         assert!(!should_fetch_trusted_original(false, false));
+    }
+
+    #[test]
+    fn only_active_stream_spills_bypass_the_background_size_cap() {
+        assert_eq!(
+            max_bytes_for_dispatch(
+                TrackAnalysisOrigin::StreamSpillFile,
+                AnalysisBackfillPriority::High,
+            ),
+            usize::MAX,
+        );
+        assert_eq!(
+            max_bytes_for_dispatch(
+                TrackAnalysisOrigin::StreamSpillFile,
+                AnalysisBackfillPriority::Middle,
+            ),
+            TRACK_STREAM_PROMOTE_MAX_BYTES,
+        );
+        assert_eq!(
+            max_bytes_for_dispatch(
+                TrackAnalysisOrigin::PrefetchOrCacheFile,
+                AnalysisBackfillPriority::High,
+            ),
+            TRACK_STREAM_PROMOTE_MAX_BYTES,
+        );
+    }
+
+    #[test]
+    fn oversized_active_spill_uses_the_played_transcode_without_an_unbounded_raw_fetch() {
+        assert!(use_oversized_active_transcode(
+            TrackAnalysisOrigin::StreamSpillFile,
+            AnalysisBackfillPriority::High,
+            TRACK_STREAM_PROMOTE_MAX_BYTES + 1,
+        ));
+        assert!(!use_oversized_active_transcode(
+            TrackAnalysisOrigin::StreamSpillFile,
+            AnalysisBackfillPriority::High,
+            TRACK_STREAM_PROMOTE_MAX_BYTES,
+        ));
+        assert!(!use_oversized_active_transcode(
+            TrackAnalysisOrigin::StreamSpillFile,
+            AnalysisBackfillPriority::Middle,
+            TRACK_STREAM_PROMOTE_MAX_BYTES + 1,
+        ));
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-audio/src/analysis_dispatch.rs
+++ b/src-tauri/crates/psysonic-audio/src/analysis_dispatch.rs
@@ -390,6 +390,7 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                     .await
                     .map(|_| provenance);
                 }
+                let mut trusted_fetch_permit = None;
                 let (analysis_bytes, analysis_bytes_transcoded) = if provenance
                     == StreamProvenance::Original
                 {
@@ -411,6 +412,19 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                     crate::app_deprintln!(
                         "[analysis][dispatch] captured bytes differ from trusted original track_id={track_id}; fetching bounded raw original"
                     );
+                    let permit = psysonic_analysis::analysis_runtime::reserve_trusted_analysis_fetch(
+                        server_id, track_id, &trusted,
+                    )
+                    .await;
+                    if permit.waited()
+                        && !trusted_original_fetch_needed(app, server_id, track_id, &trusted)
+                    {
+                        crate::app_deprintln!(
+                            "[analysis][dispatch] skip completed duplicate raw original fetch track_id={track_id}"
+                        );
+                        return Ok(provenance);
+                    }
+                    trusted_fetch_permit = Some(permit);
                     let Some(original) =
                         psysonic_analysis::raw_probe::fetch_trusted_original_bytes(
                             &client,
@@ -429,7 +443,7 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                     };
                     (original, false)
                 };
-                psysonic_analysis::analysis_runtime::enqueue_track_analysis_trusted_owned(
+                let result = psysonic_analysis::analysis_runtime::enqueue_track_analysis_trusted_owned(
                     app,
                     server_id,
                     track_id,
@@ -444,7 +458,9 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                     priority,
                 )
                 .await
-                .map(|_| provenance)
+                .map(|_| provenance);
+                drop(trusted_fetch_permit);
+                result
             }
             TrustedProbeVerdict::SkipCanonicalWrites => {
                 // No positive provenance for these HTTP-stream bytes (the

--- a/src-tauri/crates/psysonic-audio/src/analysis_dispatch.rs
+++ b/src-tauri/crates/psysonic-audio/src/analysis_dispatch.rs
@@ -109,30 +109,11 @@ pub(crate) fn emit_stream_provenance_if_current(
     );
 }
 
-fn max_bytes_for_dispatch(
-    origin: TrackAnalysisOrigin,
-    priority: AnalysisBackfillPriority,
-) -> usize {
+fn max_bytes_for_dispatch(origin: TrackAnalysisOrigin) -> usize {
     match origin {
         TrackAnalysisOrigin::LocalFilePlayback => LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES,
-        // A completed spill at high priority is the track that is still being
-        // listened to. Analyse that capture regardless of file size; preload,
-        // cache, and no-longer-current work keep the bounded background cap.
-        TrackAnalysisOrigin::StreamSpillFile if priority == AnalysisBackfillPriority::High => {
-            usize::MAX
-        }
         _ => TRACK_STREAM_PROMOTE_MAX_BYTES,
     }
-}
-
-fn use_oversized_active_transcode(
-    origin: TrackAnalysisOrigin,
-    priority: AnalysisBackfillPriority,
-    byte_len: usize,
-) -> bool {
-    origin == TrackAnalysisOrigin::StreamSpillFile
-        && priority == AnalysisBackfillPriority::High
-        && byte_len > TRACK_STREAM_PROMOTE_MAX_BYTES
 }
 
 /// Playback server scope: explicit IPC value, else pinned engine scope.
@@ -299,7 +280,11 @@ fn trusted_original_fetch_needed(
     trusted_md5_16kb: &str,
 ) -> bool {
     should_fetch_trusted_original(
-        psysonic_analysis::analysis_runtime::analysis_track_in_cpu_pipeline(server_id, track_id),
+        psysonic_analysis::analysis_runtime::analysis_revision_in_cpu_pipeline(
+            server_id,
+            track_id,
+            trusted_md5_16kb,
+        ),
         psysonic_analysis::track_analysis_plan::plan_track_analysis(
             app,
             server_id,
@@ -339,7 +324,7 @@ pub(crate) async fn dispatch_track_analysis_bytes(
             StreamProvenance::Original
         });
     }
-    let max = max_bytes_for_dispatch(origin, priority);
+    let max = max_bytes_for_dispatch(origin);
     crate::app_deprintln!(
         "[analysis][dispatch] origin={origin:?} track_id={track_id} server_id={} size_mib={:.2} priority={priority:?}",
         if server_id.is_empty() { "''" } else { server_id },
@@ -364,6 +349,15 @@ pub(crate) async fn dispatch_track_analysis_bytes(
         match verdict {
             TrustedProbeVerdict::Trusted(trusted) => {
                 let provenance = provenance_from_trusted_bytes(&bytes, &trusted);
+                if generation_guard
+                    .is_some_and(|guard| !generation_guard_is_current(guard))
+                {
+                    return Ok(provenance);
+                }
+                let trusted_generation =
+                    psysonic_analysis::analysis_runtime::begin_trusted_revision(
+                        server_id, track_id, &trusted,
+                    );
                 emit_stream_provenance_if_current(
                     app,
                     origin,
@@ -373,6 +367,29 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                     provenance,
                     generation_guard,
                 );
+                if provenance == StreamProvenance::Transcoded
+                    && !psysonic_analysis::track_analysis_plan::plan_track_analysis(
+                        app, server_id, track_id, &trusted,
+                    )
+                    .any()
+                {
+                    return psysonic_analysis::analysis_runtime::enqueue_track_analysis_trusted_owned(
+                        app,
+                        server_id,
+                        track_id,
+                        bytes,
+                        None,
+                        psysonic_analysis::analysis_runtime::TrustedAnalysisRevision {
+                            md5_16kb: trusted,
+                            generation: trusted_generation,
+                            analysis_bytes_transcoded: true,
+                            content_hash_server_id: None,
+                        },
+                        priority,
+                    )
+                    .await
+                    .map(|_| provenance);
+                }
                 let (analysis_bytes, analysis_bytes_transcoded) = if provenance
                     == StreamProvenance::Original
                 {
@@ -384,17 +401,6 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                         return Ok(provenance);
                     }
                     (bytes, false)
-                } else if use_oversized_active_transcode(origin, priority, bytes.len()) {
-                    if !trusted_original_fetch_needed(app, server_id, track_id, &trusted) {
-                        crate::app_deprintln!(
-                            "[analysis][dispatch] skip active spill track_id={track_id}: analysis complete or already queued"
-                        );
-                        return Ok(provenance);
-                    }
-                    crate::app_deprintln!(
-                        "[analysis][dispatch] active spill exceeds background cap track_id={track_id}; analysing played transcode under trusted original identity"
-                    );
-                    (bytes, true)
                 } else {
                     if !trusted_original_fetch_needed(app, server_id, track_id, &trusted) {
                         crate::app_deprintln!(
@@ -423,10 +429,6 @@ pub(crate) async fn dispatch_track_analysis_bytes(
                     };
                     (original, false)
                 };
-                let trusted_generation =
-                    psysonic_analysis::analysis_runtime::begin_trusted_revision(
-                        server_id, track_id, &trusted,
-                    );
                 psysonic_analysis::analysis_runtime::enqueue_track_analysis_trusted_owned(
                     app,
                     server_id,
@@ -549,7 +551,7 @@ pub(crate) fn spawn_track_analysis_file(
         {
             return;
         }
-        let max = max_bytes_for_dispatch(origin, priority);
+        let max = max_bytes_for_dispatch(origin);
         let file_len = match tokio::fs::metadata(&file_path).await {
             Ok(metadata) => metadata.len(),
             Err(_) => return,
@@ -649,54 +651,28 @@ mod provenance_tests {
     }
 
     #[test]
-    fn raw_original_fetch_requires_work_outside_the_cpu_pipeline() {
+    fn raw_original_fetch_requires_work_outside_the_same_revision_cpu_pipeline() {
         assert!(should_fetch_trusted_original(false, true));
         assert!(!should_fetch_trusted_original(true, true));
         assert!(!should_fetch_trusted_original(false, false));
     }
 
     #[test]
-    fn only_active_stream_spills_bypass_the_background_size_cap() {
+    fn stream_spills_keep_the_background_size_cap_even_when_active() {
         assert_eq!(
-            max_bytes_for_dispatch(
-                TrackAnalysisOrigin::StreamSpillFile,
-                AnalysisBackfillPriority::High,
-            ),
-            usize::MAX,
-        );
-        assert_eq!(
-            max_bytes_for_dispatch(
-                TrackAnalysisOrigin::StreamSpillFile,
-                AnalysisBackfillPriority::Middle,
-            ),
+            max_bytes_for_dispatch(TrackAnalysisOrigin::StreamSpillFile),
             TRACK_STREAM_PROMOTE_MAX_BYTES,
         );
         assert_eq!(
-            max_bytes_for_dispatch(
-                TrackAnalysisOrigin::PrefetchOrCacheFile,
-                AnalysisBackfillPriority::High,
-            ),
+            max_bytes_for_dispatch(TrackAnalysisOrigin::PrefetchOrCacheFile),
             TRACK_STREAM_PROMOTE_MAX_BYTES,
         );
     }
 
     #[test]
-    fn oversized_active_spill_uses_the_played_transcode_without_an_unbounded_raw_fetch() {
-        assert!(use_oversized_active_transcode(
-            TrackAnalysisOrigin::StreamSpillFile,
-            AnalysisBackfillPriority::High,
-            TRACK_STREAM_PROMOTE_MAX_BYTES + 1,
-        ));
-        assert!(!use_oversized_active_transcode(
-            TrackAnalysisOrigin::StreamSpillFile,
-            AnalysisBackfillPriority::High,
-            TRACK_STREAM_PROMOTE_MAX_BYTES,
-        ));
-        assert!(!use_oversized_active_transcode(
-            TrackAnalysisOrigin::StreamSpillFile,
-            AnalysisBackfillPriority::Middle,
-            TRACK_STREAM_PROMOTE_MAX_BYTES + 1,
-        ));
+    fn oversized_active_spill_is_rejected_before_the_file_is_read() {
+        assert!(TRACK_STREAM_PROMOTE_MAX_BYTES + 1
+            > max_bytes_for_dispatch(TrackAnalysisOrigin::StreamSpillFile));
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-audio/src/commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/commands.rs
@@ -779,6 +779,7 @@ pub async fn audio_chain_preload(
             Some(url.clone()),
             priority,
             Some((snapshot.generation, state.generation.clone())),
+            None,
         );
     }
 

--- a/src-tauri/crates/psysonic-audio/src/play_input.rs
+++ b/src-tauri/crates/psysonic-audio/src/play_input.rs
@@ -105,7 +105,12 @@ fn spawn_playback_analysis_bytes(
         Some(ctx.url.to_string()),
         high,
         Some((ctx.gen, state.generation.clone())),
+        None,
     );
+}
+
+fn ranged_analysis_seed_hold_allowed(total_size: usize) -> bool {
+    total_size <= super::stream::LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES
 }
 
 /// Resolves the play input for `audio_play` honouring (in priority order):
@@ -139,6 +144,7 @@ pub(super) async fn select_play_input(
                 Some(ctx.url.to_string()),
                 high,
                 Some((ctx.gen, state.generation.clone())),
+                None,
             );
         }
         return Ok(Some(PlayInput::Bytes(d)));
@@ -212,6 +218,7 @@ fn open_local_file_input(
             None, // genuine local file — original by definition
             high,
             Some((ctx.gen, state.generation.clone())),
+            None,
         );
     }
     let reader = LocalFileSource { file, len };
@@ -332,12 +339,13 @@ async fn open_ranged_or_streaming_input(
             gen: ctx.gen,
             format_hint: stream_hint.clone(),
         });
-        let analysis_seed_hold = (total_usize <= super::stream::TRACK_STREAM_PROMOTE_MAX_BYTES)
+        let analysis_seed_hold = ranged_analysis_seed_hold_allowed(total_usize)
             .then(|| {
                 super::stream::AnalysisSeedHoldGuard::arm(
                     Some(&state.playback_analysis_seed_hold),
                     ctx.cache_id_for_tasks,
                     ctx.gen,
+                    &state.generation,
                 )
             })
             .flatten();
@@ -430,6 +438,7 @@ async fn open_ranged_or_streaming_input(
         Some(&state.playback_analysis_seed_hold),
         ctx.cache_id_for_tasks,
         ctx.gen,
+        &state.generation,
     );
     tokio::spawn(track_download_task(
         ctx.gen,
@@ -498,7 +507,20 @@ pub(crate) fn url_stream_cap_kbps(url: &str) -> Option<u32> {
 
 #[cfg(test)]
 mod url_param_tests {
-    use super::{url_format_hint, url_stream_cap_kbps};
+    use super::{ranged_analysis_seed_hold_allowed, url_format_hint, url_stream_cap_kbps};
+
+    #[test]
+    fn ranged_analysis_hold_covers_disk_spill_sizes() {
+        assert!(ranged_analysis_seed_hold_allowed(
+            super::super::stream::TRACK_STREAM_PROMOTE_MAX_BYTES + 1
+        ));
+        assert!(ranged_analysis_seed_hold_allowed(
+            super::super::stream::LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES
+        ));
+        assert!(!ranged_analysis_seed_hold_allowed(
+            super::super::stream::LOCAL_FILE_PLAYBACK_SEED_MAX_BYTES + 1
+        ));
+    }
 
     #[test]
     fn extracts_aiff_format_hint_from_url_path() {

--- a/src-tauri/crates/psysonic-audio/src/preload_commands.rs
+++ b/src-tauri/crates/psysonic-audio/src/preload_commands.rs
@@ -122,6 +122,7 @@ fn seed_preload_analysis_bytes(
         Some(url.to_string()),
         priority,
         Some((generation, state.generation.clone())),
+        None,
     );
 }
 
@@ -156,6 +157,7 @@ fn seed_preload_analysis_file(
         file_path,
         None,
         priority,
+        None,
         None,
     );
 }

--- a/src-tauri/crates/psysonic-audio/src/source_build.rs
+++ b/src-tauri/crates/psysonic-audio/src/source_build.rs
@@ -4,6 +4,8 @@
 //! when a partial stream buffer can't be probed yet). Split out of
 //! `play_input.rs` so source *selection* stays separate from source *building*.
 
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -11,7 +13,8 @@ use std::time::Duration;
 use tauri::{AppHandle, State};
 
 use super::analysis_dispatch::{
-    prepare_playback_analysis, spawn_track_analysis_bytes, TrackAnalysisOrigin,
+    prepare_playback_analysis, prepare_track_analysis_file, spawn_track_analysis_bytes,
+    spawn_track_analysis_prepared_file, PreparedTrackAnalysisFile, TrackAnalysisOrigin,
 };
 use super::decode::{build_source, build_streaming_source, BuiltSource, SizedDecoder};
 use super::engine::AudioEngine;
@@ -22,7 +25,8 @@ use super::helpers::{
 use super::play_input::PlayInput;
 use super::state::{PreloadedTrack, StreamCompletedSpill};
 use super::stream::{
-    StreamDownloadControl, TRACK_READ_TIMEOUT_SECS, TRACK_STREAM_PROMOTE_MAX_BYTES,
+    AnalysisSeedHoldGuard, StreamDownloadControl, TRACK_READ_TIMEOUT_SECS,
+    TRACK_STREAM_PROMOTE_MAX_BYTES,
 };
 
 /// Arguments forwarded from `audio_play` into the source-build pipeline.
@@ -55,7 +59,75 @@ struct PlaybackSourceShape {
 
 struct FallbackBytes {
     data: Vec<u8>,
-    consumed_spill_path: Option<std::path::PathBuf>,
+    consumed_spill_path: Option<PathBuf>,
+}
+
+enum PublishedFallbackLocation {
+    Memory,
+    Spill {
+        path: PathBuf,
+        analysis_file: Option<PreparedTrackAnalysisFile>,
+    },
+    Uncached,
+}
+
+enum FallbackPublication {
+    Published(PublishedFallbackLocation),
+    StaleSpill(PublishedFallbackLocation),
+    Stale,
+}
+
+enum FallbackAnalysisDispatch {
+    Bytes,
+    File(Option<PreparedTrackAnalysisFile>),
+}
+
+struct FallbackAnalysisContext {
+    server_id: String,
+    track_id: String,
+    priority: psysonic_analysis::analysis_runtime::AnalysisBackfillPriority,
+    seed_hold: Option<AnalysisSeedHoldGuard>,
+}
+
+fn fallback_analysis_dispatch(
+    location: PublishedFallbackLocation,
+) -> FallbackAnalysisDispatch {
+    match location {
+        PublishedFallbackLocation::Spill { analysis_file, .. } => {
+            FallbackAnalysisDispatch::File(analysis_file)
+        }
+        PublishedFallbackLocation::Memory | PublishedFallbackLocation::Uncached => {
+            FallbackAnalysisDispatch::Bytes
+        }
+    }
+}
+
+fn stale_fallback_spill_should_unlink(candidate: &Path, source_spill_path: Option<&Path>) -> bool {
+    source_spill_path != Some(candidate)
+}
+
+struct AnalysisSelectionGuard {
+    download_control: Option<Arc<StreamDownloadControl>>,
+}
+
+impl AnalysisSelectionGuard {
+    fn new(download_control: Option<Arc<StreamDownloadControl>>) -> Self {
+        Self { download_control }
+    }
+
+    fn select_fallback(&self) -> bool {
+        self.download_control
+            .as_ref()
+            .is_some_and(|control| control.select_fallback_analysis())
+    }
+}
+
+impl Drop for AnalysisSelectionGuard {
+    fn drop(&mut self) {
+        if let Some(download_control) = self.download_control.as_ref() {
+            download_control.select_downloader_analysis();
+        }
+    }
 }
 
 /// Output of `build_source_from_play_input`: the wrapped rodio source plus
@@ -94,23 +166,49 @@ fn publish_validated_fallback_bytes(
     track_id: Option<&str>,
     gen: u64,
     data: &[u8],
-) -> bool {
+    source_spill_path: Option<&Path>,
+) -> FallbackPublication {
+    let source_spill_path = source_spill_path.map(Path::to_path_buf);
     let candidate_spill = if data.len() > TRACK_STREAM_PROMOTE_MAX_BYTES {
-        let Some(track_id) = track_id.map(str::trim).filter(|id| !id.is_empty()) else {
-            return state.generation.load(Ordering::SeqCst) == gen;
-        };
-        match write_stream_spill_file(app, &format!("{track_id}-fallback-{gen}"), data) {
-            Ok(path) => Some(path),
-            Err(e) => {
-                crate::app_eprintln!(
-                    "[stream] validated fallback spill failed track_id={track_id}: {e}"
-                );
-                return state.generation.load(Ordering::SeqCst) == gen;
+        if let Some(path) = source_spill_path.clone() {
+            Some(path)
+        } else {
+            let Some(track_id) = track_id.map(str::trim).filter(|id| !id.is_empty()) else {
+                return if state.generation.load(Ordering::SeqCst) == gen {
+                    FallbackPublication::Published(PublishedFallbackLocation::Uncached)
+                } else {
+                    FallbackPublication::Stale
+                };
+            };
+            match write_stream_spill_file(app, &format!("{track_id}-fallback-{gen}"), data) {
+                Ok(path) => Some(path),
+                Err(e) => {
+                    crate::app_eprintln!(
+                        "[stream] validated fallback spill failed track_id={track_id}: {e}"
+                    );
+                    return if state.generation.load(Ordering::SeqCst) == gen {
+                        FallbackPublication::Published(PublishedFallbackLocation::Uncached)
+                    } else {
+                        FallbackPublication::Stale
+                    };
+                }
             }
         }
     } else {
         None
     };
+    let prepared_analysis_file = candidate_spill.as_ref().and_then(|path| {
+        track_id
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .and_then(|track_id| {
+                prepare_track_analysis_file(
+                    TrackAnalysisOrigin::StreamSpillFile,
+                    track_id,
+                    path,
+                )
+            })
+    });
 
     let mut cache = state.stream_completed_cache.lock().unwrap();
     let mut spill = state.stream_completed_spill.lock().unwrap();
@@ -118,29 +216,48 @@ fn publish_validated_fallback_bytes(
         drop(spill);
         drop(cache);
         if let Some(path) = candidate_spill {
-            let _ = std::fs::remove_file(path);
+            let analysis_path = path.clone();
+            if stale_fallback_spill_should_unlink(&path, source_spill_path.as_deref()) {
+                let _ = std::fs::remove_file(&path);
+            }
+            return FallbackPublication::StaleSpill(PublishedFallbackLocation::Spill {
+                path: analysis_path,
+                analysis_file: prepared_analysis_file,
+            });
         }
-        return false;
+        return FallbackPublication::Stale;
     }
     let old_spill = spill.take().map(|entry| entry.path);
-    if let Some(path) = candidate_spill {
+    let location = if let Some(path) = candidate_spill {
+        let analysis_path = path.clone();
         *cache = None;
         *spill = Some(StreamCompletedSpill {
             url: url.to_string(),
             path,
         });
+        PublishedFallbackLocation::Spill {
+            path: analysis_path,
+            analysis_file: prepared_analysis_file,
+        }
     } else {
         *cache = Some(PreloadedTrack {
             url: url.to_string(),
             data: data.to_vec(),
         });
-    }
+        PublishedFallbackLocation::Memory
+    };
     drop(spill);
     drop(cache);
-    if let Some(path) = old_spill {
-        let _ = std::fs::remove_file(path);
+    let retained_spill = match &location {
+        PublishedFallbackLocation::Spill { path, .. } => Some(path),
+        PublishedFallbackLocation::Memory | PublishedFallbackLocation::Uncached => None,
+    };
+    for path in old_spill.into_iter().chain(source_spill_path) {
+        if retained_spill != Some(&path) {
+            let _ = std::fs::remove_file(path);
+        }
     }
-    true
+    FallbackPublication::Published(location)
 }
 
 /// A stream probe/decode failed in a way that may succeed after the background
@@ -157,21 +274,21 @@ fn is_stream_probe_failure_with_full_buffer_retry(err: &str, format_hint: Option
     ranged_failure || legacy_aiff_failure
 }
 
-/// Take ownership of completed download bytes so they cannot be promoted while
-/// fallback validation is in progress. Valid bytes are republished afterwards.
-async fn try_take_completed_stream_bytes(
+/// Read a stable snapshot of completed download bytes while leaving the shared
+/// replay entry in place until validated fallback bytes replace it.
+async fn try_read_completed_stream_bytes(
     url: &str,
     gen: u64,
     state: &State<'_, AudioEngine>,
 ) -> Option<FallbackBytes> {
     let ram = {
-        let mut guard = state.stream_completed_cache.lock().unwrap();
+        let guard = state.stream_completed_cache.lock().unwrap();
         if state.generation.load(Ordering::SeqCst) == gen
             && guard
                 .as_ref()
                 .is_some_and(|p| same_playback_target(&p.url, url))
         {
-            guard.take().map(|p| p.data)
+            guard.as_ref().map(|p| p.data.clone())
         } else {
             None
         }
@@ -182,21 +299,30 @@ async fn try_take_completed_stream_bytes(
             consumed_spill_path: None,
         });
     }
-    let spill_path = {
-        let mut guard = state.stream_completed_spill.lock().unwrap();
+    let spill_source = {
+        let guard = state.stream_completed_spill.lock().unwrap();
         if state.generation.load(Ordering::SeqCst) == gen
             && guard
                 .as_ref()
                 .is_some_and(|p| same_playback_target(&p.url, url))
         {
-            guard.take().map(|p| p.path)
+            guard.as_ref().and_then(|p| {
+                std::fs::File::open(&p.path)
+                    .ok()
+                    .map(|file| (p.path.clone(), file))
+            })
         } else {
             None
         }
     };
-    if let Some(path) = spill_path {
-        let data = tokio::fs::read(&path).await.ok();
-        let data = data?;
+    if let Some((path, mut file)) = spill_source {
+        let data = tokio::task::spawn_blocking(move || {
+            let mut data = Vec::new();
+            file.read_to_end(&mut data).map(|_| data)
+        })
+        .await
+        .ok()?
+        .ok()?;
         if !data.is_empty() {
             return Some(FallbackBytes {
                 data,
@@ -257,7 +383,7 @@ async fn wait_or_fetch_bytes_for_stream_fallback(
         if state.generation.load(Ordering::SeqCst) != gen {
             return Ok(None);
         }
-        if let Some(data) = try_take_completed_stream_bytes(url, gen, state).await {
+        if let Some(data) = try_read_completed_stream_bytes(url, gen, state).await {
             crate::app_deprintln!(
                 "[stream] full-buffer fallback: using completed download ({} KiB)",
                 data.data.len() / 1024
@@ -325,6 +451,7 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
     } = args;
     let media_hint = play_media_format_hint(&play_input);
     let download_control = play_input_download_control(&play_input);
+    let analysis_selection = AnalysisSelectionGuard::new(download_control.clone());
     let effective_hint = resolve_playback_format_hint(
         url_format_hint,
         stream_format_suffix,
@@ -360,7 +487,6 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
             let Some(download_control) = download_control.as_ref() else {
                 return Err(e);
             };
-            download_control.request_fallback_analysis();
             let fallback = match wait_or_fetch_bytes_for_stream_fallback(
                 url,
                 gen,
@@ -394,29 +520,69 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
                     effective_hint
                 );
             }
-            let dispatch_fallback_analysis = |analysis_data: Vec<u8>| -> bool {
-                if !download_control.claim_fallback_analysis() {
-                    return false;
-                }
-                if let Some(track_id) = cache_id_for_tasks
+            let prepare_fallback_analysis = || -> Result<Option<FallbackAnalysisContext>, String> {
+                let Some(track_id) = cache_id_for_tasks
                     .map(str::trim)
                     .filter(|s| !s.is_empty())
-                {
-                    let (sid, high) =
-                        prepare_playback_analysis(app, state, server_id, track_id, None);
-                    spawn_track_analysis_bytes(
-                        app.clone(),
-                        TrackAnalysisOrigin::StreamDownloadComplete,
-                        sid,
-                        track_id.to_string(),
-                        analysis_data,
-                        Some(url.to_string()),
-                        high,
-                        Some((gen, state.generation.clone())),
-                    );
+                else {
+                    return Ok(None);
+                };
+                let seed_hold = AnalysisSeedHoldGuard::arm(
+                    Some(&state.playback_analysis_seed_hold),
+                    Some(track_id),
+                    gen,
+                    &state.generation,
+                );
+                if seed_hold.is_none() && state.generation.load(Ordering::SeqCst) != gen {
+                    return Err("ranged-stream: superseded during analysis handoff".into());
                 }
-                true
+                let (server_id, priority) =
+                    prepare_playback_analysis(app, state, server_id, track_id, None);
+                Ok(Some(FallbackAnalysisContext {
+                    server_id,
+                    track_id: track_id.to_string(),
+                    priority,
+                    seed_hold,
+                }))
             };
+            let dispatch_fallback_analysis =
+                |analysis_data: Vec<u8>,
+                 location: PublishedFallbackLocation,
+                 context: Option<FallbackAnalysisContext>| {
+                    let Some(context) = context else {
+                        return;
+                    };
+                    match fallback_analysis_dispatch(location) {
+                        FallbackAnalysisDispatch::Bytes => spawn_track_analysis_bytes(
+                            app.clone(),
+                            TrackAnalysisOrigin::StreamDownloadComplete,
+                            context.server_id,
+                            context.track_id,
+                            analysis_data,
+                            Some(url.to_string()),
+                            context.priority,
+                            Some((gen, state.generation.clone())),
+                            context.seed_hold,
+                        ),
+                        FallbackAnalysisDispatch::File(Some(prepared_file)) => {
+                            spawn_track_analysis_prepared_file(
+                                app.clone(),
+                                TrackAnalysisOrigin::StreamSpillFile,
+                                context.server_id,
+                                context.track_id,
+                                prepared_file,
+                                Some(url.to_string()),
+                                context.priority,
+                                Some((gen, state.generation.clone())),
+                                context.seed_hold,
+                            )
+                        }
+                        FallbackAnalysisDispatch::File(None) => crate::app_eprintln!(
+                            "[analysis][dispatch] fallback spill unavailable track_id={}",
+                            context.track_id
+                        ),
+                    }
+                };
             match build_source_from_play_input(
                 PlayInput::Bytes(data.clone()),
                 state,
@@ -431,25 +597,37 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
                             "ranged-stream: superseded during full-buffer fallback".into()
                         );
                     }
+                    let analysis_context = prepare_fallback_analysis()?;
                     download_control.mark_fallback_succeeded();
-                    if !publish_validated_fallback_bytes(
+                    let publication = publish_validated_fallback_bytes(
                         state,
                         app,
                         url,
                         cache_id_for_tasks,
                         gen,
                         &data,
-                    ) {
-                        return Err(
-                            "ranged-stream: superseded during full-buffer fallback".into()
-                        );
-                    }
-                    if dispatch_fallback_analysis(data) {
-                        if let Some(path) = consumed_spill_path {
-                            let _ = std::fs::remove_file(path);
+                        consumed_spill_path.as_deref(),
+                    );
+                    match publication {
+                        FallbackPublication::Published(location) => {
+                            if !analysis_selection.select_fallback() {
+                                return Err(
+                                    "ranged-stream: analysis source already selected".into()
+                                );
+                            }
+                            dispatch_fallback_analysis(data, location, analysis_context);
+                            Ok(p)
+                        }
+                        FallbackPublication::StaleSpill(location) => {
+                            if analysis_selection.select_fallback() {
+                                dispatch_fallback_analysis(data, location, analysis_context);
+                            }
+                            Err("ranged-stream: superseded during full-buffer fallback".into())
+                        }
+                        FallbackPublication::Stale => {
+                            Err("ranged-stream: superseded during full-buffer fallback".into())
                         }
                     }
-                    Ok(p)
                 }
                 Err(pe) if is_in_memory_probe_failure(&pe) => {
                     if super::stream::container_hint_is_mp4(bytes_hint.as_deref()) {
@@ -499,22 +677,41 @@ pub(crate) async fn build_playback_source_with_probe_fallback(
                                 "ranged-stream: superseded during full-buffer fallback".into()
                             );
                         }
+                        let analysis_context = prepare_fallback_analysis()?;
                         download_control.mark_fallback_succeeded();
-                        if !publish_validated_fallback_bytes(
+                        let publication = publish_validated_fallback_bytes(
                             state,
                             app,
                             url,
                             cache_id_for_tasks,
                             gen,
                             &fresh,
-                        ) {
-                            return Err(
-                                "ranged-stream: superseded during full-buffer fallback".into()
-                            );
-                        }
-                        if dispatch_fallback_analysis(fresh) {
-                            if let Some(path) = consumed_spill_path {
-                                let _ = std::fs::remove_file(path);
+                            None,
+                        );
+                        match publication {
+                            FallbackPublication::Published(location) => {
+                                if !analysis_selection.select_fallback() {
+                                    return Err(
+                                        "ranged-stream: analysis source already selected".into()
+                                    );
+                                }
+                                dispatch_fallback_analysis(fresh, location, analysis_context);
+                                if let Some(path) = consumed_spill_path {
+                                    let _ = std::fs::remove_file(path);
+                                }
+                            }
+                            FallbackPublication::StaleSpill(location) => {
+                                if analysis_selection.select_fallback() {
+                                    dispatch_fallback_analysis(fresh, location, analysis_context);
+                                }
+                                return Err(
+                                    "ranged-stream: superseded during full-buffer fallback".into()
+                                );
+                            }
+                            FallbackPublication::Stale => {
+                                return Err(
+                                    "ranged-stream: superseded during full-buffer fallback".into()
+                                );
                             }
                         }
                     }
@@ -644,7 +841,42 @@ async fn build_source_from_play_input(
 
 #[cfg(test)]
 mod tests {
-    use super::is_stream_probe_failure_with_full_buffer_retry;
+    use std::path::PathBuf;
+
+    use super::{
+        fallback_analysis_dispatch, is_stream_probe_failure_with_full_buffer_retry,
+        FallbackAnalysisDispatch, PublishedFallbackLocation,
+    };
+
+    #[test]
+    fn published_fallback_spill_routes_analysis_from_the_file() {
+        let path = PathBuf::from("fallback-spill.flac");
+        match fallback_analysis_dispatch(PublishedFallbackLocation::Spill {
+            path,
+            analysis_file: None,
+        }) {
+            FallbackAnalysisDispatch::File(_) => {}
+            FallbackAnalysisDispatch::Bytes => panic!("spill analysis must use the file path"),
+        }
+    }
+
+    #[test]
+    fn in_memory_fallback_keeps_byte_analysis() {
+        assert!(matches!(
+            fallback_analysis_dispatch(PublishedFallbackLocation::Memory),
+            FallbackAnalysisDispatch::Bytes
+        ));
+    }
+
+    #[test]
+    fn stale_reused_spill_keeps_the_shared_cache_path() {
+        let path = PathBuf::from("shared-spill.flac");
+        assert!(!super::stale_fallback_spill_should_unlink(
+            &path,
+            Some(&path)
+        ));
+        assert!(super::stale_fallback_spill_should_unlink(&path, None));
+    }
 
     #[test]
     fn retries_ranged_probe_timeouts_from_full_buffer() {

--- a/src-tauri/crates/psysonic-audio/src/stream/mod.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream/mod.rs
@@ -17,8 +17,9 @@ mod ranged_http;
 mod reader;
 mod track_stream;
 
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
 
 pub(crate) use mp4::{
     container_hint_is_mp4, isobmff_buffer_looks_complete, log_isobmff_buffer_diagnostic,
@@ -55,11 +56,13 @@ pub(crate) use reader::AudioStreamReader;
 pub(crate) use track_stream::track_download_task;
 
 pub(crate) type AnalysisSeedHold = Arc<Mutex<Option<(String, u64)>>>;
+static ANALYSIS_SEED_HOLD_TOKEN: AtomicU64 = AtomicU64::new(0);
 
 /// Shared ownership state between an HTTP downloader and a full-buffer fallback.
 pub(crate) struct StreamDownloadControl {
     pub(crate) done: Arc<AtomicBool>,
-    analysis_owner: AtomicU8,
+    analysis_selection: AtomicU8,
+    analysis_selection_notify: Notify,
     fallback_succeeded: AtomicBool,
     ended_without_reusable_bytes: AtomicBool,
 }
@@ -68,32 +71,47 @@ impl StreamDownloadControl {
     pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self {
             done: Arc::new(AtomicBool::new(false)),
-            analysis_owner: AtomicU8::new(0),
+            analysis_selection: AtomicU8::new(0),
+            analysis_selection_notify: Notify::new(),
             fallback_succeeded: AtomicBool::new(false),
             ended_without_reusable_bytes: AtomicBool::new(false),
         })
     }
 
-    pub(crate) fn claim_downloader_analysis(&self) -> bool {
-        self.analysis_owner
+    pub(crate) fn select_downloader_analysis(&self) {
+        if self
+            .analysis_selection
             .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
             .is_ok()
+        {
+            self.analysis_selection_notify.notify_one();
+        }
+    }
+
+    pub(crate) fn select_fallback_analysis(&self) -> bool {
+        let selected = self
+            .analysis_selection
+            .compare_exchange(0, 2, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok();
+        if selected {
+            self.analysis_selection_notify.notify_one();
+        }
+        selected
+    }
+
+    pub(crate) async fn downloader_analysis_selected(&self) -> bool {
+        loop {
+            let notified = self.analysis_selection_notify.notified();
+            match self.analysis_selection.load(Ordering::SeqCst) {
+                1 => return true,
+                2 => return false,
+                _ => notified.await,
+            }
+        }
     }
 
     pub(crate) fn mark_fallback_succeeded(&self) {
         self.fallback_succeeded.store(true, Ordering::SeqCst);
-    }
-
-    pub(crate) fn request_fallback_analysis(&self) {
-        let _ = self
-            .analysis_owner
-            .compare_exchange(0, 2, Ordering::SeqCst, Ordering::SeqCst);
-    }
-
-    pub(crate) fn claim_fallback_analysis(&self) -> bool {
-        self.analysis_owner
-            .compare_exchange(2, 3, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok()
     }
 
     pub(crate) fn fallback_succeeded(&self) -> bool {
@@ -116,7 +134,7 @@ impl StreamDownloadControl {
 pub(crate) struct AnalysisSeedHoldGuard {
     slot: AnalysisSeedHold,
     track_id: String,
-    generation: u64,
+    token: u64,
 }
 
 impl AnalysisSeedHoldGuard {
@@ -124,6 +142,7 @@ impl AnalysisSeedHoldGuard {
         slot: Option<&AnalysisSeedHold>,
         track_id: Option<&str>,
         generation: u64,
+        generation_arc: &AtomicU64,
     ) -> Option<Self> {
         let slot = slot?;
         let track_id = track_id?.trim();
@@ -131,22 +150,26 @@ impl AnalysisSeedHoldGuard {
             return None;
         }
         if let Ok(mut guard) = slot.lock() {
-            *guard = Some((track_id.to_string(), generation));
+            if generation_arc.load(Ordering::SeqCst) != generation {
+                return None;
+            }
+            let token = ANALYSIS_SEED_HOLD_TOKEN.fetch_add(1, Ordering::Relaxed);
+            *guard = Some((track_id.to_string(), token));
+            Some(Self {
+                slot: Arc::clone(slot),
+                track_id: track_id.to_string(),
+                token,
+            })
         } else {
-            return None;
+            None
         }
-        Some(Self {
-            slot: Arc::clone(slot),
-            track_id: track_id.to_string(),
-            generation,
-        })
     }
 }
 
 impl Drop for AnalysisSeedHoldGuard {
     fn drop(&mut self) {
         if let Ok(mut guard) = self.slot.lock() {
-            if matches!(&*guard, Some((track_id, generation)) if track_id == &self.track_id && *generation == self.generation) {
+            if matches!(&*guard, Some((track_id, token)) if track_id == &self.track_id && *token == self.token) {
                 *guard = None;
             }
         }
@@ -288,13 +311,13 @@ mod container_hint_tests {
 mod stream_download_control_tests {
     use super::*;
 
-    #[test]
-    fn analysis_has_one_owner_and_fallback_state_is_shared() {
+    #[tokio::test]
+    async fn fallback_selection_wakes_downloader_and_keeps_one_owner() {
         let control = StreamDownloadControl::new();
-        control.request_fallback_analysis();
-        assert!(!control.claim_downloader_analysis());
-        assert!(control.claim_fallback_analysis());
-        assert!(!control.claim_fallback_analysis());
+        assert!(control.select_fallback_analysis());
+        assert!(!control.downloader_analysis_selected().await);
+        control.select_downloader_analysis();
+        assert!(!control.select_fallback_analysis());
         assert!(!control.fallback_succeeded());
         assert!(!control.ended_without_reusable_bytes());
         control.mark_fallback_succeeded();
@@ -304,12 +327,17 @@ mod stream_download_control_tests {
         assert!(control.done.load(Ordering::SeqCst));
     }
 
-    #[test]
-    fn downloader_claim_prevents_late_fallback_claim() {
+    #[tokio::test]
+    async fn downloader_selection_wakes_waiter_and_prevents_late_fallback() {
         let control = StreamDownloadControl::new();
-        assert!(control.claim_downloader_analysis());
-        control.request_fallback_analysis();
-        assert!(!control.claim_fallback_analysis());
+        let waiter = {
+            let control = control.clone();
+            tokio::spawn(async move { control.downloader_analysis_selected().await })
+        };
+        tokio::task::yield_now().await;
+        control.select_downloader_analysis();
+        assert!(waiter.await.unwrap());
+        assert!(!control.select_fallback_analysis());
     }
 }
 
@@ -318,27 +346,54 @@ mod analysis_seed_hold_tests {
     use super::*;
 
     #[test]
-    fn guard_sets_and_clears_matching_generation() {
+    fn guard_sets_and_clears_matching_token() {
         let slot: AnalysisSeedHold = Arc::new(Mutex::new(None));
-        let guard = AnalysisSeedHoldGuard::arm(Some(&slot), Some("track-1"), 7)
+        let generation = Arc::new(AtomicU64::new(7));
+        let guard = AnalysisSeedHoldGuard::arm(Some(&slot), Some("track-1"), 7, &generation)
             .expect("valid track should arm hold");
-        assert_eq!(*slot.lock().unwrap(), Some(("track-1".to_string(), 7)));
+        assert!(matches!(
+            &*slot.lock().unwrap(),
+            Some((track_id, _)) if track_id == "track-1"
+        ));
 
         drop(guard);
         assert_eq!(*slot.lock().unwrap(), None);
     }
 
     #[test]
-    fn stale_guard_does_not_clear_newer_playback_hold() {
+    fn stale_guard_does_not_clear_rearmed_hold_for_the_same_track() {
         let slot: AnalysisSeedHold = Arc::new(Mutex::new(None));
-        let stale = AnalysisSeedHoldGuard::arm(Some(&slot), Some("track-1"), 7)
+        let generation = Arc::new(AtomicU64::new(7));
+        let stale = AnalysisSeedHoldGuard::arm(Some(&slot), Some("track-1"), 7, &generation)
             .expect("valid track should arm hold");
-        let current = AnalysisSeedHoldGuard::arm(Some(&slot), Some("track-2"), 8)
-            .expect("new playback should replace hold");
+        let stale_token = slot.lock().unwrap().as_ref().unwrap().1;
+        let current = AnalysisSeedHoldGuard::arm(Some(&slot), Some("track-1"), 7, &generation)
+            .expect("analysis handoff should replace hold");
+        let current_token = slot.lock().unwrap().as_ref().unwrap().1;
+        assert_ne!(stale_token, current_token);
 
         drop(stale);
-        assert_eq!(*slot.lock().unwrap(), Some(("track-2".to_string(), 8)));
+        assert_eq!(
+            *slot.lock().unwrap(),
+            Some(("track-1".to_string(), current_token))
+        );
         drop(current);
         assert_eq!(*slot.lock().unwrap(), None);
+    }
+
+    #[test]
+    fn stale_generation_cannot_overwrite_a_newer_playback_hold() {
+        let slot: AnalysisSeedHold = Arc::new(Mutex::new(None));
+        let generation = Arc::new(AtomicU64::new(8));
+        let current = AnalysisSeedHoldGuard::arm(Some(&slot), Some("track-2"), 8, &generation)
+            .expect("current playback should arm hold");
+        let current_token = slot.lock().unwrap().as_ref().unwrap().1;
+
+        assert!(AnalysisSeedHoldGuard::arm(Some(&slot), Some("track-1"), 7, &generation).is_none());
+        assert_eq!(
+            *slot.lock().unwrap(),
+            Some(("track-2".to_string(), current_token))
+        );
+        drop(current);
     }
 }

--- a/src-tauri/crates/psysonic-audio/src/stream/ranged_http.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream/ranged_http.rs
@@ -28,8 +28,9 @@ use super::{
     TRACK_STREAM_PROMOTE_MAX_BYTES, StreamDownloadControl,
 };
 use crate::analysis_dispatch::{
-    analysis_priority_for_app, dispatch_track_analysis_bytes, resolve_server_id_for_app,
-    spawn_track_analysis_file, TrackAnalysisDispatchOptions, TrackAnalysisOrigin,
+    analysis_priority_for_app, dispatch_track_analysis_bytes, prepare_track_analysis_file,
+    resolve_server_id_for_app, spawn_track_analysis_prepared_file, TrackAnalysisDispatchOptions,
+    TrackAnalysisOrigin,
 };
 use crate::helpers::{install_stream_completed_spill_if, write_stream_spill_file};
 use crate::state::StreamCompletedSpill;
@@ -619,7 +620,7 @@ pub(crate) async fn ranged_download_task(
     http_headers: PlaybackHttpHeaders,
     // Armed synchronously before this task is spawned so frontend refresh cannot
     // race a duplicate HTTP backfill ahead of the downloader.
-    _analysis_seed_hold: Option<AnalysisSeedHoldGuard>,
+    mut analysis_seed_hold: Option<AnalysisSeedHoldGuard>,
     playback_armed: Arc<AtomicBool>,
     format_hint: Option<String>,
     tail_ready: Arc<AtomicBool>,
@@ -816,9 +817,10 @@ pub(crate) async fn ranged_download_task(
                 *slot = Some(PreloadedTrack { url: url.clone(), data });
             }
             crate::app_deprintln!("[stream] promoted to stream_completed_cache for replay");
-            if let Some((track_id, analysis_data)) = analysis_input
-                .filter(|_| download_control.claim_downloader_analysis())
-            {
+            if let Some((track_id, analysis_data)) = analysis_input {
+                if !download_control.downloader_analysis_selected().await {
+                    return;
+                }
                 let sid = resolve_server_id_for_app(&app, server_id.as_deref());
                 let priority = analysis_priority_for_app(&app, &sid, &track_id, None);
                 let guard = (gen, gen_arc.clone());
@@ -869,6 +871,11 @@ pub(crate) async fn ranged_download_task(
                         let _ = std::fs::remove_file(&path);
                         return;
                     }
+                    let prepared_file = prepare_track_analysis_file(
+                        TrackAnalysisOrigin::StreamSpillFile,
+                        &track_id,
+                        &path,
+                    );
                     let spill_stream_url = url.clone();
                     if !install_stream_completed_spill_if(
                         &spill_cache_slot,
@@ -883,17 +890,20 @@ pub(crate) async fn ranged_download_task(
                     }
                     let sid = resolve_server_id_for_app(&app, server_id.as_deref());
                     let priority = analysis_priority_for_app(&app, &sid, &track_id, None);
-                    if download_control.claim_downloader_analysis() {
-                        spawn_track_analysis_file(
-                            app.clone(),
-                            TrackAnalysisOrigin::StreamSpillFile,
-                            sid,
-                            track_id,
-                            path,
-                            Some(spill_stream_url), // spilled HTTP bytes keep stream provenance
-                            priority,
-                            Some((gen, gen_arc.clone())),
-                        );
+                    if download_control.downloader_analysis_selected().await {
+                        if let Some(prepared_file) = prepared_file {
+                            spawn_track_analysis_prepared_file(
+                                app.clone(),
+                                TrackAnalysisOrigin::StreamSpillFile,
+                                sid,
+                                track_id,
+                                prepared_file,
+                                Some(spill_stream_url), // spilled HTTP bytes keep stream provenance
+                                priority,
+                                Some((gen, gen_arc.clone())),
+                                analysis_seed_hold.take(),
+                            );
+                        }
                     }
                 }
                 Err(e) => {

--- a/src-tauri/crates/psysonic-audio/src/stream/track_stream.rs
+++ b/src-tauri/crates/psysonic-audio/src/stream/track_stream.rs
@@ -89,8 +89,7 @@ fn finish_legacy_stream_download(
     gen: u64,
     gen_arc: &AtomicU64,
     playback_armed: &AtomicBool,
-    after_publish: impl FnOnce(),
-) {
+) -> bool {
     let run_after_publish = if let Some(completed) = completed {
         let mut slot = promote_cache_slot.lock().unwrap();
         if gen_arc.load(Ordering::SeqCst) == gen && !download_control.fallback_succeeded() {
@@ -104,9 +103,7 @@ fn finish_legacy_stream_download(
     };
     playback_armed.store(true, Ordering::SeqCst);
     download_control.done.store(true, Ordering::SeqCst);
-    if run_after_publish {
-        after_publish();
-    }
+    run_after_publish
 }
 
 fn push_slice_or_skip_closed_consumer(prod: &mut HeapProd<u8>, bytes: &[u8]) -> (usize, bool) {
@@ -134,7 +131,7 @@ pub(crate) async fn track_download_task(
     cache_track_id: Option<String>,
     // Playback server scope for the analysis-cache write key (empty/`None` → legacy '').
     server_id: Option<String>,
-    _analysis_seed_hold: Option<AnalysisSeedHoldGuard>,
+    analysis_seed_hold: Option<AnalysisSeedHoldGuard>,
     http_headers: PlaybackHttpHeaders,
     playback_armed: Arc<AtomicBool>,
 ) {
@@ -304,6 +301,11 @@ pub(crate) async fn track_download_task(
                 downloaded as f64 / (1024.0 * 1024.0),
                 path.display()
             );
+            let prepared_file = crate::analysis_dispatch::prepare_track_analysis_file(
+                crate::analysis_dispatch::TrackAnalysisOrigin::StreamSpillFile,
+                &track_id,
+                &path,
+            );
             if !install_stream_completed_spill_if(
                 &spill_cache_slot,
                 url.clone(),
@@ -317,14 +319,16 @@ pub(crate) async fn track_download_task(
                 return;
             }
             let analysis_gen_arc = gen_arc.clone();
-            finish_legacy_stream_download(
+            let published = finish_legacy_stream_download(
                 None,
                 &promote_cache_slot,
                 &download_control,
                 gen,
                 &gen_arc,
                 &playback_armed,
-                || {
+            );
+            if published && download_control.downloader_analysis_selected().await {
+                if let Some(prepared_file) = prepared_file {
                     let sid = crate::analysis_dispatch::resolve_server_id_for_app(
                         &app,
                         server_id.as_deref(),
@@ -332,20 +336,19 @@ pub(crate) async fn track_download_task(
                     let priority = crate::analysis_dispatch::analysis_priority_for_app(
                         &app, &sid, &track_id, None,
                     );
-                    if download_control.claim_downloader_analysis() {
-                        crate::analysis_dispatch::spawn_track_analysis_file(
-                            app,
-                            crate::analysis_dispatch::TrackAnalysisOrigin::StreamSpillFile,
-                            sid,
-                            track_id,
-                            path,
-                            Some(url),
-                            priority,
-                            Some((gen, analysis_gen_arc)),
-                        );
-                    }
-                },
-            );
+                    crate::analysis_dispatch::spawn_track_analysis_prepared_file(
+                        app,
+                        crate::analysis_dispatch::TrackAnalysisOrigin::StreamSpillFile,
+                        sid,
+                        track_id,
+                        prepared_file,
+                        Some(url),
+                        priority,
+                        Some((gen, analysis_gen_arc)),
+                        analysis_seed_hold,
+                    );
+                }
+            }
             return;
         }
         if download_control.fallback_succeeded() {
@@ -372,18 +375,17 @@ pub(crate) async fn track_download_task(
             download_control.mark_ended_without_reusable_bytes();
         }
         let analysis_gen_arc = gen_arc.clone();
-        finish_legacy_stream_download(
+        let published = finish_legacy_stream_download(
             completed,
             &promote_cache_slot,
             &download_control,
             gen,
             &gen_arc,
             &playback_armed,
-            || {
-                if let (Some(track_id), Some(capture)) = (cache_track_id, analysis_capture) {
-                    if !download_control.claim_downloader_analysis() {
-                        return;
-                    }
+        );
+        if published {
+            if let (Some(track_id), Some(capture)) = (cache_track_id, analysis_capture) {
+                if download_control.downloader_analysis_selected().await {
                     crate::app_deprintln!(
                         "[stream] legacy stream: capture complete track_id={} capture_mib={:.2} — full-track analysis (cpu-seed queue)",
                         track_id,
@@ -405,10 +407,11 @@ pub(crate) async fn track_download_task(
                         Some(url),
                         priority,
                         Some((gen, analysis_gen_arc)),
+                        analysis_seed_hold,
                     );
                 }
-            },
-        );
+            }
+        }
         return;
     }
 }
@@ -442,7 +445,7 @@ mod tests {
         let analysis_started = AtomicBool::new(false);
         let generation = AtomicU64::new(7);
 
-        finish_legacy_stream_download(
+        let published = finish_legacy_stream_download(
             Some(PreloadedTrack {
                 url: "https://example.test/stream".to_string(),
                 data: body.clone(),
@@ -452,14 +455,14 @@ mod tests {
             7,
             &generation,
             &playback_armed,
-            || {
-                let completed = completed.lock().unwrap();
-                assert_eq!(completed.as_ref().unwrap().data, body);
-                assert!(playback_armed.load(Ordering::SeqCst));
-                assert!(done.load(Ordering::SeqCst));
-                analysis_started.store(true, Ordering::SeqCst);
-            },
         );
+        if published {
+            let completed = completed.lock().unwrap();
+            assert_eq!(completed.as_ref().unwrap().data, body);
+            assert!(playback_armed.load(Ordering::SeqCst));
+            assert!(done.load(Ordering::SeqCst));
+            analysis_started.store(true, Ordering::SeqCst);
+        }
 
         assert!(analysis_started.load(Ordering::SeqCst));
         assert!(done.load(Ordering::SeqCst));

--- a/src-tauri/crates/psysonic-core/src/track_enrichment.rs
+++ b/src-tauri/crates/psysonic-core/src/track_enrichment.rs
@@ -45,6 +45,8 @@ pub enum TrackEnrichmentOutcome {
     SkippedComplete,
     /// Oximedia analysis or persistence failed; facts were not stored (retry on next seed).
     Failed,
+    /// A newer trusted revision became current before facts could be stored.
+    SkippedSuperseded,
     SkippedNoServer,
     SkippedNoPort,
 }

--- a/src-tauri/crates/psysonic-integration/src/subsonic/stream_url.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/stream_url.rs
@@ -43,7 +43,6 @@ pub fn build_stream_view_url(
         q.append_pair("f", "json");
         q.append_pair("format", ANALYSIS_TRANSCODE_FORMAT);
         q.append_pair("maxBitRate", ANALYSIS_TRANSCODE_BITRATE_KBPS);
-        q.append_pair("estimateContentLength", "true");
     }
     url.to_string()
 }
@@ -62,6 +61,6 @@ mod tests {
         assert!(url.contains("&s="));
         assert!(url.contains("format=mp3"));
         assert!(url.contains("maxBitRate=64"));
-        assert!(url.contains("estimateContentLength=true"));
+        assert!(!url.contains("estimateContentLength"));
     }
 }

--- a/src-tauri/crates/psysonic-integration/src/subsonic/stream_url.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/stream_url.rs
@@ -5,6 +5,9 @@ use url::Url;
 use super::auth::SubsonicCredentials;
 use super::client::{SUBSONIC_API_VERSION, SUBSONIC_CLIENT_ID};
 
+const ANALYSIS_TRANSCODE_FORMAT: &str = "mp3";
+const ANALYSIS_TRANSCODE_BITRATE_KBPS: &str = "64";
+
 /// `{origin}/rest` — mirrors frontend `restBaseFromUrl`.
 pub fn rest_base_from_url(server_url: &str) -> String {
     let trimmed = server_url.trim().trim_end_matches('/');
@@ -16,7 +19,9 @@ pub fn rest_base_from_url(server_url: &str) -> String {
     format!("{base}/rest")
 }
 
-/// Authenticated `stream.view` URL for a library track id.
+/// Authenticated low-bandwidth `stream.view` URL for native library analysis.
+/// The original fingerprint is probed separately through `format=raw`; only the
+/// bytes decoded for waveform/loudness/BPM are transcoded.
 pub fn build_stream_view_url(
     server_url: &str,
     username: &str,
@@ -25,8 +30,8 @@ pub fn build_stream_view_url(
 ) -> String {
     let creds = SubsonicCredentials::from_password(username, password);
     let base = rest_base_from_url(server_url);
-    let mut url =
-        Url::parse(&format!("{base}/stream.view")).unwrap_or_else(|_| Url::parse("http://invalid/rest/stream.view").unwrap());
+    let mut url = Url::parse(&format!("{base}/stream.view"))
+        .unwrap_or_else(|_| Url::parse("http://invalid/rest/stream.view").unwrap());
     {
         let mut q = url.query_pairs_mut();
         q.append_pair("id", track_id);
@@ -36,6 +41,9 @@ pub fn build_stream_view_url(
         q.append_pair("v", SUBSONIC_API_VERSION);
         q.append_pair("c", SUBSONIC_CLIENT_ID);
         q.append_pair("f", "json");
+        q.append_pair("format", ANALYSIS_TRANSCODE_FORMAT);
+        q.append_pair("maxBitRate", ANALYSIS_TRANSCODE_BITRATE_KBPS);
+        q.append_pair("estimateContentLength", "true");
     }
     url.to_string()
 }
@@ -46,16 +54,14 @@ mod tests {
 
     #[test]
     fn stream_url_contains_track_and_auth_params() {
-        let url = build_stream_view_url(
-            "https://music.example",
-            "alice",
-            "secret",
-            "tr-42",
-        );
+        let url = build_stream_view_url("https://music.example", "alice", "secret", "tr-42");
         assert!(url.contains("stream.view"));
         assert!(url.contains("id=tr-42"));
         assert!(url.contains("u=alice"));
         assert!(url.contains("&t="));
         assert!(url.contains("&s="));
+        assert!(url.contains("format=mp3"));
+        assert!(url.contains("maxBitRate=64"));
+        assert!(url.contains("estimateContentLength=true"));
     }
 }

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -214,6 +214,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Performance benchmark CLI and faster scoped library browsing (PR #1382)',
       'Startup window controls and lifecycle race fixes (PR #1392)',
       'AIFF/AIF/AIFC playback across streamed, cached, and local sources (PR #1396)',
+      'Analysis pipeline — reuse playback and completed-stream sources, bound backfill resources, and prioritise active playback (PR #1419)',
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Reuse playback, preload, cache, local-file, and completed spill sources for waveform, loudness, and enrichment instead of starting duplicate original-file downloads.
- Bound analysis admission across RAM, raw HTTP probes, and disk spill paths, including range-stripping servers and unavailable local sources.
- Harden revision retries, priority handoff, and worker lifecycle races so current playback can overtake background analysis without stale workers publishing results.

## Verification

- Rust workspace tests: cargo test --workspace --all-targets -- --test-threads=1
- Rust lint: cargo clippy --workspace --all-targets -- -D warnings
- Exact CI lint toolchain: rustc/cargo/clippy 1.97.1
- Nix source build: nix build .#psysonic
- Manual lazy mode: repeated playback reused completed analysis sources with no duplicate HTTP fetch or CPU decode.
- Manual aggressive mode: low-priority backfill stayed serialized and playback high priority overtook queued background work.
- GitHub CI: Linux/Windows Rust tests and Clippy, Rust coverage, frontend checks, and ci-ok passed on final head.

## Runtime benchmark

- Applicability: required; this changes analysis caches, background work, HTTP reuse, and playback-adjacent scheduling.
- Baseline: 3f423656a111b754cfa7456482003196ea429766 / report 2026-08-15T19-18-29-864Z
- Final: c471a42512800e994dc470520e4d114563d8454a / report 2026-08-15T20-30-16-558Z
- Command: psysonic benchmark run --scenario core-pages --runs 2 --profile realistic --json
- Environment: 2554x1392 viewport, one selected server, matching user agent and library scope fingerprint, playback paused.
- Result: Home 1595 -> 1148 ms, Albums 1068 -> 930 ms, Artists 939 -> 886 ms, Favourites 1951 -> 1974 ms, Tracks 1053 -> 901 ms. No material regression; Favourites changed by 23 ms (1%).
- Repeat handling: the first final-head run had non-reproducible cold Albums/Artists and warm Home outliers; the immediate same-environment repeat above returned those routes to baseline-or-better values.
- Errors, timeouts, route mismatches, and skips: none.

## Tauri boundary

- No command names, event names, argument payloads, or return payload shapes changed.
