### PR TITLE
fix: preserve OpenSubsonic artist refs during Navidrome N1 delta sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Artists, albums and songs could each appear twice when the local index and the server response used different forms of the same server identity. Live Search now aligns that identity before combining the results, while still keeping genuinely separate matches from different servers.
 
+### Navidrome multi-artist credits survive background sync
+
+**By [@devyeah1978](https://github.com/devyeah1978), PR [#1449](https://github.com/Psysonic/psysonic/pull/1449)**
+
+* Navidrome delta updates no longer collapse structured track and album artist credits into one comma-joined artist. Current native credits replace stale names while richer OpenSubsonic artist references remain intact when the native response omits them.
+
 ### Linux shortcuts work immediately after returning to the app
 
 **By [@cucadmuh](https://github.com/cucadmuh), issue reported by HiveMind on the Psysonic Discord, PR [#1450](https://github.com/Psysonic/psysonic/pull/1450)**

--- a/src-tauri/crates/psysonic-library/src/repos/track/remap.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/remap.rs
@@ -18,6 +18,29 @@ impl TrackRepository<'_> {
         rows: &[TrackRow],
         unstable_track_ids: bool,
     ) -> Result<RemapStats, String> {
+        self.upsert_batch_with_remap_source(rows, unstable_track_ids, false)
+    }
+
+    /// Remap-aware upsert for payloads that are intentionally sparse.
+    ///
+    /// Missing JSON fields are preserved from the existing row via the
+    /// `UPSERT_SQL` json_patch branch instead of replacing `raw_json` wholesale.
+    /// This is used by Navidrome native delta ingest, whose `/api/song` shape can
+    /// omit richer OpenSubsonic fields such as `artists` and `albumArtists`.
+    pub(crate) fn upsert_sparse_batch_with_remap(
+        &self,
+        rows: &[TrackRow],
+        unstable_track_ids: bool,
+    ) -> Result<RemapStats, String> {
+        self.upsert_batch_with_remap_source(rows, unstable_track_ids, true)
+    }
+
+    fn upsert_batch_with_remap_source(
+        &self,
+        rows: &[TrackRow],
+        unstable_track_ids: bool,
+        sparse_payload: bool,
+    ) -> Result<RemapStats, String> {
         if rows.is_empty() {
             return Ok(RemapStats::default());
         }
@@ -87,7 +110,7 @@ impl TrackRepository<'_> {
                         if r.deleted { 1_i64 } else { 0 },
                         r.synced_at,
                         r.raw_json,
-                        0_i64,
+                        if sparse_payload { 1_i64 } else { 0_i64 },
                     ])?;
 
                     if let Some(old_id) = detected_old {

--- a/src-tauri/crates/psysonic-library/src/repos/track/remap.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/remap.rs
@@ -73,6 +73,29 @@ impl TrackRepository<'_> {
                             None
                         };
 
+                    // Sparse upsert normally merges against the row at the incoming id.
+                    // During an unstable-id remap that row does not exist yet: the rich
+                    // JSON is still attached to `old_id`. Merge the native payload onto
+                    // that resolved source before inserting the new id, otherwise the
+                    // later old-row deletion would discard the very fields sparse ingest
+                    // is meant to preserve.
+                    let remap_merged_raw = if sparse_payload {
+                        detected_old
+                            .as_deref()
+                            .map(|old_id| {
+                                merge_sparse_raw_from_remap_source(
+                                    &tx,
+                                    &r.server_id,
+                                    old_id,
+                                    &r.raw_json,
+                                )
+                            })
+                            .transpose()?
+                    } else {
+                        None
+                    };
+                    let raw_json = remap_merged_raw.as_deref().unwrap_or(r.raw_json.as_str());
+
                     upsert.execute(params![
                         r.server_id,
                         r.id,
@@ -109,7 +132,7 @@ impl TrackRepository<'_> {
                         r.server_created_at,
                         if r.deleted { 1_i64 } else { 0 },
                         r.synced_at,
-                        r.raw_json,
+                        raw_json,
                         if sparse_payload { 1_i64 } else { 0_i64 },
                     ])?;
 
