### PR TITLE
fix(library): show analysed BPM in tracklists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Turning off **Show Tray Icon** now also turns off both tray-dependent settings. **Minimize to Tray** and **Start Minimized to Tray** stay unavailable until the tray icon is enabled again.
 * Existing saved settings with the unsafe combination are repaired during startup, so closing the window exits instead of hiding Psysonic with no way to reopen it.
 
+### Analysed BPM appears consistently across tracklists
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1461](https://github.com/Psysonic/psysonic/pull/1461)**
+
+* Album, artist, favourites and playlist tracklists now show and sort by the locally analysed BPM when it is available, instead of continuing to use the BPM embedded in the track tag.
+
 ## [1.51.0] - 2026-08-17
 
 ## Added

--- a/src-tauri/crates/psysonic-library/src/commands/read_support/tests.rs
+++ b/src-tauri/crates/psysonic-library/src/commands/read_support/tests.rs
@@ -5,6 +5,7 @@ use crate::commands::test_support::{make_row, runtime};
 use crate::dto::local_tracks_max_updated_ms;
 use crate::repos::TrackRepository;
 use crate::store::LibraryStore;
+use rusqlite::params;
 
 // The command functions take `tauri::State` which we can't easily
 // construct in unit tests without a Tauri runtime. The tests below
@@ -123,6 +124,35 @@ fn find_batch_preserves_input_order_and_drops_unknowns() {
     let rows = TrackRepository::new(&store).find_batch(&pairs).unwrap();
     let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
     assert_eq!(ids, vec!["tr_2", "tr_1"]);
+}
+
+#[test]
+fn find_batch_resolves_analysis_bpm_over_hot_tag() {
+    let store = Arc::new(LibraryStore::open_in_memory());
+    let mut row = make_row("s1", "tr_1", "al_1", 1);
+    row.bpm = Some(90);
+    TrackRepository::new(&store).upsert_batch(&[row]).unwrap();
+    store
+        .with_conn("test.analysis_bpm", |conn| {
+            conn.execute(
+                "INSERT INTO track_fact (server_id, track_id, fact_kind, value_int, source_kind, source_id, confidence, fetched_at) \
+                 VALUES (?1, ?2, 'bpm', ?3, 'analysis', 'oximedia', 0.9, 1)",
+                params!["s1", "tr_1", 128],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    let hot = TrackRepository::new(&store)
+        .find_one("s1", "tr_1")
+        .unwrap()
+        .unwrap();
+    let resolved = TrackRepository::new(&store)
+        .find_batch(&[("s1".to_string(), "tr_1".to_string())])
+        .unwrap();
+
+    assert_eq!(hot.bpm, Some(90));
+    assert_eq!(resolved[0].bpm, Some(128));
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/repos/track/reads.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/reads.rs
@@ -24,6 +24,13 @@ const SELECT_TRACKS_BY_ALBUM: &str = "SELECT server_id, id, title, title_sort, a
   FROM track WHERE server_id = ?1 AND album_id = ?2 AND deleted = 0 \
   ORDER BY COALESCE(disc_number, 1) ASC, track_number ASC NULLS LAST, id ASC, server_id ASC";
 
+fn select_track_by_id_resolved_bpm() -> String {
+    format!(
+        "SELECT {} FROM track t WHERE t.server_id = ?1 AND t.id = ?2 AND t.deleted = 0",
+        crate::search::aliased_track_columns_with_resolved_bpm_expr("t"),
+    )
+}
+
 impl TrackRepository<'_> {
     /// SELECT a single track by `(server_id, id)`. Returns `None`
     /// when missing or deleted (`deleted = 1`). Used by
@@ -57,7 +64,8 @@ impl TrackRepository<'_> {
             return Ok(Vec::new());
         }
         self.store.with_read_conn(|conn| {
-            let mut stmt = conn.prepare(SELECT_TRACK_BY_ID)?;
+            let sql = select_track_by_id_resolved_bpm();
+            let mut stmt = conn.prepare(&sql)?;
             let mut out: Vec<TrackRow> = Vec::with_capacity(refs.len());
             for (server_id, track_id) in refs {
                 if let Some(row) = stmt

--- a/src-tauri/crates/psysonic-library/src/search.rs
+++ b/src-tauri/crates/psysonic-library/src/search.rs
@@ -346,7 +346,7 @@ pub(crate) fn aliased_track_columns_resolved_bpm(alias: &str) -> String {
     format!("{base}, ({}) AS bpm_source", bpm_source_expr(alias))
 }
 
-fn aliased_track_columns_with_resolved_bpm_expr(alias: &str) -> String {
+pub(crate) fn aliased_track_columns_with_resolved_bpm_expr(alias: &str) -> String {
     let bpm_expr = bpm_resolved_expr(alias);
     crate::repos::track_columns()
         .split(',')

--- a/src/features/album/pages/AlbumDetail.tsx
+++ b/src/features/album/pages/AlbumDetail.tsx
@@ -54,6 +54,9 @@ import { offlineActionPolicy } from '@/features/offline';
 import { resolveIndexKey } from '@/lib/server/serverIndexKey';
 import { sameQueueTrack } from '@/features/playback';
 import { deriveEntitySourceScopes } from '@/lib/library/libraryBrowseScope';
+import { useResolvedTracklistBpm } from '@/lib/hooks/useResolvedTracklistBpm';
+
+const EMPTY_SONGS: SubsonicSong[] = [];
 
 export default function AlbumDetail() {
   const { t } = useTranslation();
@@ -145,6 +148,13 @@ export default function AlbumDetail() {
     if (!losslessOnly) return album.songs;
     return album.songs.filter(s => isLosslessSuffix(s.suffix));
   }, [album?.songs, losslessOnly]);
+  // Album columns own their visibility below this page, so resolve the small
+  // album list eagerly to keep BPM sorting and cells on the same values.
+  const resolvedBpmSongs = useResolvedTracklistBpm(
+    effectiveSongs ?? EMPTY_SONGS,
+    true,
+    albumOwnerServerId,
+  );
 
   const representativeSongs = useMemo(
     () => (effectiveSongs ?? album?.songs ?? []).filter(song => (
@@ -422,16 +432,16 @@ const handleShuffleAll = () => {
   // Must be before early returns — hooks must be called unconditionally.
   const mergedStarredSongs = useMemo(() => {
     const merged = new Set<string>();
-    for (const song of effectiveSongs ?? album?.songs ?? []) {
+    for (const song of resolvedBpmSongs) {
       const key = ownedEntityKey(song);
       const override = ownedOverrideValue(starredOverrides, song);
       if (override ?? starredSongs.has(key)) merged.add(key);
     }
     return merged;
-  }, [effectiveSongs, album?.songs, starredOverrides, starredSongs]);
+  }, [resolvedBpmSongs, starredOverrides, starredSongs]);
 
   const { sortKey, sortDir, handleSort, displayedSongs } = useAlbumDetailSort({
-    songs: effectiveSongs,
+    songs: resolvedBpmSongs,
     filterText,
     starredSongs: mergedStarredSongs,
     ratings,
@@ -470,7 +480,7 @@ const handleShuffleAll = () => {
   if (!album) return <div className="empty-state">{t('albumDetail.notFound')}</div>;
 
   const { album: info } = album;
-  const songs = effectiveSongs ?? [];
+  const songs = resolvedBpmSongs;
   const headerArtistRefs = deriveAlbumHeaderArtistRefs(info, songs);
   const hasVariousArtists = songs.some(s => s.artist !== info.artist);
 

--- a/src/features/artist/components/ArtistAllTracksList.tsx
+++ b/src/features/artist/components/ArtistAllTracksList.tsx
@@ -24,6 +24,7 @@ import { useVirtualizerScrollMargin } from '@/lib/hooks/useVirtualizerScrollMarg
 import { COVER_ARTIST_TOP_TRACK_CSS_PX } from '@/cover/layoutSizes';
 import { useWarmTrackListAlbumCovers } from '@/cover/useWarmTrackListAlbumCovers';
 import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
+import { useResolvedTracklistBpm } from '@/lib/hooks/useResolvedTracklistBpm';
 import ArtistAllTracksRow, { type ArtistAllTracksRowCallbacks } from '@/features/artist/components/ArtistAllTracksRow';
 import {
   ARTIST_ALL_TRACKS_CENTERED_COLS,
@@ -76,11 +77,18 @@ export default function ArtistAllTracksList({ songs, loading, failed, onPlay, co
   const { orbitActive, queueHint, addTrackToOrbit } = useOrbitSongRowBehavior();
 
   const [sort, setSort] = useState<ArtistAllTracksSortState>({ key: 'natural', dir: 'asc' });
-  const displayed = useMemo(() => sortArtistAllTracks(songs, sort), [songs, sort]);
 
   const {
-    visibleCols, gridStyle, pickerOpen, startResize, startFlexColumnResize, tracklistRef,
+    colVisible, visibleCols, gridStyle, pickerOpen, startResize, startFlexColumnResize, tracklistRef,
   } = columns;
+  const resolvedBpmSongs = useResolvedTracklistBpm(
+    songs,
+    colVisible.has('bpm') || sort.key === 'bpm',
+  );
+  const displayed = useMemo(
+    () => sortArtistAllTracks(resolvedBpmSongs, sort),
+    [resolvedBpmSongs, sort],
+  );
 
   // ── Virtualisation against the page's own scroll container ──────────────────
   const listWrapRef = useRef<HTMLDivElement | null>(null);

--- a/src/features/favorites/pages/Favorites.tsx
+++ b/src/features/favorites/pages/Favorites.tsx
@@ -26,6 +26,7 @@ import { getLibraryBrowseScope } from '@/lib/library/libraryBrowseScope';
 import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
 import type { SubsonicSong } from '@/lib/api/subsonicTypes';
 import { sameRadioStation } from '@/features/radio';
+import { useResolvedTracklistBpm } from '@/lib/hooks/useResolvedTracklistBpm';
 
 const FAV_COLUMNS: readonly ColDef[] = [
   { key: 'num',        i18nKey: null,              minWidth: 60,  defaultWidth: 60,  required: true  },
@@ -79,6 +80,10 @@ export default function Favorites() {
     startResize, startFlexColumnResize, toggleColumn, resetColumns,
     pickerOpen, setPickerOpen, pickerRef, tracklistRef,
   } = useTracklistColumns(FAV_COLUMNS, 'psysonic_favorites_columns');
+  const resolvedBpmSongs = useResolvedTracklistBpm(
+    songs,
+    colVisible.has('bpm') || sortKey === 'bpm',
+  );
 
   const [ratings, setRatings] = useState<Record<string, number>>({});
   const [showPlPicker, setShowPlPicker] = useState(false);
@@ -110,7 +115,8 @@ export default function Favorites() {
   }
 
   const { visibleSongs, handleSortClick, getSortIndicator } = useFavoritesSongFiltering({
-    songs, sortKey, setSortKey, sortDir, setSortDir, sortClickCount, setSortClickCount,
+    songs: resolvedBpmSongs,
+    sortKey, setSortKey, sortDir, setSortDir, sortClickCount, setSortClickCount,
     selectedArtist, selectedGenres, yearRange, ratings,
   });
 

--- a/src/features/playlist/components/PlaylistSuggestions.tsx
+++ b/src/features/playlist/components/PlaylistSuggestions.tsx
@@ -22,6 +22,7 @@ import { useWarmTrackListAlbumCovers } from '@/cover/useWarmTrackListAlbumCovers
 import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
 import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
 import { appendServerQuery } from '@/lib/navigation/detailServerScope';
+import { useResolvedTracklistBpm } from '@/lib/hooks/useResolvedTracklistBpm';
 
 const PL_CENTERED = new Set(['favorite', 'rating', 'duration', 'playCount', 'bpm']);
 
@@ -43,6 +44,7 @@ interface Props {
   starredSongs: Set<string>;
   handleRate: (songId: string, rating: number) => void;
   handleToggleStar: (song: SubsonicSong, e: React.MouseEvent) => void;
+  serverId?: string;
 }
 
 export default function PlaylistSuggestions({
@@ -52,7 +54,7 @@ export default function PlaylistSuggestions({
   contextMenuSongId, setContextMenuSongId,
   hoveredSuggestionId, setHoveredSuggestionId,
   addSong, startPreview,
-  ratings, starredSongs, handleRate, handleToggleStar,
+  ratings, starredSongs, handleRate, handleToggleStar, serverId,
 }: Props) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -66,9 +68,14 @@ export default function PlaylistSuggestions({
   const suggestionsVisible = usePlaylistLayoutStore(s =>
     s.items.find(i => i.id === 'suggestions')?.visible !== false);
 
+  const resolvedBpmSuggestions = useResolvedTracklistBpm(
+    suggestions,
+    visibleCols.some(column => column.key === 'bpm'),
+    serverId,
+  );
   const filteredSuggestions = React.useMemo(
-    () => suggestions.filter(s => !existingIds.has(s.id)),
-    [suggestions, existingIds],
+    () => resolvedBpmSuggestions.filter(s => !existingIds.has(s.id)),
+    [resolvedBpmSuggestions, existingIds],
   );
 
   useWarmTrackListAlbumCovers(filteredSuggestions, COVER_ARTIST_TOP_TRACK_CSS_PX, {

--- a/src/features/playlist/pages/PlaylistDetail.tsx
+++ b/src/features/playlist/pages/PlaylistDetail.tsx
@@ -46,6 +46,7 @@ import { useOfflineBrowseContext } from '@/features/offline';
 import { offlineActionPolicy } from '@/features/offline';
 import { readDetailServerId } from '@/lib/navigation/detailServerScope';
 import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
+import { useResolvedTracklistBpm } from '@/lib/hooks/useResolvedTracklistBpm';
 
 // ── Column configuration ──────────────────────────────────────────────────────
 const PL_COLUMNS: readonly ColDef[] = [
@@ -180,6 +181,11 @@ export default function PlaylistDetail() {
     startResize, startFlexColumnResize, toggleColumn, resetColumns,
     pickerOpen, setPickerOpen, pickerRef, tracklistRef,
   } = useTracklistColumns(PL_COLUMNS, 'psysonic_playlist_columns');
+  const resolvedBpmSongs = useResolvedTracklistBpm(
+    songs,
+    colVisible.has('bpm') || sortKey === 'bpm',
+    serverId || undefined,
+  );
 
   usePlaylistRouteEffects({ setContextMenuSongId, setEditingMeta, location, navigate });
 
@@ -295,7 +301,7 @@ export default function PlaylistDetail() {
   };
 
   // ── Memoized derivations ──────────────────────────────────────
-  const { existingIds, tracks, displayedSongs, displayedTracks, isFiltered } = usePlaylistDerived(songs, {
+  const { existingIds, tracks, displayedSongs, displayedTracks, isFiltered } = usePlaylistDerived(resolvedBpmSongs, {
     filterText, sortKey, sortDir, ratings, starredSongs,
   });
 
@@ -397,7 +403,7 @@ export default function PlaylistDetail() {
         startResize={startResize}
         startFlexColumnResize={startFlexColumnResize}
         tracklistRef={tracklistRef}
-        songs={songs}
+        songs={resolvedBpmSongs}
         displayedSongs={displayedSongs}
         displayedTracks={displayedTracks}
         isFiltered={isFiltered}
@@ -450,6 +456,7 @@ export default function PlaylistDetail() {
         starredSongs={starredSongs}
         handleRate={handleRate}
         handleToggleStar={handleToggleStar}
+        serverId={serverId || undefined}
       />
 
       {editingMeta && playlist && (

--- a/src/lib/hooks/useResolvedTracklistBpm.test.ts
+++ b/src/lib/hooks/useResolvedTracklistBpm.test.ts
@@ -1,0 +1,81 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SubsonicSong } from '@/lib/api/subsonicTypes';
+
+const mocks = vi.hoisted(() => ({
+  libraryGetTracksBatchChunked: vi.fn(),
+  libraryIsReady: vi.fn(),
+}));
+
+vi.mock('@/lib/api/library', () => ({
+  libraryGetTracksBatchChunked: mocks.libraryGetTracksBatchChunked,
+}));
+vi.mock('@/lib/library/libraryReady', () => ({
+  libraryIsReady: mocks.libraryIsReady,
+}));
+vi.mock('@/lib/server/serverIndexKey', () => ({
+  resolveIndexKey: (serverId: string) => serverId === 'profile-1' ? 'index-1' : serverId,
+}));
+
+import { useResolvedTracklistBpm } from './useResolvedTracklistBpm';
+
+const songs: SubsonicSong[] = [{
+  id: 'track-1',
+  serverId: 'server-1',
+  title: 'Track',
+  artist: 'Artist',
+  album: 'Album',
+  albumId: 'album-1',
+  duration: 120,
+  bpm: 90,
+}];
+
+describe('useResolvedTracklistBpm', () => {
+  beforeEach(() => {
+    mocks.libraryIsReady.mockReset().mockResolvedValue(true);
+    mocks.libraryGetTracksBatchChunked.mockReset().mockResolvedValue([{
+      serverId: 'server-1',
+      id: 'track-1',
+      bpm: 128,
+    }]);
+  });
+
+  it('overlays analysis-resolved bpm over the song tag', async () => {
+    const { result } = renderHook(() => useResolvedTracklistBpm(songs, true));
+
+    await waitFor(() => expect(result.current[0].bpm).toBe(128));
+    expect(mocks.libraryGetTracksBatchChunked).toHaveBeenCalledWith([
+      { serverId: 'server-1', trackId: 'track-1' },
+    ]);
+  });
+
+  it('does not read the index while the bpm column is disabled', () => {
+    const { result } = renderHook(() => useResolvedTracklistBpm(songs, false));
+
+    expect(result.current).toBe(songs);
+    expect(mocks.libraryIsReady).not.toHaveBeenCalled();
+    expect(mocks.libraryGetTracksBatchChunked).not.toHaveBeenCalled();
+  });
+
+  it('uses the page owner when a network song has no server id', async () => {
+    const unowned = [{ ...songs[0], serverId: undefined }];
+    const { result } = renderHook(() => useResolvedTracklistBpm(unowned, true, 'server-1'));
+
+    await waitFor(() => expect(result.current[0].bpm).toBe(128));
+    expect(mocks.libraryGetTracksBatchChunked).toHaveBeenCalledWith([
+      { serverId: 'server-1', trackId: 'track-1' },
+    ]);
+  });
+
+  it('matches profile ids with canonical library keys', async () => {
+    mocks.libraryGetTracksBatchChunked.mockResolvedValueOnce([{
+      serverId: 'index-1',
+      id: 'track-1',
+      bpm: 128,
+    }]);
+    const profiled = [{ ...songs[0], serverId: 'profile-1' }];
+    const { result } = renderHook(() => useResolvedTracklistBpm(profiled, true));
+
+    await waitFor(() => expect(result.current[0].bpm).toBe(128));
+  });
+});

--- a/src/lib/hooks/useResolvedTracklistBpm.ts
+++ b/src/lib/hooks/useResolvedTracklistBpm.ts
@@ -1,0 +1,69 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { SubsonicSong } from '@/lib/api/subsonicTypes';
+import { libraryGetTracksBatchChunked, type TrackRefDto } from '@/lib/api/library';
+import { libraryIsReady } from '@/lib/library/libraryReady';
+import { resolveIndexKey } from '@/lib/server/serverIndexKey';
+
+function trackKey(serverId: string, trackId: string): string {
+  return `${resolveIndexKey(serverId)}\u0000${trackId}`;
+}
+
+function ownerServerId(song: SubsonicSong, fallbackServerId?: string): string | null {
+  return song.serverId?.trim() || fallbackServerId?.trim() || null;
+}
+
+/** Resolve locally analysed BPM in one batch, using the same precedence as Advanced Search. */
+export function useResolvedTracklistBpm(
+  songs: SubsonicSong[],
+  enabled: boolean,
+  fallbackServerId?: string,
+): SubsonicSong[] {
+  const [resolvedBpms, setResolvedBpms] = useState<Map<string, number>>(() => new Map());
+
+  useEffect(() => {
+    if (!enabled || songs.length === 0) return;
+    let cancelled = false;
+
+    const refsByKey = new Map<string, TrackRefDto>();
+    for (const song of songs) {
+      const serverId = ownerServerId(song, fallbackServerId);
+      if (!serverId || !song.id) continue;
+      refsByKey.set(trackKey(serverId, song.id), { serverId, trackId: song.id });
+    }
+
+    const load = async () => {
+      const serverIds = [...new Set([...refsByKey.values()].map(ref => ref.serverId))];
+      const readiness = await Promise.all(
+        serverIds.map(async serverId => [serverId, await libraryIsReady(serverId)] as const),
+      );
+      const readyServers = new Set(readiness.filter(([, ready]) => ready).map(([serverId]) => serverId));
+      const refs = [...refsByKey.values()].filter(ref => readyServers.has(ref.serverId));
+      const tracks = await libraryGetTracksBatchChunked(refs);
+      if (cancelled) return;
+
+      const next = new Map<string, number>();
+      for (const track of tracks) {
+        if (track.bpm != null && track.bpm > 0) {
+          next.set(trackKey(track.serverId, track.id), track.bpm);
+        }
+      }
+      setResolvedBpms(next);
+    };
+
+    void load();
+    return () => { cancelled = true; };
+  }, [enabled, fallbackServerId, songs]);
+
+  return useMemo(() => {
+    if (!enabled || resolvedBpms.size === 0) return songs;
+    let changed = false;
+    const resolved = songs.map(song => {
+      const serverId = ownerServerId(song, fallbackServerId);
+      const bpm = serverId ? resolvedBpms.get(trackKey(serverId, song.id)) : undefined;
+      if (bpm == null || bpm === song.bpm) return song;
+      changed = true;
+      return { ...song, bpm };
+    });
+    return changed ? resolved : songs;
+  }, [enabled, fallbackServerId, resolvedBpms, songs]);
+}


### PR DESCRIPTION
## Summary
- resolve batch library tracks with the same analysed-BPM precedence used by Advanced Search
- overlay resolved BPM before rendering, filtering, and sorting Album, Artist, Favourites, and Playlist tracklists
- canonicalise profile and library server keys and cover the overlay behaviour with frontend and Rust regression tests

## User impact
Tracklists now show and sort by the locally analysed BPM when it exists instead of continuing to display the embedded tag BPM.

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (580 files, 4,372 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- --test-threads=1`
- focused ingest timing tests: 11/11 passed after a concurrent frontend coverage run had introduced wall-clock contention
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`
- targeted `rustfmt --check` for the changed Rust files
- `git diff --check`

## Runtime benchmark
- Applicability: required; shared tracklist reads and measured routes changed
- Baseline: `1368d6f4` / report `2026-08-25T11-15-51-168Z`
- Final: `c7fdb154` / report `2026-08-25T11-20-12-921Z`
- Command: `psysonic benchmark run --scenario all-pages --runs 3 --profile realistic --json`
- Environment: 692x640 viewport, 3 selected servers, identical stable scope fingerprint
- Affected route readiness: Album `878 -> 872 ms`; Artist `754 -> 759 ms`; Favourites `1602 -> 1624 ms`; Playlist Detail `1486 -> 1102 ms`
- Timeouts/errors: none
- Skips: Label Detail was skipped in both reports because the selected library had no album with a label
- Note: the unchanged Albums browse route produced a noisy total-time outlier (`884 -> 1496 ms`); no affected route showed a material regression

## Tauri contract
No commands, events, arguments, or payload shapes changed. The existing batch track read now resolves its existing `bpm` field consistently with Advanced Search.