### PR TITLE
fix(shortcuts): restore Linux shortcuts after Alt+Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Artists, albums and songs could each appear twice when the local index and the server response used different forms of the same server identity. Live Search now aligns that identity before combining the results, while still keeping genuinely separate matches from different servers.
 
+### Linux shortcuts work immediately after returning to the app
+
+**By [@cucadmuh](https://github.com/cucadmuh), issue reported by HiveMind on the Psysonic Discord, PR [#1450](https://github.com/Psysonic/psysonic/pull/1450)**
+
+* **Linux/KDE Plasma:** Alt+Tab could return to Psysonic while leaving its webview without keyboard focus, so Space, F11 and other in-app shortcuts did nothing until the window was clicked. Psysonic now restores keyboard focus as soon as the native window is reactivated.
+
 ## [1.51.0] - 2026-08-17
 
 ## Added

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -42,6 +42,7 @@
     "core:window:allow-set-size",
     "core:webview:allow-create-webview-window",
     "core:webview:allow-set-webview-zoom",
+    "core:webview:allow-set-webview-focus",
     "process:allow-restart",
     "updater:default"
   ]

--- a/src/app/TauriEventBridge.tsx
+++ b/src/app/TauriEventBridge.tsx
@@ -9,6 +9,7 @@ import { useMediaAndWindowBridge } from '@/app/tauriBridge/useMediaAndWindowBrid
 import { usePlayerSnapshotPublisher } from '@/app/tauriBridge/usePlayerSnapshotPublisher';
 import { useLibraryDevSyncLog } from '@/app/tauriBridge/useLibraryDevSyncLog';
 import { useCoverArtBridge } from '@/app/tauriBridge/useCoverArtBridge';