@@ -178,6 +201,37 @@ impl TrackRepository<'_> {
                 Ok(RemapStats { remapped })
             })
     }
+}
+
+/// Merge a sparse incoming row against the rich row that was selected as the
+/// unstable-id remap source. SQLite's `json_patch` gives this exactly the same
+/// semantics as the normal sparse UPSERT: present fields win (including explicit
+/// null clears), while genuinely absent fields survive from the prior row.
+fn merge_sparse_raw_from_remap_source(
+    tx: &rusqlite::Transaction<'_>,
+    server_id: &str,
+    old_id: &str,
+    incoming_raw: &str,
+) -> rusqlite::Result<String> {
+    let old_raw: Option<String> = tx
+        .query_row(
+            "SELECT raw_json FROM track WHERE server_id = ?1 AND id = ?2",
+            params![server_id, old_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let Some(old_raw) = old_raw else {
+        return Ok(incoming_raw.to_string());
+    };
+
+    tx.query_row(
+        "SELECT CASE \
+           WHEN json_valid(?1) AND json_valid(?2) THEN json_patch(?1, ?2) \
+           ELSE ?2 \
+         END",
+        params![old_raw, incoming_raw],
+        |row| row.get(0),
+    )
 }
 
 // Two single-column lookups instead of one `OR` across `content_hash`

--- a/src-tauri/crates/psysonic-library/src/repos/track/tests/remap.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/tests/remap.rs
@@ -151,7 +151,8 @@ fn sparse_remap_merges_from_resolved_old_row_before_deleting_it() {
         "artists": [
             { "id": "fovos", "name": "FOVOS" },
             { "id": "someone-else", "name": "Someone Else" }
-        ]
+        ],
+        "displayArtist": "FOVOS, Someone Else"
     })
     .to_string();
 
