### PR TITLE
fix(lyrics): keep synced lyrics aligned with playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Holding the mouse button on an album while the list changed underneath — switching between grid and table, or a refresh arriving — could leave a drag primed. The next mouse movement anywhere then picked up that album, long after the pointer had moved on.
 
+### Synced lyrics keep up with the music
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1442](https://github.com/Psysonic/psysonic/pull/1442)**
+
+* Lines could light up close to a second after they were sung, and inconsistently so — some on time, others noticeably behind. The player only learned the playback position about once per second, which is imperceptible on a clock but not in lyrics, so the position is now followed continuously between those updates.
+* The fullscreen rail was worst affected, because it picked its line from an even coarser signal than its own word highlighting used. Every lyrics view now reads the same position, including after seeking to a line while paused.
+
 ## [1.51.0] - 2026-08-17
 
 ## Added

--- a/src/features/fullscreenPlayer/components/FsLyricsApple.tsx
+++ b/src/features/fullscreenPlayer/components/FsLyricsApple.tsx
@@ -60,7 +60,13 @@ export const FsLyricsApple = memo(function FsLyricsApple({ currentTrack }: { cur
     const apply = (time: number) => {
       const ls = linesRef.current;
       if (!ls.length) return;
-      const idx = ls.reduce((acc, line, i) => time >= line.time ? i : acc, -1);
+      // Lines are ordered, so stop at the first one past `time`. This runs on
+      // every emit rather than once a second now, so a full scan would be waste.
+      let idx = -1;
+      for (let i = 0; i < ls.length; i++) {
+        if (time >= ls[i].time) idx = i;
+        else break;
+      }
       if (idx !== activeIdxRef.current) {
         activeIdxRef.current = idx;
         setActiveIdx(idx);

--- a/src/features/fullscreenPlayer/components/FsLyricsApple.tsx
+++ b/src/features/fullscreenPlayer/components/FsLyricsApple.tsx
@@ -3,7 +3,7 @@ import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { useAuthStore } from '@/store/authStore';
 import { useLyrics, type WordLyricsLine } from '@/features/lyrics';
 import { useWordLyricsSync } from '@/features/lyrics';
-import { getPlaybackProgressSnapshot, subscribePlaybackProgress } from '@/features/playback/store/playbackProgress';
+import { getSmoothPlaybackTime, subscribeSmoothPlaybackTime } from '@/features/playback';
 import type { LrcLine } from '@/features/lyrics';
 import type { Track } from '@/lib/media/trackTypes';
 import { EaseScroller, targetForFraction } from '@/lib/dom/easeScroll';
@@ -66,8 +66,8 @@ export const FsLyricsApple = memo(function FsLyricsApple({ currentTrack }: { cur
         setActiveIdx(idx);
       }
     };
-    apply(getPlaybackProgressSnapshot().currentTime);
-    return subscribePlaybackProgress(s => apply(s.currentTime));
+    apply(getSmoothPlaybackTime());
+    return subscribeSmoothPlaybackTime(apply);
   }, [hasSynced, currentTrack?.id]);
 
   // Scroll the active line into view, honouring the "Lyrics scroll style" setting

--- a/src/features/fullscreenPlayer/components/FsLyricsRail.tsx
+++ b/src/features/fullscreenPlayer/components/FsLyricsRail.tsx
@@ -44,7 +44,10 @@ export const FsLyricsRail = memo(function FsLyricsRail({ currentTrack }: { curre
     };
     apply(getSmoothPlaybackTime());
     return subscribeSmoothPlaybackTime(apply);
-  }, []);
+    // Same deps as the Apple style: the lines arrive asynchronously, and while
+    // paused no progress event ever lands, so without these the rail would
+    // stay unhighlighted until playback resumes.
+  }, [hasSynced, currentTrack?.id]);
 
   const duration = usePlayerStore(s => s.currentTrack?.duration ?? 0);
   const seek     = usePlayerStore(s => s.seek);

--- a/src/features/fullscreenPlayer/components/FsLyricsRail.tsx
+++ b/src/features/fullscreenPlayer/components/FsLyricsRail.tsx
@@ -1,5 +1,9 @@
-import React, { memo, useCallback, useEffect, useRef } from 'react';
-import { usePlayerStore } from '@/features/playback';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  getSmoothPlaybackTime,
+  subscribeSmoothPlaybackTime,
+  usePlayerStore,
+} from '@/features/playback';
 import { useAuthStore } from '@/store/authStore';
 import { useLyrics, type WordLyricsLine, useWordLyricsSync } from '@/features/lyrics';
 import type { LrcLine } from '@/features/lyrics';
@@ -20,11 +24,27 @@ export const FsLyricsRail = memo(function FsLyricsRail({ currentTrack }: { curre
   const linesRef = useRef<LrcLine[]>([]);
   linesRef.current = hasSynced ? lineSrc! : [];
 
-  const activeIdx = usePlayerStore(s => {
-    const ls = linesRef.current;
-    if (ls.length === 0) return -1;
-    return ls.reduce((acc, line, i) => s.currentTime >= line.time ? i : acc, -1);
-  });
+  // The store's currentTime is committed at 20 s / 5 s granularity, which is
+  // far too coarse to pick a lyric line — the per-word highlighting in this
+  // same view already runs off the interpolated position, so the rail followed
+  // several seconds behind its own words. Both read the same clock now.
+  const [activeIdx, setActiveIdx] = useState(-1);
+  const activeIdxRef = useRef(-1);
+  useEffect(() => {
+    const apply = (time: number) => {
+      const ls = linesRef.current;
+      let idx = -1;
+      for (let i = 0; i < ls.length; i++) {
+        if (time >= ls[i].time) idx = i;
+        else break;
+      }
+      if (idx === activeIdxRef.current) return;
+      activeIdxRef.current = idx;
+      setActiveIdx(idx);
+    };
+    apply(getSmoothPlaybackTime());
+    return subscribeSmoothPlaybackTime(apply);
+  }, []);
 
   const duration = usePlayerStore(s => s.currentTrack?.duration ?? 0);
   const seek     = usePlayerStore(s => s.seek);

--- a/src/features/lyrics/components/LyricsPane.tsx
+++ b/src/features/lyrics/components/LyricsPane.tsx
@@ -1,4 +1,4 @@
-import { getPlaybackProgressSnapshot, subscribePlaybackProgress } from '@/features/playback/store/playbackProgress';
+import { getSmoothPlaybackTime, subscribeSmoothPlaybackTime } from '@/features/playback';
 import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
@@ -138,8 +138,8 @@ export default function LyricsPane({ currentTrack }: Props) {
       prevActive.current = { line: lineIdx, word: wordIdx };
     };
 
-    apply(getPlaybackProgressSnapshot().currentTime);
-    return subscribePlaybackProgress(s => apply(s.currentTime));
+    apply(getSmoothPlaybackTime());
+    return subscribeSmoothPlaybackTime(apply);
   }, [useWords, hasSynced, wordLines, syncedLines, scrollToLine]);
 
   if (!currentTrack) {

--- a/src/features/lyrics/hooks/useWordLyricsSync.ts
+++ b/src/features/lyrics/hooks/useWordLyricsSync.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { getPlaybackProgressSnapshot, subscribePlaybackProgress } from '@/features/playback/store/playbackProgress';
+import { getSmoothPlaybackTime, subscribeSmoothPlaybackTime } from '@/features/playback';
 import type { Track } from '@/lib/media/trackTypes';
 import type { WordLyricsLine } from '@/features/lyrics/types';
 
@@ -49,8 +49,8 @@ export function useWordLyricsSync({ enabled, wordLines, currentTrack, classPrefi
       }
       prevWord.current = { line: li, word: wi };
     };
-    apply(getPlaybackProgressSnapshot().currentTime);
-    return subscribePlaybackProgress(s => apply(s.currentTime));
+    apply(getSmoothPlaybackTime());
+    return subscribeSmoothPlaybackTime(apply);
   }, [enabled, wordLines, classPrefix]);
 
   const setWordRef = (lineIdx: number, wordIdx: number) => (el: HTMLSpanElement | null) => {

--- a/src/features/playback/index.ts
+++ b/src/features/playback/index.ts
@@ -8,6 +8,7 @@ export { seedQueueResolver } from './store/queueTrackResolver';
 export { queueSongStar } from './store/pendingStarSync';
 export { getPlaybackProgressSnapshot, subscribePlaybackProgress } from './store/playbackProgress';
 export type { PlaybackProgressSnapshot } from './store/playbackProgress';
+export { getSmoothPlaybackTime, subscribeSmoothPlaybackTime } from './store/playbackProgressSmooth';
 export {
   playbackCacheKeyForTrack,
   playbackCoverArtForAlbum,

--- a/src/features/playback/store/playbackProgress.ts
+++ b/src/features/playback/store/playbackProgress.ts
@@ -59,8 +59,30 @@ export function subscribePlaybackProgress(
   };
 }
 
+/**
+ * Seek notifications. The seek path knows the new position the instant the
+ * user asks for it, long before the engine reports anything — and while paused
+ * the engine never will. Consumers that interpolate need that moment.
+ *
+ * This lives here rather than in the interpolating module because this file
+ * imports nothing, so the seek path can reach it without a dependency cycle.
+ */
+const seekListeners = new Set<(seconds: number) => void>();
+
+export function emitPlaybackSeek(seconds: number): void {
+  seekListeners.forEach(cb => cb(seconds));
+}
+
+export function subscribePlaybackSeek(cb: (seconds: number) => void): () => void {
+  seekListeners.add(cb);
+  return () => {
+    seekListeners.delete(cb);
+  };
+}
+
 /** Test-only: reset module state between specs so suites stay isolated. */
 export function _resetPlaybackProgressForTest(): void {
   playbackProgressSnapshot = { currentTime: 0, progress: 0, buffered: 0, buffering: false };
   playbackProgressListeners.clear();
+  seekListeners.clear();
 }

--- a/src/features/playback/store/playbackProgressSmooth.test.ts
+++ b/src/features/playback/store/playbackProgressSmooth.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@/features/playback/store/playbackProgressSmooth';
 import { usePlaybackRateStore } from '@/features/playback/store/playbackRateStore';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { usePreviewStore } from '@/features/playback/store/previewStore';
 
 let clock = 0;
 
@@ -31,6 +32,7 @@ beforeEach(() => {
   vi.stubGlobal('cancelAnimationFrame', () => {});
   usePlayerStore.setState({ isPlaying: true });
   usePlaybackRateStore.setState({ enabled: false, speed: 1 });
+  usePreviewStore.setState({ previewingId: null });
 });
 
 afterEach(() => {
@@ -142,5 +144,62 @@ describe('subscribeSmoothPlaybackTime', () => {
     off();
     emitPlaybackProgress({ currentTime: 2, progress: 0.02, buffered: 0 });
     expect(cb).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('regressions caught in review', () => {
+  it('reports the engine position when nothing is subscribed yet', () => {
+    // Consumers read once before they subscribe. Returning a module global
+    // here made the lyrics pane open on line 0 mid-playback.
+    emitPlaybackProgress({ currentTime: 150, progress: 0.5, buffered: 0 });
+    expect(getSmoothPlaybackTime()).toBeCloseTo(150, 3);
+  });
+
+  it('reports the engine position again after the last subscriber left', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 240, progress: 0.8, buffered: 0 });
+    off();
+
+    emitPlaybackProgress({ currentTime: 5, progress: 0.01, buffered: 0 });
+    expect(getSmoothPlaybackTime()).toBeCloseTo(5, 3);
+  });
+
+  it('does not retroactively rescale elapsed time when the rate changes', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 100, progress: 0.5, buffered: 0 });
+    advance(1800);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(101.8, 3);
+
+    usePlaybackRateStore.setState({ enabled: true, speed: 2 });
+    // Must continue from where it was, not recompute 1.8 s at the new rate.
+    expect(getSmoothPlaybackTime()).toBeCloseTo(101.8, 3);
+
+    advance(1000);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(103.8, 3);
+    off();
+  });
+
+  it('freezes while a track preview is running', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 60, progress: 0.3, buffered: 0 });
+
+    // A preview pauses the main sink without clearing isPlaying.
+    usePreviewStore.setState({ previewingId: 'song-1' });
+    const atPreview = getSmoothPlaybackTime();
+
+    advance(3000);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(atPreview, 3);
+    off();
+  });
+
+  it('caps the media position, not the wall clock, at higher rates', () => {
+    usePlaybackRateStore.setState({ enabled: true, speed: 2 });
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 10, progress: 0.1, buffered: 0 });
+
+    advance(60_000);
+    // 2 s of media, not 2 s of wall clock scaled to 4 s.
+    expect(getSmoothPlaybackTime()).toBeCloseTo(12, 3);
+    off();
   });
 });

