### PR TITLE
fix(library): restore individual selection after upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Albums were fixed above; the same problem sat in every other place a track can be dragged from — the queue and the mini-player queue, playlists, favorites, search results, Random Mix and the song cards on Home. Holding the mouse button while the list changed underneath left a drag primed, and the next movement picked up a row that was no longer on screen.
 * A press whose release never arrives now ends with whatever replaces it — the pointer leaving the window, the app losing focus, or the system taking the drag over — instead of waiting for a mouse-up that is never delivered.
 
+### Individual libraries can be selected again after updating
+
+**By [@cucadmuh](https://github.com/cucadmuh), issue reported by [@tummydummy](https://github.com/tummydummy), PR [#1459](https://github.com/Psysonic/psysonic/pull/1459)**
+
+* Updating from Psysonic 1.50 to 1.51 could leave the library selector stuck on **All libraries**: clicking an individual music folder closed the menu without changing the selection. Existing saved scope is now repaired during startup, and an empty scope restores the active server before saving a new choice.
+
 ## [1.51.0] - 2026-08-17
 
 ## Added

--- a/src/store/authMusicLibraryActions.test.ts
+++ b/src/store/authMusicLibraryActions.test.ts
@@ -135,4 +135,19 @@ describe('Library browse scope', () => {
     useAuthStore.getState().setLibraryBrowseSelectionForServer(serverId, ['two', 'one']);
     expect(useAuthStore.getState().libraryBrowseSelectionByServer[serverId]).toEqual([]);
   });
+
+  it('repairs an empty server scope before storing a folder selection', () => {
+    const serverId = setUpActiveServer();
+    useAuthStore.getState().setMusicFoldersForServer(serverId, [
+      { id: 'one', name: 'One' },
+      { id: 'two', name: 'Two' },
+    ]);
+    useAuthStore.setState({ libraryBrowseServerIds: [] });
+
+    useAuthStore.getState().setLibraryBrowseSelectionForServer(serverId, ['two']);
+
+    const state = useAuthStore.getState();
+    expect(state.libraryBrowseServerIds).toEqual([serverId]);
+    expect(state.libraryBrowseSelectionByServer[serverId]).toEqual(['two']);
+  });
 });

