### PR TITLE
fix(search): prevent duplicate live search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Lines could light up close to a second after they were sung, and inconsistently so — some on time, others noticeably behind. The player only learned the playback position about once per second, which is imperceptible on a clock but not in lyrics, so the position is now followed continuously between those updates.
 * The fullscreen rail was worst affected, because it picked its line from an even coarser signal than its own word highlighting used. Every lyrics view now reads the same position, including after seeking to a line while paused.
 
+### Live Search no longer shows the same result twice
+
+**By [@cucadmuh](https://github.com/cucadmuh), reported by HiveMind on the Psysonic Discord, PR [#1448](https://github.com/Psysonic/psysonic/pull/1448)**
+
+* Artists, albums and songs could each appear twice when the local index and the server response used different forms of the same server identity. Live Search now aligns that identity before combining the results, while still keeping genuinely separate matches from different servers.
+
 ## [1.51.0] - 2026-08-17
 
 ## Added

--- a/src/lib/library/liveSearchLocal.test.ts
+++ b/src/lib/library/liveSearchLocal.test.ts
@@ -1,14 +1,23 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { onInvoke } from '@/test/mocks/tauri';
 import type { SearchResults } from '@/lib/api/subsonicTypes';
 import { useAuthStore } from '@/store/authStore';
 import { useLibraryIndexStore } from '@/store/libraryIndexStore';
 import { resetAuthStore } from '@/test/helpers/storeReset';
+
+const searchForServerMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api/subsonicSearch', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/api/subsonicSearch')>();
+  return { ...actual, searchForServer: searchForServerMock };
+});
+
 import {
   liveSearchQueryRejected,
   liveSearchQueryTooShort,
   mergeLiveSearchResults,
   runLocalLiveSearch,
+  runNetworkLiveSearch,
 } from './liveSearchLocal';
 
 const neverStale = { epoch: 1, isStale: () => false };
@@ -206,6 +215,56 @@ describe('liveSearchQueryTooShort', () => {
   it('treats one grapheme as too short', () => {
     expect(liveSearchQueryTooShort('а')).toBe(true);
     expect(liveSearchQueryTooShort('ab')).toBe(false);
+  });
+});
+
+describe('runNetworkLiveSearch', () => {
+  beforeEach(() => {
+    resetAuthStore();
+    searchForServerMock.mockReset();
+    useAuthStore.setState({
+      activeServerId: 'profile-s1',
+      servers: [{
+        id: 'profile-s1',
+        name: 'S',
+        url: 'https://s.test',
+        username: 'u',
+        password: 'p',
+      }],
+    });
+  });
+
+  it('normalizes network ownership to the profile id before the local race merge', async () => {
+    const resultsFor = (serverId: string): SearchResults => ({
+      artists: [{ serverId, id: 'a1', name: 'Artist' }],
+      albums: [{
+        serverId,
+        id: 'al1',
+        name: 'Album',
+        artist: 'Artist',
+        artistId: 'a1',
+        songCount: 1,
+        duration: 100,
+      }],
+      songs: [{
+        serverId,
+        id: 's1',
+        title: 'Song',
+        artist: 'Artist',
+        album: 'Album',
+        albumId: 'al1',
+        duration: 100,
+      }],
+    });
+    searchForServerMock.mockResolvedValue(resultsFor('s.test'));
+
+    const network = await runNetworkLiveSearch('artist', undefined, 'profile-s1');
+    expect(network).toEqual(resultsFor('profile-s1'));
+
+    const merged = mergeLiveSearchResults(resultsFor('profile-s1'), network!);
+    expect(merged.artists).toHaveLength(1);
+    expect(merged.albums).toHaveLength(1);
+    expect(merged.songs).toHaveLength(1);
   });
 });
 

--- a/src/lib/library/liveSearchLocal.ts
+++ b/src/lib/library/liveSearchLocal.ts
@@ -17,6 +17,7 @@ import { logLibrarySearch, timed } from './libraryDevLog';
 import { searchQueryIsFtsSafe } from './searchQueryFtsSafe';
 import { getLibraryBrowseScope, type LibraryBrowseScope } from './libraryBrowseScope';
 import { resolveReadyLibraryBrowseScope } from './libraryReady';
+import { resolveServerIdForIndexKey } from '@/lib/server/serverLookup';
 import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
 
 export const LIVE_SEARCH_DEBOUNCE_LOCAL_MS = 200;
@@ -160,9 +161,15 @@ export async function runNetworkLiveSearch(
       albumCount: LIVE_SEARCH_LIMITS.albums,
       songCount: LIVE_SEARCH_LIMITS.songs,
     };
-    return serverId
-      ? await searchForServer(serverId, q, options)
-      : await search(q, { ...options, signal });
+    if (!serverId) return await search(q, { ...options, signal });
+
+    const result = await searchForServer(serverId, q, options);
+    const ownerServerId = resolveServerIdForIndexKey(serverId);
+    return {
+      artists: result.artists.map(artist => ({ ...artist, serverId: ownerServerId })),
+      albums: result.albums.map(album => ({ ...album, serverId: ownerServerId })),
+      songs: result.songs.map(song => ({ ...song, serverId: ownerServerId })),
+    };
   } catch (err) {
     const name = err instanceof Error ? err.name : '';
     if (name === 'CanceledError' || name === 'AbortError') return null;


### PR DESCRIPTION
## Summary
- normalize single-server network Live Search ownership to the frontend profile ID before merging local and network results
- prevent the same artist, album, or song from appearing twice when local and network ownership used different ID forms
- preserve distinct results with equal raw IDs when they belong to different servers

Reported and verified by HiveMind on Discord.

## Verification
- `npx vitest run src/lib/library/liveSearchLocal.test.ts`
- `npm run lint`
- `npm run dep:check`
- `npm test` (566 files, 4171 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- Nix flake build was started from `github:Psysonic/psysonic?ref=fix/live-search-duplicate-results` and resolved this branch at `e4533ac9`

## Runtime benchmark
- Applicability: final smoke required because this changes search behaviour; no performance claim
- Final: `e4533ac9` / report `2026-08-22T20-30-23-640Z`
- Command: `psysonic benchmark run --scenario core-pages --runs 2 --profile realistic --json`
- Environment: 1227x694 viewport, 3 selected servers, stable library scope fingerprint
- Result: all 10 route samples reached the requested route; all measured interactions completed
- Timeouts/errors/skips: none
- The automatic comparison with an older report was not used as baseline evidence because comparability was not established

## Tauri boundary
- No commands, events, or payload contracts changed.