--- a/src/features/playback/store/playbackProgressSmooth.test.ts
+++ b/src/features/playback/store/playbackProgressSmooth.test.ts
@@ -49,6 +49,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // currentTrack drives the sameTrack branch, so a leak here would silently
+  // flip the buffering-freeze specs.
+  usePlayerStore.setState({ currentTrack: null, isPlaying: false });
   _resetSmoothPlaybackTimeForTest();
   _resetPlaybackProgressForTest();
   vi.restoreAllMocks();
@@ -311,6 +314,29 @@ describe('track boundaries', () => {
     usePlayerStore.setState({ currentTrack: { id: 'b' } as never });
     emitPlaybackProgress({ currentTime: 0, progress: 0, buffered: 0, buffering: true });
     expect(getSmoothPlaybackTime()).toBeCloseTo(0, 3);
+    off();
+  });
+});
+
+describe('first subscriber during a buffering stall', () => {
+  it('seeds from the store instead of the zeroed snapshot', () => {
+    // Mid-track stall: the progress snapshot reads 0, while the store still
+    // holds the last committed position. A view mounted now must not open at
+    // the top of the track.
+    usePlayerStore.setState({ currentTime: 137, isPlaying: true });
+    emitPlaybackProgress({ currentTime: 0, progress: 0, buffered: 0, buffering: true });
+
+    const off = subscribeSmoothPlaybackTime(() => {});
+    expect(getSmoothPlaybackTime()).toBeCloseTo(137, 3);
+    off();
+  });
+
+  it('still seeds from the snapshot when nothing is buffering', () => {
+    usePlayerStore.setState({ currentTime: 137, isPlaying: true });
+    emitPlaybackProgress({ currentTime: 42, progress: 0.4, buffered: 0 });
+
+    const off = subscribeSmoothPlaybackTime(() => {});
+    expect(getSmoothPlaybackTime()).toBeCloseTo(42, 3);
     off();
   });
 });

