### PR TITLE
docs: record the repository location rule and refresh feature docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Psysonic is **GPLv3** — see [LICENSE](LICENSE). Forks and modifications are we
 - [Quick start](#quick-start)
 - [Before you write code](#before-you-write-code)
 - [Repository layout](#repository-layout)
+- [Repository location](#repository-location)
 - [Environment and running the app](#environment-and-running-the-app)
 - [Where processes and conventions are documented](#where-processes-and-conventions-are-documented)
 - [House rules](#house-rules)
@@ -55,6 +56,25 @@ scripts/     CI helpers (coverage gates, install, version sync)
 .github/     Workflows, issue templates, hot-path lists
 flake.nix    Nix development shell + packaging
 ```
+
+---
+
+## Repository location
+
+This repository lives at **`Psysonic/psysonic`**. It moved there from a personal account in August
+2026, and GitHub redirects the old path for clones, links and release downloads.
+
+> **The old path `Psychotoxical/psysonic` must never be occupied again — no repository, no fork,
+> not even temporarily.**
+
+Creating anything at the old location permanently deletes those redirects. Every release built
+before the move carries the old URL baked into its updater endpoint, so thousands of existing
+installations depend on that redirect for the rest of their lives, and they would fail silently
+with no error a user could act on.
+
+Two things deliberately keep the old owner name and are not location references: the WinGet package
+identifier `Psychotoxical.Psysonic` (changing it would orphan every installation updated through
+WinGet) and contributor handles.
 
 ---
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -26,9 +26,6 @@ Additionally, the one service you choose as your **primary** is queried to enric
 ### LRCLIB (Lyrics)
 When lyrics are fetched from LRCLIB, Psysonic sends the track title, artist, album, and duration to [lrclib.net](https://lrclib.net) as a search query. No account is required. This feature can be disabled in Settings → Lyrics.
 
-### YouLyPlus (Lyrics)
-If YouLyPlus mode is selected in Settings → Lyrics, Psysonic sends the track title, artist, album, duration, and ISRC (when available) to a community-operated [lyricsplus](https://github.com/ibratabian17/lyricsplus) backend to fetch word-synced karaoke lyrics. No account is required. Requests are routed through a list of public mirrors; the data they receive is limited to the search query above. This feature is disabled by default.
-
 ### NetEase Cloud Music (Lyrics)
 If NetEase is enabled as a lyrics source in Settings → Lyrics, Psysonic sends the track artist and title to the NetEase Cloud Music API (via a Rust-side proxy request) to search for synced lyrics. No account is required. This feature is disabled by default.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Psysonic is built primarily for **Navidrome** and also works with **Gonic**, **A
 
 <br><br>
 
-**Available languages:** English, German, Spanish, French, Norwegian Bokmål, Dutch, Romanian, Russian, Chinese, Japanese, Hungarian and Polish.
+**Available languages:** English, German, Spanish, French, Norwegian Bokmål, Dutch, Romanian, Russian, Chinese, Japanese, Hungarian, Polish, Bulgarian and Italian.
 
 More translations are added over time.
 
@@ -57,6 +57,14 @@ The clever part: Orbit rides entirely on **your own Navidrome**. There is no ext
 <div align="left">
   <img src="public/orbit.png" alt="Orbit shared listening" width="520"/>
 </div>
+
+## 🗄️ Multi-Server — Every Server, One Library
+
+**Several servers at once, browsed as a single collection.**
+
+Configure more than one server and pick the music folders you care about across all of them, in a priority order you set. Home, Albums, Artists, Composers, Genres, Favourites, Playlists, Folder Browser, Search and Statistics aggregate into one catalogue — no switching the active server before every search, album or playback action.
+
+Shared music shows up once instead of once per server, and nothing gets thrown away doing it: every track keeps its real owner, so streaming, artwork, metadata and edits always go to the server that actually holds the file. One queue can mix tracks from different servers, and each item resolves against its own.
 
 ## ⚡ Local Library — Instant, and Almost Offline
 
@@ -117,7 +125,7 @@ Features that go well beyond the basics. Not all of these are unique to Psysonic
 
 ## Lyrics & Listening
 
-* Synced lyrics with seek support, from multiple providers ([YouLy+](https://github.com/ibratabian17/YouLyPlus), LRCLIB, NetEase)
+* Synced lyrics with seek support, from multiple providers (your own server, [LRCLIB](https://lrclib.net), NetEase)
 * Auto-scrolling sidebar lyrics and a fullscreen lyric mode
 * Last.fm scrobbling, similar artists, loved tracks and listening stats
 * Smart Radio sessions and an Infinite Queue


### PR DESCRIPTION
Closes the documentation leftovers after the organization transfer, plus two stale claims found in the 1.51.0 state review.

- `CONTRIBUTING.md`: new **Repository location** section. The old path must never be occupied again — every release built before the move carries it as the updater endpoint, so existing installations depend on the redirect permanently. Names the two places that keep the old owner deliberately: the WinGet identifier and contributor handles.
- `README.md`: multi-server added as a key feature; language list corrected to the 14 shipped locales; lyrics providers corrected.
- `PRIVACY.md`: removes the disclosure for the lyrics backend that left the app in #1391.

No changelog entry: documentation only, no user-visible behaviour change.

Test plan: no code paths touched. Claims were checked against the code — providers against `DEFAULT_LYRICS_SOURCES`, languages against `src/locales/`, the multi-server description against `scope_merge` / `scope_browse`.

Runtime benchmark: not applicable - documentation only.