+import { useWebviewFocusRecovery } from '@/app/tauriBridge/useWebviewFocusRecovery';
 
 /**
  * Single mount point for everything that bridges Rust ↔ React in the main
@@ -32,6 +33,7 @@ export function TauriEventBridge() {
   useAudioDeviceBridge();
   useCliBridge(navigate);
   useTrayIconSync();
+  useWebviewFocusRecovery();
   useInAppKeybindings(navigate);
   useMediaAndWindowBridge(navigate);
   usePlayerSnapshotPublisher();

--- a/src/app/tauriBridge/useWebviewFocusRecovery.test.ts
+++ b/src/app/tauriBridge/useWebviewFocusRecovery.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  onFocusChanged: vi.fn(),
+  setFocus: vi.fn(),
+  unlisten: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ onFocusChanged: mocks.onFocusChanged }),
+}));
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({ setFocus: mocks.setFocus }),
+}));
+vi.mock('@/lib/util/platform', () => ({ IS_LINUX: true }));
+
+import { useWebviewFocusRecovery } from './useWebviewFocusRecovery';
+
+describe('useWebviewFocusRecovery', () => {
+  let focusHandler: ((event: { payload: boolean }) => void) | undefined;
+
+  beforeEach(() => {
+    focusHandler = undefined;
+    mocks.onFocusChanged.mockReset();
+    mocks.setFocus.mockReset().mockResolvedValue(undefined);
+    mocks.unlisten.mockReset();
+    mocks.onFocusChanged.mockImplementation(async (handler) => {
+      focusHandler = handler;
+      return mocks.unlisten;
+    });
+  });
+
+  it('focuses the webview when the native window regains focus', async () => {
+    renderHook(() => useWebviewFocusRecovery());
+    await waitFor(() => expect(focusHandler).toBeDefined());
+
+    act(() => focusHandler?.({ payload: false }));
+    expect(mocks.setFocus).not.toHaveBeenCalled();
+
+    act(() => focusHandler?.({ payload: true }));
+    expect(mocks.setFocus).toHaveBeenCalledOnce();
+  });
+
+  it('removes the native focus listener on unmount', async () => {
+    const { unmount } = renderHook(() => useWebviewFocusRecovery());
+    await waitFor(() => expect(focusHandler).toBeDefined());
+
+    unmount();
+    expect(mocks.unlisten).toHaveBeenCalledOnce();
+  });
+
+  it('removes the listener when registration finishes after unmount', async () => {
+    let resolveListener!: (unlisten: () => void) => void;
+    mocks.onFocusChanged.mockImplementationOnce(() => new Promise<() => void>((resolve) => {
+      resolveListener = resolve;
+    }));
+
+    const { unmount } = renderHook(() => useWebviewFocusRecovery());
+    await waitFor(() => expect(mocks.onFocusChanged).toHaveBeenCalledOnce());
+    unmount();
+
+    resolveListener(mocks.unlisten);
+    await waitFor(() => expect(mocks.unlisten).toHaveBeenCalledOnce());
+  });
+});

--- a/src/app/tauriBridge/useWebviewFocusRecovery.ts
+++ b/src/app/tauriBridge/useWebviewFocusRecovery.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { getCurrentWebview } from '@tauri-apps/api/webview';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { IS_LINUX } from '@/lib/util/platform';
+
+/** Restore keyboard focus when a Linux compositor reactivates only the GTK window. */
+export function useWebviewFocusRecovery(): void {
+  useEffect(() => {
+    if (!IS_LINUX) return;
+
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    void getCurrentWindow().onFocusChanged(({ payload: focused }) => {
+      if (focused) getCurrentWebview().setFocus().catch(() => {});
+    }).then(stop => {
+      if (cancelled) stop();
+      else unlisten = stop;
+    }).catch(() => {});
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

- restore keyboard focus to the Linux webview when the native Tauri window regains focus
- keep the recovery Linux-only and grant the narrow `set_webview_focus` capability it needs
- cover focus, blur, normal cleanup, and delayed-listener cleanup in Vitest
- address an issue reported by HiveMind in the Psysonic Discord on NixOS with KDE Plasma; the issue does not reproduce under Hyprland

## Verification

Passed after syncing the merged Rust 1.98 cleanup from #1451:

- `npm run lint`
- `npm run dep:check`
- `npm test`
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- `cargo clippy --workspace --all-targets -- -D warnings`

The local parallel Rust suite passed 778 tests but twice exceeded the timing budget in the same two unrelated SQLite ingest performance tests. Each test passed alone in `0.07-0.08s`; the equivalent Linux and Windows workspace suites passed in #1451 CI. Refreshed #1450 CI is the authoritative final gate.

## Runtime benchmark

- Applicability: required because this adds a listener at the shared application bridge
- Baseline: `9a126d0f7110e953be1f723139967867ef3c9b39`, report `2026-08-23T09-01-50-115Z`
- Final head: `4c754cf7cc0e11f0d2ef3b17d30a013d100a7f2d`, report `2026-08-23T11-46-33-233Z`
- Confirmation run: report `2026-08-23T11-45-28-558Z`
- Command: `psysonic benchmark run --scenario core-pages --runs 2 --profile realistic --json`
- Environment: Linux WebKitGTK, 1227x694 at DPR 2, three selected servers, matching library-scope fingerprint
- Semantic readiness in ms, base -> final: Home `730 -> 629`, Albums `304 -> 0`, Artists `529 -> 0`, Favourites `133 -> 204`, Tracks `764 -> 47`
- Result: no errors, incorrect routes, timeouts, failed interactions, or long tasks; all 14 measured interactions completed
- Total-time variance moved between repeated final runs while semantic readiness and interactions stayed healthy; this was post-ready/transition noise rather than a reproduced useful-content regression

## Tauri boundary

- no command, event name, or payload contract was added or changed
- the frontend consumes the existing native window-focus event and calls the existing webview-focus API only after a Linux window regains focus
- no new high-frequency Rust-to-frontend event channel was introduced

## Manual verification

KDE Plasma confirmation is still pending. After Alt+Tab away from and back to Psysonic, `Space` and `F11` should work immediately without clicking the window.