--- a/src/features/playback/store/playbackProgressSmooth.test.ts
+++ b/src/features/playback/store/playbackProgressSmooth.test.ts
@@ -83,12 +83,18 @@ describe('getSmoothPlaybackTime', () => {
     off();
   });
 
-  it('does not advance while buffering', () => {
+  it('holds the last position while buffering instead of following the zeroed report', () => {
     const off = subscribeSmoothPlaybackTime(() => {});
-    emitPlaybackProgress({ currentTime: 5, progress: 0.05, buffered: 0, buffering: true });
+    emitPlaybackProgress({ currentTime: 60, progress: 0.3, buffered: 0 });
+    advance(200);
+
+    // audioEventHandlers sends currentTime: 0 alongside buffering: true, so a
+    // naive anchor would drop the lyrics to the start of the track.
+    emitPlaybackProgress({ currentTime: 0, progress: 0, buffered: 0, buffering: true });
+    expect(getSmoothPlaybackTime()).toBeCloseTo(60.2, 3);
 
     advance(1000);
-    expect(getSmoothPlaybackTime()).toBeCloseTo(5, 3);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(60.2, 3);
     off();
   });
 
@@ -199,6 +205,36 @@ describe('regressions caught in review', () => {
 
     advance(60_000);
     // 2 s of media, not 2 s of wall clock scaled to 4 s.
+    expect(getSmoothPlaybackTime()).toBeCloseTo(12, 3);
+    off();
+  });
+});
+
+describe('work bounds', () => {
+  it('emits on every real update regardless of how recently a frame went out', () => {
+    const seen: number[] = [];
+    const off = subscribeSmoothPlaybackTime(v => seen.push(v));
+
+    // Two engine updates in the same millisecond must both reach listeners:
+    // the throttle is for interpolated frames, not for real state.
+    emitPlaybackProgress({ currentTime: 1, progress: 0.01, buffered: 0 });
+    emitPlaybackProgress({ currentTime: 2, progress: 0.02, buffered: 0 });
+    expect(seen).toEqual([1, 2]);
+    off();
+  });
+
+  it('ignores playback-rate writes that leave the effective rate unchanged', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 10, progress: 0.1, buffered: 0 });
+    advance(1000);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(11, 3);
+
+    // UI-only writes must not re-anchor — each re-anchor would hand the
+    // estimate a fresh extrapolation budget.
+    usePlaybackRateStore.setState({ fineStep: true });
+    advance(1500);
+
+    // Still capped 2 s past the original anchor, not 2 s past the UI write.
     expect(getSmoothPlaybackTime()).toBeCloseTo(12, 3);
     off();
   });

