### PR TITLE
Add Play from Here to timeline history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Settings → Audio → Track transitions** can fade playback out before pausing and back in when resuming, with a configurable 0.1–2.0 second duration and a 1.0 second default.
 * The optional fade works with both ordinary playback and internet radio, while rapid pause, resume and stop actions cancel stale fades instead of changing playback later.
 
+### Timeline — replay from any point in listening history
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1423](https://github.com/Psychotoxical/psysonic/pull/1423)**
+
+* Right-click a past Timeline track and choose **Play from Here** to replay that occurrence, every later history entry and the existing **Up Next** list in their original order.
+* Mixed-server ownership and queue-only flags stay attached to each rebuilt entry, so the restored sequence plays from the correct servers.
+
 ## Changed
 
 ### Library index — designed for several live servers at once

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -217,6 +217,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Analysis pipeline — reuse playback and completed-stream sources, bound backfill resources, and prioritise active playback (PR #1419)',
       'Random Mix — combine several selected genres into one balanced mix (request: Gypsy on Psysonic Discord, PR #1421)',
       'Audio controls — configurable pause/resume fade for native playback and internet radio (PR #1422)',
+      'Timeline — replay listening history from any selected point (PR #1423)',
     ],
   },
   {

--- a/src/features/contextMenu/components/ContextMenu.test.tsx
+++ b/src/features/contextMenu/components/ContextMenu.test.tsx
@@ -57,8 +57,9 @@ import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { useAuthStore } from '@/store/authStore';
 import { resetAllStores } from '@/test/helpers/storeReset';
 import { makeTrack, makeServer, seedQueue } from '@/test/helpers/factories';
+import { seedQueueResolver } from '@/features/playback/store/queueTrackResolver';
 import { onInvoke } from '@/test/mocks/tauri';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 
 function setUpActiveServer(): ServerProfile {
   const server = makeServer();
@@ -70,8 +71,25 @@ function setUpActiveServer(): ServerProfile {
   return { ...server, id };
 }
 
-function openMenuFor(type: 'song' | 'album' | 'artist' | 'queue-item' | 'album-song', item: unknown, queueIndex?: number): void {
-  usePlayerStore.getState().openContextMenu(100, 100, item as never, type, queueIndex);
+function openMenuFor(
+  type: 'song' | 'album' | 'artist' | 'queue-item' | 'album-song',
+  item: unknown,
+  queueIndex?: number,
+  timelineFromHereRefs?: { serverId: string; trackId: string }[],
+): void {
+  usePlayerStore.getState().openContextMenu(
+    100,
+    100,
+    item as never,
+    type,
+    queueIndex,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    timelineFromHereRefs,
+  );
 }
 
 beforeEach(() => {
@@ -138,6 +156,50 @@ describe('ContextMenu — type=song', () => {
     expect(playNextSpy).toHaveBeenCalledTimes(1);
     expect(playNextSpy.mock.calls[0]?.[0]).toHaveLength(1);
     expect(playNextSpy.mock.calls[0]?.[0][0].id).toBe('tr-pn');
+  });
+
+  it('shows Play from Here after Play Next only for a timeline history row', () => {
+    const track = makeTrack({ id: 'history' });
+    openMenuFor('song', track, undefined, [
+      { serverId: 'srv-1', trackId: 'history' },
+      { serverId: 'srv-1', trackId: 'current' },
+    ]);
+    const { container } = renderWithProviders(<ContextMenu />);
+    const labels = [...container.querySelectorAll('.context-menu-item')]
+      .map(item => item.textContent?.trim());
+
+    expect(labels.slice(0, 4)).toEqual([
+      'Play Now',
+      'Play Next',
+      'Play from Here',
+      'Add to Queue',
+    ]);
+  });
+
+  it('does not show Play from Here for a regular song menu', () => {
+    openMenuFor('song', makeTrack({ id: 'regular' }));
+    const { queryByText } = renderWithProviders(<ContextMenu />);
+
+    expect(queryByText('Play from Here')).not.toBeInTheDocument();
+  });
+
+  it('replaces playback with the captured timeline order', async () => {
+    const history = makeTrack({ id: 'history-action', serverId: 'srv-1' });
+    const current = makeTrack({ id: 'current-action', serverId: 'srv-1' });
+    seedQueueResolver('srv-1', [history, current]);
+    const playTrackSpy = vi.spyOn(usePlayerStore.getState(), 'playTrack');
+    openMenuFor('song', history, undefined, [
+      { serverId: 'srv-1', trackId: 'history-action' },
+      { serverId: 'srv-1', trackId: 'current-action' },
+    ]);
+    const { getByText } = renderWithProviders(<ContextMenu />);
+
+    fireEvent.click(getByText('Play from Here'));
+
+    await waitFor(() => expect(playTrackSpy).toHaveBeenCalled());
+    const [track, queue] = playTrackSpy.mock.calls[playTrackSpy.mock.calls.length - 1]!;
+    expect(track.id).toBe('history-action');
+    expect(queue?.map(item => item.id)).toEqual(['history-action', 'current-action']);
   });
 
   it('"Add to Queue" click calls playerStore.enqueue', () => {

--- a/src/features/contextMenu/components/ContextMenu.tsx
+++ b/src/features/contextMenu/components/ContextMenu.tsx
@@ -180,6 +180,7 @@ export default function ContextMenu() {
     playlistSongRemove,
     shareKindOverride,
     pinToPlaybackServer = false,
+    timelineFromHereRefs,
   } = contextMenu;
   const itemServerIds = contextMenuServerIds(item);
   const capabilityServerIds = itemServerIds.length > 0
@@ -265,6 +266,7 @@ export default function ContextMenu() {
           playlistId={playlistId}
           playlistSongIndex={playlistSongIndex}
           playlistSongRemove={playlistSongRemove}
+          timelineFromHereRefs={timelineFromHereRefs}
           shareKindOverride={shareKindOverride}
           playTrack={playTrack}
           playNext={playNext}

--- a/src/features/contextMenu/components/SongContextItems.tsx
+++ b/src/features/contextMenu/components/SongContextItems.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Play, ListPlus, Radio, Heart, ChevronRight, ChevronsRight, User, Disc3, ListMusic, Info, Sparkles, Star, Trash2, HeartCrack, Share2, Orbit as OrbitIcon } from 'lucide-react';
+import { Play, ListPlus, ListStart, Radio, Heart, ChevronRight, ChevronsRight, User, Disc3, ListMusic, Info, Sparkles, Star, Trash2, HeartCrack, Share2, Orbit as OrbitIcon } from 'lucide-react';
 import { useNavigateToAlbum } from '@/features/album';
 import { useNavigateToArtist } from '@/features/artist';
 import { resolveAlbum, resolveMediaServerId } from '@/features/offline';
@@ -16,10 +16,11 @@ import StarRating from '@/ui/StarRating';
 import { AddToPlaylistSubmenu } from '@/features/contextMenu/components/AddToPlaylistSubmenu';
 import type { ContextMenuItemsProps } from '@/features/contextMenu/components/contextMenuItemTypes';
 import { appendServerQuery } from '@/lib/navigation/detailServerScope';
+import { playTimelineFromHere } from '@/features/playback';
 
 export default function SongContextItems(props: ContextMenuItemsProps) {
   const {
-    type, item, playlistId, playlistSongIndex, playlistSongRemove,
+    type, item, playlistId, playlistSongIndex, playlistSongRemove, timelineFromHereRefs,
     playTrack, playNext, enqueue, closeContextMenu,
     networkLovedCache, setNetworkLovedForSong,
     openSongInfo, userRatingOverrides, setKeyboardRating, keyboardRating,
@@ -50,6 +51,11 @@ export default function SongContextItems(props: ContextMenuItemsProps) {
               <div className="context-menu-item" onClick={() => handleAction(() => playNext([song]))}>
                 <ChevronsRight size={14} /> {t('contextMenu.playNext')}
               </div>
+              {timelineFromHereRefs && timelineFromHereRefs.length > 0 && (
+                <div className="context-menu-item" onClick={() => handleAction(() => playTimelineFromHere(timelineFromHereRefs))}>
+                  <ListStart size={14} /> {t('contextMenu.playFromHere')}
+                </div>
+              )}
               <div className="context-menu-item" onClick={() => handleAction(() => enqueue([song]))}>
                 <ListPlus size={14} /> {t('contextMenu.addToQueue')}
               </div>

--- a/src/features/contextMenu/components/contextMenuItemTypes.ts
+++ b/src/features/contextMenu/components/contextMenuItemTypes.ts
@@ -19,6 +19,7 @@ export interface ContextMenuItemsProps {
   playlistId?: string;
   playlistSongIndex?: number;
   playlistSongRemove?: () => void | Promise<void>;
+  timelineFromHereRefs?: QueueItemRef[];
   shareKindOverride?: EntityShareKind;
   playTrack: (track: Track, queue?: Track[], manual?: boolean, orbitConfirmed?: boolean, targetQueueIndex?: number) => void;
   playNext: (tracks: Track[]) => void;

--- a/src/features/playback/index.ts
+++ b/src/features/playback/index.ts
@@ -24,3 +24,4 @@ export {
 } from './utils/audio/radioEqGraph';
 export { sameQueueTrack } from './utils/playback/queueIdentity';
 export { queueTrackIdsForServerProfile } from './utils/playback/trackServerScope';
+export { playTimelineFromHere } from './utils/playTimelineHistoryTrack';

--- a/src/features/playback/store/playerStore.misc.test.ts
+++ b/src/features/playback/store/playerStore.misc.test.ts
@@ -116,6 +116,29 @@ describe('openContextMenu / closeContextMenu', () => {
     expect(cm.x).toBe(50);
     expect(cm.type).toBe('song');
   });
+
+  it('stores the timeline playback order for history-row menus', () => {
+    const track = makeTrack({ id: 'history' });
+    const refs = [
+      { serverId: 's1', trackId: 'history' },
+      { serverId: 's1', trackId: 'current' },
+    ];
+    usePlayerStore.getState().openContextMenu(
+      50,
+      50,
+      track,
+      'song',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      refs,
+    );
+
+    expect(usePlayerStore.getState().contextMenu.timelineFromHereRefs).toEqual(refs);
+  });
 });
 
 describe('openSongInfo / closeSongInfo', () => {

--- a/src/features/playback/store/playerStoreTypes.ts
+++ b/src/features/playback/store/playerStoreTypes.ts
@@ -200,6 +200,8 @@ export interface PlayerState {
     shareKindOverride?: 'track' | 'album' | 'artist' | 'composer';
     /** Menu actions target {@link queueServerId} (set for queue-item and player-sourced album menus). */
     pinToPlaybackServer?: boolean;
+    /** Timeline order from the selected history row through the current Up Next list. */
+    timelineFromHereRefs?: QueueItemRef[];
   };
   openContextMenu: (
     x: number,
@@ -212,6 +214,7 @@ export interface PlayerState {
     shareKindOverride?: 'track' | 'album' | 'artist' | 'composer',
     pinToPlaybackServer?: boolean,
     playlistSongRemove?: () => void | Promise<void>,
+    timelineFromHereRefs?: QueueItemRef[],
   ) => void;
   closeContextMenu: () => void;
 

--- a/src/features/playback/store/uiStateActions.ts
+++ b/src/features/playback/store/uiStateActions.ts
@@ -49,7 +49,7 @@ export function createUiStateActions(set: SetState): Pick<
           };
       }),
 
-    openContextMenu: (x, y, item, type, queueIndex, playlistId, playlistSongIndex, shareKindOverride, pinToPlaybackServer, playlistSongRemove) => {
+    openContextMenu: (x, y, item, type, queueIndex, playlistId, playlistSongIndex, shareKindOverride, pinToPlaybackServer, playlistSongRemove, timelineFromHereRefs) => {
       const pin = pinToPlaybackServer ?? type === 'queue-item';
       const open = () =>
         set({
@@ -65,6 +65,7 @@ export function createUiStateActions(set: SetState): Pick<
             playlistSongRemove,
             shareKindOverride,
             pinToPlaybackServer: pin,
+            timelineFromHereRefs,
           },
         });
       if (pin && playbackServerDiffersFromActive()) {

--- a/src/features/playback/utils/buildTimelineDisplayRows.test.ts
+++ b/src/features/playback/utils/buildTimelineDisplayRows.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { buildTimelineDisplayRows, findTimelineScrollLocalIndex } from '@/features/playback/utils/buildTimelineDisplayRows';
+import {
+  buildTimelineDisplayRows,
+  buildTimelineQueueFromHistory,
+  findTimelineScrollLocalIndex,
+} from '@/features/playback/utils/buildTimelineDisplayRows';
 import type { QueueItemRef } from '@/lib/media/trackTypes';
 
 const ref = (trackId: string, extra?: Partial<QueueItemRef>): QueueItemRef => ({
@@ -27,5 +31,24 @@ describe('buildTimelineDisplayRows', () => {
       queueIndex: 0,
     });
     expect(findTimelineScrollLocalIndex(rows)).toBe(2);
+  });
+
+  it('builds playback order from a selected history occurrence through Up Next', () => {
+    const rows = buildTimelineDisplayRows({
+      historyRefs: [
+        { serverId: 's1', trackId: 'h1', playedAtMs: 1 },
+        { serverId: 's2', trackId: 'h2', playedAtMs: 2 },
+        { serverId: 's1', trackId: 'h3', playedAtMs: 3 },
+      ],
+      queueItems: [ref('c'), ref('u1', { playNextAdded: true })],
+      queueIndex: 0,
+    });
+
+    expect(buildTimelineQueueFromHistory(rows, 2)).toEqual([
+      { serverId: 's2', trackId: 'h2' },
+      { serverId: 's1', trackId: 'h3' },
+      { serverId: 's1', trackId: 'c' },
+      { serverId: 's1', trackId: 'u1', playNextAdded: true },
+    ]);
   });
 });

--- a/src/features/playback/utils/buildTimelineDisplayRows.ts
+++ b/src/features/playback/utils/buildTimelineDisplayRows.ts
@@ -78,3 +78,22 @@ export function findTimelineScrollLocalIndex(rows: TimelineDisplayRow[]): number
   const firstUpcoming = rows.find(r => r.kind === 'upcoming');
   return firstUpcoming?.localIndex ?? null;
 }
+
+/** Build the playback order shown from a selected history row through Up Next. */
+export function buildTimelineQueueFromHistory(
+  rows: TimelineDisplayRow[],
+  historyLocalIndex: number,
+): QueueItemRef[] {
+  const start = rows.findIndex(
+    row => row.kind === 'history' && row.localIndex === historyLocalIndex,
+  );
+  if (start < 0) return [];
+
+  return rows.slice(start).flatMap(row => {
+    if (row.kind === 'divider') return [];
+    if (row.kind === 'history') {
+      return [{ serverId: row.ref.serverId, trackId: row.ref.trackId }];
+    }
+    return [row.ref];
+  });
+}

--- a/src/features/playback/utils/playTimelineHistoryTrack.test.ts
+++ b/src/features/playback/utils/playTimelineHistoryTrack.test.ts
@@ -3,7 +3,10 @@ import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { resetPlayerStore } from '@/test/helpers/storeReset';
 import { makeTrack, seedQueue } from '@/test/helpers/factories';
 import { seedQueueResolver } from '@/features/playback/store/queueTrackResolver';
-import { playTimelineHistoryTrack } from '@/features/playback/utils/playTimelineHistoryTrack';
+import {
+  playTimelineFromHere,
+  playTimelineHistoryTrack,
+} from '@/features/playback/utils/playTimelineHistoryTrack';
 
 vi.mock('@/features/playback/store/queueTrackResolver', async importOriginal => {
   const actual = await importOriginal<typeof import('@/features/playback/store/queueTrackResolver')>();
@@ -95,5 +98,32 @@ describe('playTimelineHistoryTrack', () => {
     const [, queue, , , targetIdx] = playTrack.mock.calls[0]!;
     expect(targetIdx).toBe(3);
     expect(queue?.map((t: { id: string }) => t.id)).toEqual(['shared', 'shared', 'b', 'shared']);
+  });
+
+  it('replaces the queue with the timeline sequence from the selected row', async () => {
+    const h2 = makeTrack({ id: 'h2', serverId: 's2' });
+    const h3 = makeTrack({ id: 'h3', serverId: 's1' });
+    const current = makeTrack({ id: 'current', serverId: 's1' });
+    const next = makeTrack({ id: 'next', serverId: 's1' });
+    seedQueueResolver('s1', [h3, current, next]);
+    seedQueueResolver('s2', [h2]);
+    const playTrack = vi.fn();
+    usePlayerStore.setState({ playTrack });
+
+    await playTimelineFromHere([
+      { serverId: 's2', trackId: 'h2' },
+      { serverId: 's1', trackId: 'h3' },
+      { serverId: 's1', trackId: 'current' },
+      { serverId: 's1', trackId: 'next', playNextAdded: true },
+    ]);
+
+    expect(playTrack).toHaveBeenCalledTimes(1);
+    const [track, queue, , , targetIdx] = playTrack.mock.calls[0]!;
+    expect(track).toEqual(expect.objectContaining({ id: 'h2', serverId: 's2' }));
+    expect(queue?.map((item: { id: string }) => item.id)).toEqual([
+      'h2', 'h3', 'current', 'next',
+    ]);
+    expect(queue?.[3]).toEqual(expect.objectContaining({ playNextAdded: true }));
+    expect(targetIdx).toBe(0);
   });
 });

--- a/src/features/playback/utils/playTimelineHistoryTrack.ts
+++ b/src/features/playback/utils/playTimelineHistoryTrack.ts
@@ -50,3 +50,15 @@ export async function playTimelineHistoryTrack(
   ];
   playTrack(track, newQueue, undefined, undefined, insertAt);
 }
+
+/** Replace the queue with the visible timeline sequence starting at a history row. */
+export async function playTimelineFromHere(refs: QueueItemRef[]): Promise<void> {
+  if (refs.length === 0) return;
+
+  await resolveBatch(refs);
+  const queue = getQueueTracksView(refs);
+  const track = queue[0];
+  if (!track) return;
+
+  usePlayerStore.getState().playTrack(track, queue, undefined, undefined, 0);
+}

--- a/src/features/queue/components/QueueList.tsx
+++ b/src/features/queue/components/QueueList.tsx
@@ -18,7 +18,10 @@ import {
 import { collectQueueResolveRefs } from '@/features/queue/utils/collectQueueResolveRefs';
 import { findQueueItemRefIndex } from '@/features/playback/utils/playback/queueIdentity';
 import type { TimelineDisplayRow } from '@/features/playback/utils/buildTimelineDisplayRows';
-import { findTimelineScrollLocalIndex } from '@/features/playback/utils/buildTimelineDisplayRows';
+import {
+  buildTimelineQueueFromHistory,
+  findTimelineScrollLocalIndex,
+} from '@/features/playback/utils/buildTimelineDisplayRows';
 import { playTimelineHistoryTrack } from '@/features/playback/utils/playTimelineHistoryTrack';
 import { OptionalQueueTrackRowCoverThumb } from '@/cover/TrackRowCoverThumb';
 import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
@@ -178,7 +181,7 @@ export function QueueList({
         data-timeline-local-idx={localIndex}
         {...(isHistory ? { 'data-timeline-kind': 'history' } : {})}
         {...(absIdx != null ? { 'data-queue-idx': absIdx } : {})}
-        className={`queue-item${showCovers ? ' queue-item--with-cover' : ''} ${isPlaying ? 'active' : ''} ${contextMenu.isOpen && contextMenu.type === (absIdx != null ? 'queue-item' : 'song') && (absIdx != null ? contextMenu.queueIndex === absIdx : contextMenu.item === track) ? 'context-active' : ''}`}
+        className={`queue-item${showCovers ? ' queue-item--with-cover' : ''} ${isPlaying ? 'active' : ''} ${contextMenu.isOpen && contextMenu.type === (isHistory || absIdx == null ? 'song' : 'queue-item') && (isHistory || absIdx == null ? contextMenu.item === track : contextMenu.queueIndex === absIdx) ? 'context-active' : ''}`}
         onClick={() => {
           if (isHistory) {
             playHistoryRow(base?.serverId ?? track.serverId ?? '', track.id);
@@ -190,8 +193,23 @@ export function QueueList({
         }}
         onContextMenu={(e) => {
           e.preventDefault();
-          if (isHistory && absIdx == null) {
-            usePlayerStore.getState().openContextMenu(e.clientX, e.clientY, track, 'song');
+          if (isHistory) {
+            const timelineFromHereRefs = timelineRows
+              ? buildTimelineQueueFromHistory(timelineRows, localIndex)
+              : [];
+            usePlayerStore.getState().openContextMenu(
+              e.clientX,
+              e.clientY,
+              track,
+              'song',
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              timelineFromHereRefs,
+            );
             return;
           }
           if (absIdx == null) return;

--- a/src/features/queue/components/QueuePanel.test.tsx
+++ b/src/features/queue/components/QueuePanel.test.tsx
@@ -40,6 +40,7 @@ import * as offlineApi from '@/features/offline';
 import { resetAllStores } from '@/test/helpers/storeReset';
 import { makeTrack, makeTracks, seedQueue } from '@/test/helpers/factories';
 import { onInvoke, registerDefaultCoverInvokeHandlers } from '@/test/mocks/tauri';
+import { appendTimelineSessionPlay } from '@/features/playback/store/timelineSessionHistory';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -171,6 +172,30 @@ describe('QueuePanel — display mode', () => {
     const { container } = renderWithProviders(<QueuePanel />);
     const idxs = [...container.querySelectorAll('[data-queue-idx]')].map(r => r.getAttribute('data-queue-idx'));
     expect(idxs).toEqual(['1', '2', '3']);
+  });
+
+  it('timeline history context menu captures playback order from that occurrence', () => {
+    const tracks = makeTracks(4);
+    const serverId = useAuthStore.getState().activeServerId!;
+    useAuthStore.getState().setQueueDisplayMode('timeline');
+    seedQueue(tracks, { index: 1, currentTrack: tracks[1], serverId });
+    const historyRef = usePlayerStore.getState().queueItems[0]!;
+    appendTimelineSessionPlay({
+      serverId: historyRef.serverId,
+      trackId: historyRef.trackId,
+      playedAtMs: 1,
+    });
+    const { container } = renderWithProviders(<QueuePanel />);
+    const historyRow = container.querySelector<HTMLElement>('[data-timeline-kind="history"]');
+
+    expect(historyRow).not.toBeNull();
+    fireEvent.contextMenu(historyRow!);
+
+    const menu = usePlayerStore.getState().contextMenu;
+    expect(menu.type).toBe('song');
+    expect(menu.timelineFromHereRefs?.map(ref => ref.trackId)).toEqual(
+      tracks.map(track => track.id),
+    );
   });
 });
 

--- a/src/locales/bg/contextMenu.ts
+++ b/src/locales/bg/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Пусни сега',
   playNext: 'Пусни следващо',
+  playFromHere: 'Пусни оттук',
   addToQueue: 'Добави в опашката',
   enqueueAlbum: 'Добави албума в опашката',
   enqueueAlbums_one: 'Добави {{count}} албум в опашката',

--- a/src/locales/de/contextMenu.ts
+++ b/src/locales/de/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Direkt abspielen',
   playNext: 'Als Nächstes abspielen',
+  playFromHere: 'Ab hier abspielen',
   addToQueue: 'Zur Warteschlange hinzufügen',
   enqueueAlbum: 'Ganzes Album einreihen',
   enqueueAlbums_one: '{{count}} Album einreihen',

--- a/src/locales/en/contextMenu.ts
+++ b/src/locales/en/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Play Now',
   playNext: 'Play Next',
+  playFromHere: 'Play from Here',
   addToQueue: 'Add to Queue',
   enqueueAlbum: 'Enqueue Album',
   enqueueAlbums_one: 'Enqueue {{count}} Album',

--- a/src/locales/es/contextMenu.ts
+++ b/src/locales/es/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Reproducir Ahora',
   playNext: 'Reproducir Siguiente',
+  playFromHere: 'Reproducir desde aquí',
   addToQueue: 'Agregar a la Cola',
   enqueueAlbum: 'Agregar Álbum a la Cola',
   enqueueAlbums_one: 'Agregar {{count}} álbum a la cola',

--- a/src/locales/fr/contextMenu.ts
+++ b/src/locales/fr/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Lire maintenant',
   playNext: 'Lire ensuite',
+  playFromHere: 'Lire à partir d’ici',
   addToQueue: 'Ajouter à la file',
   enqueueAlbum: 'Mettre l\'album en file',
   enqueueAlbums_one: 'Mettre {{count}} album en file',

--- a/src/locales/hu/contextMenu.ts
+++ b/src/locales/hu/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Lejátszás most',
   playNext: 'Lejátszás következőként',
+  playFromHere: 'Lejátszás innen',
   addToQueue: 'Hozzáadás a sorhoz',
   enqueueAlbum: 'Album a sorba',
   enqueueAlbums_one: '{{count}} album a sorba',

--- a/src/locales/it/contextMenu.ts
+++ b/src/locales/it/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Riproduci ora',
   playNext: 'Riproduci dopo',
+  playFromHere: 'Riproduci da qui',
   addToQueue: 'Aggiungi alla coda',
   enqueueAlbum: 'Aggiungi album alla coda',
   enqueueAlbums_one: 'Aggiungi {{count}} album alla coda',

--- a/src/locales/ja/contextMenu.ts
+++ b/src/locales/ja/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: '今すぐ再生',
   playNext: '次に再生',
+  playFromHere: 'ここから再生',
   addToQueue: 'キューに追加',
   enqueueAlbum: 'アルバムをキューに追加',
   enqueueAlbums_one: '{{count}} 枚のアルバムをキューに追加',

--- a/src/locales/nb/contextMenu.ts
+++ b/src/locales/nb/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Spill nå',
   playNext: 'Spill neste',
+  playFromHere: 'Spill herfra',
   addToQueue: 'Legg til i kø',
   enqueueAlbum: 'Legg albumet i kø',
   enqueueAlbums_one: 'Legg {{count}} album i kø',

--- a/src/locales/nl/contextMenu.ts
+++ b/src/locales/nl/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Nu afspelen',
   playNext: 'Volgende afspelen',
+  playFromHere: 'Vanaf hier afspelen',
   addToQueue: 'Aan wachtrij toevoegen',
   enqueueAlbum: 'Album in wachtrij',
   enqueueAlbums_one: '{{count}} album in wachtrij',

--- a/src/locales/pl/contextMenu.ts
+++ b/src/locales/pl/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Odtwarzane teraz',
   playNext: 'Odtwarzane jako następne',
+  playFromHere: 'Odtwórz od tego miejsca',
   addToQueue: 'Dodaj do kolejki',
   enqueueAlbum: 'Dodaj album do kolejki',
   enqueueAlbums_one: 'Dodaj {{count}} album do kolejki',

--- a/src/locales/ro/contextMenu.ts
+++ b/src/locales/ro/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Redă acum',
   playNext: 'Redă următorul',
+  playFromHere: 'Redă de aici',
   addToQueue: 'Adaugă la coadă',
   enqueueAlbum: 'Adaugă Albumul la coadă',
   enqueueAlbums_one: 'Adaugă la coadă {{count}} Album',

--- a/src/locales/ru/contextMenu.ts
+++ b/src/locales/ru/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: 'Играть сейчас',
   playNext: 'Играть следующим',
+  playFromHere: 'Играть отсюда',
   addToQueue: 'В конец очереди',
   enqueueAlbum: 'Альбом в очередь',
   enqueueAlbums_one: '{{count}} альбом в очередь',

--- a/src/locales/zh/contextMenu.ts
+++ b/src/locales/zh/contextMenu.ts
@@ -1,6 +1,7 @@
 export const contextMenu = {
   playNow: '立即播放',
   playNext: '下一首播放',
+  playFromHere: '从此处开始播放',
   addToQueue: '添加到队列',
   enqueueAlbum: '专辑加入队列',
   enqueueAlbums_one: '{{count}} 张专辑加入队列',


### PR DESCRIPTION
## Summary
- add a **Play from Here** action to past-track context menus in Timeline mode
- rebuild playback from the selected history occurrence through the later history, current track, and existing Up Next list
- preserve per-track server ownership and queue flags across the rebuilt sequence
- add the action label to every shipped locale and use the `ListStart` icon

Closes #1305

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (555 files, 4064 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`

Manual device playback was not run.

## Runtime benchmark
- Applicability: not applicable - the changed action exists only inside an opened Timeline history context menu; it does not alter route startup, steady-state DOM, background work, or a flow exercised by the benchmark harness.

## Tauri boundary
- No commands, events, or payloads changed.