### PR TITLE
feat(playlist): separate personal and shared playlists on the Playlists page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Song count, duration and the added date now reach every album browse surface, including filtered views and the lossless catalogue, where one or the other used to be blank.
 * Albums added in the last two days show the new-release ribbon on the All Albums grid as well, not only under New Releases.
 
+### Telling your own playlists apart from shared ones
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1454](https://github.com/Psysonic/psysonic/pull/1454)**
+
+* A server hands over your own playlists together with every public playlist of everyone else on it, all in one undivided list. The Playlists page can now separate them into your own, the ones you share, and the ones other people share with you.
+* The switch only appears once something on the server is actually shared, and it works alongside the folder view and the search box instead of replacing either.
+* Your playlists are now recognised as yours no matter how the username was capitalised when the server profile was created. A mismatch there previously also left the delete button greyed out on your own playlists.
+
 ## Changed
 
 ### Rust internals — smaller focused modules with the same behaviour

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -446,6 +446,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Theme Store — a random theme of the moment, surfacing older themes above the search box (PR #1357)',
       'Visualizer — separate switches for Now Playing and the fullscreen player (PR #1378)',
       'Cards: full name on hover when the text is cut off, optional in Appearance (PR #1433)',
+      'Playlists — a header switch separating your own playlists from the ones shared with you (PR #1454)',
     ],
   },
   {

--- a/src/features/playlist/components/PlaylistsHeader.test.tsx
+++ b/src/features/playlist/components/PlaylistsHeader.test.tsx
@@ -1,7 +1,8 @@
 import { useRef, useState } from 'react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PlaylistsHeader from '@/features/playlist/components/PlaylistsHeader';
+import { usePlaylistLayoutStore } from '@/features/playlist/store/playlistLayoutStore';
 import { renderWithProviders } from '@/test/helpers/renderWithProviders';
 
 function HeaderHarness({
@@ -9,8 +10,10 @@ function HeaderHarness({
     { id: 'server-a', label: 'Server A' },
     { id: 'server-b', label: 'Server B' },
   ],
+  ownershipCounts = { personal: 0, sharedByMe: 0, sharedWithMe: 0 },
 }: {
   createServerOptions?: Array<{ id: string; label: string }>;
+  ownershipCounts?: { personal: number; sharedByMe: number; sharedWithMe: number };
 }) {
   const [creating, setCreating] = useState(false);
   const [creatingSmart, setCreatingSmart] = useState(false);
@@ -43,6 +46,7 @@ function HeaderHarness({
         setGenreQuery={vi.fn()}
         onEditorIntent={vi.fn()}
         foldersEnabled={false}
+        ownershipCounts={ownershipCounts}
       />
       {creatingSmart && <div data-testid="smart-editor-open" />}
       <div data-testid="selected-server">{serverId}</div>
@@ -51,6 +55,12 @@ function HeaderHarness({
 }
 
 describe('PlaylistsHeader', () => {
+  // The ownership filter lives in a persisted store, so a test that clicks a
+  // bucket would otherwise decide what the next test sees.
+  beforeEach(() => {
+    usePlaylistLayoutStore.getState().setOwnershipFilter('all');
+  });
+
   it('reveals playlist name and server only after New Playlist is pressed', async () => {
     const user = userEvent.setup();
     const view = renderWithProviders(<HeaderHarness />);
@@ -95,5 +105,53 @@ describe('PlaylistsHeader', () => {
 
     expect(view.getByRole('textbox', { name: 'Playlist Name' })).toBeInTheDocument();
     expect(view.queryByRole('combobox', { name: 'Servers' })).not.toBeInTheDocument();
+  });
+
+  it('hides the ownership filter while every playlist is personal', () => {
+    const view = renderWithProviders(
+      <HeaderHarness ownershipCounts={{ personal: 4, sharedByMe: 0, sharedWithMe: 0 }} />,
+    );
+
+    expect(view.queryByRole('group', { name: 'Playlists by owner' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the filter reachable when the last shared playlist disappears', () => {
+    // The selection is persisted. Hiding the control here too would strand the
+    // user on an empty list with no way to clear it — and it would survive a
+    // restart.
+    usePlaylistLayoutStore.getState().setOwnershipFilter('sharedWithMe');
+    const view = renderWithProviders(
+      <HeaderHarness ownershipCounts={{ personal: 4, sharedByMe: 0, sharedWithMe: 0 }} />,
+    );
+
+    expect(view.getByRole('group', { name: 'Playlists by owner' })).toBeInTheDocument();
+    expect(view.getByRole('button', { name: 'All' })).toBeInTheDocument();
+  });
+
+  it('shows the ownership filter once something is shared', () => {
+    const view = renderWithProviders(
+      <HeaderHarness ownershipCounts={{ personal: 4, sharedByMe: 0, sharedWithMe: 1 }} />,
+    );
+
+    const group = view.getByRole('group', { name: 'Playlists by owner' });
+    expect(group).toBeInTheDocument();
+    for (const name of ['All', 'Personal', 'Shared by me', 'Shared with me']) {
+      expect(view.getByRole('button', { name })).toBeInTheDocument();
+    }
+    // `all` is the default, and the pressed state is what a screen reader reads out.
+    expect(view.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true');
+    expect(view.getByRole('button', { name: 'Personal' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('moves the pressed state to the bucket the user picks', async () => {
+    const user = userEvent.setup();
+    const view = renderWithProviders(
+      <HeaderHarness ownershipCounts={{ personal: 2, sharedByMe: 1, sharedWithMe: 3 }} />,
+    );
+
+    await user.click(view.getByRole('button', { name: 'Shared with me' }));
+
+    expect(view.getByRole('button', { name: 'Shared with me' })).toHaveAttribute('aria-pressed', 'true');
+    expect(view.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/src/features/playlist/components/PlaylistsHeader.tsx
+++ b/src/features/playlist/components/PlaylistsHeader.tsx
@@ -8,7 +8,9 @@ import {
 import { offlineActionPolicy, type OfflineActionPolicy } from '@/features/offline';
 import PlaylistsNewFolderButton from '@/features/playlist/components/PlaylistsNewFolderButton';
 import PlaylistsFolderViewToggle from '@/features/playlist/components/PlaylistsFolderViewToggle';
+import PlaylistsOwnershipFilter from '@/features/playlist/components/PlaylistsOwnershipFilter';
 import PlaylistCreateFields from '@/features/playlist/components/PlaylistCreateFields';
+import type { PlaylistOwnershipBucket } from '@/features/playlist/utils/playlistOwnership';
 
 interface Props {
   selectionMode: boolean;
@@ -34,6 +36,8 @@ interface Props {
   onEditorIntent: () => void;
   actionPolicy?: OfflineActionPolicy;
   foldersEnabled?: boolean;
+  /** Bucket sizes across the whole list — the filter hides itself when nothing is shared. */
+  ownershipCounts: Record<PlaylistOwnershipBucket, number>;
 }
 
 export default function PlaylistsHeader({
@@ -45,6 +49,7 @@ export default function PlaylistsHeader({
   smartCreateServerOptions, setEditingSmartId, setSmartFilters, setGenreQuery, onEditorIntent,
   actionPolicy,
   foldersEnabled = true,
+  ownershipCounts,
 }: Props) {
   const { t } = useTranslation();
   const policy = actionPolicy ?? offlineActionPolicy('playlistsHeader', false);
@@ -118,6 +123,9 @@ export default function PlaylistsHeader({
           </button>
         </div>
       </div>
+      {!(selectionMode && selectedIds.size > 0) && (
+        <PlaylistsOwnershipFilter counts={ownershipCounts} />
+      )}
       {creating && (
         <form
           className="playlist-create-panel"

--- a/src/features/playlist/components/PlaylistsOwnershipFilter.tsx
+++ b/src/features/playlist/components/PlaylistsOwnershipFilter.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { LibraryBig, Share2, User, Users } from 'lucide-react';
+import { usePlaylistLayoutStore } from '@/features/playlist/store/playlistLayoutStore';
+import {
+  hasSharedPlaylists,
+  type PlaylistOwnershipBucket,
+  type PlaylistOwnershipFilter,
+} from '@/features/playlist/utils/playlistOwnership';
+
+interface Props {
+  counts: Record<PlaylistOwnershipBucket, number>;
+}
+
+const OPTIONS: Array<{
+  value: PlaylistOwnershipFilter;
+  labelKey: string;
+  Icon: typeof User;
+}> = [
+  { value: 'all', labelKey: 'playlists.ownership.all', Icon: LibraryBig },
+  { value: 'personal', labelKey: 'playlists.ownership.personal', Icon: User },
+  { value: 'sharedByMe', labelKey: 'playlists.ownership.sharedByMe', Icon: Share2 },
+  { value: 'sharedWithMe', labelKey: 'playlists.ownership.sharedWithMe', Icon: Users },
+];
+
+/**
+ * Header control splitting the Playlists page into personal / shared-by-me /
+ * shared-with-me.
+ *
+ * Hidden while every playlist is personal — on a single-user server the control
+ * would offer three empty buckets, the same reason the folder toggle waits for a
+ * folder to exist. It filters the list the page already holds, so it composes
+ * with folder view and the scoped text search instead of competing with them.
+ *
+ * The exception keeps the page escapable: the selection is persisted, so if the
+ * last shared playlist disappears (unshared, scope narrowed to a single-user
+ * server) while a shared bucket is active, hiding the control unconditionally
+ * would strand the user on an empty list with nothing to clear — across
+ * restarts. Whenever a filter is applied, the way out stays on screen.
+ */
+export default function PlaylistsOwnershipFilter({ counts }: Props) {
+  const { t } = useTranslation();
+  const ownershipFilter = usePlaylistLayoutStore(s => s.ownershipFilter);
+  const setOwnershipFilter = usePlaylistLayoutStore(s => s.setOwnershipFilter);
+
+  if (!hasSharedPlaylists(counts) && ownershipFilter === 'all') return null;
+
+  return (
+    <div
+      className="playlists-ownership-filter"
+      role="group"
+      aria-label={t('playlists.ownership.groupLabel')}
+    >
+      {OPTIONS.map(({ value, labelKey, Icon }) => {
+        const active = ownershipFilter === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            className={`btn btn-surface${active ? ' btn-sort-active' : ''}`}
+            onClick={() => setOwnershipFilter(value)}
+            aria-pressed={active}
+            style={active ? { background: 'var(--accent)', color: 'var(--text-on-accent)' } : {}}
+          >
+            <Icon size={15} /> {t(labelKey)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/playlist/pages/Playlists.tsx
+++ b/src/features/playlist/pages/Playlists.tsx
@@ -9,6 +9,12 @@ import { useTranslation } from 'react-i18next';
 import { useRangeSelection } from '@/lib/hooks/useRangeSelection';
 import { useScopedBrowseSearchQuery } from '@/store/liveSearchScopeStore';
 import { filterPlaylistsByNameQuery } from '@/features/playlist/utils/playlistsBrowseSearch';
+import {
+  countPlaylistsByOwnership,
+  filterPlaylistsByOwnership,
+  isOwnPlaylist,
+} from '@/features/playlist/utils/playlistOwnership';
+import { usePlaylistLayoutStore } from '@/features/playlist/store/playlistLayoutStore';
 
 import {
   defaultSmartFilters,
@@ -45,13 +51,24 @@ export default function Playlists() {
   const removeId = usePlaylistStore((s) => s.removeId);
   const playlists = usePlaylistStore((s) => s.playlists);
   const playlistsSearchQuery = useScopedBrowseSearchQuery('playlists');
-  const visiblePlaylists = useMemo(
-    () => filterPlaylistsByNameQuery(playlists, playlistsSearchQuery),
-    [playlists, playlistsSearchQuery],
-  );
-  const textSearchActive = playlistsSearchQuery.trim().length > 0;
   const fetchPlaylists = usePlaylistStore((s) => s.fetchPlaylists);
   const servers = useAuthStore(s => s.servers);
+  const ownershipFilter = usePlaylistLayoutStore(s => s.ownershipFilter);
+  // Counted over the full list, not the visible one: whether the control appears
+  // must not flip while someone types in the search box.
+  const ownershipCounts = useMemo(
+    () => countPlaylistsByOwnership(playlists, servers),
+    [playlists, servers],
+  );
+  const visiblePlaylists = useMemo(
+    () => filterPlaylistsByNameQuery(
+      [...filterPlaylistsByOwnership(playlists, ownershipFilter, servers)],
+      playlistsSearchQuery,
+    ),
+    [playlists, ownershipFilter, servers, playlistsSearchQuery],
+  );
+  const textSearchActive = playlistsSearchQuery.trim().length > 0;
+  const ownershipFilterActive = ownershipFilter !== 'all';
   const activeServerId = useAuthStore(s => s.activeServerId);
   const subsonicIdentityByServer = useAuthStore(s => s.subsonicServerIdentityByServer);
   const libraryBrowseServerIds = useAuthStore(s => s.libraryBrowseServerIds);
@@ -157,12 +174,12 @@ export default function Playlists() {
   };
 
   const selectedPlaylists = visiblePlaylists.filter(p => visibleSelectedIds.has(ownedEntityKey(p)));
-  const isPlaylistDeletable = useCallback((pl: SubsonicPlaylist) => {
-    if (!pl.serverId) return false;
-    if (!pl.owner) return true;
-    const username = servers.find(server => server.id === pl.serverId)?.username;
-    return Boolean(username) && pl.owner === username;
-  }, [servers]);
+  // Deletable = ours *and* addressable. The "is this mine" half is shared with
+  // the ownership filter so both surfaces can never drift apart on the answer.
+  const isPlaylistDeletable = useCallback(
+    (pl: SubsonicPlaylist) => Boolean(pl.serverId) && isOwnPlaylist(pl, servers),
+    [servers],
+  );
 
   useEffect(() => {
     fetchPlaylists().finally(() => setLoading(false));
@@ -386,6 +403,7 @@ export default function Playlists() {
         }}
         actionPolicy={playlistsActionPolicy}
         foldersEnabled={effectiveServerIds.length === 1 && effectiveServerIds[0] === activeServerId}
+        ownershipCounts={ownershipCounts}
       />
 
       {creatingSmart && (
@@ -422,6 +440,8 @@ export default function Playlists() {
         <div className="empty-state">{t('playlists.empty')}</div>
       ) : visiblePlaylists.length === 0 && textSearchActive ? (
         <div className="empty-state">{t('playlists.noMatchingSearch')}</div>
+      ) : visiblePlaylists.length === 0 && ownershipFilterActive ? (
+        <div className="empty-state">{t('playlists.ownership.emptyBucket')}</div>
       ) : (
         <>
           {showFolderView && (
@@ -435,7 +455,7 @@ export default function Playlists() {
               playlists={visiblePlaylists}
               renderCard={renderCard}
               disableVirtualization={perfFlags.disableMainstageVirtualLists}
-              hideEmptyFolders={textSearchActive}
+              hideEmptyFolders={textSearchActive || ownershipFilterActive}
             />
           ) : (
             <VirtualCardGrid

--- a/src/features/playlist/store/playlistLayoutStore.ts
+++ b/src/features/playlist/store/playlistLayoutStore.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import {
+  isPlaylistOwnershipFilter,
+  type PlaylistOwnershipFilter,
+} from '@/features/playlist/utils/playlistOwnership';
 
 export type PlaylistLayoutItemId =
   | 'addSongs'
@@ -23,8 +27,11 @@ export const DEFAULT_PLAYLIST_LAYOUT_ITEMS: PlaylistLayoutItemConfig[] = [
 
 interface PlaylistLayoutStore {
   items: PlaylistLayoutItemConfig[];
+  /** Which ownership bucket the Playlists page shows; `all` disables the split. */
+  ownershipFilter: PlaylistOwnershipFilter;
   setItems: (items: PlaylistLayoutItemConfig[]) => void;
   toggleItem: (id: PlaylistLayoutItemId) => void;
+  setOwnershipFilter: (filter: PlaylistOwnershipFilter) => void;
   reset: () => void;
 }
 
@@ -32,6 +39,7 @@ export const usePlaylistLayoutStore = create<PlaylistLayoutStore>()(
   persist(
     (set) => ({
       items: DEFAULT_PLAYLIST_LAYOUT_ITEMS,
+      ownershipFilter: 'all',
 
       setItems: (items) => set({ items }),
 
@@ -39,6 +47,10 @@ export const usePlaylistLayoutStore = create<PlaylistLayoutStore>()(
         items: s.items.map(it => it.id === id ? { ...it, visible: !it.visible } : it),
       })),
 
+      setOwnershipFilter: (ownershipFilter) => set({ ownershipFilter }),
+
+      // Toolbar buttons only. The ownership filter is browse state, not a layout
+      // item, so "reset layout" must not silently change which playlists show.
       reset: () => set({ items: DEFAULT_PLAYLIST_LAYOUT_ITEMS }),
     }),
     {
@@ -52,6 +64,9 @@ export const usePlaylistLayoutStore = create<PlaylistLayoutStore>()(
         const seen = new Set(safe.map(i => i.id));
         const missing = DEFAULT_PLAYLIST_LAYOUT_ITEMS.filter(i => !seen.has(i.id));
         state.items = missing.length > 0 ? [...safe, ...missing] : safe;
+        // A value persisted by an older build (or a hand-edited store) must not
+        // leave the page stuck on a bucket the control can no longer clear.
+        if (!isPlaylistOwnershipFilter(state.ownershipFilter)) state.ownershipFilter = 'all';
       },
     }
   )

--- a/src/features/playlist/utils/playlistOwnership.test.ts
+++ b/src/features/playlist/utils/playlistOwnership.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countPlaylistsByOwnership,
+  filterPlaylistsByOwnership,
+  hasSharedPlaylists,
+  isOwnPlaylist,
+  isPlaylistOwnershipFilter,
+  playlistOwnershipBucket,
+  type PlaylistOwnershipServer,
+} from '@/features/playlist/utils/playlistOwnership';
+
+const servers: PlaylistOwnershipServer[] = [
+  { id: 'srv-1', username: 'tester' },
+  { id: 'srv-2', username: 'alice' },
+];
+
+const pl = (over: Partial<{ owner: string; serverId: string; public: boolean }> = {}) => ({
+  owner: undefined as string | undefined,
+  serverId: 'srv-1',
+  public: undefined as boolean | undefined,
+  ...over,
+});
+
+describe('isOwnPlaylist', () => {
+  it('treats a playlist without an owner as ours', () => {
+    // Older servers omit the field; calling those foreign would hide the
+    // user's own playlists behind a filter they never set.
+    expect(isOwnPlaylist(pl({ owner: undefined }), servers)).toBe(true);
+  });
+
+  it('matches the owner against the username of its own server profile', () => {
+    expect(isOwnPlaylist(pl({ owner: 'tester', serverId: 'srv-1' }), servers)).toBe(true);
+    expect(isOwnPlaylist(pl({ owner: 'alice', serverId: 'srv-1' }), servers)).toBe(false);
+  });
+
+  it('resolves the same owner name differently per server', () => {
+    // The multi-server trap: one flat list carries rows from several servers,
+    // each with its own account. A single global username would mislabel one
+    // of these two.
+    expect(isOwnPlaylist(pl({ owner: 'alice', serverId: 'srv-2' }), servers)).toBe(true);
+    expect(isOwnPlaylist(pl({ owner: 'tester', serverId: 'srv-2' }), servers)).toBe(false);
+  });
+
+  it('does not claim a playlist whose server profile is unknown', () => {
+    expect(isOwnPlaylist(pl({ owner: 'tester', serverId: 'srv-gone' }), servers)).toBe(false);
+  });
+
+  it('does not claim a playlist when the profile carries no username', () => {
+    expect(isOwnPlaylist(pl({ owner: 'tester' }), [{ id: 'srv-1' }])).toBe(false);
+  });
+
+  it('ignores letter case, because the server logs the user in regardless of it', () => {
+    // navidrome/navidrome#1928: a Subsonic login whose case differs from the
+    // stored account authenticates fine, but the server keeps reporting the
+    // canonical spelling as `owner`.
+    const profiles: PlaylistOwnershipServer[] = [{ id: 'srv-1', username: 'Tester' }];
+    expect(isOwnPlaylist(pl({ owner: 'tester' }), profiles)).toBe(true);
+    expect(isOwnPlaylist(pl({ owner: 'TESTER' }), profiles)).toBe(true);
+    expect(isOwnPlaylist(pl({ owner: 'someone-else' }), profiles)).toBe(false);
+  });
+
+  it('classifies a case-mismatched own playlist as personal, not shared', () => {
+    // The whole point: without this the page would file every playlist of that
+    // user under "shared with me" and show the filter on a single-user server.
+    const profiles: PlaylistOwnershipServer[] = [{ id: 'srv-1', username: 'Tester' }];
+    expect(playlistOwnershipBucket(pl({ owner: 'tester' }), profiles)).toBe('personal');
+    expect(countPlaylistsByOwnership([pl({ owner: 'tester' })], profiles))
+      .toEqual({ personal: 1, sharedByMe: 0, sharedWithMe: 0 });
+  });
+});
+
+describe('playlistOwnershipBucket', () => {
+  it('files an own private playlist as personal', () => {
+    expect(playlistOwnershipBucket(pl({ owner: 'tester', public: false }), servers)).toBe('personal');
+  });
+
+  it('treats a missing public flag as private', () => {
+    expect(playlistOwnershipBucket(pl({ owner: 'tester' }), servers)).toBe('personal');
+  });
+
+  it('files an own public playlist as shared by me', () => {
+    expect(playlistOwnershipBucket(pl({ owner: 'tester', public: true }), servers)).toBe('sharedByMe');
+  });
+
+  it('files a foreign public playlist as shared with me, not shared by me', () => {
+    // Every foreign playlist the server hands us is public — that is why it
+    // arrives at all. Reading the flag there would collapse both shared buckets.
+    expect(playlistOwnershipBucket(pl({ owner: 'bob', public: true }), servers)).toBe('sharedWithMe');
+  });
+
+  it('files a foreign playlist as shared with me even without the public flag', () => {
+    expect(playlistOwnershipBucket(pl({ owner: 'bob' }), servers)).toBe('sharedWithMe');
+  });
+});
+
+describe('filterPlaylistsByOwnership', () => {
+  const list = [
+    pl({ owner: 'tester', public: false }),
+    pl({ owner: 'tester', public: true }),
+    pl({ owner: 'bob', public: true }),
+    pl({ owner: undefined }),
+  ];
+
+  it('returns the input untouched for "all"', () => {
+    expect(filterPlaylistsByOwnership(list, 'all', servers)).toBe(list);
+  });
+
+  it('keeps only the requested bucket', () => {
+    expect(filterPlaylistsByOwnership(list, 'personal', servers)).toHaveLength(2);
+    expect(filterPlaylistsByOwnership(list, 'sharedByMe', servers)).toHaveLength(1);
+    expect(filterPlaylistsByOwnership(list, 'sharedWithMe', servers)).toHaveLength(1);
+  });
+
+  it('can return an empty bucket', () => {
+    const onlyPersonal = [pl({ owner: 'tester' })];
+    expect(filterPlaylistsByOwnership(onlyPersonal, 'sharedWithMe', servers)).toEqual([]);
+  });
+});
+
+describe('countPlaylistsByOwnership / hasSharedPlaylists', () => {
+  it('counts every bucket', () => {
+    const counts = countPlaylistsByOwnership([
+      pl({ owner: 'tester' }),
+      pl({ owner: 'tester', public: true }),
+      pl({ owner: 'bob', public: true }),
+      pl({ owner: 'bob', public: true }),
+    ], servers);
+    expect(counts).toEqual({ personal: 1, sharedByMe: 1, sharedWithMe: 2 });
+  });
+
+  it('reports nothing shared on a single-user server', () => {
+    const counts = countPlaylistsByOwnership([pl({ owner: 'tester' }), pl()], servers);
+    expect(counts).toEqual({ personal: 2, sharedByMe: 0, sharedWithMe: 0 });
+    expect(hasSharedPlaylists(counts)).toBe(false);
+  });
+
+  it('reports shared when either shared bucket is populated', () => {
+    expect(hasSharedPlaylists({ personal: 1, sharedByMe: 1, sharedWithMe: 0 })).toBe(true);
+    expect(hasSharedPlaylists({ personal: 1, sharedByMe: 0, sharedWithMe: 1 })).toBe(true);
+  });
+});
+
+describe('isPlaylistOwnershipFilter', () => {
+  it('accepts the four known values and rejects anything else', () => {
+    for (const value of ['all', 'personal', 'sharedByMe', 'sharedWithMe']) {
+      expect(isPlaylistOwnershipFilter(value)).toBe(true);
+    }
+    for (const value of ['', 'shared', 'PERSONAL', null, undefined, 3, {}]) {
+      expect(isPlaylistOwnershipFilter(value)).toBe(false);
+    }
+  });
+});
+
+describe('deletability parity', () => {
+  // `Playlists.tsx` used to inline this logic. It now composes the shared
+  // helper, so pin the equivalence deterministically instead of trusting that
+  // the rewrite was faithful.
+  const previousImplementation = (
+    playlist: { owner?: string; serverId?: string },
+    profiles: PlaylistOwnershipServer[],
+  ): boolean => {
+    if (!playlist.serverId) return false;
+    if (!playlist.owner) return true;
+    const username = profiles.find(server => server.id === playlist.serverId)?.username;
+    return Boolean(username) && playlist.owner === username;
+  };
+
+  const current = (
+    playlist: { owner?: string; serverId?: string },
+    profiles: PlaylistOwnershipServer[],
+  ): boolean => Boolean(playlist.serverId) && isOwnPlaylist(playlist, profiles);
+
+  it('agrees with the previous inline implementation wherever case matches', () => {
+    const owners = [undefined, 'tester', 'alice', 'bob'];
+    const serverIds = [undefined, 'srv-1', 'srv-2', 'srv-gone'];
+    const profileSets: PlaylistOwnershipServer[][] = [servers, [{ id: 'srv-1' }], []];
+
+    let compared = 0;
+    for (const owner of owners) {
+      for (const serverId of serverIds) {
+        for (const profiles of profileSets) {
+          const playlist = { owner, serverId };
+          expect(current(playlist, profiles)).toBe(previousImplementation(playlist, profiles));
+          compared += 1;
+        }
+      }
+    }
+    // Guard the guard: a typo in the loops must not silently assert nothing.
+    expect(compared).toBe(owners.length * serverIds.length * profileSets.length);
+  });
+
+  it('deliberately diverges from it on a case mismatch', () => {
+    // The one intended behaviour change: the old compare denied these users the
+    // delete button on their own playlists. Pinned so the divergence stays a
+    // decision rather than becoming an accident later.
+    const profiles: PlaylistOwnershipServer[] = [{ id: 'srv-1', username: 'Tester' }];
+    const playlist = { owner: 'tester', serverId: 'srv-1' };
+    expect(previousImplementation(playlist, profiles)).toBe(false);
+    expect(current(playlist, profiles)).toBe(true);
+  });
+});

--- a/src/features/playlist/utils/playlistOwnership.ts
+++ b/src/features/playlist/utils/playlistOwnership.ts
@@ -1,0 +1,128 @@
+import type { SubsonicPlaylist } from '@/lib/api/subsonicTypes';
+
+/**
+ * Playlist ownership — splitting a server's flat playlist list into the three
+ * buckets a user actually thinks in.
+ *
+ * Subsonic gives us two independent fields, and they answer different questions:
+ * `owner` says *whose* playlist it is, `public` says whether it is shared. A
+ * server returns your own playlists plus every public playlist of every other
+ * user, so without this split someone else's shared playlists sit right between
+ * your own.
+ *
+ * The username is **per server profile**, not global: under a multi-server scope
+ * the same playlist list carries rows from several servers, each with its own
+ * account. Resolving `owner` against a single "current user" would mislabel
+ * every row from the other servers.
+ */
+
+/** Which bucket a playlist belongs to. */
+export type PlaylistOwnershipBucket = 'personal' | 'sharedByMe' | 'sharedWithMe';
+
+/** Header filter value; `all` disables the split. */
+export type PlaylistOwnershipFilter = 'all' | PlaylistOwnershipBucket;
+
+export const PLAYLIST_OWNERSHIP_FILTERS: readonly PlaylistOwnershipFilter[] = [
+  'all',
+  'personal',
+  'sharedByMe',
+  'sharedWithMe',
+] as const;
+
+export function isPlaylistOwnershipFilter(value: unknown): value is PlaylistOwnershipFilter {
+  return typeof value === 'string'
+    && (PLAYLIST_OWNERSHIP_FILTERS as readonly string[]).includes(value);
+}
+
+/** Minimal shape we need from a server profile — keeps this helper store-free. */
+export interface PlaylistOwnershipServer {
+  id: string;
+  username?: string;
+}
+
+/**
+ * True when `playlist` belongs to the account we are logged in with on *its own*
+ * server.
+ *
+ * A playlist without an `owner` counts as ours: older servers and some Subsonic
+ * implementations omit the field entirely, and treating those as foreign would
+ * hide the user's own playlists behind a filter they never set.
+ */
+export function isOwnPlaylist(
+  playlist: Pick<SubsonicPlaylist, 'owner' | 'serverId'>,
+  servers: readonly PlaylistOwnershipServer[],
+): boolean {
+  if (!playlist.owner) return true;
+  const username = servers.find(server => server.id === playlist.serverId)?.username;
+  if (!username) return false;
+  // Compared case-insensitively on purpose. Navidrome authenticates a Subsonic
+  // login whose username differs in case from the stored one, while the record
+  // it then reports as `owner` keeps the canonical spelling
+  // (navidrome/navidrome#1928). A profile saved as "Tester" against an account
+  // stored as "tester" is logged in perfectly well, and an exact compare would
+  // file every single one of that user's playlists as someone else's.
+  // The profile username is already trimmed where it is stored, so case is the
+  // only difference left to absorb.
+  return playlist.owner.toLowerCase() === username.toLowerCase();
+}
+
+/**
+ * Classify one playlist.
+ *
+ * `public` only distinguishes *our* playlists — a foreign playlist is always
+ * public (that is why the server sends it at all), so re-reading the flag there
+ * would collapse the two shared buckets into one.
+ */
+export function playlistOwnershipBucket(
+  playlist: Pick<SubsonicPlaylist, 'owner' | 'serverId' | 'public'>,
+  servers: readonly PlaylistOwnershipServer[],
+): PlaylistOwnershipBucket {
+  if (!isOwnPlaylist(playlist, servers)) return 'sharedWithMe';
+  return playlist.public === true ? 'sharedByMe' : 'personal';
+}
+
+/** Apply the header filter. `all` returns the input array unchanged. */
+export function filterPlaylistsByOwnership<
+  T extends Pick<SubsonicPlaylist, 'owner' | 'serverId' | 'public'>,
+>(
+  playlists: readonly T[],
+  filter: PlaylistOwnershipFilter,
+  servers: readonly PlaylistOwnershipServer[],
+): readonly T[] {
+  if (filter === 'all') return playlists;
+  return playlists.filter(playlist => playlistOwnershipBucket(playlist, servers) === filter);
+}
+
+/**
+ * How many playlists sit in each bucket.
+ *
+ * Today the only consumer is the filter's visibility rule (via
+ * `hasSharedPlaylists`); the per-bucket numbers are not rendered anywhere. They
+ * are kept because the rule is derived from them and reads clearer that way, and
+ * because per-bucket labels are the obvious next step if they are ever wanted.
+ */
+export function countPlaylistsByOwnership(
+  playlists: readonly Pick<SubsonicPlaylist, 'owner' | 'serverId' | 'public'>[],
+  servers: readonly PlaylistOwnershipServer[],
+): Record<PlaylistOwnershipBucket, number> {
+  const counts: Record<PlaylistOwnershipBucket, number> = {
+    personal: 0,
+    sharedByMe: 0,
+    sharedWithMe: 0,
+  };
+  for (const playlist of playlists) counts[playlistOwnershipBucket(playlist, servers)] += 1;
+  return counts;
+}
+
+/**
+ * Whether the filter is worth showing at all.
+ *
+ * On a single-user server every playlist is personal, and a control with three
+ * empty buckets is noise — the same reason the folder toggle hides itself until
+ * a folder exists.
+ */
+export function hasSharedPlaylists(
+  counts: Record<PlaylistOwnershipBucket, number>,
+): boolean {
+  return counts.sharedByMe > 0 || counts.sharedWithMe > 0;
+}

--- a/src/locales/bg/playlists.ts
+++ b/src/locales/bg/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'Папките се запазват само в Psysonic на това устройство. Navidrome и Subsonic API нямат вградена поддръжка на папки за плейлисти, така че структурата не се съхранява на вашия сървър и не се синхронизира с другите ви устройства и приложения.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Плейлисти по собственик',
+    all: 'Всички',
+    personal: 'Лични',
+    sharedByMe: 'Споделени от мен',
+    sharedWithMe: 'Споделени с мен',
+    emptyBucket: 'Няма плейлисти в тази група.',
+  },
 };

--- a/src/locales/de/playlists.ts
+++ b/src/locales/de/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'Ordner werden nur in Psysonic auf diesem Gerät gespeichert. Navidrome und die Subsonic-API unterstützen keine Playlist-Ordner, daher wird die Ordnerstruktur nicht auf deinem Server gespeichert und nicht mit deinen anderen Geräten und Apps synchronisiert.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Playlists nach Besitzer',
+    all: 'Alle',
+    personal: 'Persönlich',
+    sharedByMe: 'Von mir geteilt',
+    sharedWithMe: 'Mit mir geteilt',
+    emptyBucket: 'Keine Playlists in dieser Gruppe.',
+  },
 };

--- a/src/locales/en/playlists.ts
+++ b/src/locales/en/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'Folders are saved only in Psysonic on this device. Navidrome and the Subsonic API have no native playlist-folder support, so the structure is not stored on your server or synced to your other devices and apps.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Playlists by owner',
+    all: 'All',
+    personal: 'Personal',
+    sharedByMe: 'Shared by me',
+    sharedWithMe: 'Shared with me',
+    emptyBucket: 'No playlists in this group.',
+  },
 };

--- a/src/locales/es/playlists.ts
+++ b/src/locales/es/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'Las carpetas se guardan solo en Psysonic en este dispositivo. Navidrome y la API de Subsonic no admiten carpetas de listas, por lo que la estructura no se guarda en tu servidor ni se sincroniza con tus otros dispositivos y aplicaciones.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Listas por propietario',
+    all: 'Todas',
+    personal: 'Personales',
+    sharedByMe: 'Compartidas por mí',
+    sharedWithMe: 'Compartidas conmigo',
+    emptyBucket: 'No hay listas en este grupo.',
+  },
 };

--- a/src/locales/fr/playlists.ts
+++ b/src/locales/fr/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'Les dossiers sont enregistrés uniquement dans Psysonic sur cet appareil. Navidrome et l\'API Subsonic ne prennent pas en charge les dossiers de playlists, la structure n\'est donc pas stockée sur ton serveur ni synchronisée avec tes autres appareils et applications.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Playlists par propriétaire',
+    all: 'Toutes',
+    personal: 'Personnelles',
+    sharedByMe: 'Partagées par moi',
+    sharedWithMe: 'Partagées avec moi',
+    emptyBucket: 'Aucune playlist dans ce groupe.',
+  },
 };

--- a/src/locales/hu/playlists.ts
+++ b/src/locales/hu/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'A mappák csak ezen az eszközön, a Psysonicban vannak elmentve. A Navidrome és a Subsonic API nem támogatja natívan a lejátszásilista-mappákat, így a struktúra nem tárolódik a szervereden, és nem szinkronizálódik a többi eszközödre és alkalmazásodba.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Lejátszási listák tulajdonos szerint',
+    all: 'Összes',
+    personal: 'Személyes',
+    sharedByMe: 'Általam megosztott',
+    sharedWithMe: 'Velem megosztott',
+    emptyBucket: 'Nincs lejátszási lista ebben a csoportban.',
+  },
 };

--- a/src/locales/it/playlists.ts
+++ b/src/locales/it/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'Le cartelle vengono salvate solo in Psysonic su questo dispositivo. Navidrome e l\'API Subsonic non supportano nativamente le cartelle di playlist, quindi la struttura non viene memorizzata sul server né sincronizzata con gli altri tuoi dispositivi e app.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Playlist per proprietario',
+    all: 'Tutte',
+    personal: 'Personali',
+    sharedByMe: 'Condivise da me',
+    sharedWithMe: 'Condivise con me',
+    emptyBucket: 'Nessuna playlist in questo gruppo.',
+  },
 };

--- a/src/locales/ja/playlists.ts
+++ b/src/locales/ja/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'フォルダーはこのデバイス上の Psysonic にのみ保存されます。Navidrome と Subsonic API にはプレイリストフォルダーのネイティブ対応がないため、この構造はサーバーには保存されず、他のデバイスやアプリとも同期されません。',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: '所有者別のプレイリスト',
+    all: 'すべて',
+    personal: '個人',
+    sharedByMe: '自分が共有',
+    sharedWithMe: '自分に共有',
+    emptyBucket: 'このグループにプレイリストはありません。',
+  },
 };

--- a/src/locales/nb/playlists.ts
+++ b/src/locales/nb/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'Mapper lagres bare i Psysonic på denne enheten. Navidrome og Subsonic-API-et støtter ikke spillelistemapper, så strukturen lagres ikke på serveren din og synkroniseres ikke med dine andre enheter og apper.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Spillelister etter eier',
+    all: 'Alle',
+    personal: 'Personlige',
+    sharedByMe: 'Delt av meg',
+    sharedWithMe: 'Delt med meg',
+    emptyBucket: 'Ingen spillelister i denne gruppen.',
+  },
 };

--- a/src/locales/nl/playlists.ts
+++ b/src/locales/nl/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'Mappen worden alleen in Psysonic op dit apparaat opgeslagen. Navidrome en de Subsonic-API ondersteunen geen playlistmappen, dus de structuur wordt niet op je server opgeslagen of met je andere apparaten en apps gesynchroniseerd.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Afspeellijsten op eigenaar',
+    all: 'Alle',
+    personal: 'Persoonlijk',
+    sharedByMe: 'Door mij gedeeld',
+    sharedWithMe: 'Met mij gedeeld',
+    emptyBucket: 'Geen afspeellijsten in deze groep.',
+  },
 };

--- a/src/locales/pl/playlists.ts
+++ b/src/locales/pl/playlists.ts
@@ -120,4 +120,13 @@ export const playlists = {
     localOnlyNotice:
         'Foldery są zapisywane tylko w PsySonic na tym urządzeniu. Navidrome i API Subsonic nie obsługują natywnie folderów playlist, więc ta struktura nie jest przechowywana na serwerze ani synchronizowana z innymi urządzeniami i aplikacjami.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Playlisty według właściciela',
+    all: 'Wszystkie',
+    personal: 'Osobiste',
+    sharedByMe: 'Udostępnione przeze mnie',
+    sharedWithMe: 'Udostępnione mnie',
+    emptyBucket: 'Brak playlist w tej grupie.',
+  },
 };

--- a/src/locales/ro/playlists.ts
+++ b/src/locales/ro/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'Folderele sunt salvate doar în Psysonic pe acest dispozitiv. Navidrome și API-ul Subsonic nu acceptă foldere de playlisturi, așa că structura nu este stocată pe serverul tău și nu se sincronizează cu celelalte dispozitive și aplicații ale tale.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Playlisturi după proprietar',
+    all: 'Toate',
+    personal: 'Personale',
+    sharedByMe: 'Partajate de mine',
+    sharedWithMe: 'Partajate cu mine',
+    emptyBucket: 'Niciun playlist în acest grup.',
+  },
 };

--- a/src/locales/ru/playlists.ts
+++ b/src/locales/ru/playlists.ts
@@ -123,4 +123,13 @@ export const playlists = {
     localOnlyNotice:
       'Папки сохраняются только в Psysonic на этом устройстве. Navidrome и API Subsonic не поддерживают папки плейлистов, поэтому структура не хранится на твоём сервере и не синхронизируется с другими твоими устройствами и приложениями.',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: 'Плейлисты по владельцу',
+    all: 'Все',
+    personal: 'Личные',
+    sharedByMe: 'Мои общие',
+    sharedWithMe: 'Доступные мне',
+    emptyBucket: 'В этой группе нет плейлистов.',
+  },
 };

--- a/src/locales/zh/playlists.ts
+++ b/src/locales/zh/playlists.ts
@@ -121,4 +121,13 @@ export const playlists = {
     localOnlyNotice:
       '文件夹仅保存在此设备上的 Psysonic 中。Navidrome 和 Subsonic API 不支持播放列表文件夹，因此该结构不会存储在你的服务器上，也不会同步到你的其他设备和应用。',
   },
+  // Ownership split (personal / shared by me / shared with me)
+  ownership: {
+    groupLabel: '按所有者分类的播放列表',
+    all: '全部',
+    personal: '个人',
+    sharedByMe: '我分享的',
+    sharedWithMe: '分享给我的',
+    emptyBucket: '此分组中没有播放列表。',
+  },
 };

--- a/src/styles/components/playlists-overview-header.css
+++ b/src/styles/components/playlists-overview-header.css
@@ -78,3 +78,21 @@
     flex: 1;
   }
 }
+
+/* ─ Ownership filter (personal / shared by me / shared with me) ─ */
+.playlists-ownership-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+/*
+ * Content width, never an equal share. These labels differ a lot in length once
+ * translated ("All" against "Shared with me"), and an equal-share flex basis
+ * combined with the button's own nowrap clips the longer ones at both ends —
+ * a failure that only shows up in some locales.
+ */
+.playlists-ownership-filter > .btn {
+  flex: 0 0 auto;
+}


### PR DESCRIPTION
## Summary

- Split the Playlists page into personal, shared by me, and shared with me, driven by a header filter that hides itself while nothing is shared
- Resolve ownership per server profile, since a multi-server scope carries rows from several accounts at once
- Share that check with the playlist delete permission instead of keeping a second copy of it
- Compare the owner case-insensitively: the server authenticates a login whose spelling differs from the stored account (navidrome/navidrome#1928) while still reporting the canonical name, which previously left those users unable to delete their own playlists

## Test plan

- `npx tsc --noEmit`, `npm run lint`, `npm run dep:check` - clean, no new violations
- `npx vitest run` - 568 files / 4199 tests green
- Mutation probes on the ownership resolution, the personal/shared split and the filter's escape hatch; each one turns its covering tests red

Runtime benchmark: smoke - all-pages, realistic, 2 runs. The Playlists route sits at 958 ms median, -14% against the previous stored run, while the 29 untouched routes span -31% to +15% around a +1% median - the change carries no signal of its own.