--- a/src/features/playback/store/playbackProgressSmooth.test.ts
+++ b/src/features/playback/store/playbackProgressSmooth.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit coverage for the interpolated playback position. The point of the
+ * module is that it keeps advancing between the throttled updates it receives,
+ * so the tests drive `performance.now()` by hand and assert on the estimate
+ * rather than on frame callbacks.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _resetPlaybackProgressForTest,
+  emitPlaybackProgress,
+} from '@/features/playback/store/playbackProgress';
+import {
+  _resetSmoothPlaybackTimeForTest,
+  getSmoothPlaybackTime,
+  subscribeSmoothPlaybackTime,
+} from '@/features/playback/store/playbackProgressSmooth';
+import { usePlaybackRateStore } from '@/features/playback/store/playbackRateStore';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+
+let clock = 0;
+
+/** Advance the wall clock the module reads, without running real frames. */
+function advance(ms: number): void {
+  clock += ms;
+}
+
+beforeEach(() => {
+  clock = 0;
+  vi.spyOn(performance, 'now').mockImplementation(() => clock);
+  vi.stubGlobal('requestAnimationFrame', () => 1);
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+  usePlayerStore.setState({ isPlaying: true });
+  usePlaybackRateStore.setState({ enabled: false, speed: 1 });
+});
+
+afterEach(() => {
+  _resetSmoothPlaybackTimeForTest();
+  _resetPlaybackProgressForTest();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('getSmoothPlaybackTime', () => {
+  it('advances between updates while playing', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 10, progress: 0.1, buffered: 0 });
+
+    advance(400);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(10.4, 3);
+
+    advance(500);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(10.9, 3);
+    off();
+  });
+
+  it('re-anchors on every real update instead of drifting', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 10, progress: 0.1, buffered: 0 });
+    advance(900);
+
+    // The engine reports a position slightly behind the estimate; the estimate
+    // must follow the engine, not its own extrapolation.
+    emitPlaybackProgress({ currentTime: 10.8, progress: 0.2, buffered: 0 });
+    expect(getSmoothPlaybackTime()).toBeCloseTo(10.8, 3);
+
+    advance(100);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(10.9, 3);
+    off();
+  });
+
+  it('freezes while paused', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 30, progress: 0.3, buffered: 0 });
+    advance(200);
+
+    usePlayerStore.setState({ isPlaying: false });
+    const atPause = getSmoothPlaybackTime();
+
+    advance(5000);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(atPause, 3);
+    off();
+  });
+
+  it('does not advance while buffering', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 5, progress: 0.05, buffered: 0, buffering: true });
+
+    advance(1000);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(5, 3);
+    off();
+  });
+
+  it('scales with the playback rate when one is active', () => {
+    usePlaybackRateStore.setState({ enabled: true, speed: 1.5 });
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 0, progress: 0, buffered: 0 });
+
+    advance(1000);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(1.5, 3);
+    off();
+  });
+
+  it('ignores the rate while the feature is disabled', () => {
+    usePlaybackRateStore.setState({ enabled: false, speed: 1.5 });
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 0, progress: 0, buffered: 0 });
+
+    advance(1000);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(1, 3);
+    off();
+  });
+
+  it('caps how far it runs past the last update', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 100, progress: 0.5, buffered: 0 });
+
+    // Updates stop arriving; the estimate must not run away.
+    advance(60_000);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(102, 3);
+    off();
+  });
+});
+
+describe('subscribeSmoothPlaybackTime', () => {
+  it('pushes the current estimate to listeners on each update', () => {
+    const seen: number[] = [];
+    const off = subscribeSmoothPlaybackTime(v => seen.push(v));
+
+    emitPlaybackProgress({ currentTime: 7, progress: 0.07, buffered: 0 });
+    emitPlaybackProgress({ currentTime: 8, progress: 0.08, buffered: 0 });
+
+    expect(seen).toEqual([7, 8]);
+    off();
+  });
+
+  it('stops listening once the last subscriber leaves', () => {
+    const cb = vi.fn();
+    const off = subscribeSmoothPlaybackTime(cb);
+    emitPlaybackProgress({ currentTime: 1, progress: 0.01, buffered: 0 });
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    off();
+    emitPlaybackProgress({ currentTime: 2, progress: 0.02, buffered: 0 });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/playback/store/playbackProgressSmooth.test.ts
+++ b/src/features/playback/store/playbackProgressSmooth.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   _resetPlaybackProgressForTest,
   emitPlaybackProgress,
+  emitPlaybackSeek,
 } from '@/features/playback/store/playbackProgress';
 import {
   _resetSmoothPlaybackTimeForTest,
@@ -326,6 +327,8 @@ describe('first subscriber during a buffering stall', () => {
     usePlayerStore.setState({ currentTime: 137, isPlaying: true });
     emitPlaybackProgress({ currentTime: 0, progress: 0, buffered: 0, buffering: true });
 
+    // Consumers read before they subscribe, so that is the order under test.
+    expect(getSmoothPlaybackTime()).toBeCloseTo(137, 3);
     const off = subscribeSmoothPlaybackTime(() => {});
     expect(getSmoothPlaybackTime()).toBeCloseTo(137, 3);
     off();
@@ -335,8 +338,61 @@ describe('first subscriber during a buffering stall', () => {
     usePlayerStore.setState({ currentTime: 137, isPlaying: true });
     emitPlaybackProgress({ currentTime: 42, progress: 0.4, buffered: 0 });
 
+    expect(getSmoothPlaybackTime()).toBeCloseTo(42, 3);
     const off = subscribeSmoothPlaybackTime(() => {});
     expect(getSmoothPlaybackTime()).toBeCloseTo(42, 3);
+    off();
+  });
+});
+
+describe('seeking', () => {
+  it('follows a seek immediately while paused', () => {
+    // The engine emits no progress at all while paused, so without the seek
+    // signal the views would stay on the old line until playback resumed.
+    usePlayerStore.setState({ isPlaying: false });
+    const seen: number[] = [];
+    const off = subscribeSmoothPlaybackTime(v => seen.push(v));
+    emitPlaybackProgress({ currentTime: 30, progress: 0.3, buffered: 0 });
+
+    emitPlaybackSeek(90);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(90, 3);
+    expect(seen.at(-1)).toBeCloseTo(90, 3);
+
+    advance(5000);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(90, 3); // paused: no drift
+    off();
+  });
+
+  it('keeps advancing from the seeked position while playing', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 30, progress: 0.3, buffered: 0 });
+
+    emitPlaybackSeek(90);
+    advance(500);
+    expect(getSmoothPlaybackTime()).toBeCloseTo(90.5, 3);
+    off();
+  });
+
+  it('is ignored when nobody is listening', () => {
+    emitPlaybackProgress({ currentTime: 12, progress: 0.12, buffered: 0 });
+    emitPlaybackSeek(90);
+    // No subscriber means no anchor to move; the reported position still wins.
+    expect(getSmoothPlaybackTime()).toBeCloseTo(12, 3);
+  });
+});
+
+describe('hidden windows', () => {
+  it('skips the work but keeps the loop alive', () => {
+    const seen: number[] = [];
+    const off = subscribeSmoothPlaybackTime(v => seen.push(v));
+    emitPlaybackProgress({ currentTime: 1, progress: 0.01, buffered: 0 });
+    const before = seen.length;
+
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+    advance(100);
+    runFrame();
+    expect(seen).toHaveLength(before); // nothing pushed
+    expect(rafQueue.length).toBe(1);   // loop still armed
     off();
   });
 });

--- a/src/features/playback/store/playbackProgressSmooth.test.ts
+++ b/src/features/playback/store/playbackProgressSmooth.test.ts
@@ -19,6 +19,15 @@ import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { usePreviewStore } from '@/features/playback/store/previewStore';
 
 let clock = 0;
+let rafQueue: FrameRequestCallback[] = [];
+
+/** Run whatever frames are queued, once. Frames scheduled by those callbacks
+ *  land in the next batch, so a loop that re-arms keeps the queue non-empty. */
+function runFrame(): void {
+  const batch = rafQueue;
+  rafQueue = [];
+  batch.forEach(cb => cb(clock));
+}
 
 /** Advance the wall clock the module reads, without running real frames. */
 function advance(ms: number): void {
@@ -28,7 +37,11 @@ function advance(ms: number): void {
 beforeEach(() => {
   clock = 0;
   vi.spyOn(performance, 'now').mockImplementation(() => clock);
-  vi.stubGlobal('requestAnimationFrame', () => 1);
+  rafQueue = [];
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  });
   vi.stubGlobal('cancelAnimationFrame', () => {});
   usePlayerStore.setState({ isPlaying: true });
   usePlaybackRateStore.setState({ enabled: false, speed: 1 });
@@ -236,6 +249,68 @@ describe('work bounds', () => {
 
     // Still capped 2 s past the original anchor, not 2 s past the UI write.
     expect(getSmoothPlaybackTime()).toBeCloseTo(12, 3);
+    off();
+  });
+});
+
+describe('frame loop', () => {
+  it('stops re-arming once the estimate sits at the cap', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 10, progress: 0.1, buffered: 0 });
+    expect(rafQueue.length).toBe(1);
+
+    advance(500);
+    runFrame();
+    expect(rafQueue.length).toBe(1); // below the cap, still running
+
+    advance(2000); // now past MAX_EXTRAPOLATION_SEC
+    runFrame();
+    expect(rafQueue.length).toBe(0); // nothing left to compute
+    off();
+  });
+
+  it('resumes the loop when a real update arrives after the cap', () => {
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 10, progress: 0.1, buffered: 0 });
+    advance(3000);
+    runFrame();
+    expect(rafQueue.length).toBe(0);
+
+    emitPlaybackProgress({ currentTime: 13, progress: 0.13, buffered: 0 });
+    expect(rafQueue.length).toBe(1);
+    off();
+  });
+
+  it('spaces interpolated pushes without delaying real updates', () => {
+    const seen: number[] = [];
+    const off = subscribeSmoothPlaybackTime(v => seen.push(v));
+    // Not 0: the channel below drops a snapshot identical to its own starting
+    // value, so that update would never arrive here.
+    emitPlaybackProgress({ currentTime: 1, progress: 0.01, buffered: 0 });
+    expect(seen).toHaveLength(1);
+
+    advance(10);
+    runFrame();
+    expect(seen).toHaveLength(1); // inside the 30 ms window, skipped
+
+    advance(40);
+    runFrame();
+    expect(seen).toHaveLength(2); // window elapsed, pushed
+    off();
+  });
+});
+
+describe('track boundaries', () => {
+  it('follows the reported zero when the track changed', () => {
+    usePlayerStore.setState({ currentTrack: { id: 'a' } as never });
+    const off = subscribeSmoothPlaybackTime(() => {});
+    emitPlaybackProgress({ currentTime: 240, progress: 0.99, buffered: 0 });
+    expect(getSmoothPlaybackTime()).toBeCloseTo(240, 3);
+
+    // Gapless advance: new track, position 0, buffering while the stream fills.
+    usePlayerStore.setState({ currentTrack: { id: 'b' } as never });
+    emitPlaybackProgress({ currentTime: 0, progress: 0, buffered: 0, buffering: true });
+    expect(getSmoothPlaybackTime()).toBeCloseTo(0, 3);
     off();
   });
 });