@@ -171,7 +172,7 @@ fn sparse_remap_merges_from_resolved_old_row_before_deleting_it() {
         .unwrap();
     let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
 
-    // Present current credits replace the old array.
+    // Present current credits replace the old array and display value.
     assert_eq!(
         raw["artists"],
         json!([
@@ -179,6 +180,7 @@ fn sparse_remap_merges_from_resolved_old_row_before_deleting_it() {
             { "id": "someone-else", "name": "Someone Else" }
         ])
     );
+    assert_eq!(raw["displayArtist"], json!("FOVOS, Someone Else"));
     // Truly absent rich fields survive from the old id across the remap.
     assert_eq!(
         raw["albumArtists"],
@@ -187,7 +189,6 @@ fn sparse_remap_merges_from_resolved_old_row_before_deleting_it() {
             { "id": "max-cardona", "name": "Max Cardona" }
         ])
     );
-    assert_eq!(raw["displayArtist"], json!("FOVOS, Max Cardona"));
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/repos/track/tests/remap.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/tests/remap.rs
@@ -1,4 +1,5 @@
 use rusqlite::params;
+use serde_json::json;
 
 use super::super::remap::{REMAP_LOOKUP_BY_HASH_SQL, REMAP_LOOKUP_BY_PATH_SQL};
 use super::*;
@@ -119,6 +120,74 @@ fn remap_via_content_hash_replaces_old_row_and_records_history() {
         hist.lookup_new_id("s1", "tr_old").unwrap().as_deref(),
         Some("tr_new")
     );
+}
+
+#[test]
+fn sparse_remap_merges_from_resolved_old_row_before_deleting_it() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+
+    let mut old = row_with_id_hash("s1", "tr_old", "deadbeef", "/path/x.flac");
+    old.raw_json = json!({
+        "id": "tr_old",
+        "artist": "FOVOS, Max Cardona",
+        "artists": [
+            { "id": "fovos", "name": "FOVOS" },
+            { "id": "max-cardona", "name": "Max Cardona" }
+        ],
+        "albumArtists": [
+            { "id": "fovos", "name": "FOVOS" },
+            { "id": "max-cardona", "name": "Max Cardona" }
+        ],
+        "displayArtist": "FOVOS, Max Cardona"
+    })
+    .to_string();
+    repo.upsert_batch(&[old]).unwrap();
+
+    let mut incoming = row_with_id_hash("s1", "tr_new", "deadbeef", "/path/x.flac");
+    incoming.raw_json = json!({
+        "id": "tr_new",
+        "artist": "FOVOS, Someone Else",
+        "artists": [
+            { "id": "fovos", "name": "FOVOS" },
+            { "id": "someone-else", "name": "Someone Else" }
+        ]
+    })
+    .to_string();
+
+    let stats = repo
+        .upsert_sparse_batch_with_remap(&[incoming], true)
+        .unwrap();
+    assert_eq!(stats.remapped.len(), 1);
+
+    let raw: String = store
+        .with_conn("misc", |c| {
+            c.query_row(
+                "SELECT raw_json FROM track WHERE server_id = 's1' AND id = 'tr_new'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .unwrap();
+    let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+    // Present current credits replace the old array.
+    assert_eq!(
+        raw["artists"],
+        json!([
+            { "id": "fovos", "name": "FOVOS" },
+            { "id": "someone-else", "name": "Someone Else" }
+        ])
+    );
+    // Truly absent rich fields survive from the old id across the remap.
+    assert_eq!(
+        raw["albumArtists"],
+        json!([
+            { "id": "fovos", "name": "FOVOS" },
+            { "id": "max-cardona", "name": "Max Cardona" }
+        ])
+    );
+    assert_eq!(raw["displayArtist"], json!("FOVOS, Max Cardona"));
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/sync/delta/ingest.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/delta/ingest.rs
@@ -5,7 +5,7 @@ use psysonic_integration::navidrome::queries::nd_list_songs_internal;
 use super::{
     retry_with_backoff, DeltaSyncReport, DeltaSyncRunner, SyncError, S2_DELTA_MAX_PAGES_PER_TYPE,
 };
-use crate::repos::TrackRow;
+use crate::repos::{TrackRepository, TrackRow};
 use crate::sync::ingest_parallel::next_album_list_offset;
 use crate::sync::mapping::navidrome_song_to_track_row;
 use crate::sync::now_unix_ms;
@@ -65,9 +65,19 @@ impl DeltaSyncRunner<'_> {
                 }
             }
             if !rows.is_empty() {
-                let (changed, remapped) = self.write_batch(&rows)?;
-                report.changed_count = report.changed_count.saturating_add(changed);
-                report.remapped_count = report.remapped_count.saturating_add(remapped);
+                // Navidrome native `/api/song` is a sparse representation compared
+                // with OpenSubsonic song payloads. Preserve richer fields already
+                // stored in raw_json (notably `artists` / `albumArtists`) when the
+                // native delta row omits them, while still retaining id-remap logic.
+                let stats = TrackRepository::new(self.store)
+                    .upsert_sparse_batch_with_remap(&rows, self.unstable_track_ids())
+                    .map_err(SyncError::Storage)?;
+                report.changed_count = report
+                    .changed_count
+                    .saturating_add(rows.len() as u32);
+                report.remapped_count = report
+                    .remapped_count
+                    .saturating_add(stats.remapped.len() as u32);
             }
             if crossed_watermark || (array.len() as u32) < self.batch_size {
                 break;

--- a/src-tauri/crates/psysonic-library/src/sync/delta/tests/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/delta/tests/mod.rs
@@ -1,3 +1,4 @@
 include!("poll.rs");
 include!("ingest.rs");
+include!("n1_sparse.rs");
 include!("completion.rs");

--- a/src-tauri/crates/psysonic-library/src/sync/delta/tests/n1_sparse.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/delta/tests/n1_sparse.rs
@@ -1,0 +1,130 @@
+// ── N1 native delta preserves richer OpenSubsonic raw fields ─────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn n1_delta_preserves_structured_artist_refs_when_native_row_omits_them() {
+    let server = MockServer::start().await;
+
+    // Trigger DS-4 with an artists watermark change. The same response also
+    // satisfies the DS-9 refresh after ingest.
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/rest/getArtists.view"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "ok",
+                "artists": {
+                    "lastModified": 1_717_200_000_000_i64,
+                    "ignoredArticles": "",
+                    "index": []
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    // Navidrome native /api/song carries the flat display artist but omits
+    // OpenSubsonic `artists[]`. This is the shape that previously replaced the
+    // richer raw_json and collapsed "FOVOS, Max Cardona" into one UI artist.
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/api/song"))
+        .and(query_param("_start", "0"))
+        .and(query_param("_sort", "updated_at"))
+        .and(query_param("_order", "DESC"))
+        .and(header("X-ND-Authorization", "Bearer nd-tok"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "id": "tr_existing",
+                "title": "Adore You (Extended Mix)",
+                "artist": "FOVOS, Max Cardona",
+                "artistId": "fovos",
+                "updatedAt": "2024-06-01T00:00:00Z"
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let store = LibraryStore::open_in_memory();
+    seed_track(&store, "tr_existing", "al_x", 1_714_521_600_000);
+
+    let rich_raw = json!({
+        "id": "tr_existing",
+        "title": "Adore You (Extended Mix)",
+        "artist": "FOVOS, Max Cardona",
+        "artistId": "fovos",
+        "displayArtist": "FOVOS, Max Cardona",
+        "artists": [
+            { "id": "fovos", "name": "FOVOS" },
+            { "id": "max-cardona", "name": "Max Cardona" }
+        ],
+        "albumArtists": [
+            { "id": "fovos", "name": "FOVOS" },
+            { "id": "max-cardona", "name": "Max Cardona" }
+        ]
+    })
+    .to_string();
+
+    store
+        .with_conn("misc", |c| {
+            c.execute(
+                "UPDATE track SET artist = ?1, artist_id = ?2, raw_json = ?3 \
+                 WHERE server_id = 's1' AND id = 'tr_existing'",
+                rusqlite::params!["FOVOS, Max Cardona", "fovos", rich_raw],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    let nav = NavidromeProbeCredentials {
+        server_url: server.uri(),
+        bearer_token: "nd-tok".into(),
+    };
+    let subsonic = test_subsonic(&server.uri());
+    let report = DeltaSyncRunner::new(
+        &store,
+        &subsonic,
+        "s1",
+        "",
+        flags(
+            CapabilityFlags::NAVIDROME_NATIVE_BULK
+                | CapabilityFlags::UNSTABLE_TRACK_IDS,
+        ),
+    )
+    .with_navidrome_credentials(nav)
+    .with_batch_size(10)
+    .with_sleep_disabled()
+    .run()
+    .await
+    .unwrap();
+
+    assert_eq!(report.strategy.as_deref(), Some("n1"));
+    assert_eq!(report.changed_count, 1);
+
+    let (title, raw): (String, String) = store
+        .with_read_conn(|c| {
+            c.query_row(
+                "SELECT title, raw_json FROM track \
+                 WHERE server_id = 's1' AND id = 'tr_existing'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+        })
+        .unwrap();
+    assert_eq!(title, "Adore You (Extended Mix)");
+
+    let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let artists = raw
+        .get("artists")
+        .and_then(|v| v.as_array())
+        .expect("structured artists[] must survive sparse N1 delta");
+    assert_eq!(artists.len(), 2);
+    assert_eq!(artists[0].get("name").and_then(|v| v.as_str()), Some("FOVOS"));
+    assert_eq!(
+        artists[1].get("name").and_then(|v| v.as_str()),
+        Some("Max Cardona")
+    );
+
+    let album_artists = raw
+        .get("albumArtists")
+        .and_then(|v| v.as_array())
+        .expect("albumArtists[] must survive sparse N1 delta");
+    assert_eq!(album_artists.len(), 2);
+}

--- a/src-tauri/crates/psysonic-library/src/sync/mapping.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping.rs
@@ -204,6 +204,33 @@ pub fn subsonic_song_to_track_row(
     }
 }
 
+/// Normalize Navidrome native participant roles onto the OpenSubsonic keys the
+/// rest of Psysonic already consumes. Presence is authoritative here: an empty
+/// array or explicit null means the native payload observed that role and must
+/// be allowed to clear a stale value during sparse json_patch. Only a genuinely
+/// absent role falls back to the previously stored rich field.
+fn normalize_navidrome_participants(raw: &Value) -> Value {
+    let mut normalized = raw.clone();
+    let Some(participants) = raw.get("participants").and_then(Value::as_object) else {
+        return normalized;
+    };
+    let Some(obj) = normalized.as_object_mut() else {
+        return normalized;
+    };
+
+    if let Some(artists) = participants.get("artist") {
+        obj.insert("artists".to_string(), artists.clone());
+    }
+    if let Some(album_artists) = participants
+        .get("albumartist")
+        .or_else(|| participants.get("albumArtist"))
+    {
+        obj.insert("albumArtists".to_string(), album_artists.clone());
+    }
+
+    normalized
+}
+
 /// Project a Navidrome `/api/song` row (native REST shape) into a
 /// `TrackRow`. Field names mostly overlap with Subsonic but use
 /// snake_case JSON aliases — we read fields by `get(name)` rather
@@ -215,6 +242,8 @@ pub fn navidrome_song_to_track_row(
     synced_at: i64,
     library_id_fallback: Option<&str>,
 ) -> Option<TrackRow> {
+    let normalized = normalize_navidrome_participants(raw);
+    let raw = &normalized;
     let id = raw.get("id").and_then(|v| v.as_str())?.to_string();
     let title = raw
         .get("title")

--- a/src-tauri/crates/psysonic-library/src/sync/mapping.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping.rs
@@ -204,28 +204,55 @@ pub fn subsonic_song_to_track_row(
     }
 }
 
-/// Normalize Navidrome native participant roles onto the OpenSubsonic keys the
-/// rest of Psysonic already consumes. Presence is authoritative here: an empty
-/// array or explicit null means the native payload observed that role and must
-/// be allowed to clear a stale value during sparse json_patch. Only a genuinely
-/// absent role falls back to the previously stored rich field.
+/// Normalize Navidrome native artist data onto the OpenSubsonic keys the rest
+/// of Psysonic consumes. Native flat artist strings are current display values,
+/// so when present they replace stale `displayArtist` / `displayAlbumArtist`.
+///
+/// `participants` has a stricter contract: an absent or null field means the
+/// native endpoint did not provide structured credits, so sparse merge may keep
+/// the previously stored OpenSubsonic arrays for compatibility. Once a
+/// participants object is present, however, it is authoritative as a whole.
+/// Present roles replace their arrays and missing roles become empty arrays so a
+/// later `json_patch` cannot retain stale structured credits.
 fn normalize_navidrome_participants(raw: &Value) -> Value {
     let mut normalized = raw.clone();
-    let Some(participants) = raw.get("participants").and_then(Value::as_object) else {
-        return normalized;
-    };
     let Some(obj) = normalized.as_object_mut() else {
         return normalized;
     };
 
-    if let Some(artists) = participants.get("artist") {
-        obj.insert("artists".to_string(), artists.clone());
+    if let Some(artist) = raw.get("artist") {
+        obj.insert("displayArtist".to_string(), artist.clone());
     }
-    if let Some(album_artists) = participants
-        .get("albumartist")
-        .or_else(|| participants.get("albumArtist"))
-    {
-        obj.insert("albumArtists".to_string(), album_artists.clone());
+    if let Some(album_artist) = raw.get("albumArtist") {
+        obj.insert("displayAlbumArtist".to_string(), album_artist.clone());
+    }
+
+    let Some(participants_value) = raw.get("participants") else {
+        return normalized;
+    };
+    if participants_value.is_null() {
+        return normalized;
+    }
+
+    let empty = Value::Array(Vec::new());
+    if let Some(participants) = participants_value.as_object() {
+        obj.insert(
+            "artists".to_string(),
+            participants.get("artist").cloned().unwrap_or_else(|| empty.clone()),
+        );
+        obj.insert(
+            "albumArtists".to_string(),
+            participants
+                .get("albumartist")
+                .or_else(|| participants.get("albumArtist"))
+                .cloned()
+                .unwrap_or(empty),
+        );
+    } else {
+        // A non-null malformed value still means the server supplied the field;
+        // do not fall back to stale structured credits.
+        obj.insert("artists".to_string(), empty.clone());
+        obj.insert("albumArtists".to_string(), empty);
     }
 
     normalized

--- a/src-tauri/crates/psysonic-library/src/sync/mapping/tests/rows.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping/tests/rows.rs
@@ -69,6 +69,9 @@ fn navidrome_song_normalizes_current_participants_into_structured_artist_refs() 
         "title": "Adore You (Extended Mix)",
         "artist": "FOVOS, Someone Else",
         "artistId": "fovos",
+        "albumArtist": "FOVOS",
+        "displayArtist": "FOVOS, Max Cardona",
+        "displayAlbumArtist": "FOVOS, Max Cardona",
         "artists": [
             { "id": "fovos", "name": "FOVOS" },
             { "id": "max-cardona", "name": "Max Cardona" }
@@ -102,6 +105,76 @@ fn navidrome_song_normalizes_current_participants_into_structured_artist_refs() 
         normalized["albumArtists"],
         json!([{ "id": "fovos", "name": "FOVOS" }])
     );
+    assert_eq!(normalized["displayArtist"], json!("FOVOS, Someone Else"));
+    assert_eq!(normalized["displayAlbumArtist"], json!("FOVOS"));
+}
+
+#[test]
+fn navidrome_song_present_participants_clears_missing_roles() {
+    let raw = json!({
+        "id": "tr_1",
+        "title": "Current credits",
+        "artist": "FOVOS",
+        "albumArtist": "FOVOS",
+        "artists": [
+            { "id": "old-track", "name": "Old Track Artist" }
+        ],
+        "albumArtists": [
+            { "id": "old-album", "name": "Old Album Artist" }
+        ],
+        "participants": {
+            "artist": [
+                { "id": "fovos", "name": "FOVOS" }
+            ]
+        }
+    });
+
+    let row = navidrome_song_to_track_row("s1", &raw, 1, None).unwrap();
+    let normalized: serde_json::Value = serde_json::from_str(&row.raw_json).unwrap();
+
+    assert_eq!(
+        normalized["artists"],
+        json!([{ "id": "fovos", "name": "FOVOS" }])
+    );
+    assert_eq!(normalized["albumArtists"], json!([]));
+}
+
+#[test]
+fn navidrome_song_absent_or_null_participants_keeps_compatibility_arrays() {
+    let stale_artists = json!([
+        { "id": "fovos", "name": "FOVOS" },
+        { "id": "max-cardona", "name": "Max Cardona" }
+    ]);
+    let stale_album_artists = json!([
+        { "id": "fovos", "name": "FOVOS" }
+    ]);
+
+    let without_participants = json!({
+        "id": "tr_absent",
+        "title": "Compatibility",
+        "artist": "FOVOS, Max Cardona",
+        "albumArtist": "FOVOS",
+        "artists": stale_artists.clone(),
+        "albumArtists": stale_album_artists.clone()
+    });
+    let null_participants = json!({
+        "id": "tr_null",
+        "title": "Compatibility",
+        "artist": "FOVOS, Max Cardona",
+        "albumArtist": "FOVOS",
+        "artists": stale_artists.clone(),
+        "albumArtists": stale_album_artists.clone(),
+        "participants": null
+    });
+
+    for raw in [without_participants, null_participants] {
+        let row = navidrome_song_to_track_row("s1", &raw, 1, None).unwrap();
+        let normalized: serde_json::Value = serde_json::from_str(&row.raw_json).unwrap();
+        assert_eq!(normalized["artists"], stale_artists);
+        assert_eq!(normalized["albumArtists"], stale_album_artists);
+        assert_eq!(normalized["displayArtist"], json!("FOVOS, Max Cardona"));
+        assert_eq!(normalized["displayAlbumArtist"], json!("FOVOS"));
+    }
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/sync/mapping/tests/rows.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping/tests/rows.rs
@@ -63,6 +63,48 @@ fn navidrome_song_maps_native_field_shape() {
 }
 
 #[test]
+fn navidrome_song_normalizes_current_participants_into_structured_artist_refs() {
+    let raw = json!({
+        "id": "tr_1",
+        "title": "Adore You (Extended Mix)",
+        "artist": "FOVOS, Someone Else",
+        "artistId": "fovos",
+        "artists": [
+            { "id": "fovos", "name": "FOVOS" },
+            { "id": "max-cardona", "name": "Max Cardona" }
+        ],
+        "albumArtists": [
+            { "id": "fovos", "name": "FOVOS" },
+            { "id": "max-cardona", "name": "Max Cardona" }
+        ],
+        "participants": {
+            "artist": [
+                { "id": "fovos", "name": "FOVOS" },
+                { "id": "someone-else", "name": "Someone Else" }
+            ],
+            "albumartist": [
+                { "id": "fovos", "name": "FOVOS" }
+            ]
+        }
+    });
+
+    let row = navidrome_song_to_track_row("s1", &raw, 1, None).unwrap();
+    let normalized: serde_json::Value = serde_json::from_str(&row.raw_json).unwrap();
+
+    assert_eq!(
+        normalized["artists"],
+        json!([
+            { "id": "fovos", "name": "FOVOS" },
+            { "id": "someone-else", "name": "Someone Else" }
+        ])
+    );
+    assert_eq!(
+        normalized["albumArtists"],
+        json!([{ "id": "fovos", "name": "FOVOS" }])
+    );
+}
+
+#[test]
 fn navidrome_song_maps_numeric_library_id() {
     let raw = json!({ "id": "tr_1", "title": "Hello", "libraryId": 3 });
     let row = navidrome_song_to_track_row("s1", &raw, 1, None).unwrap();

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -543,6 +543,13 @@ const CONTRIBUTOR_ENTRIES = [
       'Configurable scrobble threshold and force-scrobble action (PR #1425)',
     ],
   },
+  {
+    github: 'devyeah1978',
+    since: '1.52.0',
+    contributions: [
+      'Navidrome delta sync preserves structured multi-artist credits (PR #1449)',
+    ],
+  },
 ] as const;
 
 // PR number of a contributor's first listed contribution, used as the


### PR DESCRIPTION
## What changed

Navidrome's native `/api/song` payload used by N1 delta sync can omit richer OpenSubsonic fields such as `artists`, `albumArtists`, and `displayArtist`.

Previously, N1 delta updates used the normal remap-aware upsert path, which replaced the existing `raw_json` wholesale. This could erase structured artist references previously captured from richer OpenSubsonic responses.

The result is that a track such as:

- `artist = "FOVOS, Max Cardona"`
- `artists = [{FOVOS}, {Max Cardona}]`

could later lose `artists[]` after an N1 delta refresh. The frontend then falls back to the flat display string, and because commas are intentionally not treated as artist separators, the two artists appear as one combined artist.

This change:

- adds a sparse remap-aware upsert path
- uses it for Navidrome N1 delta ingest
- preserves existing JSON fields that are absent from the native delta payload via the existing `json_patch` behavior
- adds a regression test reproducing the multi-artist case

## User impact

Navidrome users with multi-artist tracks should no longer see structured artist credits collapse into a single combined artist after background/delta synchronization.

## How to verify

1. Start with a locally indexed track whose `raw_json` contains structured `artists[]`.
2. Run an N1 delta where `/api/song` returns the same track with only the flat `artist` string.
3. Confirm the updated row still contains the original structured `artists[]`.
4. Confirm the UI continues to show individually resolved artists.

The included regression test reproduces this with `FOVOS` and `Max Cardona`.

## Scope

Backend/Rust only.

- No frontend changes.
- No Tauri command/event contract changes.
- No schema or migration changes.
- No changes to server-side metadata.
- Existing sparse-upsert behavior is reused rather than introducing comma-based artist splitting.

## Testing

Added an N1 delta regression test covering preservation of `artists[]` and `albumArtists[]`.

Upstream CI should run:

- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`