### PR TITLE
fix(album): resolve a held album press that loses its source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Large analysis, audio, library, sync, cache, integration, CLI and startup modules are split into focused child modules behind the same public APIs and Tauri command/event contracts. Hand-written Rust files above 600 lines drop from 61 to 5 without an intended user-visible change.
 * Hot-path coverage follows the extracted implementation files, including Discord presence URL safety and text helpers. Comparable runtime benchmarks plus Linux and Windows CI found no reproducible behaviour or performance regression.
 
+## Fixed
+
+### Albums no longer start dragging on their own
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1437](https://github.com/Psysonic/psysonic/pull/1437)**
+
+* Holding the mouse button on an album while the list changed underneath — switching between grid and table, or a refresh arriving — could leave a drag primed. The next mouse movement anywhere then picked up that album, long after the pointer had moved on.
+
 ## [1.51.0] - 2026-08-17
 
 ## Added

--- a/src/features/album/hooks/useAlbumDragStart.test.tsx
+++ b/src/features/album/hooks/useAlbumDragStart.test.tsx
@@ -94,4 +94,37 @@ describe('useAlbumDragStart', () => {
     expect(acquireUrl).not.toHaveBeenCalled();
     expect(startDrag.mock.calls[0][0].coverUrl).toBeUndefined();
   });
+
+  // Rows are virtualised and the list can be swapped under a held button, so a
+  // press can lose its source before any mouseup arrives. Without cleanup the
+  // listeners outlive the component and the next pointer travel drags an album
+  // that is no longer there.
+  it('drops its listeners when the source unmounts mid-press', () => {
+    const { unmount } = render(<Probe />);
+    press(screen.getByTestId('source'));
+    unmount();
+    moveTo(140, 100);
+    expect(startDrag).not.toHaveBeenCalled();
+  });
+
+  // Selection mode can arrive while a press is armed. The press must not survive
+  // it and drag a row the user is now trying to tick.
+  it('resolves an armed press when it becomes disabled', () => {
+    const { rerender } = render(<Probe />);
+    press(screen.getByTestId('source'));
+    rerender(<Probe disabled />);
+    moveTo(140, 100);
+    expect(startDrag).not.toHaveBeenCalled();
+  });
+
+  // Two presses without a release in between — the first must not stay armed
+  // alongside the second and fire a second drag from a stale start point.
+  it('supersedes a press that never resolved', () => {
+    render(<Probe />);
+    const source = screen.getByTestId('source');
+    press(source);
+    press(source);
+    moveTo(140, 100);
+    expect(startDrag).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/features/album/hooks/useAlbumDragStart.test.tsx
+++ b/src/features/album/hooks/useAlbumDragStart.test.tsx
@@ -107,8 +107,9 @@ describe('useAlbumDragStart', () => {
     expect(startDrag).not.toHaveBeenCalled();
   });
 
-  // Selection mode can arrive while a press is armed. The press must not survive
-  // it and drag a row the user is now trying to tick.
+  // Selection mode can arrive while a press is armed. The effect cleanup runs on
+  // the dependency change, so the press must not survive it and drag a row the
+  // user is now trying to tick.
   it('resolves an armed press when it becomes disabled', () => {
     const { rerender } = render(<Probe />);
     press(screen.getByTestId('source'));

--- a/src/features/album/hooks/useAlbumDragStart.ts
+++ b/src/features/album/hooks/useAlbumDragStart.ts
@@ -29,14 +29,10 @@ export function useAlbumDragStart(
   // flip, and a refresh replaces the list. The listeners would then outlive the
   // component and turn the next pointer travel into a drag for an album that is
   // no longer on screen.
-  // The same applies when the press is disabled mid-flight: selection mode
-  // turning on must not leave a drag armed behind it. Today the toggle is a
-  // button, so releasing it resolves the press anyway — the dependency keeps
-  // that true when the trigger is not a click any more.
-  useEffect(() => {
-    if (disabled) endPressRef.current?.();
-    return () => endPressRef.current?.();
-  }, [disabled]);
+  // `disabled` is a dependency for the same reason: React runs this cleanup
+  // before re-running on a change, so selection mode turning on resolves an
+  // armed press instead of leaving a drag primed behind the new mode.
+  useEffect(() => () => endPressRef.current?.(), [disabled]);
 
   return useCallback((e: React.MouseEvent) => {
     if (disabled || e.button !== 0) return;

--- a/src/features/album/hooks/useAlbumDragStart.ts
+++ b/src/features/album/hooks/useAlbumDragStart.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { SubsonicAlbum } from '@/lib/api/subsonicTypes';
 import { acquireUrl } from '@/cover';
 import { useDragDrop } from '@/lib/dnd/DragDropContext';
@@ -20,9 +20,29 @@ export function useAlbumDragStart(
   disabled = false,
 ): (e: React.MouseEvent) => void {
   const psyDrag = useDragDrop();
+  /** Detaches the listeners of the press in flight, while one is unresolved. */
+  const endPressRef = useRef<(() => void) | null>(null);
+
+  // A press detaches its own listeners once it resolves — into a drag, or into a
+  // release. Nothing resolves it when the source disappears mid-press, and rows
+  // do disappear under a held button: they are virtualised, the view mode can
+  // flip, and a refresh replaces the list. The listeners would then outlive the
+  // component and turn the next pointer travel into a drag for an album that is
+  // no longer on screen.
+  // The same applies when the press is disabled mid-flight: selection mode
+  // turning on must not leave a drag armed behind it. Today the toggle is a
+  // button, so releasing it resolves the press anyway — the dependency keeps
+  // that true when the trigger is not a click any more.
+  useEffect(() => {
+    if (disabled) endPressRef.current?.();
+    return () => endPressRef.current?.();
+  }, [disabled]);
+
   return useCallback((e: React.MouseEvent) => {
     if (disabled || e.button !== 0) return;
     e.preventDefault();
+    // A second press supersedes one that never resolved.
+    endPressRef.current?.();
     const sx = e.clientX;
     const sy = e.clientY;
     const onMove = (me: MouseEvent) => {
@@ -30,8 +50,7 @@ export function useAlbumDragStart(
         Math.abs(me.clientX - sx) <= DRAG_THRESHOLD_PX
         && Math.abs(me.clientY - sy) <= DRAG_THRESHOLD_PX
       ) return;
-      document.removeEventListener('mousemove', onMove);
-      document.removeEventListener('mouseup', onUp);
+      endPress();
       const coverUrl = coverStorageKey ? acquireUrl(coverStorageKey) ?? undefined : undefined;
       psyDrag.startDrag({
         data: JSON.stringify({
@@ -44,11 +63,13 @@ export function useAlbumDragStart(
         coverUrl,
       }, me.clientX, me.clientY);
     };
-    const onUp = () => {
+    const endPress = () => {
       document.removeEventListener('mousemove', onMove);
-      document.removeEventListener('mouseup', onUp);
+      document.removeEventListener('mouseup', endPress);
+      endPressRef.current = null;
     };
     document.addEventListener('mousemove', onMove);
-    document.addEventListener('mouseup', onUp);
+    document.addEventListener('mouseup', endPress);
+    endPressRef.current = endPress;
   }, [album.id, album.name, album.serverId, coverStorageKey, disabled, psyDrag]);
 }


### PR DESCRIPTION
A held press keeps `mousemove`/`mouseup` on `document` and only detaches them when it resolves — into a drag, or into a release. Nothing resolved a press whose source disappeared while the button was still down, and album rows do disappear under a held button: they are virtualised, the view mode can flip, and a refresh replaces the list. The listeners then outlived the row, and the next pointer travel started a drag for an album no longer on screen.

- A press now registers how to end itself, and three things end it: unmount, a second press, and selection mode turning on.
- Found during the review of #1435 and deliberately left out of that PR, since it predates it — the hook was extracted from `AlbumCard` with the behaviour unchanged.

## Known gap, deliberately not fixed here

A `mouseup` that never arrives still leaves the press armed. `DragDropContext` already documents this for Wayland ("webview may not get `mouseup` when the pointer leaves the surface") and guards an in-flight drag with `pointerup`, `pointercancel`, `blur` and `visibilitychange`. The armed press has none of those — and neither do the eight other drag sources in the app, which are virtualised as well. Patching it into this one hook would leave the pattern half-solved, so it belongs in a follow-up that lifts arm/resolve into one shared place.

## Test plan
- `npx vitest run src/features/album/hooks/useAlbumDragStart.test.tsx` — 9 tests; the three new ones were each verified against the unfixed hook
- `npm run test` — 565 files, 4143 tests
- `tsc --noEmit`, `npm run lint`, `npm run dep:check`

Runtime benchmark: not applicable - event listener cleanup, no render, query or route path affected.
