### PR TITLE
fix(syncfs): satisfy Rust 1.98 clippy

### DIFF
--- a/src-tauri/crates/psysonic-syncfs/src/sync/batch.rs
+++ b/src-tauri/crates/psysonic-syncfs/src/sync/batch.rs
@@ -340,10 +340,9 @@ pub async fn sync_batch_to_device(
             let dest_path = std::path::Path::new(&dest).join(&file_name);
             let path_str = dest_path.to_string_lossy().to_string();
 
-            let status;
-            if dest_path.exists() {
+            let status = if dest_path.exists() {
                 s.fetch_add(1, Ordering::Relaxed);
-                status = "skipped";
+                "skipped"
             } else {
                 // Ensure parent directories exist.
                 if let Some(parent) = dest_path.parent() {
@@ -410,8 +409,8 @@ pub async fn sync_batch_to_device(
                 }
 
                 d.fetch_add(1, Ordering::Relaxed);
-                status = "done";
-            }
+                "done"
+            };
 
             // Throttled progress event — max once per 500ms.
             let should_emit = {


### PR DESCRIPTION
## Summary
- initialize the sync result status directly from the existing destination branch
- preserve the existing skipped/done behavior while satisfying Rust 1.98 `needless_late_init`
- keep the CI cleanup isolated from the Linux focus recovery work in #1450

## Verification
- `cargo test --workspace --all-targets` (passed on final warmed run)
- `cargo clippy --workspace --all-targets -- -D warnings` (passed with the repository Nix toolchain)

## Scope
- Tauri boundary: not changed
- Runtime benchmark: not applicable - assignment-only Rust cleanup with no runtime behavior change
- Changelog: not applicable - no user-visible behavior change