### PR TITLE
chore(updater): match the WinGet moderation delay to measured times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Large analysis, audio, library, sync, cache, integration, CLI and startup modules are split into focused child modules behind the same public APIs and Tauri command/event contracts. Hand-written Rust files above 600 lines drop from 61 to 5 without an intended user-visible change.
 * Hot-path coverage follows the extracted implementation files, including Discord presence URL safety and text helpers. Comparable runtime benchmarks plus Linux and Windows CI found no reproducible behaviour or performance regression.
 
+### Windows update notices arrive hours after a release instead of days
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1440](https://github.com/Psysonic/psysonic/pull/1440)**
+
+* On Windows the update notice is held back until WinGet has had time to moderate a new release, so it never points at a version `winget upgrade` cannot install yet. That wait was set to two days before any real timings were available.
+* Recent releases cleared WinGet moderation in one to two hours, so the wait is now twelve hours. Windows users see a new version roughly a day and a half sooner, with room left for a slower submission.
+
 ## Fixed
 
 ### Albums no longer start dragging on their own

--- a/src/lib/util/appUpdaterHelpers.test.ts
+++ b/src/lib/util/appUpdaterHelpers.test.ts
@@ -26,6 +26,13 @@ describe('isWithinModerationWindow', () => {
     expect(isWithinModerationWindow(published, now, 3 * 60 * 60 * 1000)).toBe(true);
   });
 
+  // Every other assertion is relative to the constant, so a slip such as
+  // `6 * 60 * 1000` (six minutes) would disable the guard with a green suite.
+  it('keeps the window within a plausible order of magnitude', () => {
+    expect(WINGET_MODERATION_DELAY_MS).toBeGreaterThanOrEqual(60 * 60 * 1000);
+    expect(WINGET_MODERATION_DELAY_MS).toBeLessThanOrEqual(48 * 60 * 60 * 1000);
+  });
+
   it('fails open on a missing date', () => {
     expect(isWithinModerationWindow(undefined, publishedMs)).toBe(false);
   });

--- a/src/lib/util/appUpdaterHelpers.test.ts
+++ b/src/lib/util/appUpdaterHelpers.test.ts
@@ -6,7 +6,7 @@ describe('isWithinModerationWindow', () => {
   const publishedMs = Date.parse(published);
 
   it('returns true while the release is younger than the window', () => {
-    const now = publishedMs + 12 * 60 * 60 * 1000; // 12h after release
+    const now = publishedMs + WINGET_MODERATION_DELAY_MS / 2; // halfway into the window
     expect(isWithinModerationWindow(published, now)).toBe(true);
   });
 

--- a/src/lib/util/appUpdaterHelpers.ts
+++ b/src/lib/util/appUpdaterHelpers.ts
@@ -17,11 +17,13 @@ export function isNewer(a: string, b: string): boolean {
 // while after the GitHub release goes live (installer scan + manual review,
 // longer for freshly signed binaries building SmartScreen reputation). Holding
 // the update notice back until the release clears this window avoids pointing
-// Windows users at a version WinGet has not published yet. Measured across the
-// 1.49.0, 1.50.0 and 1.51.0 submissions, winget-pkgs merged them in 1h22,
-// 1h01 and 1h09, so six hours keeps headroom for a slower run without
-// holding the notice back for two days.
-export const WINGET_MODERATION_DELAY_MS = 6 * 60 * 60 * 1000;
+// Windows users at a version WinGet has not published yet. Measured from release
+// publish to winget-pkgs merge — the same span this guard checks — 1.49.0
+// took 1h23, 1.50.0 1h02 and 1.51.0 1h58. The last of those was submitted by
+// hand because the automation failed, which is the case worth sizing for: a
+// release that goes out late and is only submitted the next morning. Twelve
+// hours covers that without holding the notice back for two days.
+export const WINGET_MODERATION_DELAY_MS = 12 * 60 * 60 * 1000;
 
 // True while `publishedAt` is younger than `windowMs` relative to `now`.
 // Missing or unparseable date → false (fail open: show the notice rather than

--- a/src/lib/util/appUpdaterHelpers.ts
+++ b/src/lib/util/appUpdaterHelpers.ts
@@ -20,9 +20,12 @@ export function isNewer(a: string, b: string): boolean {
 // Windows users at a version WinGet has not published yet. Measured from release
 // publish to winget-pkgs merge — the same span this guard checks — 1.49.0
 // took 1h23, 1.50.0 1h02 and 1.51.0 1h58. The last of those was submitted by
-// hand because the automation failed, which is the case worth sizing for: a
-// release that goes out late and is only submitted the next morning. Twelve
-// hours covers that without holding the notice back for two days.
+// hand after the automation failed, and still cleared within two hours because
+// the submission followed quickly. Twelve hours covers the automated path with
+// wide margin instead of holding the notice back for two days. It does not
+// cover an unattended failure — a release published late at night and only
+// submitted the next morning can exceed this window, and the notice would then
+// appear before WinGet has the version.
 export const WINGET_MODERATION_DELAY_MS = 12 * 60 * 60 * 1000;
 
 // True while `publishedAt` is younger than `windowMs` relative to `now`.

--- a/src/lib/util/appUpdaterHelpers.ts
+++ b/src/lib/util/appUpdaterHelpers.ts
@@ -17,9 +17,11 @@ export function isNewer(a: string, b: string): boolean {
 // while after the GitHub release goes live (installer scan + manual review,
 // longer for freshly signed binaries building SmartScreen reputation). Holding
 // the update notice back until the release clears this window avoids pointing
-// Windows users at a version WinGet has not published yet. Conservative start
-// value — tune down once real winget-pkgs merge times are known.
-export const WINGET_MODERATION_DELAY_MS = 48 * 60 * 60 * 1000;
+// Windows users at a version WinGet has not published yet. Measured across the
+// 1.49.0, 1.50.0 and 1.51.0 submissions, winget-pkgs merged them in 1h22,
+// 1h01 and 1h09, so six hours keeps headroom for a slower run without
+// holding the notice back for two days.
+export const WINGET_MODERATION_DELAY_MS = 6 * 60 * 60 * 1000;
 
 // True while `publishedAt` is younger than `windowMs` relative to `now`.
 // Missing or unparseable date → false (fail open: show the notice rather than


### PR DESCRIPTION
## Summary

- The 48 hour window was a deliberately conservative starting value, chosen before any real winget-pkgs timings existed — the constant's own comment asked for it to be tuned down once they were known.
- Measured across the span this guard actually checks (GitHub release publish → winget-pkgs merge): **1h23** for 1.49.0, **1h02** for 1.50.0, **1h58** for 1.51.0. Windows users were therefore held back from the update notice roughly two days longer than necessary.
- Twelve hours keeps wide margin over the automated path. The comment now also states the case it does **not** cover: an unattended automation failure where submission only happens the next morning.
- The window test derived its timestamp from a hardcoded twelve hours and would have stopped testing its own claim; it is relative now, with one assertion pinning the constant's order of magnitude so a slip to minutes cannot pass silently.

## Test plan

- [x] `npx tsc --noEmit`, `npm run lint`, `npm run dep:check` — all clean
- [x] `npx vitest run` — 565 files, 4144 tests passing
- [x] Order-of-magnitude assertion verified against the failure it guards: setting the constant to `6 * 60 * 1000` fails that test and only that test

Runtime benchmark: not applicable - single constant in the update-notice time check; no route, query, render or layout path touched.
