### PR TITLE
Fix MPRIS volume synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -464,6 +464,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Narrow bass bands no longer move in flat lockstep plateaus when several bars share one FFT bin. Frequency positions stay correct at standard and Hi-Res sample rates, while bands with real bin coverage keep their peak response.
 
+### Linux media controls — keep volume in sync
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1420](https://github.com/Psychotoxical/psysonic/pull/1420)**, reported by [@Logey](https://github.com/Logey)
+
+* Changing volume through `playerctl` or other MPRIS controls now updates Psysonic, and volume changes inside Psysonic are reflected back to the desktop controls instead of the two levels drifting apart.
+
 ## [1.50.0]
 
 ## Added

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,6 +99,24 @@ fn scheduler_idle_payload(
 /// `None` if souvlaki failed to initialize (e.g. no D-Bus session on Linux).
 type MprisControls = Mutex<Option<souvlaki::MediaControls>>;
 
+fn normalize_mpris_volume(volume: f64) -> Option<f64> {
+    volume.is_finite().then(|| volume.clamp(0.0, 1.0))
+}
+
+#[cfg(test)]
+mod mpris_volume_tests {
+    use super::normalize_mpris_volume;
+
+    #[test]
+    fn normalizes_mpris_volume_to_player_range() {
+        assert_eq!(normalize_mpris_volume(-0.5), Some(0.0));
+        assert_eq!(normalize_mpris_volume(0.42), Some(0.42));
+        assert_eq!(normalize_mpris_volume(1.5), Some(1.0));
+        assert_eq!(normalize_mpris_volume(f64::NAN), None);
+        assert_eq!(normalize_mpris_volume(f64::INFINITY), None);
+    }
+}
+
 /// Focus or CLI-hand off when a second instance of the same build channel launches.
 #[cfg(any(target_os = "linux", not(debug_assertions)))]
 fn on_second_instance<R: tauri::Runtime>(
@@ -357,6 +375,7 @@ fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             crate::lib_commands::app_api::integration::unregister_global_shortcut,
             crate::lib_commands::app_api::integration::mpris_set_metadata,
             crate::lib_commands::app_api::integration::mpris_set_playback,
+            crate::lib_commands::app_api::integration::mpris_set_volume,
             crate::lib_commands::app_api::integration::check_dir_accessible,
             crate::lib_commands::ui::mini::open_mini_player,
             crate::lib_commands::ui::mini::preload_mini_player,
@@ -1216,6 +1235,11 @@ pub fn run() {
                                         let secs = pos.0.as_secs_f64();
                                         let _ = app_handle.emit("media:seek-absolute", secs);
                                     }
+                                    MediaControlEvent::SetVolume(volume) => {
+                                        if let Some(volume) = normalize_mpris_volume(volume) {
+                                            let _ = app_handle.emit("media:set-volume", volume);
+                                        }
+                                    }
                                     _ => {}
                                 }
                             }) {
@@ -1392,6 +1416,7 @@ pub fn run() {
             unregister_global_shortcut,
             mpris_set_metadata,
             mpris_set_playback,
+            mpris_set_volume,
             audio::commands::audio_play,
             audio::transport_commands::audio_pause,
             audio::transport_commands::audio_resume,

--- a/src-tauri/src/lib_commands/app_api/integration.rs
+++ b/src-tauri/src/lib_commands/app_api/integration.rs
@@ -170,6 +170,30 @@ pub(crate) fn mpris_set_playback(
         .map_err(|e| format!("MPRIS set_playback failed: {e:?}"))
 }
 
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn mpris_set_volume(
+    controls: tauri::State<MprisControls>,
+    volume: f64,
+) -> Result<(), String> {
+    let volume = crate::normalize_mpris_volume(volume)
+        .ok_or_else(|| "MPRIS volume must be finite".to_string())?;
+
+    #[cfg(target_os = "linux")]
+    {
+        let mut guard = controls.lock().unwrap();
+        let Some(ctrl) = guard.as_mut() else { return Ok(()); };
+        ctrl.set_volume(volume)
+            .map_err(|e| format!("MPRIS set_volume failed: {e:?}"))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (controls, volume);
+        Ok(())
+    }
+}
+
 /// Returns true if `path` is an accessible directory (used for pre-flight checks in the frontend).
 #[tauri::command]
 #[specta::specta]

--- a/src-tauri/src/lib_commands/app_api/mod.rs
+++ b/src-tauri/src/lib_commands/app_api/mod.rs
@@ -39,8 +39,8 @@ pub(crate) use platform::{
     sync_wayland_text_profile_cache_from_disk,
 };
 pub(crate) use integration::{
-    check_dir_accessible, mpris_set_metadata, mpris_set_playback, register_global_shortcut,
-    unregister_global_shortcut,
+    check_dir_accessible, mpris_set_metadata, mpris_set_playback, mpris_set_volume,
+    register_global_shortcut, unregister_global_shortcut,
 };
 pub(crate) use migration::{migration_inspect, migration_run};
 pub(crate) use network::{

--- a/src/app/tauriBridge/useMediaAndWindowBridge.test.tsx
+++ b/src/app/tauriBridge/useMediaAndWindowBridge.test.tsx
@@ -1,0 +1,25 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NavigateFunction } from 'react-router';
+import { emitTauriEvent, onInvoke, tauriMockListenerCount } from '@/test/mocks/tauri';
+import { resetPlayerStore } from '@/test/helpers/storeReset';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { useMediaAndWindowBridge } from './useMediaAndWindowBridge';
+
+describe('useMediaAndWindowBridge MPRIS volume', () => {
+  beforeEach(() => {
+    resetPlayerStore();
+    onInvoke('audio_set_volume', () => undefined);
+  });
+
+  it('applies normalized media volume events to the player store', async () => {
+    const navigate = vi.fn() as unknown as NavigateFunction;
+    const { unmount } = renderHook(() => useMediaAndWindowBridge(navigate));
+
+    await waitFor(() => expect(tauriMockListenerCount('media:set-volume')).toBe(1));
+    emitTauriEvent('media:set-volume', 0.42);
+
+    expect(usePlayerStore.getState().volume).toBe(0.42);
+    unmount();
+  });
+});

--- a/src/app/tauriBridge/useMediaAndWindowBridge.ts
+++ b/src/app/tauriBridge/useMediaAndWindowBridge.ts
@@ -87,8 +87,8 @@ export function useMediaAndWindowBridge(navigate: NavigateFunction) {
       {
         const u = await listen<number>('media:set-volume', e => {
           const p = e.payload;
-          if (typeof p !== 'number' || Number.isNaN(p)) return;
-          usePlayerStore.getState().setVolume(Math.min(1, Math.max(0, p / 100)));
+          if (typeof p !== 'number' || !Number.isFinite(p)) return;
+          usePlayerStore.getState().setVolume(Math.min(1, Math.max(0, p)));
         });
         if (cancelled) { u(); return; }
         unlisten.push(u);

--- a/src/features/playback/store/audioListenerSetup/mprisSync.test.ts
+++ b/src/features/playback/store/audioListenerSetup/mprisSync.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const hoisted = vi.hoisted(() => ({
   mprisSetMetadata: vi.fn(() => Promise.resolve()),
   mprisSetPlayback: vi.fn(() => Promise.resolve()),
+  mprisSetVolume: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(() => Promise.resolve()) }));
 vi.mock('@/lib/api/mpris', () => ({
   mprisSetMetadata: hoisted.mprisSetMetadata,
   mprisSetPlayback: hoisted.mprisSetPlayback,
+  mprisSetVolume: hoisted.mprisSetVolume,
 }));
 vi.mock('@/cover/resolveEntryLibrary', () => ({
   resolveTrackCoverRefFromLibrary: vi.fn(() => Promise.resolve(null)),
@@ -30,6 +32,7 @@ describe('setupMprisSync radio ownership', () => {
     resetPlayerStore();
     hoisted.mprisSetMetadata.mockClear();
     hoisted.mprisSetPlayback.mockClear();
+    hoisted.mprisSetVolume.mockClear();
   });
 
   it('pushes metadata when radio ownership changes but the raw id is the same', () => {
@@ -59,6 +62,18 @@ describe('setupMprisSync radio ownership', () => {
     expect(hoisted.mprisSetMetadata).toHaveBeenNthCalledWith(2, expect.objectContaining({
       title: 'Beta Radio',
     }));
+    cleanup();
+  });
+
+  it('pushes the initial volume and subsequent changes', () => {
+    usePlayerStore.setState({ volume: 0.35 });
+    const cleanup = setupMprisSync();
+
+    expect(hoisted.mprisSetVolume).toHaveBeenNthCalledWith(1, 0.35);
+
+    usePlayerStore.setState({ volume: 0.7 });
+
+    expect(hoisted.mprisSetVolume).toHaveBeenNthCalledWith(2, 0.7);
     cleanup();
   });
 });

--- a/src/features/playback/store/audioListenerSetup/mprisSync.ts
+++ b/src/features/playback/store/audioListenerSetup/mprisSync.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { mprisSetMetadata, mprisSetPlayback } from '@/lib/api/mpris';
+import { mprisSetMetadata, mprisSetPlayback, mprisSetVolume } from '@/lib/api/mpris';
 import { resolvePlaybackCoverScope } from '@/cover/ref';
 import { resolveTrackCoverRefFromLibrary } from '@/cover/resolveEntryLibrary';
 import { coverArtUrlForMpris } from '@/cover/integrations/mpris';
@@ -8,18 +8,26 @@ import { getPlaybackProgressSnapshot, subscribePlaybackProgress } from '@/featur
 import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
 
 /**
- * MPRIS / OS media-controls sync. Whenever the current track or playback state
- * changes, pushes updates to the Rust souvlaki MediaControls so the OS media
- * overlay stays accurate. Returns a cleanup function.
+ * MPRIS / OS media-controls sync. Whenever the current track, playback state,
+ * or volume changes, pushes updates to the Rust souvlaki MediaControls so the
+ * OS media overlay stays accurate. Returns a cleanup function.
  */
 export function setupMprisSync(): () => void {
   let prevTrackId: string | null = null;
   let prevRadioKey: string | null = null;
   let prevIsPlaying: boolean | null = null;
+  let prevVolume = usePlayerStore.getState().volume;
   let lastMprisPositionUpdate = 0;
 
+  mprisSetVolume(prevVolume).catch(() => {});
+
   const unsubMpris = usePlayerStore.subscribe((state) => {
-    const { currentTrack, currentRadio, isPlaying } = state;
+    const { currentTrack, currentRadio, isPlaying, volume } = state;
+
+    if (volume !== prevVolume) {
+      prevVolume = volume;
+      mprisSetVolume(volume).catch(() => {});
+    }
 
     // Update metadata when track changes
     if (currentTrack && currentTrack.id !== prevTrackId) {

--- a/src/generated/bindings.ts
+++ b/src/generated/bindings.ts
@@ -613,6 +613,7 @@ export const commands = {
 	unregisterGlobalShortcut: (shortcut: string) => typedError<null, string>(__TAURI_INVOKE("unregister_global_shortcut", { shortcut })),
 	mprisSetMetadata: (title: string | null, artist: string | null, album: string | null, coverUrl: string | null, durationSecs: number | null) => typedError<null, string>(__TAURI_INVOKE("mpris_set_metadata", { title, artist, album, coverUrl, durationSecs })),
 	mprisSetPlayback: (playing: boolean, positionSecs: number | null) => typedError<null, string>(__TAURI_INVOKE("mpris_set_playback", { playing, positionSecs })),
+	mprisSetVolume: (volume: number | null) => typedError<null, string>(__TAURI_INVOKE("mpris_set_volume", { volume })),
 	/**  Returns true if `path` is an accessible directory (used for pre-flight checks in the frontend). */
 	checkDirAccessible: (path: string) => __TAURI_INVOKE<boolean>("check_dir_accessible", { path }),
 	/**

--- a/src/lib/api/mpris.ts
+++ b/src/lib/api/mpris.ts
@@ -1,6 +1,6 @@
 /**
  * Typed facade over the generated MPRIS commands (Linux desktop media controls
- * + souvlaki bridge). Both commands are Result-wrapped: the facade re-throws on
+ * + souvlaki bridge). Commands are Result-wrapped: the facade re-throws on
  * error so the callers' `.catch()` fire-and-forget semantics stay unchanged.
  */
 import { commands } from '@/generated/bindings';
@@ -27,5 +27,10 @@ export async function mprisSetPlayback(args: {
   positionSecs: number | null;
 }): Promise<void> {
   const res = await commands.mprisSetPlayback(args.playing, args.positionSecs);
+  if (res.status === 'error') throw new Error(res.error);
+}
+
+export async function mprisSetVolume(volume: number): Promise<void> {
+  const res = await commands.mprisSetVolume(volume);
   if (res.status === 'error') throw new Error(res.error);
 }


### PR DESCRIPTION
## Summary
- handle MPRIS `SetVolume` events and forward normalized `0..1` values to the player store
- publish the initial player volume and later volume changes back to MPRIS
- add Rust and Vitest coverage for both directions of the volume bridge

Closes #1418

## Tauri boundary
- Added command: `mpris_set_volume { volume }`
- Added Rust producer for existing event: `media:set-volume`, with normalized `0..1` payload semantics
- Removed commands/events: none
- Updated generated Specta bindings and frontend Tauri mocks/tests
- Volume updates reuse the existing player-store subscription and emit IPC only when the volume value changes

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test`
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- `RUST_TEST_THREADS=1 cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- release build completed successfully
- manual MPRIS round trip: `playerctl volume 0.42`, relative volume, and Psysonic CLI volume all stayed synchronized

## Runtime benchmark
- Applicability: required; adds a player-store subscription and Tauri volume path
- Baseline: `b1e27033ec8098ade6531cfc4ad5a87b1952f772` / report `2026-08-15T21-14-01-976Z`
- Final code: `d0a8273d` / report `2026-08-15T21-31-25-762Z`
- Current PR head: `3bc33e29` (changelog-only follow-up; runtime code unchanged)
- Command: `nix develop -c bash -lc './.build-local/cargo-target/release/psysonic benchmark run --scenario core-pages --runs 2 --profile realistic --json'`
- Environment: same machine, WebKit user agent, 1 selected server, and scope fingerprint; viewport height `694`, reported inner width `1275 -> 1284` due scrollbar state
- Median total: Home `1162 -> 978 ms`; Albums `875 -> 908 ms`; Artists `840 -> 822 ms`; Tracks `913 -> 885 ms`; Favourites `1593 -> 1609 ms`
- Tracks pagination completed in both samples; all routes reached the requested route
- Timeouts/errors/skips: none
- Favourites cold server refresh varied (`86 -> 337 ms`), while warm refresh remained stable (`83 -> 79 ms`) and total route time changed by 1%

## Notes
The discarded final attempts were launched outside the Nix runtime and entered a false offline state because required WebKit/runtime libraries were absent. The recorded final report was captured inside `nix develop`, matching the valid baseline runtime.