--- a/src/features/playback/store/playbackProgressSmooth.test.ts
+++ b/src/features/playback/store/playbackProgressSmooth.test.ts
@@ -356,7 +356,7 @@ describe('seeking', () => {
 
     emitPlaybackSeek(90);
     expect(getSmoothPlaybackTime()).toBeCloseTo(90, 3);
-    expect(seen.at(-1)).toBeCloseTo(90, 3);
+    expect(seen[seen.length - 1]).toBeCloseTo(90, 3);
 
     advance(5000);
     expect(getSmoothPlaybackTime()).toBeCloseTo(90, 3); // paused: no drift

--- a/src/features/playback/store/playbackProgressSmooth.ts
+++ b/src/features/playback/store/playbackProgressSmooth.ts
@@ -129,7 +129,13 @@ function attachSources(): void {
   lastKnownPreviewing = usePreviewStore.getState().previewingId != null;
   lastKnownRate = effectivePlaybackRate();
   anchoredTrackId = usePlayerStore.getState().currentTrack?.id ?? null;
-  anchor(snapshot.currentTime, isMoving(snapshot.buffering));
+  // The snapshot carries 0 during a buffering stall, so seeding from it would
+  // start a fresh subscriber at the top of the track. The store's committed
+  // position is coarse but keeps the last real one.
+  const seed = snapshot.buffering
+    ? usePlayerStore.getState().currentTime
+    : snapshot.currentTime;
+  anchor(seed, isMoving(snapshot.buffering));
 
   const offProgress = subscribePlaybackProgress(next => {
     const trackId = usePlayerStore.getState().currentTrack?.id ?? null;

--- a/src/features/playback/store/playbackProgressSmooth.ts
+++ b/src/features/playback/store/playbackProgressSmooth.ts
@@ -17,6 +17,7 @@
 import {
   getPlaybackProgressSnapshot,
   subscribePlaybackProgress,
+  subscribePlaybackSeek,
 } from '@/features/playback/store/playbackProgress';
 import { effectivePlaybackRate } from '@/features/playback/store/playbackReportSession';
 import { usePlaybackRateStore } from '@/features/playback/store/playbackRateStore';
@@ -56,11 +57,21 @@ let anchoredTrackId: string | null = null;
 
 /** Position the last real update reported, advanced by elapsed time while
  *  playback is running. */
+/** The position the engine last reported. While buffering the progress
+ *  snapshot carries 0, so the store's committed position — coarse but real —
+ *  stands in for it. */
+function reportedPosition(): number {
+  const snapshot = getPlaybackProgressSnapshot();
+  return snapshot.buffering
+    ? usePlayerStore.getState().currentTime
+    : snapshot.currentTime;
+}
+
 export function getSmoothPlaybackTime(): number {
   // Consumers read this once before subscribing, and the module only anchors
   // itself once it has a listener. Without this fallback that first read would
   // return a stale module global — or zero on the very first mount.
-  if (unsubscribeSources == null) return getPlaybackProgressSnapshot().currentTime;
+  if (unsubscribeSources == null) return reportedPosition();
   if (!extrapolating) return baseSeconds;
   const elapsed = (performance.now() - baseAtMs) / 1000;
   // Clamp the media position, not the wall clock: at 2x the latter would allow
@@ -105,6 +116,12 @@ function syncRateIfChanged(): void {
 function tick(): void {
   frame = null;
   if (listeners.size === 0) return;
+  // Same guard the waveform interpolation uses: a Tauri window the app counts
+  // as hidden may still be composited, so skip the work but keep the loop.
+  if (document.hidden || window.__psyHidden) {
+    frame = requestAnimationFrame(tick);
+    return;
+  }
   syncRateIfChanged();
   emit();
   if (extrapolating && !capReached()) frame = requestAnimationFrame(tick);
@@ -129,13 +146,7 @@ function attachSources(): void {
   lastKnownPreviewing = usePreviewStore.getState().previewingId != null;
   lastKnownRate = effectivePlaybackRate();
   anchoredTrackId = usePlayerStore.getState().currentTrack?.id ?? null;
-  // The snapshot carries 0 during a buffering stall, so seeding from it would
-  // start a fresh subscriber at the top of the track. The store's committed
-  // position is coarse but keeps the last real one.
-  const seed = snapshot.buffering
-    ? usePlayerStore.getState().currentTime
-    : snapshot.currentTime;
-  anchor(seed, isMoving(snapshot.buffering));
+  anchor(reportedPosition(), isMoving(snapshot.buffering));
 
   const offProgress = subscribePlaybackProgress(next => {
     const trackId = usePlayerStore.getState().currentTrack?.id ?? null;
@@ -181,6 +192,14 @@ function attachSources(): void {
   // A rate change must re-anchor before it takes effect: the estimate is
   // base + elapsed x rate, so applying a new rate to time already elapsed at
   // the old one would retroactively rescale the whole window and jump.
+  // A seek is the one position change the engine does not announce — and
+  // while paused it never would, so the views would sit on the old line.
+  const offSeek = subscribePlaybackSeek(seconds => {
+    anchor(seconds, isMoving(getPlaybackProgressSnapshot().buffering));
+    emit(true);
+    startFrameLoop();
+  });
+
   const offRate = usePlaybackRateStore.subscribe(() => {
     const rate = effectivePlaybackRate();
     if (rate === lastKnownRate) return;
@@ -193,6 +212,7 @@ function attachSources(): void {
     offPlayer();
     offPreview();
     offRate();
+    offSeek();
   };
   startFrameLoop();
 }

--- a/src/features/playback/store/playbackProgressSmooth.ts
+++ b/src/features/playback/store/playbackProgressSmooth.ts
@@ -18,8 +18,10 @@ import {
   getPlaybackProgressSnapshot,
   subscribePlaybackProgress,
 } from '@/features/playback/store/playbackProgress';
+import { effectivePlaybackRate } from '@/features/playback/store/playbackReportSession';
 import { usePlaybackRateStore } from '@/features/playback/store/playbackRateStore';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { usePreviewStore } from '@/features/playback/store/previewStore';
 
 /** Never extrapolate further than this past the last real update. Bounds the
  *  error if updates stop arriving (stall, suspended timers) instead of letting
@@ -33,21 +35,26 @@ const listeners = new Set<Listener>();
 let baseSeconds = 0;
 let baseAtMs = 0;
 let extrapolating = false;
+/** Rate in force since the last anchor. Read live, a rate change would apply
+ *  the new value to time already elapsed at the old one. */
+let anchoredRate = 1;
 let frame: number | null = null;
 let unsubscribeSources: (() => void) | null = null;
-
-function effectiveRate(): number {
-  const { enabled, speed } = usePlaybackRateStore.getState();
-  if (!enabled) return 1;
-  return speed > 0 ? speed : 1;
-}
+let lastKnownPlaying = false;
+let lastKnownPreviewing = false;
 
 /** Position the last real update reported, advanced by elapsed time while
  *  playback is running. */
 export function getSmoothPlaybackTime(): number {
+  // Consumers read this once before subscribing, and the module only anchors
+  // itself once it has a listener. Without this fallback that first read would
+  // return a stale module global — or zero on the very first mount.
+  if (unsubscribeSources == null) return getPlaybackProgressSnapshot().currentTime;
   if (!extrapolating) return baseSeconds;
   const elapsed = (performance.now() - baseAtMs) / 1000;
-  const advanced = Math.min(elapsed, MAX_EXTRAPOLATION_SEC) * effectiveRate();
+  // Clamp the media position, not the wall clock: at 2x the latter would allow
+  // twice the drift the cap is meant to permit.
+  const advanced = Math.min(elapsed * anchoredRate, MAX_EXTRAPOLATION_SEC);
   return baseSeconds + Math.max(0, advanced);
 }
 
@@ -55,6 +62,7 @@ function anchor(seconds: number, moving: boolean): void {
   baseSeconds = seconds;
   baseAtMs = performance.now();
   extrapolating = moving;
+  anchoredRate = effectivePlaybackRate();
 }
 
 function emit(): void {
@@ -76,11 +84,16 @@ function startFrameLoop(): void {
 }
 
 function isMoving(buffering: boolean | undefined): boolean {
+  // A running track preview pauses the main sink in Rust while `isPlaying`
+  // stays true and progress events stop — the same guard the waveform uses.
+  if (usePreviewStore.getState().previewingId != null) return false;
   return usePlayerStore.getState().isPlaying && !buffering;
 }
 
 function attachSources(): void {
   const snapshot = getPlaybackProgressSnapshot();
+  lastKnownPlaying = usePlayerStore.getState().isPlaying;
+  lastKnownPreviewing = usePreviewStore.getState().previewingId != null;
   anchor(snapshot.currentTime, isMoving(snapshot.buffering));
 
   const offProgress = subscribePlaybackProgress(next => {
@@ -92,17 +105,38 @@ function attachSources(): void {
   // Pausing stops the position without producing a progress event, so the
   // player state has to re-anchor as well — otherwise the estimate would keep
   // advancing through a pause.
-  const offPlayer = usePlayerStore.subscribe(state => {
-    const moving = state.isPlaying && !getPlaybackProgressSnapshot().buffering;
-    if (moving === extrapolating) return;
+  const reanchor = (): void => {
+    const moving = isMoving(getPlaybackProgressSnapshot().buffering);
     anchor(getSmoothPlaybackTime(), moving);
     emit();
     startFrameLoop();
+  };
+
+  const offPlayer = usePlayerStore.subscribe(state => {
+    if (state.isPlaying === lastKnownPlaying) return;
+    lastKnownPlaying = state.isPlaying;
+    reanchor();
+  });
+
+  const offPreview = usePreviewStore.subscribe(state => {
+    const previewing = state.previewingId != null;
+    if (previewing === lastKnownPreviewing) return;
+    lastKnownPreviewing = previewing;
+    reanchor();
+  });
+
+  // A rate change must re-anchor before it takes effect: the estimate is
+  // base + elapsed x rate, so applying a new rate to time already elapsed at
+  // the old one would retroactively rescale the whole window and jump.
+  const offRate = usePlaybackRateStore.subscribe(() => {
+    reanchor();
   });
 
   unsubscribeSources = () => {
     offProgress();
     offPlayer();
+    offPreview();
+    offRate();
   };
   startFrameLoop();
 }
@@ -134,4 +168,7 @@ export function _resetSmoothPlaybackTimeForTest(): void {
   baseSeconds = 0;
   baseAtMs = 0;
   extrapolating = false;
+  anchoredRate = 1;
+  lastKnownPlaying = false;
+  lastKnownPreviewing = false;
 }

--- a/src/features/playback/store/playbackProgressSmooth.ts
+++ b/src/features/playback/store/playbackProgressSmooth.ts
@@ -49,6 +49,10 @@ let lastKnownPlaying = false;
 let lastKnownPreviewing = false;
 let lastKnownRate = 1;
 let lastEmitAtMs = Number.NEGATIVE_INFINITY;
+/** Track the current anchor belongs to. A boundary reports currentTime 0 with
+ *  buffering set, and that zero is real — without this the estimate would hold
+ *  the previous track's end position into the new one. */
+let anchoredTrackId: string | null = null;
 
 /** Position the last real update reported, advanced by elapsed time while
  *  playback is running. */
@@ -89,9 +93,19 @@ function capReached(): boolean {
   return elapsed * anchoredRate >= MAX_EXTRAPOLATION_SEC;
 }
 
+/** The effective rate also depends on the Orbit session, which changes
+ *  without a rate-store write, so the value is re-checked as frames run. */
+function syncRateIfChanged(): void {
+  const rate = effectivePlaybackRate();
+  if (rate === anchoredRate) return;
+  anchor(getSmoothPlaybackTime(), extrapolating);
+  lastKnownRate = rate;
+}
+
 function tick(): void {
   frame = null;
   if (listeners.size === 0) return;
+  syncRateIfChanged();
   emit();
   if (extrapolating && !capReached()) frame = requestAnimationFrame(tick);
 }
@@ -114,12 +128,19 @@ function attachSources(): void {
   lastKnownPlaying = usePlayerStore.getState().isPlaying;
   lastKnownPreviewing = usePreviewStore.getState().previewingId != null;
   lastKnownRate = effectivePlaybackRate();
+  anchoredTrackId = usePlayerStore.getState().currentTrack?.id ?? null;
   anchor(snapshot.currentTime, isMoving(snapshot.buffering));
 
   const offProgress = subscribePlaybackProgress(next => {
-    if (next.buffering) {
-      // audioEventHandlers reports currentTime as 0 while buffering, so the
-      // reported value must not be trusted here — freeze where we are.
+    const trackId = usePlayerStore.getState().currentTrack?.id ?? null;
+    const sameTrack = trackId === anchoredTrackId;
+    anchoredTrackId = trackId;
+
+    if (next.buffering && sameTrack) {
+      // Mid-track buffering reports currentTime as 0, so the reported value
+      // must not be trusted — freeze where we are. A track boundary also
+      // reports 0 with buffering set, but there the zero is the truth, which
+      // is why this only applies while the track is unchanged.
       anchor(getSmoothPlaybackTime(), false);
     } else {
       anchor(next.currentTime, isMoving(next.buffering));
@@ -202,4 +223,5 @@ export function _resetSmoothPlaybackTimeForTest(): void {
   lastKnownPreviewing = false;
   lastKnownRate = 1;
   lastEmitAtMs = Number.NEGATIVE_INFINITY;
+  anchoredTrackId = null;
 }

--- a/src/features/playback/store/playbackProgressSmooth.ts
+++ b/src/features/playback/store/playbackProgressSmooth.ts
@@ -1,0 +1,137 @@
+/**
+ * Sub-second playback position for consumers that need it.
+ *
+ * `playbackProgress` is throttled twice on the way here — once in the Rust
+ * progress task and again in the audio event handler — so a subscriber sees a
+ * new position roughly every 0.9 s. That is invisible on a mm:ss clock but not
+ * in synced lyrics, where a line can light up close to a second late depending
+ * on where it falls between two updates.
+ *
+ * Rather than loosen either throttle, which would cost every subscriber, this
+ * advances the last reported position locally: base time plus elapsed
+ * wall-clock, scaled by the playback rate. Each real update re-anchors the
+ * base, so the estimate never drifts further than one update apart. The frame
+ * loop only runs while something is subscribed and playback is actually
+ * moving.
+ */
+import {
+  getPlaybackProgressSnapshot,
+  subscribePlaybackProgress,
+} from '@/features/playback/store/playbackProgress';
+import { usePlaybackRateStore } from '@/features/playback/store/playbackRateStore';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+
+/** Never extrapolate further than this past the last real update. Bounds the
+ *  error if updates stop arriving (stall, suspended timers) instead of letting
+ *  the estimate run away. */
+const MAX_EXTRAPOLATION_SEC = 2;
+
+type Listener = (seconds: number) => void;
+
+const listeners = new Set<Listener>();
+
+let baseSeconds = 0;
+let baseAtMs = 0;
+let extrapolating = false;
+let frame: number | null = null;
+let unsubscribeSources: (() => void) | null = null;
+
+function effectiveRate(): number {
+  const { enabled, speed } = usePlaybackRateStore.getState();
+  if (!enabled) return 1;
+  return speed > 0 ? speed : 1;
+}
+
+/** Position the last real update reported, advanced by elapsed time while
+ *  playback is running. */
+export function getSmoothPlaybackTime(): number {
+  if (!extrapolating) return baseSeconds;
+  const elapsed = (performance.now() - baseAtMs) / 1000;
+  const advanced = Math.min(elapsed, MAX_EXTRAPOLATION_SEC) * effectiveRate();
+  return baseSeconds + Math.max(0, advanced);
+}
+
+function anchor(seconds: number, moving: boolean): void {
+  baseSeconds = seconds;
+  baseAtMs = performance.now();
+  extrapolating = moving;
+}
+
+function emit(): void {
+  const value = getSmoothPlaybackTime();
+  listeners.forEach(cb => cb(value));
+}
+
+function tick(): void {
+  frame = null;
+  if (listeners.size === 0) return;
+  emit();
+  if (extrapolating) frame = requestAnimationFrame(tick);
+}
+
+function startFrameLoop(): void {
+  if (frame == null && extrapolating && listeners.size > 0) {
+    frame = requestAnimationFrame(tick);
+  }
+}
+
+function isMoving(buffering: boolean | undefined): boolean {
+  return usePlayerStore.getState().isPlaying && !buffering;
+}
+
+function attachSources(): void {
+  const snapshot = getPlaybackProgressSnapshot();
+  anchor(snapshot.currentTime, isMoving(snapshot.buffering));
+
+  const offProgress = subscribePlaybackProgress(next => {
+    anchor(next.currentTime, isMoving(next.buffering));
+    emit();
+    startFrameLoop();
+  });
+
+  // Pausing stops the position without producing a progress event, so the
+  // player state has to re-anchor as well — otherwise the estimate would keep
+  // advancing through a pause.
+  const offPlayer = usePlayerStore.subscribe(state => {
+    const moving = state.isPlaying && !getPlaybackProgressSnapshot().buffering;
+    if (moving === extrapolating) return;
+    anchor(getSmoothPlaybackTime(), moving);
+    emit();
+    startFrameLoop();
+  });
+
+  unsubscribeSources = () => {
+    offProgress();
+    offPlayer();
+  };
+  startFrameLoop();
+}
+
+function detachSources(): void {
+  unsubscribeSources?.();
+  unsubscribeSources = null;
+  if (frame != null) {
+    cancelAnimationFrame(frame);
+    frame = null;
+  }
+}
+
+/** Subscribe to the interpolated position. Mirrors `subscribePlaybackProgress`
+ *  so a consumer only swaps which channel it listens to. */
+export function subscribeSmoothPlaybackTime(cb: Listener): () => void {
+  listeners.add(cb);
+  if (listeners.size === 1) attachSources();
+  return () => {
+    listeners.delete(cb);
+    if (listeners.size === 0) detachSources();
+  };
+}
+
+/** Test-only: drop all state so specs stay isolated. */
+export function _resetSmoothPlaybackTimeForTest(): void {
+  detachSources();
+  listeners.clear();
+  baseSeconds = 0;
+  baseAtMs = 0;
+  extrapolating = false;
+}

--- a/src/features/playback/store/playbackProgressSmooth.ts
+++ b/src/features/playback/store/playbackProgressSmooth.ts
@@ -28,6 +28,11 @@ import { usePreviewStore } from '@/features/playback/store/previewStore';
  *  the estimate run away. */
 const MAX_EXTRAPOLATION_SEC = 2;
 
+/** Lower bound between pushes. Frame rate is far finer than anyone can
+ *  perceive in a highlighted lyric, and the raw channel this replaces ran at
+ *  roughly one update per second — 30 ms keeps the gain and drops the churn. */
+const EMIT_MIN_INTERVAL_MS = 30;
+
 type Listener = (seconds: number) => void;
 
 const listeners = new Set<Listener>();
@@ -42,6 +47,8 @@ let frame: number | null = null;
 let unsubscribeSources: (() => void) | null = null;
 let lastKnownPlaying = false;
 let lastKnownPreviewing = false;
+let lastKnownRate = 1;
+let lastEmitAtMs = Number.NEGATIVE_INFINITY;
 
 /** Position the last real update reported, advanced by elapsed time while
  *  playback is running. */
@@ -65,20 +72,32 @@ function anchor(seconds: number, moving: boolean): void {
   anchoredRate = effectivePlaybackRate();
 }
 
-function emit(): void {
+/** `force` is for real state changes (engine update, pause, rate) — those
+ *  must reach subscribers regardless of when the last frame went out. */
+function emit(force = false): void {
+  const now = performance.now();
+  if (!force && now - lastEmitAtMs < EMIT_MIN_INTERVAL_MS) return;
+  lastEmitAtMs = now;
   const value = getSmoothPlaybackTime();
   listeners.forEach(cb => cb(value));
+}
+
+/** True once the estimate sits at the cap: from here it cannot change until
+ *  a real update arrives, so running frames would push a constant value. */
+function capReached(): boolean {
+  const elapsed = (performance.now() - baseAtMs) / 1000;
+  return elapsed * anchoredRate >= MAX_EXTRAPOLATION_SEC;
 }
 
 function tick(): void {
   frame = null;
   if (listeners.size === 0) return;
   emit();
-  if (extrapolating) frame = requestAnimationFrame(tick);
+  if (extrapolating && !capReached()) frame = requestAnimationFrame(tick);
 }
 
 function startFrameLoop(): void {
-  if (frame == null && extrapolating && listeners.size > 0) {
+  if (frame == null && extrapolating && listeners.size > 0 && !capReached()) {
     frame = requestAnimationFrame(tick);
   }
 }
@@ -94,11 +113,18 @@ function attachSources(): void {
   const snapshot = getPlaybackProgressSnapshot();
   lastKnownPlaying = usePlayerStore.getState().isPlaying;
   lastKnownPreviewing = usePreviewStore.getState().previewingId != null;
+  lastKnownRate = effectivePlaybackRate();
   anchor(snapshot.currentTime, isMoving(snapshot.buffering));
 
   const offProgress = subscribePlaybackProgress(next => {
-    anchor(next.currentTime, isMoving(next.buffering));
-    emit();
+    if (next.buffering) {
+      // audioEventHandlers reports currentTime as 0 while buffering, so the
+      // reported value must not be trusted here — freeze where we are.
+      anchor(getSmoothPlaybackTime(), false);
+    } else {
+      anchor(next.currentTime, isMoving(next.buffering));
+    }
+    emit(true);
     startFrameLoop();
   });
 
@@ -108,7 +134,7 @@ function attachSources(): void {
   const reanchor = (): void => {
     const moving = isMoving(getPlaybackProgressSnapshot().buffering);
     anchor(getSmoothPlaybackTime(), moving);
-    emit();
+    emit(true);
     startFrameLoop();
   };
 
@@ -129,6 +155,9 @@ function attachSources(): void {
   // base + elapsed x rate, so applying a new rate to time already elapsed at
   // the old one would retroactively rescale the whole window and jump.
   const offRate = usePlaybackRateStore.subscribe(() => {
+    const rate = effectivePlaybackRate();
+    if (rate === lastKnownRate) return;
+    lastKnownRate = rate;
     reanchor();
   });
 
@@ -171,4 +200,6 @@ export function _resetSmoothPlaybackTimeForTest(): void {
   anchoredRate = 1;
   lastKnownPlaying = false;
   lastKnownPreviewing = false;
+  lastKnownRate = 1;
+  lastEmitAtMs = Number.NEGATIVE_INFINITY;
 }

--- a/src/features/playback/store/playbackReportSession.ts
+++ b/src/features/playback/store/playbackReportSession.ts
@@ -42,8 +42,10 @@ function extensionActive(serverId: string): boolean {
   return isFeatureActiveForServer(serverId, FEATURE_PLAYBACK_REPORT);
 }
 
-/** Effective playback speed sent to the server (1.0 when the speed DSP is off). */
-function effectivePlaybackRate(): number {
+/** Effective playback speed: the engine's real rate, 1.0 when the speed DSP is
+ *  off or an Orbit session forces passthrough. Used for the server report and
+ *  by the interpolated lyrics position. */
+export function effectivePlaybackRate(): number {
   const { enabled, strategy, speed, pitchSemitones } = usePlaybackRateStore.getState();
   return isPlaybackRateApplied(enabled, strategy, speed, pitchSemitones, isOrbitPlaybackSyncActive())
     ? speed

--- a/src/features/playback/store/seekAction.ts
+++ b/src/features/playback/store/seekAction.ts
@@ -20,6 +20,7 @@ import {
   clearSeekTarget,
   setSeekTarget,
 } from '@/features/playback/store/seekTargetState';
+import { emitPlaybackSeek } from '@/features/playback/store/playbackProgress';
 
 type SetState = (
   partial: Partial<PlayerState> | ((state: PlayerState) => Partial<PlayerState>),
@@ -47,6 +48,10 @@ export function runSeek(set: SetState, get: GetState, progress: number): void {
   if (!dur || !isFinite(dur)) return;
   const time = Math.max(0, Math.min(progress * dur, dur - 0.25));
   set({ progress: time / dur, currentTime: time });
+  // Views on the interpolated clock have no other way to learn about this:
+  // while paused the engine emits no progress at all, so without this a seek
+  // would leave the lyrics parked until playback resumed.
+  emitPlaybackSeek(time);
   armSeekDebounce(100, () => {
     const s0 = get();
     if (!s0.currentTrack) return;


### PR DESCRIPTION
Closes #1441.

## Summary

- The position the lyrics scroller reads is throttled twice on its way from the engine — `progress_task.rs:98` and `playbackThrottles.ts:19`, both `1500 ms / 0.9 s` — so a line could be highlighted almost a second late, and how late depended on where it fell between two updates. That is why the delay reads as inconsistent rather than as a fixed offset.
- Rather than loosen either throttle, which every subscriber would pay for, a small channel advances the last reported position by elapsed time scaled by the playback rate, re-anchoring on each real update so it cannot drift. It freezes while paused, buffering or previewing, follows seeks directly, caps how far it may run past the last update, and skips work while the window is hidden.
- The fullscreen rail picked its active line from the store's committed position — throttled to `20 s / 5 s` — while its own per-word highlighting already ran off the finer clock. All four lyrics views read one clock now, which is what makes this reach the view the report singled out.
- Engine-side timing is untouched: the 100 ms tick and the sample-counter position were always accurate, only their resolution was discarded before it arrived.

## Test plan

- [x] `npx tsc --noEmit`, `npm run lint`, `npm run dep:check` — clean
- [x] `npx vitest run` — 4151 tests passing, 0 failed
- [x] 26 unit tests on the new channel: anchoring, rate scaling and Orbit passthrough, the media-position cap, pause / buffering / preview freezes, track boundaries, seeks while paused, the pre-subscribe read, frame-loop start and stop, emit spacing, hidden windows
- [x] Key fixes verified against the failure they prevent — with each one reverted, the covering test fails and only that test
- [ ] Not covered by tests: the two fullscreen views have no component specs in the repo; their effect dependencies were matched to the existing `FsLyricsApple` pattern instead

Runtime benchmark: not applicable - the scenario runner drives routes, not playback, so it cannot observe lyric timing during a track; this is the same blind spot rule 10 records for the audio path. Instead: interpolated pushes are spaced at least 30 ms apart, the frame loop runs only while something is subscribed and playback is advancing, it stops at the extrapolation cap and while the window is hidden, and each consumer keeps its existing line/word guard so a frame that changes nothing touches no DOM.
