### PR TITLE
fix(dnd): resolve armed presses across every drag source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **Linux/KDE Plasma:** Alt+Tab could return to Psysonic while leaving its webview without keyboard focus, so Space, F11 and other in-app shortcuts did nothing until the window was clicked. Psysonic now restores keyboard focus as soon as the native window is reactivated.
 
+### Drags no longer start on their own when a press goes nowhere
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1456](https://github.com/Psysonic/psysonic/pull/1456)**
+
+* Albums were fixed above; the same problem sat in every other place a track can be dragged from — the queue and the mini-player queue, playlists, favorites, search results, Random Mix and the song cards on Home. Holding the mouse button while the list changed underneath left a drag primed, and the next movement picked up a row that was no longer on screen.
+* A press whose release never arrives now ends with whatever replaces it — the pointer leaving the window, the app losing focus, or the system taking the drag over — instead of waiting for a mouse-up that is never delivered.
+
 ## [1.51.0] - 2026-08-17
 
 ## Added

--- a/src/features/album/components/TrackRow.tsx
+++ b/src/features/album/components/TrackRow.tsx
@@ -21,6 +21,7 @@ import { buildArtistDetailPath } from '@/lib/navigation/detailServerScope';
 import { ResolvedArtistRefInline } from '@/ui/ResolvedArtistRefInline';
 import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
 import { sameQueueTrack } from '@/features/playback';
+import { useDragPress } from '@/lib/dnd/useDragPress';
 
 type ContextMenuFn = (
   x: number,
@@ -115,6 +116,10 @@ export const TrackRow = React.memo(function TrackRow({
   const isActive = sameQueueTrack(currentTrack, song);
   const isPreviewing = usePreviewStore(s => sameQueueTrack(s.previewingTrack, song));
   const isPreviewAudioStarted = usePreviewStore(s => sameQueueTrack(s.previewingTrack, song) && s.audioStarted);
+
+  const onRowMouseDown = useDragPress({
+    onStart: (me) => onDragStart(song, me),
+  });
 
   const renderCell = (colDef: ColDef) => {
     const key = colDef.key as ColKey;
@@ -263,24 +268,7 @@ export const TrackRow = React.memo(function TrackRow({
         onContextMenu(e.clientX, e.clientY, songToTrack(song), 'album-song');
       }}
       role="row"
-      onMouseDown={e => {
-        if (e.button !== 0) return;
-        e.preventDefault();
-        const sx = e.clientX, sy = e.clientY;
-        const onMove = (me: MouseEvent) => {
-          if (Math.abs(me.clientX - sx) > 5 || Math.abs(me.clientY - sy) > 5) {
-            document.removeEventListener('mousemove', onMove);
-            document.removeEventListener('mouseup', onUp);
-            onDragStart(song, me);
-          }
-        };
-        const onUp = () => {
-          document.removeEventListener('mousemove', onMove);
-          document.removeEventListener('mouseup', onUp);
-        };
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', onUp);
-      }}
+      onMouseDown={onRowMouseDown}
     >
       {visibleCols.map(colDef => renderCell(colDef))}
     </div>

--- a/src/features/album/hooks/useAlbumDragStart.ts
+++ b/src/features/album/hooks/useAlbumDragStart.ts
@@ -1,10 +1,8 @@
-import { useCallback, useEffect, useRef } from 'react';
+import type React from 'react';
 import type { SubsonicAlbum } from '@/lib/api/subsonicTypes';
 import { acquireUrl } from '@/cover';
 import { useDragDrop } from '@/lib/dnd/DragDropContext';
-
-/** Pointer travel before a press turns into a drag rather than a click. */
-const DRAG_THRESHOLD_PX = 5;
+import { useDragPress } from '@/lib/dnd/useDragPress';
 
 /**
  * Album drag source shared by the card and the table row: a left-press that
@@ -20,33 +18,10 @@ export function useAlbumDragStart(
   disabled = false,
 ): (e: React.MouseEvent) => void {
   const psyDrag = useDragDrop();
-  /** Detaches the listeners of the press in flight, while one is unresolved. */
-  const endPressRef = useRef<(() => void) | null>(null);
 
-  // A press detaches its own listeners once it resolves — into a drag, or into a
-  // release. Nothing resolves it when the source disappears mid-press, and rows
-  // do disappear under a held button: they are virtualised, the view mode can
-  // flip, and a refresh replaces the list. The listeners would then outlive the
-  // component and turn the next pointer travel into a drag for an album that is
-  // no longer on screen.
-  // `disabled` is a dependency for the same reason: React runs this cleanup
-  // before re-running on a change, so selection mode turning on resolves an
-  // armed press instead of leaving a drag primed behind the new mode.
-  useEffect(() => () => endPressRef.current?.(), [disabled]);
-
-  return useCallback((e: React.MouseEvent) => {
-    if (disabled || e.button !== 0) return;
-    e.preventDefault();
-    // A second press supersedes one that never resolved.
-    endPressRef.current?.();
-    const sx = e.clientX;
-    const sy = e.clientY;
-    const onMove = (me: MouseEvent) => {
-      if (
-        Math.abs(me.clientX - sx) <= DRAG_THRESHOLD_PX
-        && Math.abs(me.clientY - sy) <= DRAG_THRESHOLD_PX
-      ) return;
-      endPress();
+  return useDragPress({
+    disabled,
+    onStart: (me) => {
       const coverUrl = coverStorageKey ? acquireUrl(coverStorageKey) ?? undefined : undefined;
       psyDrag.startDrag({
         data: JSON.stringify({
@@ -58,14 +33,6 @@ export function useAlbumDragStart(
         label: album.name,
         coverUrl,
       }, me.clientX, me.clientY);
-    };
-    const endPress = () => {
-      document.removeEventListener('mousemove', onMove);
-      document.removeEventListener('mouseup', endPress);
-      endPressRef.current = null;
-    };
-    document.addEventListener('mousemove', onMove);
-    document.addEventListener('mouseup', endPress);
-    endPressRef.current = endPress;
-  }, [album.id, album.name, album.serverId, coverStorageKey, disabled, psyDrag]);
+    },
+  });
 }

--- a/src/features/favorites/components/FavoritesSongsTracklist.tsx
+++ b/src/features/favorites/components/FavoritesSongsTracklist.tsx
@@ -11,6 +11,7 @@ import { previewInputFromSong, usePreviewStore } from '@/features/playback/store
 import { useSelectionStore } from '@/store/selectionStore';
 import { useThemeStore } from '@/store/themeStore';
 import { useDragDrop } from '@/lib/dnd/DragDropContext';
+import { useDragPressHandle } from '@/lib/dnd/useDragPress';
 import { useOrbitSongRowBehavior } from '@/features/orbit';
 import { songToTrack } from '@/lib/media/songToTrack';
 import { appendServerQuery, buildArtistDetailPath } from '@/lib/navigation/detailServerScope';
@@ -68,6 +69,8 @@ export default function FavoritesSongsTracklist({
   const showBitrate = useThemeStore(s => s.showBitrate);
   const trackListCoversOn = useTrackListCoverArtEnabled('pages');
   const psyDrag = useDragDrop();
+  // Rows are virtualised, so one can be recycled out from under a held button.
+  const dragPress = useDragPressHandle();
   const { orbitActive, queueHint, addTrackToOrbit } = useOrbitSongRowBehavior();
 
   const visibleTracks = useMemo(() => visibleSongs.map(songToTrack), [visibleSongs]);
@@ -101,28 +104,19 @@ export default function FavoritesSongsTracklist({
       latest.current.openContextMenu(e.clientX, e.clientY, songToTrack(song), 'favorite-song');
     },
     mouseDownRow: (song, e) => {
-      if (e.button !== 0) return;
-      if ((e.target as HTMLElement).closest('button, a, input')) return;
-      e.preventDefault();
-      const sx = e.clientX, sy = e.clientY;
-      const track = songToTrack(song);
-      const onMove = (me: MouseEvent) => {
-        if (Math.abs(me.clientX - sx) > 5 || Math.abs(me.clientY - sy) > 5) {
-          document.removeEventListener('mousemove', onMove);
-          document.removeEventListener('mouseup', onUp);
+      dragPress.arm(e, {
+        canStart: (ev) => !(ev.target as HTMLElement).closest('button, a, input'),
+        onStart: (me) => {
           const L = latest.current;
           const { selectedIds: selIds } = useSelectionStore.getState();
-           if (selIds.has(ownedEntityKey(song)) && selIds.size > 1) {
-             const bulkTracks = L.visibleSongs.filter(s => selIds.has(ownedEntityKey(s))).map(songToTrack);
+          if (selIds.has(ownedEntityKey(song)) && selIds.size > 1) {
+            const bulkTracks = L.visibleSongs.filter(s => selIds.has(ownedEntityKey(s))).map(songToTrack);
             L.psyDrag.startDrag({ data: JSON.stringify({ type: 'songs', tracks: bulkTracks }), label: `${bulkTracks.length} Songs` }, me.clientX, me.clientY);
           } else {
-            L.psyDrag.startDrag({ data: JSON.stringify({ type: 'song', track }), label: song.title }, me.clientX, me.clientY);
+            L.psyDrag.startDrag({ data: JSON.stringify({ type: 'song', track: songToTrack(song) }), label: song.title }, me.clientX, me.clientY);
           }
-        }
-      };
-      const onUp = () => { document.removeEventListener('mousemove', onMove); document.removeEventListener('mouseup', onUp); };
-      document.addEventListener('mousemove', onMove);
-      document.addEventListener('mouseup', onUp);
+        },
+      });
     },
     toggleSelect: (songId, index, shift) => latest.current.toggleSelect(songId, index, shift),
     play: (index) => {
@@ -143,7 +137,7 @@ export default function FavoritesSongsTracklist({
       const query = appendServerQuery(undefined, serverId);
       latest.current.navigate(query ? `/album/${albumId}?${query}` : `/album/${albumId}`);
     },
-  }), []);
+  }), [dragPress]);
 
   const listWrapRef = useRef<HTMLDivElement | null>(null);
   const [scrollMargin, setScrollMargin] = useState(0);

--- a/src/features/home/components/SongCard.tsx
+++ b/src/features/home/components/SongCard.tsx
@@ -12,6 +12,7 @@ import { useTrackCoverRef } from '@/cover/useLibraryCoverRef';
 import { COVER_DENSE_RAIL_CELL_CSS_PX } from '@/cover/layoutSizes';
 import { enqueueAndPlay } from '@/features/playback/utils/playback/playSong';
 import { useDragDrop } from '@/lib/dnd/DragDropContext';
+import { useDragPress } from '@/lib/dnd/useDragPress';
 import { useOrbitSongRowBehavior } from '@/features/orbit';
 import { useNavigateToAlbum } from '@/features/album';
 import { useNavigateToArtist } from '@/features/artist';
@@ -82,6 +83,18 @@ function SongCard({
     navigateToAlbum(song.albumId, { search: appendServerQuery(undefined, song.serverId) });
   };
 
+  const onCardMouseDown = useDragPress({
+    preventDefault: false,
+    onStart: (me) => psyDrag.startDrag(
+      {
+        data: JSON.stringify({ type: 'song', track: songToTrack(song) }),
+        label: song.title,
+        coverUrl: coverUrl || undefined,
+      },
+      me.clientX, me.clientY,
+    ),
+  });
+
   return (
     <div
       className="song-card card"
@@ -94,30 +107,7 @@ function SongCard({
         e.preventDefault();
         openContextMenu(e.clientX, e.clientY, song, 'song');
       }}
-      onMouseDown={e => {
-        if (e.button !== 0) return;
-        const sx = e.clientX, sy = e.clientY;
-        const onMove = (me: MouseEvent) => {
-          if (Math.abs(me.clientX - sx) > 5 || Math.abs(me.clientY - sy) > 5) {
-            document.removeEventListener('mousemove', onMove);
-            document.removeEventListener('mouseup', onUp);
-            psyDrag.startDrag(
-              {
-                data: JSON.stringify({ type: 'song', track: songToTrack(song) }),
-                label: song.title,
-                coverUrl: coverUrl || undefined,
-              },
-              me.clientX, me.clientY,
-            );
-          }
-        };
-        const onUp = () => {
-          document.removeEventListener('mousemove', onMove);
-          document.removeEventListener('mouseup', onUp);
-        };
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', onUp);
-      }}
+      onMouseDown={onCardMouseDown}
     >
       <div className="song-card-cover cover-circle">
         {!disableArtwork && coverRef ? (

--- a/src/features/miniPlayer/components/MiniQueue.tsx
+++ b/src/features/miniPlayer/components/MiniQueue.tsx
@@ -5,6 +5,7 @@ import OverlayScrollArea from '@/ui/OverlayScrollArea';
 import type { MiniSyncPayload, MiniTrackInfo } from '@/features/miniPlayer/utils/miniPlayerBridge';
 import { OptionalQueueTrackRowCoverThumb } from '@/cover/TrackRowCoverThumb';
 import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
+import { useDragPressHandle } from '@/lib/dnd/useDragPress';
 
 // Stable initial rect so the virtualizer never re-initializes on re-render (an
 // inline literal would be a new ref each render → render loop). Replaced by the
@@ -39,6 +40,8 @@ export function MiniQueue({
   jumpTo, t,
 }: Props) {
   const showCovers = useTrackListCoverArtEnabled('queue');
+  // Rows are virtualised, so one can be recycled out from under a held button.
+  const dragPress = useDragPressHandle();
   // Virtualize so a multi-thousand-track queue keeps the mini window's DOM at
   // O(visible rows). Scroll element is the OverlayScrollArea viewport.
   // React Compiler incompatible-library rule: third-party hook/value the compiler cannot analyze; usage is correct.
@@ -109,30 +112,20 @@ export function MiniQueue({
                 setCtxMenu({ x: e.clientX, y: e.clientY, track, index: i });
               }}
               onMouseDown={(e) => {
-                if (e.button !== 0) return;
-                // Don't start drag while a click would also be valid —
-                // the threshold check below upgrades to a drag once
-                // the pointer leaves the deadband.
-                const startX = e.clientX;
-                const startY = e.clientY;
-                const onMove = (me: MouseEvent) => {
-                  if (Math.abs(me.clientX - startX) > 5 || Math.abs(me.clientY - startY) > 5) {
-                    document.removeEventListener('mousemove', onMove);
-                    document.removeEventListener('mouseup', onUp);
+                // Don't start drag while a click would also be valid — the
+                // threshold check upgrades to a drag once the pointer leaves
+                // the deadband. The row is a <button>, so its default stands.
+                dragPress.arm(e, {
+                  preventDefault: false,
+                  onStart: (me) => {
                     psyDragFromIdxRef.current = i;
                     startDrag(
                       { data: JSON.stringify({ type: 'queue_reorder', index: i }), label: track.title },
                       me.clientX,
                       me.clientY,
                     );
-                  }
-                };
-                const onUp = () => {
-                  document.removeEventListener('mousemove', onMove);
-                  document.removeEventListener('mouseup', onUp);
-                };
-                document.addEventListener('mousemove', onMove);
-                document.addEventListener('mouseup', onUp);
+                  },
+                });
               }}
               style={{ position: 'absolute', top: 0, left: 0, width: '100%', transform: `translateY(${vi.start}px)`, ...dragStyle }}
             >

--- a/src/features/playlist/pages/PlaylistDetail.tsx
+++ b/src/features/playlist/pages/PlaylistDetail.tsx
@@ -14,6 +14,7 @@ import { useAuthStore } from '@/store/authStore';
 import { useDownloadModalStore } from '@/features/offline';
 import { useZipDownloadStore } from '@/features/offline';
 import { useDragDrop } from '@/lib/dnd/DragDropContext';
+import { useDragPressHandle } from '@/lib/dnd/useDragPress';
 import { useTranslation } from 'react-i18next';
 import type { SpotifyCsvTrack } from '@/features/playlist/utils/spotifyCsvImport';
 import { runPlaylistCsvImport } from '@/features/playlist/utils/runPlaylistCsvImport';
@@ -77,6 +78,8 @@ export default function PlaylistDetail() {
   );
   const touchPlaylist = usePlaylistStore((s) => s.touchPlaylist);
   const { startDrag } = useDragDrop();
+  // Rows are virtualised, so one can be recycled out from under a held button.
+  const dragPress = useDragPressHandle();
   const downloadPlaylist = useOfflineStore(s => s.downloadPlaylist);
   const deleteAlbum = useOfflineStore(s => s.deleteAlbum);
   const activeServerId = useAuthStore(s => s.activeServerId);
@@ -285,7 +288,10 @@ export default function PlaylistDetail() {
 
   // ── Row mousedown: threshold drag for reorder (from anywhere on the row) ──
   const handleRowMouseDown = (e: React.MouseEvent, idx: number) => {
-    startPlaylistRowDrag({ e, idx, songs, selectedIds, isFiltered, startDrag });
+    dragPress.arm(e, {
+      canStart: (ev) => !(ev.target as HTMLElement).closest('button, input'),
+      onStart: (me) => startPlaylistRowDrag({ me, idx, songs, selectedIds, isFiltered, startDrag }),
+    });
   };
 
   // ── Memoized derivations ──────────────────────────────────────

--- a/src/features/playlist/utils/startPlaylistRowDrag.ts
+++ b/src/features/playlist/utils/startPlaylistRowDrag.ts
@@ -1,9 +1,9 @@
-import type React from 'react';
 import type { SubsonicSong } from '@/lib/api/subsonicTypes';
 import { songToTrack } from '@/lib/media/songToTrack';
 
 export interface StartPlaylistRowDragDeps {
-  e: React.MouseEvent;
+  /** The `mousemove` that carried the press past the drag threshold. */
+  me: MouseEvent;
   idx: number;
   songs: SubsonicSong[];
   selectedIds: Set<string>;
@@ -11,37 +11,29 @@ export interface StartPlaylistRowDragDeps {
   startDrag: (payload: { data: string; label: string }, x: number, y: number) => void;
 }
 
+/**
+ * Picks the payload a playlist row drags and starts the drag. Which of the three
+ * it is depends on the selection and whether a filter is narrowing the list, so
+ * it is read here rather than when the press was armed.
+ *
+ * Arming and resolving the press belongs to `useDragPress` — see
+ * `src/lib/dnd/useDragPress.ts`.
+ */
 export function startPlaylistRowDrag(deps: StartPlaylistRowDragDeps): void {
-  const { e, idx, songs, selectedIds, isFiltered, startDrag } = deps;
-  if (e.button !== 0) return;
-  if ((e.target as HTMLElement).closest('button, input')) return;
-  e.preventDefault();
-  const sx = e.clientX, sy = e.clientY;
-  const onMove = (me: MouseEvent) => {
-    if (Math.abs(me.clientX - sx) > 5 || Math.abs(me.clientY - sy) > 5) {
-      document.removeEventListener('mousemove', onMove);
-      document.removeEventListener('mouseup', onUp);
-      if (!isFiltered && selectedIds.has(songs[idx]?.id) && selectedIds.size > 1) {
-        const bulkTracks = songs.filter(s => selectedIds.has(s.id)).map(songToTrack);
-        startDrag({ data: JSON.stringify({ type: 'songs', tracks: bulkTracks }), label: `${bulkTracks.length} Songs` }, me.clientX, me.clientY);
-      } else if (!isFiltered) {
-        startDrag(
-          { data: JSON.stringify({ type: 'playlist_reorder', index: idx }), label: songs[idx]?.title ?? '' },
-          me.clientX, me.clientY
-        );
-      } else {
-        // filtered view: single-song drag to queue
-        startDrag(
-          { data: JSON.stringify({ type: 'song', track: songToTrack(songs[idx]) }), label: songs[idx]?.title ?? '' },
-          me.clientX, me.clientY
-        );
-      }
-    }
-  };
-  const onUp = () => {
-    document.removeEventListener('mousemove', onMove);
-    document.removeEventListener('mouseup', onUp);
-  };
-  document.addEventListener('mousemove', onMove);
-  document.addEventListener('mouseup', onUp);
+  const { me, idx, songs, selectedIds, isFiltered, startDrag } = deps;
+  if (!isFiltered && selectedIds.has(songs[idx]?.id) && selectedIds.size > 1) {
+    const bulkTracks = songs.filter(s => selectedIds.has(s.id)).map(songToTrack);
+    startDrag({ data: JSON.stringify({ type: 'songs', tracks: bulkTracks }), label: `${bulkTracks.length} Songs` }, me.clientX, me.clientY);
+  } else if (!isFiltered) {
+    startDrag(
+      { data: JSON.stringify({ type: 'playlist_reorder', index: idx }), label: songs[idx]?.title ?? '' },
+      me.clientX, me.clientY
+    );
+  } else {
+    // filtered view: single-song drag to queue
+    startDrag(
+      { data: JSON.stringify({ type: 'song', track: songToTrack(songs[idx]) }), label: songs[idx]?.title ?? '' },
+      me.clientX, me.clientY
+    );
+  }
 }

--- a/src/features/queue/components/QueueList.tsx
+++ b/src/features/queue/components/QueueList.tsx
@@ -25,6 +25,7 @@ import {
 import { playTimelineHistoryTrack } from '@/features/playback/utils/playTimelineHistoryTrack';
 import { OptionalQueueTrackRowCoverThumb } from '@/cover/TrackRowCoverThumb';
 import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
+import { useDragPressHandle } from '@/lib/dnd/useDragPress';
 
 type StartDrag = (
   payload: { data: string; label: string },
@@ -66,6 +67,8 @@ export function QueueList({
 }: Props) {
   useSyncExternalStore(subscribeQueueResolver, getQueueResolverVersion);
   const showCovers = useTrackListCoverArtEnabled('queue');
+  // Rows are virtualised, so one can be recycled out from under a held button.
+  const dragPress = useDragPressHandle();
 
   const usingTimeline = queueDisplayMode === 'timeline' && timelineRows != null;
   const rowCount = usingTimeline ? timelineRows.length : queue.length;
@@ -217,24 +220,12 @@ export function QueueList({
         }}
         onMouseDown={(e) => {
           if (isHistory || absIdx == null) return;
-          if (e.button !== 0) return;
-          e.preventDefault();
-          const startX = e.clientX;
-          const startY = e.clientY;
-          const onMove = (me: MouseEvent) => {
-            if (Math.abs(me.clientX - startX) > 5 || Math.abs(me.clientY - startY) > 5) {
-              document.removeEventListener('mousemove', onMove);
-              document.removeEventListener('mouseup', onUp);
+          dragPress.arm(e, {
+            onStart: (me) => {
               psyDragFromIdxRef.current = absIdx;
               startDrag({ data: JSON.stringify({ type: 'queue_reorder', index: absIdx }), label: track.title }, me.clientX, me.clientY);
-            }
-          };
-          const onUp = () => {
-            document.removeEventListener('mousemove', onMove);
-            document.removeEventListener('mouseup', onUp);
-          };
-          document.addEventListener('mousemove', onMove);
-          document.addEventListener('mouseup', onUp);
+            },
+          });
         }}
         style={{ ...(isPast && !isPlaying ? { opacity: 0.5 } : null), ...dragStyle }}
       >

--- a/src/features/randomMix/components/RandomMixTrackRow.tsx
+++ b/src/features/randomMix/components/RandomMixTrackRow.tsx
@@ -5,6 +5,7 @@ import type { SubsonicSong } from '@/lib/api/subsonicTypes';
 import type { Track } from '@/lib/media/trackTypes';
 import { previewInputFromSong, usePreviewStore } from '@/features/playback/store/previewStore';
 import { useDragDrop } from '@/lib/dnd/DragDropContext';
+import { useDragPress } from '@/lib/dnd/useDragPress';
 import { formatRandomMixDuration } from '@/features/randomMix/utils/randomMixHelpers';
 import { OptionalBrowseTrackRowCoverThumb } from '@/cover/TrackRowCoverThumb';
 
@@ -47,6 +48,13 @@ export default function RandomMixTrackRow({
   const { t } = useTranslation();
   const psyDrag = useDragDrop();
 
+  const onRowMouseDown = useDragPress({
+    onStart: (me) => psyDrag.startDrag(
+      { data: JSON.stringify({ type: 'song', track }), label: song.title },
+      me.clientX, me.clientY,
+    ),
+  });
+
   const artist = song.artist;
   const genre = song.genre;
   const isArtistBlocked = !!artist && customGenreBlacklist.some(bg => artist.toLowerCase().includes(bg.toLowerCase()));
@@ -71,21 +79,7 @@ export default function RandomMixTrackRow({
       } : undefined}
       role="row"
       onContextMenu={onOpenContextMenu}
-      onMouseDown={e => {
-        if (e.button !== 0) return;
-        e.preventDefault();
-        const sx = e.clientX, sy = e.clientY;
-        const onMove = (me: MouseEvent) => {
-          if (Math.abs(me.clientX - sx) > 5 || Math.abs(me.clientY - sy) > 5) {
-            document.removeEventListener('mousemove', onMove);
-            document.removeEventListener('mouseup', onUp);
-            psyDrag.startDrag({ data: JSON.stringify({ type: 'song', track }), label: song.title }, me.clientX, me.clientY);
-          }
-        };
-        const onUp = () => { document.removeEventListener('mousemove', onMove); document.removeEventListener('mouseup', onUp); };
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', onUp);
-      }}
+      onMouseDown={onRowMouseDown}
     >
       <div className={`track-num${isCurrentTrack ? ' track-num-active' : ''}`}>
         {isCurrentTrack && isPlaying ? (

--- a/src/features/search/components/SongRow.tsx
+++ b/src/features/search/components/SongRow.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { enqueueAndPlay } from '@/features/playback/utils/playback/playSong';
 import { useDragDrop } from '@/lib/dnd/DragDropContext';
+import { useDragPress } from '@/lib/dnd/useDragPress';
 import { useOrbitSongRowBehavior } from '@/features/orbit';
 import { formatTrackTime } from '@/lib/format/formatDuration';
 import { resolveTrackArtistRefs } from '@/features/playback/utils/playback/trackArtistRefs';
@@ -51,6 +52,14 @@ function SongRow({ song, showBpm }: Props) {
     enqueue([songToTrack(song)]);
   };
 
+  const onRowMouseDown = useDragPress({
+    preventDefault: false,
+    onStart: (me) => psyDrag.startDrag(
+      { data: JSON.stringify({ type: 'song', track: songToTrack(song) }), label: song.title },
+      me.clientX, me.clientY,
+    ),
+  });
+
   const artistRefs = resolveTrackArtistRefs(song);
   const activeServerId = useAuthStore(s => s.activeServerId ?? '');
 
@@ -69,27 +78,7 @@ function SongRow({ song, showBpm }: Props) {
         e.preventDefault();
         openContextMenu(e.clientX, e.clientY, song, 'song');
       }}
-      onMouseDown={(e) => {
-        if (e.button !== 0) return;
-        const sx = e.clientX, sy = e.clientY;
-        const track = songToTrack(song);
-        const onMove = (me: MouseEvent) => {
-          if (Math.abs(me.clientX - sx) > 5 || Math.abs(me.clientY - sy) > 5) {
-            document.removeEventListener('mousemove', onMove);
-            document.removeEventListener('mouseup', onUp);
-            psyDrag.startDrag(
-              { data: JSON.stringify({ type: 'song', track }), label: song.title },
-              me.clientX, me.clientY,
-            );
-          }
-        };
-        const onUp = () => {
-          document.removeEventListener('mousemove', onMove);
-          document.removeEventListener('mouseup', onUp);
-        };
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', onUp);
-      }}
+      onMouseDown={onRowMouseDown}
     >
       <div className="song-list-row-cell song-list-row-actions">
         <button

--- a/src/lib/dnd/DragDropContext.tsx
+++ b/src/lib/dnd/DragDropContext.tsx
@@ -20,6 +20,7 @@ import React, {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { Trash2 } from 'lucide-react';
+import { useDragPress } from './useDragPress';
 
 // ── Types ─────────────────────────────────────────────────────────
 export interface DragPayload {
@@ -279,7 +280,6 @@ export function DragDropProvider({ children }: { children: React.ReactNode }) {
 }
 
 // ── useDragSource hook ────────────────────────────────────────────
-const DRAG_THRESHOLD = 5; // px before drag starts
 
 /**
  * Returns an onMouseDown handler for a draggable element.
@@ -289,47 +289,14 @@ const DRAG_THRESHOLD = 5; // px before drag starts
 // eslint-disable-next-line react-refresh/only-export-components
 export function useDragSource(getPayload: () => DragPayload) {
   const { startDrag } = useDragDrop();
-  const startPosRef = useRef<{ x: number; y: number } | null>(null);
   const payloadRef = useRef(getPayload);
   // React Compiler refs rule: latest-value box kept in sync for use in handlers; not render data.
   // eslint-disable-next-line react-hooks/refs
   payloadRef.current = getPayload;
 
-  const onMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      // Only left-click
-      if (e.button !== 0) return;
-      // Prevent the browser from starting a text-selection drag during the
-      // threshold detection phase (mousedown → mousemove before startDrag).
-      e.preventDefault();
-
-      const startX = e.clientX;
-      const startY = e.clientY;
-      startPosRef.current = { x: startX, y: startY };
-
-      const onMove = (me: MouseEvent) => {
-        if (!startPosRef.current) return;
-        const dx = me.clientX - startX;
-        const dy = me.clientY - startY;
-        if (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD) {
-          startPosRef.current = null;
-          document.removeEventListener('mousemove', onMove);
-          document.removeEventListener('mouseup', onUp);
-          startDrag(payloadRef.current(), me.clientX, me.clientY);
-        }
-      };
-
-      const onUp = () => {
-        startPosRef.current = null;
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', onUp);
-      };
-
-      document.addEventListener('mousemove', onMove);
-      document.addEventListener('mouseup', onUp);
-    },
-    [startDrag],
-  );
+  const onMouseDown = useDragPress({
+    onStart: (me) => startDrag(payloadRef.current(), me.clientX, me.clientY),
+  });
 
   return { onMouseDown };
 }

--- a/src/lib/dnd/useDragPress.test.tsx
+++ b/src/lib/dnd/useDragPress.test.tsx
@@ -1,0 +1,319 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { useDragPress, useDragPressHandle, type ArmDragPressOptions } from './useDragPress';
+
+const onStart = vi.fn();
+
+function Probe({
+  disabled = false,
+  preventDefault,
+  canStart,
+  onResolved,
+}: {
+  disabled?: boolean;
+  preventDefault?: boolean;
+  canStart?: (e: React.MouseEvent) => boolean;
+  onResolved?: () => void;
+}) {
+  const onMouseDown = useDragPress({ onStart, disabled, preventDefault, canStart, onResolved });
+  return <div data-testid="source" onMouseDown={onMouseDown} />;
+}
+
+/** A list whose rows arm the press from a row callback rather than their own hook. */
+function ListProbe({ rows, options }: { rows: number[]; options?: Partial<ArmDragPressOptions> }) {
+  const dragPress = useDragPressHandle();
+  return (
+    <div>
+      {rows.map(i => (
+        <div
+          key={i}
+          data-testid={`row-${i}`}
+          onMouseDown={e => dragPress.arm(e, { onStart: () => onStart(i), ...options })}
+        />
+      ))}
+    </div>
+  );
+}
+
+function press(target: HTMLElement, button = 0) {
+  fireEvent.mouseDown(target, { button, clientX: 100, clientY: 100 });
+}
+
+function moveTo(x: number, y: number) {
+  fireEvent.mouseMove(document, { clientX: x, clientY: y });
+}
+
+/** Dispatched on `document` so the capture-phase guards see it, like the real one. */
+function raise(type: string) {
+  fireEvent(document, new Event(type, { bubbles: true }));
+}
+
+describe('useDragPress', () => {
+  beforeEach(() => {
+    onStart.mockReset();
+  });
+
+  // A press that stays put is a click on the row — only travel turns it into a
+  // drag, otherwise every click on a source would start one.
+  it('ignores pointer travel below the threshold', () => {
+    render(<Probe />);
+    press(screen.getByTestId('source'));
+    moveTo(104, 103);
+    expect(onStart).not.toHaveBeenCalled();
+    fireEvent.mouseUp(document);
+  });
+
+  it('starts once the pointer leaves the threshold, carrying the move event', () => {
+    render(<Probe />);
+    press(screen.getByTestId('source'));
+    moveTo(140, 100);
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    const me = onStart.mock.calls[0][0] as MouseEvent;
+    expect([me.clientX, me.clientY]).toEqual([140, 100]);
+  });
+
+  it('stops listening once the drag has started', () => {
+    render(<Probe />);
+    press(screen.getByTestId('source'));
+    moveTo(140, 100);
+    moveTo(180, 100);
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-primary buttons', () => {
+    render(<Probe />);
+    press(screen.getByTestId('source'), 2);
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('leaves the press unarmed when the guard says no', () => {
+    render(<Probe canStart={() => false} />);
+    press(screen.getByTestId('source'));
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('does not arm while disabled', () => {
+    render(<Probe disabled />);
+    press(screen.getByTestId('source'));
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  // Sources on a <button> need the browser's own handling, so the default is
+  // only prevented when the call site asks for it.
+  it('prevents the mousedown default unless the source opts out', () => {
+    const { unmount } = render(<Probe />);
+    const prevented = fireEvent.mouseDown(screen.getByTestId('source'), { button: 0, clientX: 1, clientY: 1 });
+    expect(prevented).toBe(false);
+    fireEvent.mouseUp(document);
+    unmount();
+
+    render(<Probe preventDefault={false} />);
+    const notPrevented = fireEvent.mouseDown(screen.getByTestId('source'), { button: 0, clientX: 1, clientY: 1 });
+    expect(notPrevented).toBe(true);
+    fireEvent.mouseUp(document);
+  });
+
+  // Rows are virtualised and the list can be swapped under a held button, so a
+  // press can lose its source before any mouseup arrives. Without the teardown
+  // the listeners outlive the component and the next pointer travel drags an
+  // entry that is no longer there.
+  it('drops its listeners when the source unmounts mid-press', () => {
+    const { unmount } = render(<Probe />);
+    press(screen.getByTestId('source'));
+    unmount();
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  // Selection mode can arrive while a press is armed. The effect cleanup runs on
+  // the dependency change, so the press must not survive it and drag a row the
+  // user is now trying to tick.
+  it('resolves an armed press when it becomes disabled', () => {
+    const { rerender } = render(<Probe />);
+    press(screen.getByTestId('source'));
+    rerender(<Probe disabled />);
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  // Two presses without a release in between — the first must not stay armed
+  // alongside the second and fire a second drag from a stale start point.
+  it('supersedes a press that never resolved', () => {
+    render(<Probe />);
+    const source = screen.getByTestId('source');
+    press(source);
+    press(source);
+    moveTo(140, 100);
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves on mouseup', () => {
+    render(<Probe />);
+    press(screen.getByTestId('source'));
+    fireEvent.mouseUp(document);
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  // The lost-release guards. `DragDropContext` already carries these for an
+  // in-flight drag ("Wayland: webview may not get `mouseup` when the pointer
+  // leaves the surface"); an armed press had none of them.
+  it.each(['pointerup', 'pointercancel'])('resolves on %s', (type) => {
+    render(<Probe />);
+    press(screen.getByTestId('source'));
+    raise(type);
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  // The sources that leave the mousedown default in place are the ones where a
+  // native image drag can begin, which fires `pointercancel` and then suppresses
+  // every further mouse event — so the press can never become a drag anyway and
+  // must not stay armed waiting for one.
+  it('resolves on pointercancel even when the default stands', () => {
+    render(<Probe preventDefault={false} />);
+    press(screen.getByTestId('source'));
+    raise('pointercancel');
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('resolves when the window loses focus', () => {
+    render(<Probe />);
+    press(screen.getByTestId('source'));
+    fireEvent.blur(window);
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('resolves when the document becomes hidden', () => {
+    const visibility = vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+    render(<Probe />);
+    press(screen.getByTestId('source'));
+    raise('visibilitychange');
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+    visibility.mockRestore();
+  });
+
+  // A tab switch that leaves the document visible is not a lost release — the
+  // press stays armed so the drag the user is still holding survives it.
+  it('keeps the press armed while the document stays visible', () => {
+    render(<Probe />);
+    press(screen.getByTestId('source'));
+    raise('visibilitychange');
+    moveTo(140, 100);
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  // `onResolved` is part of the hook's options, so it has to reach the press —
+  // forwarding only some of the options would accept it and silently drop it.
+  it('forwards onResolved to the press', () => {
+    const onResolved = vi.fn();
+    render(<Probe onResolved={onResolved} />);
+    press(screen.getByTestId('source'));
+    expect(onResolved).not.toHaveBeenCalled();
+    fireEvent.mouseUp(document);
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useDragPressHandle', () => {
+  beforeEach(() => {
+    onStart.mockReset();
+  });
+
+  it('starts the drag of the row that armed the press', () => {
+    render(<ListProbe rows={[0, 1, 2]} />);
+    press(screen.getByTestId('row-1'));
+    moveTo(140, 100);
+    expect(onStart).toHaveBeenCalledExactlyOnceWith(1);
+  });
+
+  // The virtualiser recycles rows out of the DOM while the button is held; the
+  // list owns the press so it still resolves when the row is gone.
+  it('drops its listeners when the list unmounts mid-press', () => {
+    const { unmount } = render(<ListProbe rows={[0, 1, 2]} />);
+    press(screen.getByTestId('row-1'));
+    unmount();
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  // The case the list-level teardown alone does not reach: the virtualiser
+  // recycles the pressed row out while the list itself stays mounted, so no
+  // React cleanup fires. The press would otherwise still be armed and drag the
+  // row's stale index once the pointer travels.
+  it('resolves when the pressed row leaves the DOM under a live list', () => {
+    const { rerender } = render(<ListProbe rows={[0, 1, 2]} />);
+    press(screen.getByTestId('row-1'));
+    rerender(<ListProbe rows={[0, 2]} />);
+    expect(screen.queryByTestId('row-1')).toBeNull();
+    moveTo(140, 100);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('supersedes a press from another row that never resolved', () => {
+    render(<ListProbe rows={[0, 1, 2]} />);
+    press(screen.getByTestId('row-0'));
+    press(screen.getByTestId('row-2'));
+    moveTo(140, 100);
+    expect(onStart).toHaveBeenCalledExactlyOnceWith(2);
+  });
+
+  // A press that never armed must leave the earlier one alone, which is what the
+  // per-site copies did: they returned before touching anything.
+  it('leaves an armed press alone when a later press does not arm', () => {
+    render(<ListProbe rows={[0, 1]} />);
+    press(screen.getByTestId('row-0'));
+    press(screen.getByTestId('row-1'), 2);
+    moveTo(140, 100);
+    expect(onStart).toHaveBeenCalledExactlyOnceWith(0);
+  });
+
+  // The handle wraps the caller's own `onResolved` to drop its reference to the
+  // resolved press; wrapping must not swallow the caller's callback.
+  it('still calls the row\'s own onResolved', () => {
+    const onResolved = vi.fn();
+    render(<ListProbe rows={[0]} options={{ onResolved }} />);
+    press(screen.getByTestId('row-0'));
+    expect(onResolved).not.toHaveBeenCalled();
+    fireEvent.mouseUp(document);
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('armDragPress', () => {
+  // The resolver closes over the row payload and its DOM node, so whoever holds
+  // it needs to learn when the press is over — otherwise a list pins the last
+  // pressed row for as long as it lives.
+  it.each([
+    ['mouseup', () => fireEvent.mouseUp(document)],
+    ['pointerup', () => raise('pointerup')],
+    ['pointercancel', () => raise('pointercancel')],
+    ['blur', () => fireEvent.blur(window)],
+    ['a drag start', () => fireEvent.mouseMove(document, { clientX: 140, clientY: 100 })],
+  ])('reports the press as resolved on %s', (_label, resolve) => {
+    const onResolved = vi.fn();
+    render(<ListProbe rows={[0]} options={{ onResolved }} />);
+    press(screen.getByTestId('row-0'));
+    resolve();
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the press as resolved exactly once', () => {
+    const onResolved = vi.fn();
+    render(<ListProbe rows={[0]} options={{ onResolved }} />);
+    press(screen.getByTestId('row-0'));
+    fireEvent.mouseUp(document);
+    raise('pointerup');
+    fireEvent.blur(window);
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/dnd/useDragPress.ts
+++ b/src/lib/dnd/useDragPress.ts
@@ -1,0 +1,204 @@
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+
+/** Pointer travel before a press turns into a drag rather than a click. */
+export const DRAG_THRESHOLD_PX = 5;
+
+export interface ArmDragPressOptions {
+  /**
+   * Runs once the pointer has travelled past the threshold. The press has
+   * already detached its listeners by then, so this is where the payload is
+   * built and the drag begins.
+   */
+  onStart: (e: MouseEvent) => void;
+  /**
+   * Whether `mousedown` gets its default prevented. On by default: it stops the
+   * browser from turning the threshold phase into a text selection. Sources
+   * that sit on a `<button>` keep the default so the element still focuses.
+   */
+  preventDefault?: boolean;
+  /**
+   * Evaluated on `mousedown` — a falsy result leaves the press unarmed. Rows
+   * use it to keep presses on their own buttons and inputs out of the drag.
+   */
+  canStart?: (e: React.MouseEvent) => boolean;
+  /**
+   * Runs once the press has resolved, whichever way it went. An owner holding
+   * the returned resolver uses it to drop that reference — the resolver closes
+   * over the row's payload and its DOM node, which would otherwise stay
+   * reachable for as long as the owner lives.
+   */
+  onResolved?: () => void;
+}
+
+/**
+ * Arms a press and owns everything that ends it. Returns the resolver, or
+ * `null` when the press was not armed at all.
+ *
+ * A `mousedown` attaches `mousemove`/`mouseup` to `document` and detaches them
+ * when the press resolves — into a drag, or into a release. Two things used to
+ * leave those listeners behind, and every drag source in the app repeated both:
+ *
+ * - **The source disappears while the button is held.** Rows are virtualised, a
+ *   view switch or a refresh replaces the list, and nothing then resolves the
+ *   press. The listeners outlive their row and the next pointer travel drags an
+ *   entry that is no longer on screen. The React wrappers below own that half.
+ * - **The release never arrives.** `DragDropContext` documents this for Wayland
+ *   ("webview may not get `mouseup` when the pointer leaves the surface") and
+ *   guards an *in-flight drag* with `pointerup`, `pointercancel`, `blur` and
+ *   `visibilitychange`. An *armed press* had none of them; it does now.
+ *
+ * Prefer `useDragPress` (one source per component) or `useDragPressHandle` (a
+ * list that arms presses from a row callback) — both add the unmount teardown
+ * this function cannot do on its own.
+ */
+export function armDragPress(
+  e: React.MouseEvent,
+  options: ArmDragPressOptions,
+): (() => void) | null {
+  const { onStart, preventDefault = true, canStart, onResolved } = options;
+  if (e.button !== 0) return null;
+  if (canStart && !canStart(e)) return null;
+  if (preventDefault) e.preventDefault();
+
+  // The element the press started on, read while the handler still owns the
+  // event. A virtualised row can be recycled out of the DOM under a held button
+  // while the list around it stays mounted — React's unmount teardown never
+  // fires for that, so the element itself is the only thing that knows it left.
+  const source = e.currentTarget;
+  const sx = e.clientX;
+  const sy = e.clientY;
+  let resolved = false;
+
+  const endPress = () => {
+    if (resolved) return;
+    resolved = true;
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', endPress);
+    document.removeEventListener('pointerup', endPress, true);
+    document.removeEventListener('pointercancel', endPress, true);
+    window.removeEventListener('blur', endPress);
+    document.removeEventListener('visibilitychange', onVisibility);
+    onResolved?.();
+  };
+
+  const onMove = (me: MouseEvent) => {
+    if (!source.isConnected) {
+      endPress();
+      return;
+    }
+    if (
+      Math.abs(me.clientX - sx) <= DRAG_THRESHOLD_PX
+      && Math.abs(me.clientY - sy) <= DRAG_THRESHOLD_PX
+    ) return;
+    endPress();
+    onStart(me);
+  };
+
+  const onVisibility = () => {
+    if (document.hidden) endPress();
+  };
+
+  document.addEventListener('mousemove', onMove);
+  document.addEventListener('mouseup', endPress);
+  // The lost-release guards. `pointerup` fires ahead of `mouseup`, so a normal
+  // release still resolves the press exactly once — `endPress` detaches both.
+  document.addEventListener('pointerup', endPress, true);
+  // `pointercancel` also covers the sources that leave the mousedown default in
+  // place: pressing a row's cover image can start a *native* drag there, and the
+  // spec fires `pointercancel` "as part of the drag operation initiation
+  // algorithm" (w3c.github.io/pointerevents) while device input events "must be
+  // suppressed" for the duration (html.spec.whatwg.org/multipage/dnd.html). No
+  // `mousemove` reaches us after that, so this resolves a press that can no
+  // longer become a drag — rather than one that still could.
+  document.addEventListener('pointercancel', endPress, true);
+  window.addEventListener('blur', endPress);
+  document.addEventListener('visibilitychange', onVisibility);
+
+  return endPress;
+}
+
+export interface DragPressHandle {
+  /** Arms a press from a `mousedown`; supersedes one that never resolved. */
+  arm: (e: React.MouseEvent, options: ArmDragPressOptions) => void;
+  /** Resolves the press in flight, if there is one. */
+  endPress: () => void;
+}
+
+/**
+ * Owns the press of a list whose rows arm it from a callback rather than from
+ * their own hook — a virtualised row, a shared row-handler object. The press is
+ * resolved when the list unmounts, so a row that disappears under a held button
+ * cannot leave listeners behind.
+ */
+export function useDragPressHandle(): DragPressHandle {
+  /** Detaches the listeners of the press in flight, while one is unresolved. */
+  const endPressRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => () => endPressRef.current?.(), []);
+
+  return useMemo(() => ({
+    arm: (e, options) => {
+      // The slot lets the resolver identify itself once it fires: the ref is
+      // dropped only while it still points at *this* press, so an owner outliving
+      // a long list of clicks stops pinning the last row's payload and DOM node.
+      const slot: { end: (() => void) | null } = { end: null };
+      const end = armDragPress(e, {
+        ...options,
+        onResolved: () => {
+          options.onResolved?.();
+          if (endPressRef.current === slot.end) endPressRef.current = null;
+        },
+      });
+      // A press that was not armed at all — a non-primary button, a guard that
+      // said no — leaves an earlier one alone, exactly as the per-site copies did.
+      if (!end) return;
+      slot.end = end;
+      // A second press supersedes one that never resolved.
+      endPressRef.current?.();
+      endPressRef.current = end;
+    },
+    endPress: () => {
+      endPressRef.current?.();
+      endPressRef.current = null;
+    },
+  }), []);
+}
+
+export interface DragPressOptions extends ArmDragPressOptions {
+  /**
+   * Leaves a press unarmed — and resolves one already in flight, because the
+   * effect below re-runs on the change. Selection mode uses this so a held row
+   * cannot drag itself once the mode the user switched to takes over.
+   */
+  disabled?: boolean;
+}
+
+/**
+ * A component's own drag source: returns the `mousedown` handler and resolves
+ * an armed press on unmount, on `disabled` flipping, and on a second press.
+ */
+export function useDragPress(options: DragPressOptions): (e: React.MouseEvent) => void {
+  const { disabled = false } = options;
+  const handle = useDragPressHandle();
+
+  // React Compiler refs rule: latest-value box so the handler stays stable
+  // across renders while still calling this render's callbacks; not render data.
+  const latest = useRef(options);
+  // eslint-disable-next-line react-hooks/refs
+  latest.current = options;
+
+  // React runs this cleanup before re-running on a `disabled` change, so a mode
+  // turning on under a held button resolves the press instead of leaving a drag
+  // primed behind it. Unmount is covered by the handle itself.
+  useEffect(() => handle.endPress, [disabled, handle]);
+
+  return useCallback((e: React.MouseEvent) => {
+    if (disabled) return;
+    handle.arm(e, {
+      preventDefault: latest.current.preventDefault,
+      canStart: (ev) => latest.current.canStart?.(ev) ?? true,
+      onStart: (me) => latest.current.onStart(me),
+      onResolved: () => latest.current.onResolved?.(),
+    });
+  }, [disabled, handle]);
+}


### PR DESCRIPTION
`useAlbumDragStart` was fixed for album cards and table rows in #1437; the same pattern was still unfixed in the other drag sources. A `mousedown` attaches `mousemove`/`mouseup` to `document` and detaches them only when the press resolves — into a drag, or into a release. A source that disappears under a held button, or a release that never arrives, leaves the listeners armed, and the next pointer travel drags an entry that is no longer on screen.

- One place now owns the listeners, the 5px threshold and the teardown, in three shapes: a hook for a component's own source, a handle for lists whose rows arm the press from a row callback, and the React-free core under both.
- An armed press carries the same lost-release guards `DragDropContext` already uses for an in-flight drag: `pointerup`, `pointercancel`, `blur` and `visibilitychange`.
- A press also resolves once its source leaves the DOM — a virtualised row does that without unmounting the list around it, so no React cleanup fires.
- Nine call sites migrated, `useDragSource` among them, which five further components reach through. Per-site behaviour is unchanged: primary-button guard, whether the mousedown default is prevented, and each row's own button/input exclusions.

## Test plan
- `npx vitest run src/lib/dnd/useDragPress.test.tsx` — 30 tests; each guard was verified against the unfixed hook by removing it and confirming exactly the matching tests fail
- `npm run test` — 571 files, 4247 tests
- `tsc --noEmit`, `npm run lint`, `npm run dep:check`

Runtime benchmark: not applicable - event listener lifecycle, no render, query or route path affected.

Closes #1438