--- a/src/store/authMusicLibraryActions.ts
+++ b/src/store/authMusicLibraryActions.ts
@@ -259,7 +259,14 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
 
     setLibraryBrowseSelectionForServer: (serverId, libraryIds) => {
       const s = get();
-      if (!s.libraryBrowseServerIds.includes(serverId)) {
+      const effectiveServerIds = deriveLibraryBrowseServerIdsWithFallback({
+        servers: s.servers,
+        activeServerId: s.activeServerId,
+        libraryBrowseServerIds: s.libraryBrowseServerIds,
+      });
+      const scopeChanged = effectiveServerIds.length !== s.libraryBrowseServerIds.length
+        || effectiveServerIds.some((id, index) => id !== s.libraryBrowseServerIds[index]);
+      if (!effectiveServerIds.includes(serverId)) {
         emitMultiServerDebug('library_folder_selection_skip', {
           serverId,
           requestedLibraryIds: libraryIds,
@@ -273,7 +280,8 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
       const unique = [...new Set(libraryIds)].filter(id => folders.length === 0 || knownFolderIds.has(id));
       const selection = collapseServerSelection(folders, unique);
       const previous = s.libraryBrowseSelectionByServer[serverId] ?? [];
-      if (selection.length === previous.length
+      if (!scopeChanged
+        && selection.length === previous.length
         && selection.every((id, index) => id === previous[index])) {
         emitMultiServerDebug('library_folder_selection_skip', {
           serverId,
@@ -284,6 +292,7 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
         return;
       }
       set(state => ({
+        ...(scopeChanged ? { libraryBrowseServerIds: effectiveServerIds } : {}),
         libraryBrowseSelectionByServer: {
           ...state.libraryBrowseSelectionByServer,
           [serverId]: selection,
@@ -295,6 +304,7 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
         requestedLibraryIds: libraryIds,
         previousLibraryIds: previous,
         normalizedLibraryIds: selection,
+        configuredServerIds: get().libraryBrowseServerIds,
         availableFolderIds: folders.map(folder => folder.id),
         libraryBrowseScopeVersion: get().libraryBrowseScopeVersion,
       });

--- a/src/store/authStore.autoHydration.test.ts
+++ b/src/store/authStore.autoHydration.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const server = {
+  id: 'server-a',
+  name: 'Wall of Sound',
+  url: 'https://music.example.com',
+  username: 'alice',
+  password: 'pw',
+};
+
+function writePersistedState(state: Record<string, unknown>): void {
+  localStorage.setItem('psysonic-auth', JSON.stringify({ state, version: 0 }));
+}
+
+describe('authStore first automatic hydration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  it.each([
+    ['a pre-1.51 payload without the browse scope', {}],
+    ['an affected 1.51 payload with an empty browse scope', { libraryBrowseServerIds: [] }],
+  ])('repairs %s before exposing the store', async (_label, extraState) => {
+    writePersistedState({
+      servers: [server],
+      activeServerId: server.id,
+      isLoggedIn: true,
+      ...extraState,
+    });
+
+    const { useAuthStore } = await import('./authStore');
+
+    expect(useAuthStore.getState().libraryBrowseServerIds).toEqual([server.id]);
+    const persisted = JSON.parse(localStorage.getItem('psysonic-auth') ?? '{}') as {
+      state?: { libraryBrowseServerIds?: string[] };
+      version?: number;
+    };
+    expect(persisted.version).toBe(1);
+    expect(persisted.state?.libraryBrowseServerIds).toEqual([server.id]);
+  });
+});

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -204,6 +204,18 @@ export const useAuthStore = create<AuthState>()(
     {
       name: 'psysonic-auth',
       storage: createJSONStorage(() => localStorage),
+      version: 1,
+      // Version 1 moves post-hydration repairs into `merge`. Returning the
+      // version-0 payload unchanged makes Zustand rewrite the repaired state.
+      migrate: persistedState => persistedState,
+      merge: (persistedState, currentState) => {
+        const state = {
+          ...currentState,
+          ...(persistedState as Partial<AuthState> | undefined),
+        };
+        const patch = computeAuthStoreRehydration(state);
+        return { ...state, ...patch };
+      },
       partialize: state => {
         const {
           musicFolders: _mf,
@@ -215,9 +227,7 @@ export const useAuthStore = create<AuthState>()(
       },
       onRehydrateStorage: () => (state, error) => {
         if (error || !state) return;
-        useAuthStore.setState(computeAuthStoreRehydration(state));
-        const current = useAuthStore.getState();
-        void syncAllServerHttpContexts(current.servers, current.subsonicServerIdentityByServer);
+        void syncAllServerHttpContexts(state.servers, state.subsonicServerIdentityByServer);
       },
     }
   )

--- a/src/store/authStoreRehydrate.ts
+++ b/src/store/authStoreRehydrate.ts
@@ -39,9 +39,8 @@ import { sanitizeDebugLoggingDepth } from '@/lib/perf/debugLoggingMode';
 /**
  * Computes the post-rehydration patch for the auth store. Runs all
  * legacy-shape migrations + numeric sanitization that the persist
- * middleware can't express declaratively. The caller (the store's
- * `onRehydrateStorage` callback) applies the returned partial via
- * `useAuthStore.setState`.
+ * middleware can't express declaratively. The store's custom persist `merge`
+ * applies the returned partial before the hydrated state is published.
  *
  * Side effects this function takes: deletes obsolete legacy fields
  * directly off the rehydrated state object (`animationMode`,

--- a/src/store/localPlaybackStore.autoHydration.test.ts
+++ b/src/store/localPlaybackStore.autoHydration.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const server = {
+  id: 'server-a',
+  name: 'Wall of Sound',
+  url: 'https://music.example.com',
+  username: 'alice',
+  password: 'pw',
+};
+
+describe('localPlaybackStore first automatic hydration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  it('imports legacy offline entries before exposing the store', async () => {
+    localStorage.setItem('psysonic-auth', JSON.stringify({
+      version: 1,
+      state: {
+        servers: [server],
+        activeServerId: server.id,
+        libraryBrowseServerIds: [server.id],
+      },
+    }));
+    localStorage.setItem('psysonic-offline', JSON.stringify({
+      version: 0,
+      state: {
+        tracks: {
+          [`${server.id}:track-1`]: {
+            localPath: '/disk/track-1.flac',
+            cachedAt: '2026-01-01T00:00:00.000Z',
+            suffix: 'flac',
+          },
+        },
+        albums: {},
+      },
+    }));
+
+    const { useLocalPlaybackStore } = await import('./localPlaybackStore');
+
+    const entries = Object.values(useLocalPlaybackStore.getState().entries);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      trackId: 'track-1',
+      localPath: '/disk/track-1.flac',
+      tier: 'library',
+    });
+    expect(localStorage.getItem('psysonic-local-playback-migrated-v1')).toBe('1');
+
+    const persisted = JSON.parse(localStorage.getItem('psysonic-local-playback') ?? '{}') as {
+      state?: { entries?: Record<string, unknown> };
+    };
+    expect(Object.values(persisted.state?.entries ?? {})).toHaveLength(1);
+  });
+});

--- a/src/store/localPlaybackStore.ts
+++ b/src/store/localPlaybackStore.ts
@@ -66,6 +66,7 @@ export const LOCAL_PLAYBACK_PROTECT_AFTER_CURRENT = 1;
 
 interface LocalPlaybackState {
   entries: Record<string, LocalPlaybackEntry>;
+  applyHydratedEntries: (entries: Record<string, LocalPlaybackEntry>) => void;
   getEntry: (trackId: string, serverIndexKey: string) => LocalPlaybackEntry | null;
   getLocalUrl: (trackId: string, serverIndexKey: string, tier?: LocalPlaybackTier) => string | null;
   hasLocalBytes: (trackId: string, serverIndexKey: string) => boolean;
@@ -151,6 +152,7 @@ export const useLocalPlaybackStore = create<LocalPlaybackState>()(
   persist(
     (set, get) => ({
       entries: {},
+      applyHydratedEntries: entries => set({ entries }),
 
       getEntry: (trackId, serverIndexKey) =>
         get().entries[localPlaybackEntryKey(serverIndexKey, trackId)] ?? null,
@@ -485,7 +487,7 @@ export const useLocalPlaybackStore = create<LocalPlaybackState>()(
           return;
         }
         const merged = { ...imported, ...state.entries };
-        useLocalPlaybackStore.setState({ entries: merged });
+        state.applyHydratedEntries(merged);
         markLegacyMigrationDone();
       },
     },


### PR DESCRIPTION
## Summary

- repair persisted library scope during synchronous auth-store hydration so individual libraries remain selectable after upgrading from 1.50 to 1.51
- self-heal an empty selected-server scope from the active server before persisting a library choice
- remove the equivalent temporal-dead-zone hydration path from the local playback store

Closes #1431.

## Root cause

Zustand can synchronously hydrate local storage while the exported store binding is still being initialized. The auth and local playback hydration callbacks referenced their own exported stores during that window, so the resulting `ReferenceError` was caught by the persistence layer and the legacy state remained unrepaired. For the library selector, the missing or empty server scope then made individual-library updates no-ops while the `All libraries` fallback still appeared to work.

## Existing installs

The `psysonic-auth` persist version is bumped to `1`. Its custom merge repairs legacy or malformed library scope before publishing hydrated state; Zustand then rewrites the repaired payload. No on-disk database or Tauri contract changes are involved.

## Verification

- `npm run lint`
- `npm run dep:check`
- `npm test` (`578` files, `4365` tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- focused hydration/store tests (`7` files, `75` tests)

Regression coverage includes cold imports of pre-1.51 and malformed 1.51 auth payloads, first-import legacy offline entries, and self-healing of an empty server scope.

## Runtime benchmark

- Applicability: required because auth/local-playback stores hydrate during application startup and auth scope is shared by measured library routes
- Baseline: `94c9b3ee` / report `2026-08-25T00-38-34-586Z`
- Final application code: `702d5183` / report `2026-08-25T00-43-01-019Z` (current PR head `1a891e25` adds only the changelog entry)
- Command: `psysonic benchmark run --scenario core-pages --runs 2 --profile realistic --json`
- Environment: Linux debug, `649x640` at DPR `2`, 3 selected servers, identical stable library-scope fingerprint
- Startup: `migrationReadyMs` `20,195 -> 20,091`
- Route median total: Home `3346 -> 2160 ms`; Albums `1616 -> 1675 ms`; Artists `1255 -> 1283 ms`; Favourites `1636 -> 1636 ms`; Tracks `2239 -> 1475 ms`
- Result: no errors, wrong routes, timeouts, skipped routes, incomplete interactions, or material regressions

## Boundary and placement

- Tauri commands/events/payloads: unchanged
- Reuses the existing auth rehydration and music-library action paths rather than adding a parallel migration flow
